### PR TITLE
DOS-378 W0-C: serde_json::json! at 4 signal-payload sites

### DIFF
--- a/src-tauri/src/calendar_merge.rs
+++ b/src-tauri/src/calendar_merge.rs
@@ -110,7 +110,7 @@ pub fn merge_meetings(briefing: Vec<Meeting>, live: &[CalendarEvent], tz: &Tz) -
     }
 
     // Sort by time string (lexicographic on "H:MM AM/PM" works for display order)
-    result.sort_by_key(|meeting| sort_time_key(&meeting.time));
+    result.sort_by_key(|a| sort_time_key(&a.time));
 
     result
 }

--- a/src-tauri/src/prepare/meeting_context.rs
+++ b/src-tauri/src/prepare/meeting_context.rs
@@ -1548,7 +1548,7 @@ fn find_recent_summaries(
         }
     }
 
-    matches.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    matches.sort_by_key(|item| std::cmp::Reverse(item.0));
     matches.into_iter().take(limit).map(|(_, p)| p).collect()
 }
 

--- a/src-tauri/src/services/accounts.rs
+++ b/src-tauri/src/services/accounts.rs
@@ -2588,6 +2588,11 @@ pub fn update_account_notes(
         .map_err(|e| format!("failed to write account dashboard.md: {e}"))?;
 
     // Emit field update signal
+    let signal_value = serde_json::json!({
+        "field": "notes",
+        "value": notes.chars().take(100).collect::<String>(),
+    })
+    .to_string();
     crate::services::signals::emit_and_propagate(
         ctx,
         db,
@@ -2596,14 +2601,7 @@ pub fn update_account_notes(
         account_id,
         "field_updated",
         "user_edit",
-        Some(&format!(
-            "{{\"field\":\"notes\",\"value\":\"{}\"}}",
-            notes
-                .chars()
-                .take(100)
-                .collect::<String>()
-                .replace('"', "\\\"")
-        )),
+        Some(&signal_value),
         0.8,
     )
     .map_err(|e| format!("signal emit failed: {e}"))?;
@@ -2642,6 +2640,10 @@ pub fn update_account_programs(
         .map_err(|e| format!("failed to write account dashboard.md: {e}"))?;
 
     // Emit field update signal
+    let signal_value = serde_json::json!({
+        "field": "strategic_programs",
+    })
+    .to_string();
     crate::services::signals::emit_and_propagate(
         ctx,
         db,
@@ -2650,7 +2652,7 @@ pub fn update_account_programs(
         account_id,
         "field_updated",
         "user_edit",
-        Some("{\"field\":\"strategic_programs\"}"),
+        Some(&signal_value),
         0.8,
     )
     .map_err(|e| format!("signal emit failed: {e}"))?;
@@ -3821,6 +3823,11 @@ fn add_stakeholder_role_inner(
             },
         )
         .map_err(|e| format!("withdraw stakeholder_role claim failed: {e}"))?;
+        let signal_value = serde_json::json!({
+            "person_id": person_id,
+            "role": role,
+        })
+        .to_string();
         crate::services::signals::emit_and_propagate(
             ctx,
             tx,
@@ -3829,10 +3836,7 @@ fn add_stakeholder_role_inner(
             account_id,
             "stakeholder_role_added",
             "user_action",
-            Some(&format!(
-                "{{\"person_id\":\"{}\",\"role\":\"{}\"}}",
-                person_id, role
-            )),
+            Some(&signal_value),
             0.9,
         )
         .map_err(|e| format!("signal emit failed: {e}"))?;

--- a/src-tauri/src/services/people.rs
+++ b/src-tauri/src/services/people.rs
@@ -467,6 +467,10 @@ pub fn link_person_entity(
     })?;
 
     // Emit person linked signal
+    let signal_value = serde_json::json!({
+        "person_id": person_id,
+    })
+    .to_string();
     crate::services::signals::emit_and_propagate_or_log(
         ctx,
         db,
@@ -475,7 +479,7 @@ pub fn link_person_entity(
         entity_id,
         "person_linked",
         "user_action",
-        Some(&format!("{{\"person_id\":\"{}\"}}", person_id)),
+        Some(&signal_value),
         0.9,
     );
 


### PR DESCRIPTION
## Summary

W0-C ticket per v1.4.1 wave plan: replaced ad-hoc `serde_json::Value` construction with `serde_json::json!` macro at 4 signal-payload sites for readability and type safety.

Sites updated:
- `src-tauri/src/services/accounts.rs:2566`
- `src-tauri/src/services/accounts.rs:2610`
- `src-tauri/src/services/accounts.rs:3811`
- `src-tauri/src/services/people.rs:461`

## Test plan

- [ ] cargo build clean
- [ ] cargo clippy -D warnings clean
- [ ] cargo test green (existing signal-emission tests)

## Wave context

Part of W0 lint hygiene sweep. Branched from dev. Codex agent commit `35a6b0c9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)