### PR TITLE
DOS-380 W0-E: stakeholder_writer signal helper + CI lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Enforce write_intelligence_json fence usage
         run: ./scripts/check_write_fence_usage.sh
 
+      - name: Enforce stakeholder graph writer signal helper
+        run: ./scripts/check_stakeholder_writer_emits_signal.sh
+
       - name: Enforce ability surface drift guard
         run: |
           bash src-tauri/scripts/check_ability_surface_drift.sh

--- a/scripts/check_stakeholder_writer_emits_signal.sh
+++ b/scripts/check_stakeholder_writer_emits_signal.sh
@@ -43,6 +43,7 @@ while IFS= read -r -d '' file; do
 
   awk -v file="$rel" -v allowlisted_writer="$allowlisted_writer" -v helper_file="$helper_file" '
     function min(a, b) { return a < b ? a : b }
+    function max(a, b) { return a > b ? a : b }
     function scan_line(input,    i, ch, next_ch) {
       clean_line = ""
       syntax_line = ""
@@ -101,14 +102,61 @@ while IFS= read -r -d '' file; do
     function is_function_decl(text) {
       return text ~ /(^|[^[:alnum:]_])((pub(\([^)]*\))?|async|unsafe|extern|const)[[:space:]]+)*fn[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*(<|\()/
     }
-    function has_stakeholder_signal_call(start, stop,    j) {
-      for (j = start; j <= stop; j++) {
-        if (syntax_lines[j] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/ ||
-            syntax_lines[j] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?emit_stakeholders_changed(_for_entities)?[[:space:]]*\(/) {
+    function is_stakeholder_write_wrapper_call(line) {
+      return syntax_lines[line] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/
+    }
+    function is_stakeholder_emit_helper_call(line) {
+      return syntax_lines[line] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?emit_stakeholders_changed(_for_entities)?[[:space:]]*\(/
+    }
+    function call_span_stop(start,    j, depth) {
+      depth = 0
+      for (j = start; j <= n; j++) {
+        depth += count_char(syntax_lines[j], "(")
+        depth -= count_char(syntax_lines[j], ")")
+        if (depth <= 0) {
+          return j
+        }
+      }
+      return n
+    }
+    function index_stakeholder_signal_calls(    j) {
+      for (j = 1; j <= n; j++) {
+        if (is_stakeholder_write_wrapper_call(j)) {
+          write_wrapper_count++
+          write_wrapper_start[write_wrapper_count] = j
+          write_wrapper_end[write_wrapper_count] = call_span_stop(j)
+        } else if (is_stakeholder_emit_helper_call(j)) {
+          emit_helper_count++
+          emit_helper_start[emit_helper_count] = j
+          emit_helper_end[emit_helper_count] = call_span_stop(j)
+        }
+      }
+    }
+    function is_inside_stakeholder_write_wrapper(line,    k) {
+      for (k = 1; k <= write_wrapper_count; k++) {
+        if (write_wrapper_start[k] <= line && line <= write_wrapper_end[k]) {
           return 1
         }
       }
       return 0
+    }
+    function has_nearby_stakeholder_emit(line, fn_idx,    k, window_start, window_end) {
+      if (fn_idx <= 0) {
+        return 0
+      }
+      window_start = max(fn_start[fn_idx], line - 30)
+      window_end = min(fn_end[fn_idx], line + 30)
+      for (k = 1; k <= emit_helper_count; k++) {
+        if ((window_start <= emit_helper_start[k] && emit_helper_start[k] <= window_end) ||
+            (window_start <= emit_helper_end[k] && emit_helper_end[k] <= window_end)) {
+          return 1
+        }
+      }
+      return 0
+    }
+    function has_write_level_stakeholder_signal(line, fn_idx) {
+      return is_inside_stakeholder_write_wrapper(line) ||
+        has_nearby_stakeholder_emit(line, fn_idx)
     }
     function enclosing_function(line,    k, best) {
       best = 0
@@ -183,6 +231,7 @@ while IFS= read -r -d '' file; do
         fn_end[fn_stack[stack_len]] = n
         stack_len--
       }
+      index_stakeholder_signal_calls()
 
       write_re = "(insert([[:space:]]+or[[:space:]]+(ignore|replace))?[[:space:]]+into|update|delete[[:space:]]+from)[^\"]*(account_stakeholders|entity_members)([^[:alnum:]_]|$)"
       for (i = 1; i <= n; i++) {
@@ -193,10 +242,10 @@ while IFS= read -r -d '' file; do
         stop = min(n, i + 30)
         fn_idx = enclosing_function(i)
         if (allowlisted_writer || is_non_graph_update(i, stop) ||
-            (fn_idx > 0 && has_stakeholder_signal_call(fn_start[fn_idx], fn_end[fn_idx]))) {
+            has_write_level_stakeholder_signal(i, fn_idx)) {
           continue
         }
-        printf "%s:%d: stakeholder graph write must call stakeholder_writer::write_with_stakeholders_changed/emit_stakeholders_changed in the same function or use an allowlisted DB writer\n", file, i
+        printf "%s:%d: stakeholder graph write must be covered at the write site by stakeholder_writer::write_with_stakeholders_changed/emit_stakeholders_changed or use an allowlisted DB writer\n", file, i
         failures++
       }
 

--- a/scripts/check_stakeholder_writer_emits_signal.sh
+++ b/scripts/check_stakeholder_writer_emits_signal.sh
@@ -42,27 +42,93 @@ while IFS= read -r -d '' file; do
   fi
 
   awk -v file="$rel" -v allowlisted_writer="$allowlisted_writer" -v helper_file="$helper_file" '
-    function max(a, b) { return a > b ? a : b }
     function min(a, b) { return a < b ? a : b }
-    function has_wrapper(start, stop,    j) {
+    function scan_line(input,    i, ch, next_ch) {
+      clean_line = ""
+      syntax_line = ""
+      for (i = 1; i <= length(input); i++) {
+        ch = substr(input, i, 1)
+        next_ch = substr(input, i + 1, 1)
+
+        if (scan_block_comment) {
+          if (ch == "*" && next_ch == "/") {
+            scan_block_comment = 0
+            i++
+          }
+          continue
+        }
+
+        if (scan_string) {
+          clean_line = clean_line ch
+          if (scan_escape) {
+            scan_escape = 0
+          } else if (ch == "\\") {
+            scan_escape = 1
+          } else if (ch == "\"") {
+            scan_string = 0
+          }
+          continue
+        }
+
+        if (ch == "/" && next_ch == "/") {
+          break
+        }
+        if (ch == "/" && next_ch == "*") {
+          scan_block_comment = 1
+          i++
+          continue
+        }
+        if (ch == "\"") {
+          scan_string = 1
+          scan_escape = 0
+          clean_line = clean_line ch
+          continue
+        }
+
+        clean_line = clean_line ch
+        syntax_line = syntax_line ch
+      }
+    }
+    function count_char(text, needle,    i, count) {
+      count = 0
+      for (i = 1; i <= length(text); i++) {
+        if (substr(text, i, 1) == needle) {
+          count++
+        }
+      }
+      return count
+    }
+    function is_function_decl(text) {
+      return text ~ /(^|[^[:alnum:]_])((pub(\([^)]*\))?|async|unsafe|extern|const)[[:space:]]+)*fn[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*(<|\()/
+    }
+    function has_stakeholder_signal_call(start, stop,    j) {
       for (j = start; j <= stop; j++) {
-        if (lines[j] ~ /stakeholder_writer::write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/ ||
-            lines[j] ~ /write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/) {
+        if (syntax_lines[j] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/ ||
+            syntax_lines[j] ~ /(^|[^[:alnum:]_:])((crate::services::)?stakeholder_writer::)?emit_stakeholders_changed(_for_entities)?[[:space:]]*\(/) {
           return 1
         }
       }
       return 0
     }
+    function enclosing_function(line,    k, best) {
+      best = 0
+      for (k = 1; k <= fn_count; k++) {
+        if (fn_start[k] <= line && line <= fn_end[k] &&
+            (best == 0 || fn_start[k] > fn_start[best])) {
+          best = k
+        }
+      }
+      return best
+    }
     function is_non_graph_update(i, stop,    j, text) {
-      if (tolower(lines[i]) !~ /update[^\"]*account_stakeholders/) {
+      if (tolower(code_lines[i]) !~ /update[^\"]*account_stakeholders/) {
         return 0
       }
       text = ""
       for (j = i; j <= stop; j++) {
-        text = text "\n" tolower(lines[j])
+        text = text "\n" tolower(code_lines[j])
       }
-      if (text ~ /(set[[:space:]]+(engagement|assessment)|data_source_engagement|data_source_assessment)/ &&
-          text !~ /(set|,)[[:space:]]*(account_id|person_id|status|relationship_type)[[:space:]]*=/) {
+      if (text !~ /(set|,)[[:space:]]*(account_id|person_id|status|relationship_type)[[:space:]]*=/) {
         return 1
       }
       return 0
@@ -71,10 +137,10 @@ while IFS= read -r -d '' file; do
       saw_emit = 0
       saw_signal = 0
       for (j = i; j <= stop; j++) {
-        if (lines[j] ~ /emit_in_transaction[[:space:]]*\(/) {
+        if (code_lines[j] ~ /emit_in_transaction[[:space:]]*\(/) {
           saw_emit = 1
         }
-        if (lines[j] ~ /STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
+        if (code_lines[j] ~ /STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
           saw_signal = 1
         }
       }
@@ -82,35 +148,61 @@ while IFS= read -r -d '' file; do
     }
     {
       lines[NR] = $0
-      if (!test_tail_seen && $0 ~ /#\[cfg\(test\)\]/) {
-        test_tail_seen = 1
-        test_tail_start = NR
+      scan_line($0)
+      code_lines[NR] = clean_line
+      syntax_lines[NR] = syntax_line
+
+      if (!pending_fn && is_function_decl(syntax_line)) {
+        pending_fn = 1
+        pending_fn_line = NR
+      }
+
+      opens = count_char(syntax_line, "{")
+      closes = count_char(syntax_line, "}")
+      if (pending_fn && opens > 0) {
+        fn_count++
+        fn_start[fn_count] = NR
+        fn_decl[fn_count] = pending_fn_line
+        fn_depth[fn_count] = brace_depth + 1
+        stack_len++
+        fn_stack[stack_len] = fn_count
+        pending_fn = 0
+      } else if (pending_fn && syntax_line ~ /;/) {
+        pending_fn = 0
+      }
+
+      brace_depth += opens - closes
+      while (stack_len > 0 && brace_depth < fn_depth[fn_stack[stack_len]]) {
+        fn_end[fn_stack[stack_len]] = NR
+        stack_len--
       }
     }
     END {
       n = NR
-      if (test_tail_seen) {
-        n = test_tail_start - 1
+      while (stack_len > 0) {
+        fn_end[fn_stack[stack_len]] = n
+        stack_len--
       }
 
       write_re = "(insert([[:space:]]+or[[:space:]]+(ignore|replace))?[[:space:]]+into|update|delete[[:space:]]+from)[^\"]*(account_stakeholders|entity_members)([^[:alnum:]_]|$)"
       for (i = 1; i <= n; i++) {
-        line = tolower(lines[i])
+        line = tolower(code_lines[i])
         if (line !~ write_re) {
           continue
         }
-        start = max(1, i - 60)
         stop = min(n, i + 30)
-        if (allowlisted_writer || is_non_graph_update(i, stop) || has_wrapper(start, stop)) {
+        fn_idx = enclosing_function(i)
+        if (allowlisted_writer || is_non_graph_update(i, stop) ||
+            (fn_idx > 0 && has_stakeholder_signal_call(fn_start[fn_idx], fn_end[fn_idx]))) {
           continue
         }
-        printf "%s:%d: stakeholder graph write must use stakeholder_writer::write_with_stakeholders_changed or an allowlisted DB writer\n", file, i
+        printf "%s:%d: stakeholder graph write must call stakeholder_writer::write_with_stakeholders_changed/emit_stakeholders_changed in the same function or use an allowlisted DB writer\n", file, i
         failures++
       }
 
       if (!helper_file) {
         for (i = 1; i <= n; i++) {
-          if (lines[i] !~ /emit_in_transaction[[:space:]]*\(|STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
+          if (code_lines[i] !~ /emit_in_transaction[[:space:]]*\(|STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
             continue
           }
           stop = min(n, i + 12)

--- a/scripts/check_stakeholder_writer_emits_signal.sh
+++ b/scripts/check_stakeholder_writer_emits_signal.sh
@@ -9,6 +9,17 @@ if [[ ! -d "$SRC_DIR" ]]; then
   exit 2
 fi
 
+is_allowlisted_writer_file() {
+  case "$1" in
+    src-tauri/src/db/accounts.rs) return 0 ;;
+    src-tauri/src/db/core.rs) return 0 ;;
+    src-tauri/src/db/entity_linking.rs) return 0 ;;
+    src-tauri/src/db/people.rs) return 0 ;;
+    src-tauri/src/db/projects.rs) return 0 ;;
+  esac
+  return 1
+}
+
 failures=0
 
 while IFS= read -r -d '' file; do
@@ -20,7 +31,55 @@ while IFS= read -r -d '' file; do
     src-tauri/src/devtools/*) continue ;;
   esac
 
-  awk -v file="$rel" '
+  allowlisted_writer=0
+  if is_allowlisted_writer_file "$rel"; then
+    allowlisted_writer=1
+  fi
+
+  helper_file=0
+  if [[ "$rel" == "src-tauri/src/services/stakeholder_writer.rs" ]]; then
+    helper_file=1
+  fi
+
+  awk -v file="$rel" -v allowlisted_writer="$allowlisted_writer" -v helper_file="$helper_file" '
+    function max(a, b) { return a > b ? a : b }
+    function min(a, b) { return a < b ? a : b }
+    function has_wrapper(start, stop,    j) {
+      for (j = start; j <= stop; j++) {
+        if (lines[j] ~ /stakeholder_writer::write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/ ||
+            lines[j] ~ /write_with_stakeholders_changed(_for_entities)?[[:space:]]*\(/) {
+          return 1
+        }
+      }
+      return 0
+    }
+    function is_non_graph_update(i, stop,    j, text) {
+      if (tolower(lines[i]) !~ /update[^\"]*account_stakeholders/) {
+        return 0
+      }
+      text = ""
+      for (j = i; j <= stop; j++) {
+        text = text "\n" tolower(lines[j])
+      }
+      if (text ~ /(set[[:space:]]+(engagement|assessment)|data_source_engagement|data_source_assessment)/ &&
+          text !~ /(set|,)[[:space:]]*(account_id|person_id|status|relationship_type)[[:space:]]*=/) {
+        return 1
+      }
+      return 0
+    }
+    function has_direct_stakeholder_emit(i, stop,    j, saw_emit, saw_signal) {
+      saw_emit = 0
+      saw_signal = 0
+      for (j = i; j <= stop; j++) {
+        if (lines[j] ~ /emit_in_transaction[[:space:]]*\(/) {
+          saw_emit = 1
+        }
+        if (lines[j] ~ /STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
+          saw_signal = 1
+        }
+      }
+      return saw_emit && saw_signal
+    }
     {
       lines[NR] = $0
       if (!test_tail_seen && $0 ~ /#\[cfg\(test\)\]/) {
@@ -33,38 +92,35 @@ while IFS= read -r -d '' file; do
       if (test_tail_seen) {
         n = test_tail_start - 1
       }
+
       write_re = "(insert([[:space:]]+or[[:space:]]+(ignore|replace))?[[:space:]]+into|update|delete[[:space:]]+from)[^\"]*(account_stakeholders|entity_members)([^[:alnum:]_]|$)"
       for (i = 1; i <= n; i++) {
-        if (tolower(lines[i]) !~ write_re) {
+        line = tolower(lines[i])
+        if (line !~ write_re) {
           continue
         }
-        start = i - 30
-        if (start < 1) {
-          start = 1
+        start = max(1, i - 60)
+        stop = min(n, i + 30)
+        if (allowlisted_writer || is_non_graph_update(i, stop) || has_wrapper(start, stop)) {
+          continue
         }
-        stop = i + 30
-        if (stop > n) {
-          stop = n
-        }
-        skip = 0
-        emit = 0
-        signal = 0
-        for (j = start; j <= stop; j++) {
-          if (lines[j] ~ /stakeholder-cache-skip:[[:space:]]*[^[:space:]]/) {
-            skip = 1
+        printf "%s:%d: stakeholder graph write must use stakeholder_writer::write_with_stakeholders_changed or an allowlisted DB writer\n", file, i
+        failures++
+      }
+
+      if (!helper_file) {
+        for (i = 1; i <= n; i++) {
+          if (lines[i] !~ /emit_in_transaction[[:space:]]*\(|STAKEHOLDERS_CHANGED_SIGNAL|stakeholders_changed/) {
+            continue
           }
-          if (lines[j] ~ /emit_in_transaction[[:space:]]*\(/) {
-            emit = 1
+          stop = min(n, i + 12)
+          if (has_direct_stakeholder_emit(i, stop)) {
+            printf "%s:%d: direct stakeholders_changed emit must use services::stakeholder_writer helper\n", file, i
+            failures++
           }
-          if (lines[j] ~ /stakeholders_changed|STAKEHOLDERS_CHANGED_SIGNAL/) {
-            signal = 1
-          }
-        }
-        if (!skip && !(emit && signal)) {
-          printf "%s:%d: stakeholder table write lacks nearby emit_in_transaction(stakeholders_changed) or stakeholder-cache-skip rationale\n", file, i
-          failures++
         }
       }
+
       if (failures > 0) {
         exit 1
       }

--- a/src-tauri/src/calendar_merge.rs
+++ b/src-tauri/src/calendar_merge.rs
@@ -110,7 +110,7 @@ pub fn merge_meetings(briefing: Vec<Meeting>, live: &[CalendarEvent], tz: &Tz) -
     }
 
     // Sort by time string (lexicographic on "H:MM AM/PM" works for display order)
-    result.sort_by_key(|meeting| sort_time_key(&meeting.time));
+    result.sort_by_key(|a| sort_time_key(&a.time));
 
     result
 }

--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -494,43 +494,37 @@ pub fn purge_source(db: &ActionDb, source: DataSource) -> Result<PurgeReport, Db
                 .map_err(|e| format!("collect purged stakeholder accounts failed: {e}"))?
         };
 
-        tx.conn_ref()
-            .execute(
-                "DELETE FROM account_stakeholder_roles WHERE data_source = ?1",
-                [source_str],
-            )
-            .map_err(|e| format!("purge account_stakeholder_roles failed: {e}"))?;
-        let people_cleared = tx
-            .conn_ref()
-            .execute(
-                "DELETE FROM account_stakeholders WHERE data_source = ?1",
-                [source_str],
-            )
-            .map_err(|e| format!("purge account_stakeholders failed: {e}"))?;
-
-        if !affected_accounts.is_empty() {
-            let clock = crate::services::context::SystemClock;
-            let rng = crate::services::context::SystemRng;
-            let ext = crate::services::context::ExternalClients::default();
-            let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-            let mutation_source = format!("purge_source:{source_str}");
-            for account_id in affected_accounts {
-                crate::services::signals::emit_in_transaction(
-                    &ctx,
-                    tx,
-                    "account",
-                    &account_id,
-                    crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
-                    "purge_source",
-                    serde_json::json!({
-                        "entity_id": account_id,
-                        "entity_type": "account",
-                        "mutation_source": &mutation_source,
-                    }),
-                )
-                .map_err(|e| format!("emit stakeholder purge signal failed: {e}"))?;
-            }
-        }
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let ext = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
+        let mutation_source = format!("purge_source:{source_str}");
+        let people_cleared = crate::services::stakeholder_writer::write_with_stakeholders_changed_for_entities(
+            &ctx,
+            tx,
+            &mutation_source,
+            |tx| {
+                tx.conn_ref()
+                    .execute(
+                        "DELETE FROM account_stakeholder_roles WHERE data_source = ?1",
+                        [source_str],
+                    )
+                    .map_err(|e| format!("purge account_stakeholder_roles failed: {e}"))?;
+                let people_cleared = tx
+                    .conn_ref()
+                    .execute(
+                        "DELETE FROM account_stakeholders WHERE data_source = ?1",
+                        [source_str],
+                    )
+                    .map_err(|e| format!("purge account_stakeholders failed: {e}"))?;
+                let affected_entities = affected_accounts
+                    .into_iter()
+                    .map(|account_id| (account_id, "account".to_string()))
+                    .collect();
+                Ok((people_cleared, affected_entities))
+            },
+        )
+        .map_err(|e| format!("emit stakeholder purge signal failed: {e}"))?;
 
         let signals_deleted = if source == DataSource::Glean {
             tx.conn_ref()

--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -731,34 +731,10 @@ mod tests {
         let db = test_db();
         seed_person(&db, "p1", None);
 
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source)
-                 VALUES ('a1', 'p1', 'glean')",
-                [],
-            )
+        db.link_person_to_account_with_source("a1", "p1", "champion", "glean")
             .expect("seed glean stakeholder");
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES ('a1', 'p1', 'champion', 'glean')",
-                [],
-            )
-            .expect("seed glean stakeholder role");
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source)
-                 VALUES ('a2', 'p1', 'user')",
-                [],
-            )
+        db.link_person_to_account_with_source("a2", "p1", "champion", "user")
             .expect("seed user stakeholder");
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES ('a2', 'p1', 'champion', 'user')",
-                [],
-            )
-            .expect("seed user stakeholder role");
 
         db.conn_ref()
             .execute(

--- a/src-tauri/src/db/entity_linking.rs
+++ b/src-tauri/src/db/entity_linking.rs
@@ -613,7 +613,7 @@ impl ActionDb {
         person_id: &str,
         data_source: &str,
         confidence: f64,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
         self.conn_ref()
             .execute(
                 "INSERT OR IGNORE INTO account_stakeholders \
@@ -621,19 +621,17 @@ impl ActionDb {
                  VALUES (?1, ?2, ?3, ?4, 'pending_review')",
                 params![account_id, person_id, data_source, confidence],
             )
-            .map(|_| ())
             .map_err(|e| format!("suggest_stakeholder_pending: {e}"))
     }
 
     /// Promote a pending_review suggestion to active.
-    pub fn confirm_stakeholder(&self, account_id: &str, person_id: &str) -> Result<(), String> {
+    pub fn confirm_stakeholder(&self, account_id: &str, person_id: &str) -> Result<usize, String> {
         self.conn_ref()
             .execute(
                 "UPDATE account_stakeholders SET status = 'active' \
                  WHERE account_id = ?1 AND person_id = ?2 AND status = 'pending_review'",
                 params![account_id, person_id],
             )
-            .map(|_| ())
             .map_err(|e| format!("confirm_stakeholder: {e}"))
     }
 
@@ -642,14 +640,13 @@ impl ActionDb {
         &self,
         account_id: &str,
         person_id: &str,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
         self.conn_ref()
             .execute(
                 "UPDATE account_stakeholders SET status = 'dismissed' \
                  WHERE account_id = ?1 AND person_id = ?2 AND status = 'pending_review'",
                 params![account_id, person_id],
             )
-            .map(|_| ())
             .map_err(|e| format!("dismiss_stakeholder_suggestion: {e}"))
     }
 

--- a/src-tauri/src/db/mod_tests.rs
+++ b/src-tauri/src/db/mod_tests.rs
@@ -5809,13 +5809,7 @@ fn seed_w0g_stakeholder(db: &ActionDb, account_id: &str, person_id: &str) {
             rusqlite::params![person_id, format!("{person_id}@example.com")],
         )
         .expect("seed person");
-    db.conn_ref()
-        .execute(
-            "INSERT OR IGNORE INTO account_stakeholders
-             (account_id, person_id, data_source, created_at)
-             VALUES (?1, ?2, 'user', '2026-01-01T00:00:00Z')",
-            rusqlite::params![account_id, person_id],
-        )
+    db.add_account_team_member(account_id, person_id, "associated")
         .expect("seed stakeholder");
 }
 

--- a/src-tauri/src/google_api/gmail.rs
+++ b/src-tauri/src/google_api/gmail.rs
@@ -632,7 +632,7 @@ pub async fn fetch_frequent_correspondents(
             message_count: count,
         })
         .collect();
-    results.sort_by_key(|result| std::cmp::Reverse(result.message_count));
+    results.sort_by_key(|item| std::cmp::Reverse(item.message_count));
     results.truncate(limit);
 
     Ok(results)

--- a/src-tauri/src/prepare/meeting_context.rs
+++ b/src-tauri/src/prepare/meeting_context.rs
@@ -1548,7 +1548,7 @@ fn find_recent_summaries(
         }
     }
 
-    matches.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    matches.sort_by_key(|item| std::cmp::Reverse(item.0));
     matches.into_iter().take(limit).map(|(_, p)| p).collect()
 }
 

--- a/src-tauri/src/proactive/detectors.rs
+++ b/src-tauri/src/proactive/detectors.rs
@@ -1173,15 +1173,7 @@ mod tests {
             "INSERT INTO people (id, email, name, updated_at) VALUES ('p1', 'jane@acme.com', 'Jane Doe', '2026-01-01')",
             [],
         ).unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholders (account_id, person_id) VALUES ('a1', 'p1')",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholder_roles (account_id, person_id, role) VALUES ('a1', 'p1', 'champion')",
-            [],
-        ).unwrap();
+        db.add_account_team_member("a1", "p1", "champion").unwrap();
 
         // Old meeting (60 days ago)
         conn.execute(
@@ -1231,15 +1223,7 @@ mod tests {
             "INSERT INTO people (id, email, name, updated_at) VALUES ('p1', 'jane@acme.com', 'Jane Doe', '2026-01-01')",
             [],
         ).unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholders (account_id, person_id) VALUES ('a1', 'p1')",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholder_roles (account_id, person_id, role) VALUES ('a1', 'p1', 'champion')",
-            [],
-        ).unwrap();
+        db.add_account_team_member("a1", "p1", "champion").unwrap();
 
         // Recent meeting (10 days ago)
         conn.execute(

--- a/src-tauri/src/services/accounts.rs
+++ b/src-tauri/src/services/accounts.rs
@@ -4166,13 +4166,10 @@ mod tests {
                 [],
             )
             .expect("insert person");
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source, status)
-                 VALUES ('acc-promote-active', 'p-promote-active', 'ai', 'dismissed')",
-                [],
-            )
-            .expect("insert dismissed stakeholder");
+        db.suggest_stakeholder_pending("acc-promote-active", "p-promote-active", "ai", 1.0)
+            .expect("insert pending stakeholder");
+        db.dismiss_stakeholder_suggestion("acc-promote-active", "p-promote-active")
+            .expect("dismiss stakeholder");
 
         db.add_account_team_member("acc-promote-active", "p-promote-active", "champion")
             .expect("add team member");
@@ -4415,18 +4412,12 @@ mod tests {
         db.with_transaction(|tx| {
             tx.remove_account_team_member("acc-tm", "p-tm", "csm")
                 .map_err(|e| e.to_string())?;
-            crate::services::signals::emit_in_transaction(
+            crate::services::stakeholder_writer::emit_stakeholders_changed(
                 &ctx,
                 tx,
                 "account",
                 "acc-tm",
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                 "remove_account_team_member",
-                serde_json::json!({
-                    "entity_id": "acc-tm",
-                    "entity_type": "account",
-                    "mutation_source": "remove_account_team_member",
-                }),
             )?;
             crate::services::signals::emit_and_propagate(
                 &ctx,
@@ -4493,22 +4484,11 @@ mod tests {
                 [],
             )
             .unwrap();
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source) VALUES ('acc-rp', 'p-rp', 'user')",
-                [],
-            )
+        db.add_account_team_member("acc-rp", "p-rp", "champion")
             .unwrap();
 
-        // Seed two existing roles: one user-pinned (champion), one
-        // AI-surfaced (technical). This is the Chris-on-Globex shape.
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES ('acc-rp', 'p-rp', 'champion', 'user')",
-                [],
-            )
-            .unwrap();
+        // Seed a second existing AI-surfaced technical role. Together with
+        // add_account_team_member above, this is the Chris-on-Globex shape.
         db.conn_ref()
             .execute(
                 "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
@@ -4610,20 +4590,7 @@ mod tests {
                 [],
             )
             .unwrap();
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source) \
-                 VALUES ('acc-rt', 'p-rt', 'user')",
-                [],
-            )
-            .unwrap();
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles \
-                 (account_id, person_id, role, data_source) \
-                 VALUES ('acc-rt', 'p-rt', 'champion', 'user')",
-                [],
-            )
+        db.add_account_team_member("acc-rt", "p-rt", "champion")
             .unwrap();
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -4706,20 +4673,7 @@ mod tests {
                 [],
             )
             .unwrap();
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source) VALUES ('acc-dsm', 'p-dsm', 'user')",
-                [],
-            )
-            .unwrap();
-
-        // Seed a user-pinned role (what `add_stakeholder_role` writes).
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES ('acc-dsm', 'p-dsm', 'associated', 'user')",
-                [],
-            )
+        db.add_account_team_member("acc-dsm", "p-dsm", "associated")
             .unwrap();
 
         let visible_after_add: Vec<String> = db
@@ -4814,19 +4768,8 @@ mod tests {
                 [],
             )
             .unwrap();
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source) VALUES ('acc-pr', 'p-pr', 'ai')",
-                [],
-            )
-            .unwrap();
         // AI had surfaced Chris as Champion; user now explicitly pins Champion.
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES ('acc-pr', 'p-pr', 'champion', 'ai')",
-                [],
-            )
+        db.link_person_to_account_with_source("acc-pr", "p-pr", "champion", "ai")
             .unwrap();
 
         db.set_team_member_role("acc-pr", "p-pr", "champion")

--- a/src-tauri/src/services/accounts.rs
+++ b/src-tauri/src/services/accounts.rs
@@ -14,6 +14,7 @@ use crate::commands::{
 };
 use crate::db::ActionDb;
 use crate::services::context::ServiceContext;
+use crate::services::stakeholder_writer;
 use crate::signals::propagation::PropagationEngine;
 use crate::state::AppState;
 
@@ -86,20 +87,16 @@ pub fn create_child_account_record(
             .map_err(|e| e.to_string())?;
 
         if let Some(owner_id) = owner_person_id {
-            tx.link_person_to_entity(owner_id, &account.id, "owner")
-                .map_err(|e| e.to_string())?;
-            crate::services::signals::emit_in_transaction(
+            stakeholder_writer::write_with_stakeholders_changed(
                 ctx,
                 tx,
                 "account",
                 &account.id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                 "create_child_account",
-                serde_json::json!({
-                    "entity_id": &account.id,
-                    "entity_type": "account",
-                    "mutation_source": "create_child_account",
-                }),
+                |tx| {
+                    tx.link_person_to_entity(owner_id, &account.id, "owner")
+                        .map_err(|e| e.to_string())
+                },
             )?;
         }
 
@@ -2802,18 +2799,12 @@ pub fn merge_accounts(
             .merge_accounts(from_id, into_id)
             .map_err(|e| e.to_string())?;
         for account_id in [from_id, into_id] {
-            crate::services::signals::emit_in_transaction(
+            stakeholder_writer::emit_stakeholders_changed(
                 ctx,
                 tx,
                 "account",
                 account_id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                 "merge_accounts",
-                serde_json::json!({
-                    "entity_id": account_id,
-                    "entity_type": "account",
-                    "mutation_source": "merge_accounts",
-                }),
             )?;
         }
         crate::services::signals::emit_and_propagate(
@@ -2886,20 +2877,16 @@ pub(crate) fn add_team_member_with_cache_rebuild(
     person_id: &str,
     role: &str,
 ) -> Result<(), String> {
-    tx.add_account_team_member(account_id, person_id, role)
-        .map_err(|e| e.to_string())?;
-    crate::services::signals::emit_in_transaction(
+    stakeholder_writer::write_with_stakeholders_changed(
         ctx,
         tx,
         "account",
         account_id,
-        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
         "add_account_team_member",
-        serde_json::json!({
-            "entity_id": account_id,
-            "entity_type": "account",
-            "mutation_source": "add_account_team_member",
-        }),
+        |tx| {
+            tx.add_account_team_member(account_id, person_id, role)
+                .map_err(|e| e.to_string())
+        },
     )?;
     Ok(())
 }
@@ -2912,20 +2899,16 @@ pub(crate) fn link_person_to_account_with_source_with_cache_rebuild(
     role: &str,
     data_source: &str,
 ) -> Result<(), String> {
-    tx.link_person_to_account_with_source(account_id, person_id, role, data_source)
-        .map_err(|e| e.to_string())?;
-    crate::services::signals::emit_in_transaction(
+    stakeholder_writer::write_with_stakeholders_changed(
         ctx,
         tx,
         "account",
         account_id,
-        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
         "link_person_to_account_with_source",
-        serde_json::json!({
-            "entity_id": account_id,
-            "entity_type": "account",
-            "mutation_source": "link_person_to_account_with_source",
-        }),
+        |tx| {
+            tx.link_person_to_account_with_source(account_id, person_id, role, data_source)
+                .map_err(|e| e.to_string())
+        },
     )?;
     Ok(())
 }
@@ -3024,20 +3007,16 @@ pub fn remove_account_team_member(
 ) -> Result<(), String> {
     ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     db.with_transaction(|tx| {
-        tx.remove_account_team_member(account_id, person_id, role)
-            .map_err(|e| e.to_string())?;
-        crate::services::signals::emit_in_transaction(
+        stakeholder_writer::write_with_stakeholders_changed(
             ctx,
             tx,
             "account",
             account_id,
-            crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
             "remove_account_team_member",
-            serde_json::json!({
-                "entity_id": account_id,
-                "entity_type": "account",
-                "mutation_source": "remove_account_team_member",
-            }),
+            |tx| {
+                tx.remove_account_team_member(account_id, person_id, role)
+                    .map_err(|e| e.to_string())
+            },
         )?;
         crate::services::signals::emit_and_propagate(
             ctx,
@@ -3452,18 +3431,12 @@ pub async fn create_internal_organization(
 
                     if !created_people.is_empty() || !existing_person_ids.is_empty() {
                         for account_id in [&root_account.id, &initial_team.id] {
-                            crate::services::signals::emit_in_transaction(
+                            stakeholder_writer::emit_stakeholders_changed(
                                 &ctx,
                                 db,
                                 "account",
                                 account_id,
-                                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                                 "create_internal_organization",
-                                serde_json::json!({
-                                    "entity_id": account_id,
-                                    "entity_type": "account",
-                                    "mutation_source": "create_internal_organization",
-                                }),
                             )?;
                         }
                     }
@@ -3611,18 +3584,12 @@ pub fn backfill_internal_meeting_associations(
                 .cascade_meeting_entity_to_people(&meeting_id, Some(&account.id), None)
                 .map_err(|e| e.to_string())?;
             if linked > 0 {
-                crate::services::signals::emit_in_transaction(
+                stakeholder_writer::emit_stakeholders_changed(
                     ctx,
                     tx,
                     "account",
                     &account.id,
-                    crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                     "link_internal_meetings_to_account",
-                    serde_json::json!({
-                        "entity_id": &account.id,
-                        "entity_type": "account",
-                        "mutation_source": "link_internal_meetings_to_account",
-                    }),
                 )?;
             }
             Ok(())
@@ -3996,69 +3963,65 @@ pub fn accept_stakeholder_suggestion(
             return Err("Cannot accept suggestion: no person_id, email, or name".to_string());
         };
 
-        // Ensure stakeholder link exists
-        // stakeholder-cache-skip: grouped suggestion writes emit stakeholders_changed below before commit.
         let now = ctx.clock.now().to_rfc3339();
-        tx.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source, status, created_at)
-                 VALUES (?1, ?2, 'user', 'active', ?3)
-                 ON CONFLICT(account_id, person_id) DO UPDATE SET
-                    data_source = 'user',
-                    status = 'active'",
-                rusqlite::params![suggestion.account_id, person_id, now],
-            )
-            .map_err(|e| e.to_string())?;
-
-        // Add suggested role if present
-        if let Some(role) = suggestion.suggested_role.as_deref() {
-            let role = role.trim().to_lowercase();
-            if !role.is_empty() {
-                tx.conn_ref()
-                    .execute(
-                        "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source, created_at)
-                         VALUES (?1, ?2, ?3, 'user', ?4)
-                         ON CONFLICT(account_id, person_id, role) DO UPDATE SET data_source = 'user'",
-                        rusqlite::params![suggestion.account_id, person_id, role, now],
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-        }
-
-        // Set engagement if suggested
-        if let Some(engagement) = suggestion.suggested_engagement.as_deref() {
-            tx.conn_ref()
-                .execute(
-                    "UPDATE account_stakeholders
-                     SET engagement = ?1, data_source_engagement = 'user'
-                     WHERE account_id = ?2 AND person_id = ?3",
-                    rusqlite::params![engagement, suggestion.account_id, person_id],
-                )
-                .map_err(|e| e.to_string())?;
-        }
-
-        // Mark suggestion as accepted
-        tx.conn_ref()
-            .execute(
-                "UPDATE stakeholder_suggestions
-                 SET status = 'accepted', resolved_at = datetime('now')
-                 WHERE id = ?1",
-                rusqlite::params![suggestion_id],
-            )
-            .map_err(|e| e.to_string())?;
-
-        crate::services::signals::emit_in_transaction(
+        stakeholder_writer::write_with_stakeholders_changed(
             ctx,
             tx,
             "account",
             &suggestion.account_id,
-            crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
             "accept_stakeholder_suggestion",
-            serde_json::json!({
-                "entity_id": &suggestion.account_id,
-                "entity_type": "account",
-                "mutation_source": "accept_stakeholder_suggestion",
-            }),
+            |tx| {
+                // Ensure stakeholder link exists.
+                tx.conn_ref()
+                    .execute(
+                        "INSERT INTO account_stakeholders (account_id, person_id, data_source, status, created_at)
+                         VALUES (?1, ?2, 'user', 'active', ?3)
+                         ON CONFLICT(account_id, person_id) DO UPDATE SET
+                            data_source = 'user',
+                            status = 'active'",
+                        rusqlite::params![suggestion.account_id, person_id, now],
+                    )
+                    .map_err(|e| e.to_string())?;
+
+                // Add suggested role if present.
+                if let Some(role) = suggestion.suggested_role.as_deref() {
+                    let role = role.trim().to_lowercase();
+                    if !role.is_empty() {
+                        tx.conn_ref()
+                            .execute(
+                                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source, created_at)
+                                 VALUES (?1, ?2, ?3, 'user', ?4)
+                                 ON CONFLICT(account_id, person_id, role) DO UPDATE SET data_source = 'user'",
+                                rusqlite::params![suggestion.account_id, person_id, role, now],
+                            )
+                            .map_err(|e| e.to_string())?;
+                    }
+                }
+
+                // Set engagement if suggested.
+                if let Some(engagement) = suggestion.suggested_engagement.as_deref() {
+                    tx.conn_ref()
+                        .execute(
+                            "UPDATE account_stakeholders
+                             SET engagement = ?1, data_source_engagement = 'user'
+                             WHERE account_id = ?2 AND person_id = ?3",
+                            rusqlite::params![engagement, suggestion.account_id, person_id],
+                        )
+                        .map_err(|e| e.to_string())?;
+                }
+
+                // Mark suggestion as accepted.
+                tx.conn_ref()
+                    .execute(
+                        "UPDATE stakeholder_suggestions
+                         SET status = 'accepted', resolved_at = datetime('now')
+                         WHERE id = ?1",
+                        rusqlite::params![suggestion_id],
+                    )
+                    .map_err(|e| e.to_string())?;
+
+                Ok(())
+            },
         )?;
 
         crate::services::signals::emit_and_propagate(

--- a/src-tauri/src/services/entity_linking/cascade.rs
+++ b/src-tauri/src/services/entity_linking/cascade.rs
@@ -115,7 +115,7 @@ pub fn run_cascade(
                 .unwrap_or(false);
 
             if auto_resolved {
-                c2_suggest_stakeholders(link_ctx, &primary.entity_id, db);
+                c2_suggest_stakeholders(ctx, link_ctx, &primary.entity_id, db)?;
             } else {
                 // C3 — User-set primary: promote domain-matching attendees directly.
                 c3_promote_trusted_stakeholders(ctx, link_ctx, &primary.entity_id, db)?;
@@ -198,44 +198,66 @@ pub fn run_cascade(
 // C2 helpers
 // ---------------------------------------------------------------------------
 
-fn c2_suggest_stakeholders(ctx: &LinkingContext, account_id: &str, db: &ActionDb) {
+fn c2_suggest_stakeholders(
+    ctx: &ServiceContext<'_>,
+    link_ctx: &LinkingContext,
+    account_id: &str,
+    db: &ActionDb,
+) -> Result<(), String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     // Get account domains to identify domain-matching external participants.
     let account_domains = get_account_domains(db, account_id);
 
-    for p in ctx.external_participants() {
-        let p_domain = p.email.rsplit_once('@').map(|(_, d)| d.to_lowercase());
+    db.with_transaction(|tx| {
+        let mut suggested_any = false;
+        for p in link_ctx.external_participants() {
+            let p_domain = p.email.rsplit_once('@').map(|(_, d)| d.to_lowercase());
 
-        let domain_matches = p_domain
-            .as_deref()
-            .map(|d| account_domains.iter().any(|ad| ad.eq_ignore_ascii_case(d)))
-            .unwrap_or(false);
+            let domain_matches = p_domain
+                .as_deref()
+                .map(|d| account_domains.iter().any(|ad| ad.eq_ignore_ascii_case(d)))
+                .unwrap_or(false);
 
-        if !domain_matches {
-            continue;
-        }
-
-        let person_id = match &p.person_id {
-            Some(id) => id,
-            None => continue,
-        };
-
-        // Skip if already an active/pending stakeholder on this account.
-        let already = db
-            .is_stakeholder_on_account(account_id, person_id)
-            .unwrap_or(false);
-        if already {
-            continue;
-        }
-
-        let data_source = match ctx.owner.owner_type {
-            super::types::OwnerType::Meeting => "calendar_attendance",
-            super::types::OwnerType::Email | super::types::OwnerType::EmailThread => {
-                "email_correspondence"
+            if !domain_matches {
+                continue;
             }
-        };
 
-        let _ = db.suggest_stakeholder_pending(account_id, person_id, data_source, 0.75);
-    }
+            let person_id = match &p.person_id {
+                Some(id) => id,
+                None => continue,
+            };
+
+            // Skip if already an active/pending stakeholder on this account.
+            let already = tx
+                .is_stakeholder_on_account(account_id, person_id)
+                .unwrap_or(false);
+            if already {
+                continue;
+            }
+
+            let data_source = match link_ctx.owner.owner_type {
+                super::types::OwnerType::Meeting => "calendar_attendance",
+                super::types::OwnerType::Email | super::types::OwnerType::EmailThread => {
+                    "email_correspondence"
+                }
+            };
+
+            let inserted =
+                tx.suggest_stakeholder_pending(account_id, person_id, data_source, 0.75)?;
+            suggested_any = suggested_any || inserted > 0;
+        }
+
+        if suggested_any {
+            crate::services::stakeholder_writer::emit_stakeholders_changed(
+                ctx,
+                tx,
+                "account",
+                account_id,
+                "suggest_stakeholders_pending",
+            )?;
+        }
+        Ok(())
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -373,18 +395,12 @@ fn c3_promote_trusted_stakeholders(
         }
 
         if promoted_any {
-            crate::services::signals::emit_in_transaction(
+            crate::services::stakeholder_writer::emit_stakeholders_changed(
                 ctx,
                 tx,
                 "account",
                 account_id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                 "manual_set_primary",
-                serde_json::json!({
-                    "entity_id": account_id,
-                    "entity_type": "account",
-                    "mutation_source": "manual_set_primary",
-                }),
             )?;
         }
         Ok(())

--- a/src-tauri/src/services/entity_linking/mod.rs
+++ b/src-tauri/src/services/entity_linking/mod.rs
@@ -457,24 +457,26 @@ pub(crate) fn confirm_stakeholder_suggestion_inner(
     user_domains: &[String],
 ) -> Result<(), String> {
     db.with_transaction(|tx| {
-        tx.confirm_stakeholder(account_id, person_id)?;
-        if let Err(e) =
-            stakeholder_domains::backfill_domains_for_account(ctx, tx, account_id, user_domains)
-        {
-            log::warn!("stakeholder_domains: confirm backfill for {account_id} failed: {e}");
-        }
-        crate::services::signals::emit_in_transaction(
+        crate::services::stakeholder_writer::write_with_stakeholders_changed(
             ctx,
             tx,
             "account",
             account_id,
-            crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
             "confirm_stakeholder_suggestion",
-            serde_json::json!({
-                "entity_id": account_id,
-                "entity_type": "account",
-                "mutation_source": "confirm_stakeholder_suggestion",
-            }),
+            |tx| {
+                tx.confirm_stakeholder(account_id, person_id)?;
+                if let Err(e) = stakeholder_domains::backfill_domains_for_account(
+                    ctx,
+                    tx,
+                    account_id,
+                    user_domains,
+                ) {
+                    log::warn!(
+                        "stakeholder_domains: confirm backfill for {account_id} failed: {e}"
+                    );
+                }
+                Ok(())
+            },
         )?;
         Ok(())
     })
@@ -503,19 +505,16 @@ pub(crate) fn dismiss_stakeholder_suggestion_inner(
     person_id: &str,
 ) -> Result<(), String> {
     db.with_transaction(|tx| {
-        tx.dismiss_stakeholder_suggestion(account_id, person_id)?;
-        crate::services::signals::emit_in_transaction(
+        crate::services::stakeholder_writer::write_with_stakeholders_changed(
             ctx,
             tx,
             "account",
             account_id,
-            crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
             "dismiss_stakeholder_suggestion",
-            serde_json::json!({
-                "entity_id": account_id,
-                "entity_type": "account",
-                "mutation_source": "dismiss_stakeholder_suggestion",
-            }),
+            |tx| {
+                tx.dismiss_stakeholder_suggestion(account_id, person_id)?;
+                Ok(())
+            },
         )?;
         Ok(())
     })

--- a/src-tauri/src/services/entity_linking/phases.rs
+++ b/src-tauri/src/services/entity_linking/phases.rs
@@ -438,13 +438,10 @@ mod tests {
     }
 
     fn seed_active_stakeholder(db: &ActionDb, account_id: &str, person_id: &str) {
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source, status, confidence, created_at) \
-                 VALUES (?1, ?2, 'test', 'active', 1.0, '2026-01-01')",
-                rusqlite::params![account_id, person_id],
-            )
+        db.suggest_stakeholder_pending(account_id, person_id, "test", 1.0)
             .expect("insert stakeholder");
+        db.confirm_stakeholder(account_id, person_id)
+            .expect("activate stakeholder");
     }
 
     fn one_on_one_ctx(person_id: &str) -> LinkingContext {

--- a/src-tauri/src/services/entity_linking/repair.rs
+++ b/src-tauri/src/services/entity_linking/repair.rs
@@ -774,22 +774,24 @@ mod tests {
     }
 
     fn seed_candidate_pair(db: &ActionDb, account_id: &str, person_id: &str, created_at: &str) {
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders
-                 (account_id, person_id, data_source, status, confidence, created_at)
-                 VALUES (?1, ?2, 'user', 'active', NULL, ?3)",
-                params![account_id, person_id, created_at],
-            )
+        db.add_account_team_member(account_id, person_id, "associated")
             .expect("insert stakeholder");
         db.conn_ref()
             .execute(
-                "INSERT INTO account_stakeholder_roles
-                 (account_id, person_id, role, data_source, created_at)
-                 VALUES (?1, ?2, 'associated', 'ai', ?3)",
+                "UPDATE account_stakeholders
+                 SET created_at = ?3
+                 WHERE account_id = ?1 AND person_id = ?2",
                 params![account_id, person_id, created_at],
             )
-            .expect("insert role");
+            .expect("set stakeholder batch timestamp");
+        db.conn_ref()
+            .execute(
+                "UPDATE account_stakeholder_roles
+                 SET data_source = 'ai', created_at = ?3
+                 WHERE account_id = ?1 AND person_id = ?2 AND role = 'associated'",
+                params![account_id, person_id, created_at],
+            )
+            .expect("seed role provenance");
     }
 
     fn seed_fixture() -> ActionDb {

--- a/src-tauri/src/services/entity_linking/repair.rs
+++ b/src-tauri/src/services/entity_linking/repair.rs
@@ -120,39 +120,35 @@ pub fn apply_repair(db: &ActionDb, opts: &RepairOptions) -> Result<RepairReport,
         let now = Utc::now().to_rfc3339();
         let ledger_items = write_ledger(tx, &repair_id, &now)?;
 
-        tx.conn_ref()
-            .execute(
-                "UPDATE account_stakeholders \
-                 SET status = 'dismissed', data_source = ?1, confidence = 0.0 \
-                 WHERE EXISTS ( \
-                   SELECT 1 FROM dos345_candidates c \
-                   WHERE c.account_id = account_stakeholders.account_id \
-                     AND c.person_id = account_stakeholders.person_id \
-                 )",
-                params![REPAIR_SOURCE],
-            )
-            .map_err(|e| format!("quarantine stakeholders: {e}"))?;
-
-        let affected_accounts = repair_candidate_account_ids(tx)?;
         let clock = crate::services::context::SystemClock;
         let rng = crate::services::context::SystemRng;
         let ext = crate::services::context::ExternalClients::default();
         let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-        for account_id in affected_accounts {
-            crate::services::signals::emit_in_transaction(
-                &ctx,
-                tx,
-                "account",
-                &account_id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
-                "apply_repair",
-                serde_json::json!({
-                    "entity_id": account_id,
-                    "entity_type": "account",
-                    "mutation_source": "apply_repair",
-                }),
-            )?;
-        }
+        crate::services::stakeholder_writer::write_with_stakeholders_changed_for_entities(
+            &ctx,
+            tx,
+            "apply_repair",
+            |tx| {
+                let affected_accounts = repair_candidate_account_ids(tx)?;
+                tx.conn_ref()
+                    .execute(
+                        "UPDATE account_stakeholders \
+                         SET status = 'dismissed', data_source = ?1, confidence = 0.0 \
+                         WHERE EXISTS ( \
+                           SELECT 1 FROM dos345_candidates c \
+                           WHERE c.account_id = account_stakeholders.account_id \
+                             AND c.person_id = account_stakeholders.person_id \
+                         )",
+                        params![REPAIR_SOURCE],
+                    )
+                    .map_err(|e| format!("quarantine stakeholders: {e}"))?;
+                let affected_entities = affected_accounts
+                    .into_iter()
+                    .map(|account_id| (account_id, "account".to_string()))
+                    .collect();
+                Ok(((), affected_entities))
+            },
+        )?;
 
         // L2 cycle-22 fix: snapshot the (person_id, role) tuples
         // we're about to dismiss BEFORE the UPDATE so we can write

--- a/src-tauri/src/services/entity_linking/rules/p4a_stakeholder.rs
+++ b/src-tauri/src/services/entity_linking/rules/p4a_stakeholder.rs
@@ -130,13 +130,20 @@ mod tests {
     }
 
     fn seed_stakeholder(db: &ActionDb, account_id: &str, person_id: &str, status: &str) {
-        db.conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source, status, confidence, created_at) \
-                 VALUES (?1, ?2, 'test', ?3, 1.0, '2026-01-01')",
-                rusqlite::params![account_id, person_id, status],
-            )
+        db.suggest_stakeholder_pending(account_id, person_id, "test", 1.0)
             .expect("insert stakeholder");
+        match status {
+            "active" => {
+                db.confirm_stakeholder(account_id, person_id)
+                    .expect("activate stakeholder");
+            }
+            "dismissed" => {
+                db.dismiss_stakeholder_suggestion(account_id, person_id)
+                    .expect("dismiss stakeholder");
+            }
+            "pending_review" => {}
+            other => panic!("unsupported stakeholder status fixture: {other}"),
+        }
     }
 
     fn mk_ctx(external_person_id: Option<&str>, email: &str) -> LinkingContext {

--- a/src-tauri/src/services/entity_linking/stakeholder_domains.rs
+++ b/src-tauri/src/services/entity_linking/stakeholder_domains.rs
@@ -261,14 +261,20 @@ mod tests {
     }
 
     fn link_stakeholder(db: &ActionDb, account_id: &str, person_id: &str, status: &str) {
-        db.conn_ref()
-            .execute(
-                "INSERT OR REPLACE INTO account_stakeholders \
-                 (account_id, person_id, data_source, confidence, status, created_at) \
-                 VALUES (?1, ?2, 'test', 1.0, ?3, ?4)",
-                params![account_id, person_id, status, Utc::now().to_rfc3339()],
-            )
+        db.suggest_stakeholder_pending(account_id, person_id, "test", 1.0)
             .expect("insert stakeholder");
+        match status {
+            "active" => {
+                db.confirm_stakeholder(account_id, person_id)
+                    .expect("activate stakeholder");
+            }
+            "dismissed" => {
+                db.dismiss_stakeholder_suggestion(account_id, person_id)
+                    .expect("dismiss stakeholder");
+            }
+            "pending_review" => {}
+            other => panic!("unsupported stakeholder status fixture: {other}"),
+        }
     }
 
     fn count_domain_signals(db: &ActionDb, account_id: &str) -> i64 {

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -2951,14 +2951,20 @@ mod mutation_smoke_tests {
         db.upsert_account(&account).unwrap();
         seed_account_domain(&db, "acc-compose-rollback", "compose.example");
         seed_person(&db, "p-compose-rollback", "Existing Buyer");
+        db.add_account_team_member("acc-compose-rollback", "p-compose-rollback", "associated")
+            .expect("seed account stakeholder");
         db.conn_ref()
             .execute(
-                "INSERT INTO account_stakeholders
-                 (account_id, person_id, engagement, data_source_engagement, assessment, data_source_assessment, data_source)
-                 VALUES (?1, ?2, 'neutral', 'ai', 'prior assessment', 'ai', 'ai')",
+                "UPDATE account_stakeholders
+                 SET engagement = 'neutral',
+                     data_source_engagement = 'ai',
+                     assessment = 'prior assessment',
+                     data_source_assessment = 'ai',
+                     data_source = 'ai'
+                 WHERE account_id = ?1 AND person_id = ?2",
                 params!["acc-compose-rollback", "p-compose-rollback"],
             )
-            .expect("seed account stakeholder");
+            .expect("seed account stakeholder metadata");
         db.conn_ref()
             .execute(
                 "INSERT INTO suppression_tombstones
@@ -4676,53 +4682,24 @@ mod live_acceptance_tests {
             .expect("count user relationships before");
 
         snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source)
-                 VALUES (?1, ?2, 'glean')",
-                params![account_glean, glean_person_id],
+            .link_person_to_account_with_source(
+                &account_glean,
+                &glean_person_id,
+                "champion",
+                "glean",
             )
             .expect("seed glean stakeholder");
         snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES (?1, ?2, 'champion', 'glean')",
-                params![account_glean, glean_person_id],
-            )
-            .expect("seed glean stakeholder role");
-        snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source)
-                 VALUES (?1, ?2, 'google')",
-                params![account_google, google_person_id],
+            .link_person_to_account_with_source(
+                &account_google,
+                &google_person_id,
+                "champion",
+                "google",
             )
             .expect("seed google stakeholder");
         snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES (?1, ?2, 'champion', 'google')",
-                params![account_google, google_person_id],
-            )
-            .expect("seed google stakeholder role");
-        snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholders (account_id, person_id, data_source)
-                 VALUES (?1, ?2, 'user')",
-                params![account_user, user_person_id],
-            )
+            .link_person_to_account_with_source(&account_user, &user_person_id, "champion", "user")
             .expect("seed user stakeholder");
-        snapshot_db
-            .conn_ref()
-            .execute(
-                "INSERT INTO account_stakeholder_roles (account_id, person_id, role, data_source)
-                 VALUES (?1, ?2, 'champion', 'user')",
-                params![account_user, user_person_id],
-            )
-            .expect("seed user stakeholder role");
 
         snapshot_db
             .conn_ref()

--- a/src-tauri/src/services/meetings.rs
+++ b/src-tauri/src/services/meetings.rs
@@ -983,18 +983,12 @@ async fn mutate_meeting_entities_and_refresh_briefing(
                         .map_err(|e| e.to_string())?;
                         if linked_people > 0 {
                             if let Some(ref eid) = entity_id {
-                                crate::services::signals::emit_in_transaction(
+                                crate::services::stakeholder_writer::emit_stakeholders_changed(
                                     &signal_ctx,
                                     db,
                                     &entity_type,
                                     eid,
-                                    crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                                     "cascade_meeting_entity_to_people",
-                                    serde_json::json!({
-                                        "entity_id": eid,
-                                        "entity_type": &entity_type,
-                                        "mutation_source": "cascade_meeting_entity_to_people",
-                                    }),
                                 )?;
                             }
                         }
@@ -1070,18 +1064,12 @@ async fn mutate_meeting_entities_and_refresh_briefing(
                         )
                         .map_err(|e| e.to_string())?;
                         if linked_people > 0 {
-                            crate::services::signals::emit_in_transaction(
+                            crate::services::stakeholder_writer::emit_stakeholders_changed(
                                 &signal_ctx,
                                 db,
                                 &entity_type,
                                 &entity_id,
-                                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
                                 "cascade_meeting_entity_to_people",
-                                serde_json::json!({
-                                    "entity_id": &entity_id,
-                                    "entity_type": &entity_type,
-                                    "mutation_source": "cascade_meeting_entity_to_people",
-                                }),
                             )?;
                         }
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -30,6 +30,7 @@ pub mod sensitivity;
 pub mod settings;
 pub mod signals;
 pub mod source_asof_backfill;
+pub mod stakeholder_writer;
 pub mod success_plans;
 pub mod threads;
 pub mod trust_extraction;

--- a/src-tauri/src/services/people.rs
+++ b/src-tauri/src/services/people.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use crate::commands::{EntitySummary, MeetingSummary, PersonDetailResult};
 use crate::db::ActionDb;
 use crate::services::context::ServiceContext;
+use crate::services::stakeholder_writer;
 use crate::state::AppState;
 use rusqlite::OptionalExtension;
 
@@ -108,23 +109,16 @@ pub(crate) fn delete_person_with_stakeholder_cache_rebuild(
     person_id: &str,
 ) -> Result<(), String> {
     db.with_transaction(|tx| {
-        let affected_entities = affected_stakeholder_entities_for_person(tx, person_id)?;
-        tx.delete_person(person_id).map_err(|e| e.to_string())?;
-        for (entity_id, entity_type) in affected_entities {
-            crate::services::signals::emit_in_transaction(
-                ctx,
-                tx,
-                &entity_type,
-                &entity_id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
-                "delete_person",
-                serde_json::json!({
-                    "entity_id": entity_id,
-                    "entity_type": entity_type,
-                    "mutation_source": "delete_person",
-                }),
-            )?;
-        }
+        stakeholder_writer::write_with_stakeholders_changed_for_entities(
+            ctx,
+            tx,
+            "delete_person",
+            |tx| {
+                let affected_entities = affected_stakeholder_entities_for_person(tx, person_id)?;
+                tx.delete_person(person_id).map_err(|e| e.to_string())?;
+                Ok(((), affected_entities))
+            },
+        )?;
         Ok(())
     })
 }
@@ -136,29 +130,22 @@ pub(crate) fn merge_people_with_stakeholder_cache_rebuild(
     remove_id: &str,
 ) -> Result<(), String> {
     db.with_transaction(|tx| {
-        let mut affected_entities = affected_stakeholder_entities_for_person(tx, remove_id)?;
-        affected_entities.extend(affected_stakeholder_entities_for_person(tx, keep_id)?);
-        affected_entities.sort();
-        affected_entities.dedup();
+        stakeholder_writer::write_with_stakeholders_changed_for_entities(
+            ctx,
+            tx,
+            "merge_people",
+            |tx| {
+                let mut affected_entities =
+                    affected_stakeholder_entities_for_person(tx, remove_id)?;
+                affected_entities.extend(affected_stakeholder_entities_for_person(tx, keep_id)?);
+                affected_entities.sort();
+                affected_entities.dedup();
 
-        tx.merge_people(keep_id, remove_id)
-            .map_err(|e| e.to_string())?;
-
-        for (entity_id, entity_type) in affected_entities {
-            crate::services::signals::emit_in_transaction(
-                ctx,
-                tx,
-                &entity_type,
-                &entity_id,
-                crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
-                "merge_people",
-                serde_json::json!({
-                    "entity_id": entity_id,
-                    "entity_type": entity_type,
-                    "mutation_source": "merge_people",
-                }),
-            )?;
-        }
+                tx.merge_people(keep_id, remove_id)
+                    .map_err(|e| e.to_string())?;
+                Ok(((), affected_entities))
+            },
+        )?;
         Ok(())
     })
 }
@@ -171,20 +158,16 @@ pub(crate) fn link_person_to_entity_with_stakeholder_cache_rebuild(
     relationship_type: &str,
 ) -> Result<String, String> {
     let entity_type = stakeholder_entity_type_for_id(tx, entity_id)?;
-    tx.link_person_to_entity(person_id, entity_id, relationship_type)
-        .map_err(|e| e.to_string())?;
-    crate::services::signals::emit_in_transaction(
+    stakeholder_writer::write_with_stakeholders_changed(
         ctx,
         tx,
         &entity_type,
         entity_id,
-        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
         "link_person_entity",
-        serde_json::json!({
-            "entity_id": entity_id,
-            "entity_type": &entity_type,
-            "mutation_source": "link_person_entity",
-        }),
+        |tx| {
+            tx.link_person_to_entity(person_id, entity_id, relationship_type)
+                .map_err(|e| e.to_string())
+        },
     )?;
     Ok(entity_type)
 }
@@ -196,20 +179,16 @@ pub(crate) fn unlink_person_from_entity_with_stakeholder_cache_rebuild(
     entity_id: &str,
 ) -> Result<String, String> {
     let entity_type = stakeholder_entity_type_for_id(tx, entity_id)?;
-    tx.unlink_person_from_entity(person_id, entity_id)
-        .map_err(|e| e.to_string())?;
-    crate::services::signals::emit_in_transaction(
+    stakeholder_writer::write_with_stakeholders_changed(
         ctx,
         tx,
         &entity_type,
         entity_id,
-        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
         "unlink_person_entity",
-        serde_json::json!({
-            "entity_id": entity_id,
-            "entity_type": &entity_type,
-            "mutation_source": "unlink_person_entity",
-        }),
+        |tx| {
+            tx.unlink_person_from_entity(person_id, entity_id)
+                .map_err(|e| e.to_string())
+        },
     )?;
     Ok(entity_type)
 }
@@ -686,20 +665,16 @@ pub fn create_person_from_stakeholder(
         tx.upsert_person(&person).map_err(|e| e.to_string())?;
 
         // Link to the parent entity
-        tx.link_person_to_entity(&id, entity_id, "associated")
-            .map_err(|e| e.to_string())?;
-        crate::services::signals::emit_in_transaction(
+        stakeholder_writer::write_with_stakeholders_changed(
             ctx,
             tx,
             entity_type,
             entity_id,
-            crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
             "create_person_from_stakeholder",
-            serde_json::json!({
-                "entity_id": entity_id,
-                "entity_type": entity_type,
-                "mutation_source": "create_person_from_stakeholder",
-            }),
+            |tx| {
+                tx.link_person_to_entity(&id, entity_id, "associated")
+                    .map_err(|e| e.to_string())
+            },
         )?;
         Ok(())
     })?;

--- a/src-tauri/src/services/stakeholder_writer.rs
+++ b/src-tauri/src/services/stakeholder_writer.rs
@@ -1,0 +1,66 @@
+//! Canonical stakeholder graph write helpers.
+//!
+//! Any service-layer mutation that changes `account_stakeholders` or
+//! `entity_members` membership must route through these helpers so the
+//! stakeholder cache invalidation signal is co-committed with the source write.
+
+use crate::db::ActionDb;
+use crate::services::context::ServiceContext;
+
+pub(crate) fn write_with_stakeholders_changed<T>(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    mutation_source: &str,
+    write: impl FnOnce(&ActionDb) -> Result<T, String>,
+) -> Result<T, String> {
+    let result = write(tx)?;
+    emit_stakeholders_changed(ctx, tx, entity_type, entity_id, mutation_source)?;
+    Ok(result)
+}
+
+pub(crate) fn emit_stakeholders_changed(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    mutation_source: &str,
+) -> Result<String, String> {
+    crate::services::signals::emit_in_transaction(
+        ctx,
+        tx,
+        entity_type,
+        entity_id,
+        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
+        mutation_source,
+        serde_json::json!({
+            "entity_id": entity_id,
+            "entity_type": entity_type,
+            "mutation_source": mutation_source,
+        }),
+    )
+}
+
+pub(crate) fn emit_stakeholders_changed_for_entities(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    affected_entities: impl IntoIterator<Item = (String, String)>,
+    mutation_source: &str,
+) -> Result<(), String> {
+    for (entity_id, entity_type) in affected_entities {
+        emit_stakeholders_changed(ctx, tx, &entity_type, &entity_id, mutation_source)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn write_with_stakeholders_changed_for_entities<T>(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    mutation_source: &str,
+    write: impl FnOnce(&ActionDb) -> Result<(T, Vec<(String, String)>), String>,
+) -> Result<T, String> {
+    let (result, affected_entities) = write(tx)?;
+    emit_stakeholders_changed_for_entities(ctx, tx, affected_entities, mutation_source)?;
+    Ok(result)
+}

--- a/src-tauri/src/signals/rules.rs
+++ b/src-tauri/src/signals/rules.rs
@@ -981,16 +981,8 @@ mod tests {
             [],
         )
         .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholders (account_id, person_id) VALUES ('a1', 'p1')",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholder_roles (account_id, person_id, role) VALUES ('a1', 'p1', 'associated')",
-            [],
-        )
-        .unwrap();
+        db.add_account_team_member("a1", "p1", "associated")
+            .unwrap();
 
         let signal = make_signal(
             "person",
@@ -1099,16 +1091,7 @@ mod tests {
             [],
         )
         .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholders (account_id, person_id) VALUES ('a1', 'p1')",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO account_stakeholder_roles (account_id, person_id, role) VALUES ('a1', 'p1', 'champion')",
-            [],
-        )
-        .unwrap();
+        db.add_account_team_member("a1", "p1", "champion").unwrap();
 
         // Renewal in 60 days
         let renewal_date = (chrono::Utc::now() + chrono::Duration::days(60))

--- a/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
+++ b/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
@@ -10,6 +10,14 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
+fn run_lint(root: &std::path::Path) -> std::process::Output {
+    Command::new("bash")
+        .arg(repo_root().join("scripts/check_stakeholder_writer_emits_signal.sh"))
+        .env("STAKEHOLDER_LINT_ROOT", root)
+        .output()
+        .expect("run lint")
+}
+
 #[test]
 fn lint_stakeholder_writer_emits_signal_catches_missing_emission() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -30,15 +38,86 @@ fn bad(tx: &ActionDb) {
     )
     .expect("write fixture");
 
-    let output = Command::new("bash")
-        .arg(repo_root().join("scripts/check_stakeholder_writer_emits_signal.sh"))
-        .env("STAKEHOLDER_LINT_ROOT", tmp.path())
-        .output()
-        .expect("run lint");
+    let output = run_lint(tmp.path());
 
     assert!(
         !output.status.success(),
         "lint must fail when stakeholder writer omits stakeholders_changed signal. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_stakeholder_writer_allows_canonical_wrapper() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("good_writer.rs"),
+        r#"
+fn good(ctx: &ServiceContext<'_>, tx: &ActionDb) {
+    crate::services::stakeholder_writer::write_with_stakeholders_changed(
+        ctx,
+        tx,
+        "account",
+        "acc-1",
+        "fixture",
+        |tx| {
+            tx.conn_ref()
+                .execute(
+                    "INSERT INTO account_stakeholders (account_id, person_id) VALUES (?1, ?2)",
+                    params,
+                )
+                .unwrap();
+            Ok(())
+        },
+    )
+    .unwrap();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        output.status.success(),
+        "lint must pass for canonical stakeholder writer wrapper. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_stakeholder_writer_rejects_direct_stakeholders_changed_emit() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("bad_emit.rs"),
+        r#"
+fn bad_emit(ctx: &ServiceContext<'_>, tx: &ActionDb) {
+    crate::services::signals::emit_in_transaction(
+        ctx,
+        tx,
+        "account",
+        "acc-1",
+        crate::services::signals::STAKEHOLDERS_CHANGED_SIGNAL,
+        "fixture",
+        serde_json::json!({"entity_id":"acc-1","entity_type":"account","mutation_source":"fixture"}),
+    )
+    .unwrap();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        !output.status.success(),
+        "lint must reject direct stakeholders_changed emit. stdout: {}, stderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );

--- a/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
+++ b/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
@@ -90,6 +90,112 @@ fn good(ctx: &ServiceContext<'_>, tx: &ActionDb) {
 }
 
 #[test]
+fn lint_stakeholder_writer_rejects_comment_only_wrapper_mention() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("comment_bypass.rs"),
+        r#"
+fn bad(tx: &ActionDb) {
+    // crate::services::stakeholder_writer::write_with_stakeholders_changed(...)
+    tx.conn_ref()
+        .execute(
+            "INSERT INTO account_stakeholders (account_id, person_id) VALUES (?1, ?2)",
+            params,
+        )
+        .unwrap();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        !output.status.success(),
+        "lint must reject comment-only stakeholder writer mentions. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_stakeholder_writer_rejects_sibling_wrapper_bypass() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("sibling_bypass.rs"),
+        r#"
+fn unrelated(ctx: &ServiceContext<'_>, tx: &ActionDb) {
+    crate::services::stakeholder_writer::write_with_stakeholders_changed(
+        ctx,
+        tx,
+        "account",
+        "acc-1",
+        "fixture",
+        |_tx| Ok(()),
+    )
+    .unwrap();
+}
+
+fn bad(tx: &ActionDb) {
+    tx.conn_ref()
+        .execute(
+            "INSERT INTO account_stakeholders (account_id, person_id) VALUES (?1, ?2)",
+            params,
+        )
+        .unwrap();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        !output.status.success(),
+        "lint must reject wrapper calls outside the mutating function. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_stakeholder_writer_checks_cfg_test_modules() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("test_module_bypass.rs"),
+        r#"
+#[cfg(test)]
+mod tests {
+    fn bad_test_fixture(tx: &ActionDb) {
+        tx.conn_ref()
+            .execute(
+                "INSERT INTO account_stakeholders (account_id, person_id) VALUES (?1, ?2)",
+                params,
+            )
+            .unwrap();
+    }
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        !output.status.success(),
+        "lint must inspect cfg(test) modules. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
 fn lint_stakeholder_writer_rejects_direct_stakeholders_changed_emit() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let src_dir = tmp.path().join("src-tauri/src/services");

--- a/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
+++ b/src-tauri/tests/dos8_stakeholder_signal_lint_test.rs
@@ -163,6 +163,46 @@ fn bad(tx: &ActionDb) {
 }
 
 #[test]
+fn lint_stakeholder_writer_rejects_same_function_wrapper_bypass() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src_dir = tmp.path().join("src-tauri/src/services");
+    std::fs::create_dir_all(&src_dir).expect("mkdir fixture");
+    std::fs::write(
+        src_dir.join("same_function_bypass.rs"),
+        r#"
+fn bad(ctx: &ServiceContext<'_>, tx: &ActionDb) {
+    crate::services::stakeholder_writer::write_with_stakeholders_changed(
+        ctx,
+        tx,
+        "account",
+        "acc-1",
+        "fixture",
+        |_tx| Ok(()),
+    )
+    .unwrap();
+
+    tx.conn_ref()
+        .execute(
+            "INSERT INTO account_stakeholders (account_id, person_id) VALUES (?1, ?2)",
+            params,
+        )
+        .unwrap();
+}
+"#,
+    )
+    .expect("write fixture");
+
+    let output = run_lint(tmp.path());
+
+    assert!(
+        !output.status.success(),
+        "lint must reject direct writes outside a helper call even when the same function mentions a wrapper. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
 fn lint_stakeholder_writer_checks_cfg_test_modules() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let src_dir = tmp.path().join("src-tauri/src/services");


### PR DESCRIPTION
## Summary

W0-E per v1.4.1 wave plan. Centralizes stakeholder graph writes through a single `services::stakeholder_writer` helper. CI lint rejects direct writes outside the helper.

## Changes

- New canonical `services::stakeholder_writer` helper module
- Refactored stakeholder graph writes + emits through it
- Rewrote `scripts/check_stakeholder_writer_emits_signal.sh` to reject direct writes/emits outside helper or allowlisted DB writers
- Wired lint into CI
- Extended DOS-8 lint regression tests

## Test plan

- ✅ `bash scripts/check_stakeholder_writer_emits_signal.sh`
- ✅ `cargo test --test dos8_stakeholder_signal_lint_test`
- ✅ `cargo clippy -- -D warnings`
- ✅ `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)