### PR TITLE
fix(DOS-87, DOS-92): Intelligence Pipeline data loss and DB-first violations

### DIFF
--- a/.docs/architecture/MODULE-MAP.md
+++ b/.docs/architecture/MODULE-MAP.md
@@ -1,9 +1,9 @@
 # Module Map
 
 > Rust backend module inventory (`src-tauri/src/`).
-> **Auto-generated:** 2026-04-15 by `.docs/generators/gen-module-map.sh`
+> **Auto-generated:** 2026-04-16 by `.docs/generators/gen-module-map.sh`
 
-**238** Rust files across **30** module directories and **44** standalone modules.
+**238** Rust files across **29** module directories and **44** standalone modules.
 
 ---
 
@@ -11,7 +11,6 @@
 
 | Module | Files | Public Fns | Purpose |
 |--------|-------|-----------|---------|
-| `bin/` | 0 | 0 | Binary entry points |
 | `clay/` | 5 | 6 | Clay.earth MCP integration for contact and company enrichment (I228). |
 | `commands/` | 10 | 367 | Tauri IPC command handlers |
 | `context_provider/` | 4 | 2 | Context provider abstraction for dual-mode operation (ADR-0095). |
@@ -47,8 +46,8 @@
 | `accounts.rs` | 1879 | 11 | Account workspace file I/O (I72 / ADR-0047). |
 | `action_status.rs` | 85 | 2 | — |
 | `activity.rs` | 187 | 3 | User activity monitoring for background task throttling. |
-| `audit_log.rs` | 453 | 4 | Tamper-evident audit log for enterprise observability (I471, ADR-0094). |
 | `audit.rs` | 150 | 2 | Audit trail for AI-generated data (I297). |
+| `audit_log.rs` | 453 | 4 | Tamper-evident audit log for enterprise observability (I471, ADR-0094). |
 | `backfill_meetings.rs` | 456 | 1 | — |
 | `calendar_merge.rs` | 289 | 1 | Calendar hybrid overlay merge (ADR-0032) |
 | `capture.rs` | 386 | 1 | Post-meeting capture state machine |
@@ -61,9 +60,9 @@
 | `demo.rs` | 994 | 6 | Production demo data for first-run experience (I56). |
 | `embeddings.rs` | 315 | 3 | Local semantic search (nomic-embed-text) |
 | `enrichment.rs` | 475 | 1 | Unified enrichment processor. |
-| `entity_io.rs` | 166 | 5 | Shared entity I/O helpers (I290). |
 | `entity.rs` | 61 | 0
 0 | Profile-agnostic tracked entity abstraction (ADR-0045). |
+| `entity_io.rs` | 166 | 5 | Shared entity I/O helpers (I290). |
 | `error.rs` | 139 | 0
 0 | Error types for workflow execution |
 | `executor.rs` | 1439 | 1 | Workflow execution engine |

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -2346,7 +2346,7 @@ fn dual_write_enrichment_products(
 
     for feature in &adoption.feature_adoption {
         // Parse "Core platform: 95%" → name = "Core platform", adoption_pct ~0.95
-        let (name, _adoption_pct) = if let Some(colon_pos) = feature.find(':') {
+        let (name, adoption_pct) = if let Some(colon_pos) = feature.find(':') {
             let raw_name = feature[..colon_pos].trim();
             let pct_str = feature[colon_pos + 1..].trim().trim_end_matches('%');
             let pct = pct_str.parse::<f64>().ok().map(|v| v / 100.0);
@@ -2359,7 +2359,7 @@ fn dual_write_enrichment_products(
             continue;
         }
 
-        match db.upsert_account_product(entity_id, &name, None, "active", None, source, 0.55, None)
+        match db.upsert_account_product(entity_id, &name, None, "active", adoption_pct, source, 0.55, None)
         {
             Ok(_) => upserted += 1,
             Err(e) => {

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -1347,7 +1347,16 @@ pub async fn dismiss_recommendation(
                 account.as_ref(),
             )?;
 
-            let mut intel = crate::intelligence::read_intelligence_json(&dir).unwrap_or_default();
+            // DOS-92: DB is sole source of truth — no filesystem fallback.
+            let mut intel = db
+                .get_entity_intelligence(&entity_id)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| {
+                    format!(
+                        "DOS-92: no DB intelligence row for {} — cannot dismiss recommendation",
+                        entity_id
+                    )
+                })?;
 
             if index >= intel.recommended_actions.len() {
                 return Err(format!("Recommendation index {} out of bounds", index));


### PR DESCRIPTION
## Summary
- **DOS-87**: `dual_write_enrichment_products` parsed adoption percentages from enrichment data (e.g. "Core platform: 95%") but passed `None` to `upsert_account_product`, silently dropping the parsed value. Product health dimension was missing adoption data.
- **DOS-92**: `dismiss_recommendation` read intelligence from filesystem via `read_intelligence_json` instead of DB, violating DB-first architecture (ADR). Could overwrite DB state with stale file data. Now follows the same DB-first pattern already used by `dismiss_intelligence_item`.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (10/10)
- [x] `npx tsc --noEmit` passes
- [ ] Manual: dismiss a recommended action → verify it persists after app restart
- [ ] Manual: trigger enrichment with product adoption data → verify adoption_pct appears in account_products table

🤖 Generated with [Claude Code](https://claude.com/claude-code)