### PR TITLE
fix(DOS-102): eliminate stale filesystem reads in account mutation path

### DIFF
--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -179,11 +179,16 @@ pub fn write_account_json(
             csm: None,
             champion: None,
         },
-        company_overview: existing_json.and_then(|j| j.company_overview.clone()),
-        strategic_programs: existing_json
-            .map(|j| j.strategic_programs.clone())
+        company_overview: account
+            .company_overview
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok()),
+        strategic_programs: account
+            .strategic_programs
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
             .unwrap_or_default(),
-        notes: existing_json.and_then(|j| j.notes.clone()),
+        notes: account.notes.clone(),
         custom_sections: existing_json
             .map(|j| j.custom_sections.clone())
             .unwrap_or_default(),
@@ -195,12 +200,12 @@ pub fn write_account_json(
 
 /// Write `dashboard.md` for an account (generated artifact).
 ///
-/// Combines structured data from SQLite with narrative data from JSON
-/// and auto-generated sections from meeting/action/capture history.
+/// Combines structured data from SQLite with auto-generated sections
+/// from meeting/action/capture history.
 pub fn write_account_markdown(
     workspace: &Path,
     account: &DbAccount,
-    json: Option<&AccountJson>,
+    _json: Option<&AccountJson>,
     db: &ActionDb,
 ) -> Result<(), String> {
     let dir = resolve_account_dir(workspace, account);
@@ -253,13 +258,17 @@ pub fn write_account_markdown(
     // Read intelligence from DB (I513)
     let intel_data = db.get_entity_intelligence(&account.id).ok().flatten();
 
-    // Company Overview (from JSON — skipped when intelligence.json has company_context)
+    // Company Overview (from DB — skipped when intelligence has company_context)
     let intel_has_company = intel_data
         .as_ref()
         .and_then(|i| i.company_context.as_ref())
         .is_some();
     if !intel_has_company {
-        if let Some(overview) = json.and_then(|j| j.company_overview.as_ref()) {
+        let overview: Option<CompanyOverview> = account
+            .company_overview
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok());
+        if let Some(overview) = overview {
             md.push_str("## Company Overview\n\n");
             if let Some(ref desc) = overview.description {
                 md.push_str(desc);
@@ -278,29 +287,32 @@ pub fn write_account_markdown(
         }
     }
 
-    // Strategic Programs (from JSON)
-    if let Some(programs) = json.map(|j| &j.strategic_programs) {
-        if !programs.is_empty() {
-            md.push_str("## Strategic Programs\n\n");
-            for p in programs.iter() {
-                let status_badge = match p.status.as_str() {
-                    "completed" => "✅",
-                    "in_progress" => "🔄",
-                    "planned" => "📋",
-                    _ => "•",
-                };
-                md.push_str(&format!("- {} **{}** — {}", status_badge, p.name, p.status));
-                if let Some(ref notes) = p.notes {
-                    md.push_str(&format!(" — {}", notes));
-                }
-                md.push('\n');
+    // Strategic Programs (from DB)
+    let programs: Vec<StrategicProgram> = account
+        .strategic_programs
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+    if !programs.is_empty() {
+        md.push_str("## Strategic Programs\n\n");
+        for p in &programs {
+            let status_badge = match p.status.as_str() {
+                "completed" => "✅",
+                "in_progress" => "🔄",
+                "planned" => "📋",
+                _ => "•",
+            };
+            md.push_str(&format!("- {} **{}** — {}", status_badge, p.name, p.status));
+            if let Some(ref notes) = p.notes {
+                md.push_str(&format!(" — {}", notes));
             }
             md.push('\n');
         }
+        md.push('\n');
     }
 
-    // Notes (from JSON)
-    if let Some(notes) = json.and_then(|j| j.notes.as_ref()) {
+    // Notes (from DB)
+    if let Some(ref notes) = account.notes {
         if !notes.is_empty() {
             md.push_str("## Notes\n\n");
             md.push_str(notes);
@@ -1028,7 +1040,7 @@ pub fn build_file_context(_workspace: &Path, db: &ActionDb, account_id: &str) ->
 // Account enrichment via PTY removed per ADR-0086 (I376).
 // Entity intelligence is now enriched solely via intel_queue.
 
-/// Create a minimal AccountJson from a DbAccount (no narrative fields).
+/// Create an AccountJson from a DbAccount, reading narrative fields from DB columns.
 fn default_account_json(account: &DbAccount) -> AccountJson {
     AccountJson {
         version: 1,
@@ -1043,9 +1055,16 @@ fn default_account_json(account: &DbAccount) -> AccountJson {
             csm: None,
             champion: None,
         },
-        company_overview: None,
-        strategic_programs: Vec::new(),
-        notes: None,
+        company_overview: account
+            .company_overview
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok()),
+        strategic_programs: account
+            .strategic_programs
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default(),
+        notes: account.notes.clone(),
         custom_sections: Vec::new(),
         parent_id: account.parent_id.clone(),
     }
@@ -1108,40 +1127,27 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let workspace = dir.path();
         let db = test_db();
-        let account = sample_account("Acme Corp");
+
+        let overview = CompanyOverview {
+            description: Some("A great company.".to_string()),
+            industry: Some("Tech".to_string()),
+            size: None,
+            headquarters: None,
+            enriched_at: None,
+        };
+        let programs = vec![StrategicProgram {
+            name: "Migration".to_string(),
+            status: "in_progress".to_string(),
+            notes: Some("Phase 2".to_string()),
+        }];
+
+        let mut account = sample_account("Acme Corp");
+        account.company_overview = Some(serde_json::to_string(&overview).unwrap());
+        account.strategic_programs = Some(serde_json::to_string(&programs).unwrap());
+        account.notes = Some("Key account.".to_string());
         db.upsert_account(&account).unwrap();
 
-        let json = AccountJson {
-            version: 1,
-            entity_type: "account".to_string(),
-            structured: AccountStructured {
-                arr: account.arr,
-                health: account.health.clone(),
-                lifecycle: account.lifecycle.clone(),
-                renewal_date: account.contract_end.clone(),
-                nps: account.nps,
-                account_team: Vec::new(),
-                csm: None,
-                champion: None,
-            },
-            company_overview: Some(CompanyOverview {
-                description: Some("A great company.".to_string()),
-                industry: Some("Tech".to_string()),
-                size: None,
-                headquarters: None,
-                enriched_at: None,
-            }),
-            strategic_programs: vec![StrategicProgram {
-                name: "Migration".to_string(),
-                status: "in_progress".to_string(),
-                notes: Some("Phase 2".to_string()),
-            }],
-            notes: Some("Key account.".to_string()),
-            custom_sections: vec![],
-            parent_id: None,
-        };
-
-        write_account_markdown(workspace, &account, Some(&json), &db).unwrap();
+        write_account_markdown(workspace, &account, None, &db).unwrap();
 
         let md_path = workspace.join("Accounts/Acme Corp/dashboard.md");
         assert!(md_path.exists());
@@ -1217,38 +1223,21 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let workspace = dir.path();
         let db = test_db();
-        let account = sample_account("Gamma Ltd");
 
-        let existing = AccountJson {
-            version: 1,
-            entity_type: "account".to_string(),
-            structured: AccountStructured {
-                arr: account.arr,
-                health: account.health.clone(),
-                lifecycle: account.lifecycle.clone(),
-                renewal_date: account.contract_end.clone(),
-                nps: account.nps,
-                account_team: Vec::new(),
-                csm: None,
-                champion: None,
-            },
-            company_overview: Some(CompanyOverview {
-                description: Some("Important context.".to_string()),
-                industry: None,
-                size: None,
-                headquarters: None,
-                enriched_at: None,
-            }),
-            strategic_programs: vec![],
-            notes: Some("Don't lose these notes.".to_string()),
-            custom_sections: vec![],
-            parent_id: None,
+        let overview = CompanyOverview {
+            description: Some("Important context.".to_string()),
+            industry: None,
+            size: None,
+            headquarters: None,
+            enriched_at: None,
         };
 
-        // Write with existing narrative data
-        write_account_json(workspace, &account, Some(&existing), &db).unwrap();
+        let mut account = sample_account("Gamma Ltd");
+        account.company_overview = Some(serde_json::to_string(&overview).unwrap());
+        account.notes = Some("Don't lose these notes.".to_string());
 
-        // Read back and verify narrative preserved
+        write_account_json(workspace, &account, None, &db).unwrap();
+
         let json_path = workspace.join("Accounts/Gamma Ltd/dashboard.json");
         let result = read_account_json(&json_path).unwrap();
         assert_eq!(

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -1003,6 +1003,16 @@ impl ActionDb {
     /// Update a single whitelisted field on an account.
     pub fn update_account_field(&self, id: &str, field: &str, value: &str) -> Result<(), DbError> {
         let now = Utc::now().to_rfc3339();
+        // JSON-typed columns: validate non-empty values parse as JSON to prevent
+        // silently storing corrupt data that later fails parse-on-read.
+        if matches!(field, "strategic_programs" | "company_overview") && !value.is_empty() {
+            serde_json::from_str::<serde_json::Value>(value).map_err(|e| {
+                DbError::Sqlite(rusqlite::Error::InvalidParameterName(format!(
+                    "Invalid JSON for field '{}': {}",
+                    field, e
+                )))
+            })?;
+        }
         // parent_id uses NULL for empty values (top-level accounts)
         if field == "parent_id" {
             if value.is_empty() {

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -1068,6 +1068,18 @@ impl ActionDb {
             "sentiment_set_at" => {
                 "UPDATE accounts SET sentiment_set_at = ?1, updated_at = ?3 WHERE id = ?2"
             }
+            "tracker_path" => {
+                "UPDATE accounts SET tracker_path = ?1, updated_at = ?3 WHERE id = ?2"
+            }
+            "notes" => {
+                "UPDATE accounts SET notes = CASE WHEN ?1 = '' THEN NULL ELSE ?1 END, updated_at = ?3 WHERE id = ?2"
+            }
+            "strategic_programs" => {
+                "UPDATE accounts SET strategic_programs = ?1, updated_at = ?3 WHERE id = ?2"
+            }
+            "company_overview" => {
+                "UPDATE accounts SET company_overview = ?1, updated_at = ?3 WHERE id = ?2"
+            }
             _ => {
                 return Err(DbError::Sqlite(rusqlite::Error::InvalidParameterName(
                     format!("Field '{}' is not updatable", field),

--- a/src-tauri/src/services/accounts.rs
+++ b/src-tauri/src/services/accounts.rs
@@ -83,20 +83,25 @@ pub fn create_child_account_record(
             .map_err(|e| e.to_string())?;
     }
 
+    if let Some(desc) = description {
+        let trimmed = desc.trim();
+        if !trimmed.is_empty() {
+            let _ = db.update_account_field(&account.id, "notes", trimmed);
+        }
+    }
+
+    let account = db
+        .get_account(&account.id)
+        .map_err(|e| e.to_string())?
+        .unwrap_or(account);
+
     if let Some(ws) = workspace {
         let account_dir = crate::accounts::resolve_account_dir(ws, &account);
         let _ = std::fs::create_dir_all(&account_dir);
         let _ = crate::util::bootstrap_entity_directory(&account_dir, name, "account");
 
-        let mut json = default_account_json(&account);
-        if let Some(desc) = description {
-            let trimmed = desc.trim();
-            if !trimmed.is_empty() {
-                json.notes = Some(trimmed.to_string());
-            }
-        }
-        let _ = crate::accounts::write_account_json(ws, &account, Some(&json), db);
-        let _ = crate::accounts::write_account_markdown(ws, &account, Some(&json), db);
+        let _ = crate::accounts::write_account_json(ws, &account, None, db);
+        let _ = crate::accounts::write_account_markdown(ws, &account, None, db);
     }
 
     Ok(account)
@@ -117,9 +122,16 @@ pub fn default_account_json(account: &crate::db::DbAccount) -> crate::accounts::
             csm: None,
             champion: None,
         },
-        company_overview: None,
-        strategic_programs: Vec::new(),
-        notes: None,
+        company_overview: account
+            .company_overview
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok()),
+        strategic_programs: account
+            .strategic_programs
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default(),
+        notes: account.notes.clone(),
         custom_sections: Vec::new(),
         parent_id: account.parent_id.clone(),
     }
@@ -1575,18 +1587,8 @@ pub fn update_account_field(
                 .ok()
                 .flatten()
                 .unwrap_or(account);
-            let json_path =
-                crate::accounts::resolve_account_dir(workspace, &account).join("dashboard.json");
-            let existing = if json_path.exists() {
-                crate::accounts::read_account_json(&json_path)
-                    .ok()
-                    .map(|r| r.json)
-            } else {
-                None
-            };
-            let _ = crate::accounts::write_account_json(workspace, &account, existing.as_ref(), db);
-            let _ =
-                crate::accounts::write_account_markdown(workspace, &account, existing.as_ref(), db);
+            let _ = crate::accounts::write_account_json(workspace, &account, None, db);
+            let _ = crate::accounts::write_account_markdown(workspace, &account, None, db);
         }
     }
 
@@ -1637,14 +1639,17 @@ pub fn set_user_health_sentiment(
     Ok(())
 }
 
-/// Update account notes (narrative field — JSON only, not SQLite).
-/// Writes dashboard.json + regenerates dashboard.md.
+/// Update account notes (narrative field).
+/// Writes to SQLite, then regenerates dashboard.json + dashboard.md.
 pub fn update_account_notes(
     db: &ActionDb,
     state: &AppState,
     account_id: &str,
     notes: &str,
 ) -> Result<(), String> {
+    db.update_account_field(account_id, "notes", notes)
+        .map_err(|e| e.to_string())?;
+
     let account = db
         .get_account(account_id)
         .map_err(|e| e.to_string())?
@@ -1654,24 +1659,8 @@ pub fn update_account_notes(
     let config = config.as_ref().ok_or("Config not loaded")?;
     let workspace = Path::new(&config.workspace_path);
 
-    let json_path =
-        crate::accounts::resolve_account_dir(workspace, &account).join("dashboard.json");
-    let mut existing = if json_path.exists() {
-        crate::accounts::read_account_json(&json_path)
-            .map(|r| r.json)
-            .unwrap_or_else(|_| default_account_json(&account))
-    } else {
-        default_account_json(&account)
-    };
-
-    existing.notes = if notes.is_empty() {
-        None
-    } else {
-        Some(notes.to_string())
-    };
-
-    let _ = crate::accounts::write_account_json(workspace, &account, Some(&existing), db);
-    let _ = crate::accounts::write_account_markdown(workspace, &account, Some(&existing), db);
+    let _ = crate::accounts::write_account_json(workspace, &account, None, db);
+    let _ = crate::accounts::write_account_markdown(workspace, &account, None, db);
 
     // Emit field update signal (I377)
     crate::services::signals::emit_and_propagate(
@@ -1696,40 +1685,31 @@ pub fn update_account_notes(
     Ok(())
 }
 
-/// Update account strategic programs (narrative field — JSON only).
-/// Writes dashboard.json + regenerates dashboard.md.
+/// Update account strategic programs (narrative field).
+/// Validates JSON, writes to SQLite, then regenerates dashboard.json + dashboard.md.
 pub fn update_account_programs(
     db: &ActionDb,
     state: &AppState,
     account_id: &str,
     programs_json: &str,
 ) -> Result<(), String> {
+    let _: Vec<crate::accounts::StrategicProgram> =
+        serde_json::from_str(programs_json).map_err(|e| format!("Invalid programs JSON: {}", e))?;
+
+    db.update_account_field(account_id, "strategic_programs", programs_json)
+        .map_err(|e| e.to_string())?;
+
     let account = db
         .get_account(account_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Account not found: {}", account_id))?;
 
-    let programs: Vec<crate::accounts::StrategicProgram> =
-        serde_json::from_str(programs_json).map_err(|e| format!("Invalid programs JSON: {}", e))?;
-
     let config = state.config.read();
     let config = config.as_ref().ok_or("Config not loaded")?;
     let workspace = Path::new(&config.workspace_path);
 
-    let json_path =
-        crate::accounts::resolve_account_dir(workspace, &account).join("dashboard.json");
-    let mut existing = if json_path.exists() {
-        crate::accounts::read_account_json(&json_path)
-            .map(|r| r.json)
-            .unwrap_or_else(|_| default_account_json(&account))
-    } else {
-        default_account_json(&account)
-    };
-
-    existing.strategic_programs = programs;
-
-    let _ = crate::accounts::write_account_json(workspace, &account, Some(&existing), db);
-    let _ = crate::accounts::write_account_markdown(workspace, &account, Some(&existing), db);
+    let _ = crate::accounts::write_account_json(workspace, &account, None, db);
+    let _ = crate::accounts::write_account_markdown(workspace, &account, None, db);
 
     // Emit field update signal (I377)
     crate::services::signals::emit_and_propagate(


### PR DESCRIPTION
## Summary

- **Account mutations now read/write narrative fields (notes, strategic_programs, company_overview) via SQLite instead of dashboard.json files**
- Eliminates data asymmetry: detail page read from DB, but mutations were reading from stale filesystem state — edits could silently overwrite newer DB data
- Added `notes`, `strategic_programs`, `company_overview`, `tracker_path` to the `update_account_field` match arms in `db/accounts.rs` (previously these field updates silently failed)
- `write_account_json` and `write_account_markdown` now source narrative data from `DbAccount` columns (promoted via I644), not from `existing_json`/`json` parameters

## Changes by file

| File | Change |
|------|--------|
| `accounts.rs` | `write_account_json` + `write_account_markdown` read narrative from `DbAccount`; tests updated |
| `db/accounts.rs` | 4 new field match arms in `update_account_field` |
| `services/accounts.rs` | 3 mutation functions write to DB first, then regenerate; `create_child_account_record` persists description to DB |

## Test plan

- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib` — 1415 passed, 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] `test_preserves_narrative_on_structured_update` — updated and passing
- [x] `test_write_markdown` — updated and passing
- [x] Adversarial code review caught and fixed 2 regressions (write_account_markdown narrative dropout, create_child_account_record description loss)

Closes DOS-102

🤖 Generated with [Claude Code](https://claude.com/claude-code)