### PR TITLE
DOS-381 W0-F: claim immutability allowlist parser

### DIFF
--- a/src-tauri/scripts/check_claim_immutability_allowlist.sh
+++ b/src-tauri/scripts/check_claim_immutability_allowlist.sh
@@ -369,7 +369,44 @@ def iter_files():
                 yield path
 
 
+def path_text(path: pathlib.Path) -> str:
+    return path.as_posix()
+
+
+def is_claim_service_path(path: pathlib.Path) -> bool:
+    path_str = path_text(path)
+    return path_str.endswith("src/services/claims.rs")
+
+
+def is_migration_or_backfill_path(path: pathlib.Path) -> bool:
+    path_str = path_text(path)
+    return (
+        "/src/migrations/" in f"/{path_str}"
+        or path_str.endswith("src/migrations.rs")
+        or path_str.endswith("src/services/claims_backfill.rs")
+        or path_str.endswith("src/services/source_asof_backfill.rs")
+    )
+
+
+def is_test_path(path: pathlib.Path) -> bool:
+    return "/tests/" in f"/{path_text(path)}/"
+
+
+def marker_can_exempt_forbidden_set(path: pathlib.Path) -> bool:
+    # `dos7-allowed:` is reserved for the central claim-service parser tests and
+    # documented one-time migration/backfill exceptions. Runtime code must not
+    # be able to silence immutable SET targets with a local marker.
+    return is_claim_service_path(path) or is_migration_or_backfill_path(path) or is_test_path(path)
+
+
+def direct_runtime_update_allowed_here(path: pathlib.Path) -> bool:
+    # Runtime UPDATEs outside services/claims.rs must go through a shared claim
+    # service helper so the Rust allowlist guard runs before SQLite execution.
+    return is_claim_service_path(path) or is_migration_or_backfill_path(path) or is_test_path(path)
+
+
 violations = []
+direct_runtime_violations = []
 IDENT = r"(?:[\"`']?[A-Za-z_][A-Za-z0-9_]*[\"`']?|\[[^\]]+\])"
 CLAIMS_TABLE = r"(?:[\"`']?intelligence_claims[\"`']?|\[intelligence_claims\])"
 update_re = re.compile(
@@ -383,23 +420,33 @@ for path in iter_files():
         window = text[match.start(): match.start() + 8000]
         statement_end = window.find(");")
         statement = window if statement_end == -1 else window[:statement_end]
-        if "dos7-allowed:" in statement:
-            continue
 
         columns = parse_update_columns(text, match.start())
         denied = sorted({column for column in columns if column not in ALLOWED})
-        if denied:
-            line = text.count("\n", 0, match.start()) + 1
+        line = text.count("\n", 0, match.start()) + 1
+        has_marker = "dos7-allowed:" in statement
+        if denied and not (has_marker and marker_can_exempt_forbidden_set(path)):
             violations.append((str(path), line, ", ".join(denied)))
+        if not direct_runtime_update_allowed_here(path):
+            direct_runtime_violations.append((str(path), line))
 
-if violations:
-    print("UPDATE on non-allowlisted intelligence_claims columns is forbidden.")
-    print("Allowed columns are parsed from services/claims.rs::CLAIM_UPDATE_ALLOWED_COLUMNS:")
-    print("  " + ", ".join(sorted(ALLOWED)))
-    print("Use /* dos7-allowed: ... */ only for documented one-time migration/backfill exceptions.")
-    print()
-    for path, line, columns in sorted(set(violations)):
-        print(f"{path}:{line}: non-allowlisted SET column(s): {columns}")
+if violations or direct_runtime_violations:
+    if violations:
+        print("UPDATE on non-allowlisted intelligence_claims columns is forbidden.")
+        print("Allowed columns are parsed from services/claims.rs::CLAIM_UPDATE_ALLOWED_COLUMNS:")
+        print("  " + ", ".join(sorted(ALLOWED)))
+        print("Use /* dos7-allowed: ... */ only for documented one-time migration/backfill exceptions.")
+        print()
+        for path, line, columns in sorted(set(violations)):
+            print(f"{path}:{line}: non-allowlisted SET column(s): {columns}")
+        print()
+    if direct_runtime_violations:
+        print("Runtime UPDATE statements against intelligence_claims must use services/claims.rs helpers.")
+        print("Direct UPDATE is allowed only in services/claims.rs, migration/backfill code, and tests.")
+        print()
+        for path, line in sorted(set(direct_runtime_violations)):
+            print(f"{path}:{line}: direct runtime UPDATE intelligence_claims")
+        print()
     sys.exit(1)
 
 print("All UPDATE statements against intelligence_claims target allowlisted mutable columns only.")

--- a/src-tauri/scripts/check_claim_immutability_allowlist.sh
+++ b/src-tauri/scripts/check_claim_immutability_allowlist.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Claims-substrate lint: intelligence_claims UPDATE statements may mutate only
-# the DOS-7 amendment D lifecycle/trust/threading allowlist owned by
+# the amendment D lifecycle/trust/threading allowlist owned by
 # services/claims.rs. The scanner parses full multi-line SET clauses instead
 # of grepping a bounded line window, so forbidden columns are caught in any SET
 # position and with SQLite quoted identifier forms.

--- a/src-tauri/scripts/check_claim_immutability_allowlist.sh
+++ b/src-tauri/scripts/check_claim_immutability_allowlist.sh
@@ -1,22 +1,15 @@
 #!/usr/bin/env bash
 #
-# Claims-substrate lint: assertion columns on intelligence_claims are immutable
-# after insert. Per plan §"Memory substrate amendments — D. Immutability
-# allowlist (formalized)":
-#
-# UPDATE-FORBIDDEN columns (assertion identity — never change after insert):
-#   text, claim_type, subject_ref, source_asof, created_at
-#
-# UPDATE-ALLOWED columns (lifecycle, trust, threading — owned by services):
-#   claim_state, surfacing_state, demotion_reason, reactivated_at,
-#   superseded_by, trust_score, trust_computed_at, trust_version, thread_id,
-#   retraction_reason, expires_at, item_hash (legacy backfill only)
-#
-# This lint scans any `UPDATE intelligence_claims SET <col>` where <col> is
-# in the forbidden list. The services/claims.rs writer is exempt because
-# the assertion columns there are only set via INSERT, never UPDATE.
+# Claims-substrate lint: intelligence_claims UPDATE statements may mutate only
+# the DOS-7 amendment D lifecycle/trust/threading allowlist owned by
+# services/claims.rs. The scanner parses full multi-line SET clauses instead
+# of grepping a bounded line window, so forbidden columns are caught in any SET
+# position and with SQLite quoted identifier forms.
 
 set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+allowlist_source="$script_dir/../src/services/claims.rs"
 
 if [[ -d "src-tauri" ]]; then
   roots=("src-tauri/src" "src-tauri/tests")
@@ -24,43 +17,325 @@ else
   roots=("src" "tests")
 fi
 
-# L2 cycle-19 + cycle-20 fix: catch forbidden columns ANYWHERE in
-# the SET clause AND in any quoted-identifier shape SQLite accepts.
-#
-# Previous regex `SET[[:space:]]+(forbidden)` matched only the FIRST
-# SET target, so `SET dedup_key = ?, subject_ref = ?` bypassed.
-# Cycle-19 broadened to scan a 7-line context window for any
-# `<forbidden>[[:space:]]*=`, but only matched bare identifiers.
-# SQLite also accepts quoted forms:
-#   "subject_ref"   (SQL standard double-quote)
-#   `subject_ref`   (MySQL-style backtick)
-#   [subject_ref]   (SQL Server-style brackets)
-# Cycle-20 fix: regex now matches any of those wrappings before
-# the column name.
-#
-# The dos7-allowed marker still exempts legitimate canonicalization
-# rewrites (rekey path).
-matches="$(
-  grep -rEni --include='*.rs' --include='*.sql' -A 7 \
-    "UPDATE[[:space:]]+intelligence_claims" "${roots[@]}" 2>/dev/null \
-    | grep -E '("|`|\[)?\b(text|claim_type|subject_ref|source_asof|created_at)\b("|`|\])?[[:space:]]*=' \
-    | grep -Ev '(text|claim_type|subject_ref|source_asof|created_at)("|`|\])?[[:space:]]*=[[:space:]]*=' \
-    | grep -v 'dos7-allowed:' \
-    || true
-)"
+python3 - "$allowlist_source" "${roots[@]}" <<'PY'
+import pathlib
+import re
+import sys
 
-combined="$(printf '%s\n' "$matches" | sort -u | sed '/^$/d' || true)"
+allowlist_source = pathlib.Path(sys.argv[1])
+roots = [pathlib.Path(arg) for arg in sys.argv[2:]]
 
-if [[ -n "$combined" ]]; then
-  echo "UPDATE on assertion-identity columns of intelligence_claims is forbidden."
-  echo "Forbidden: text, claim_type, subject_ref, source_asof, created_at"
-  echo "These are immutable after insert per plan amendment D."
-  echo "Allowed lifecycle columns: claim_state, surfacing_state, superseded_by,"
-  echo "  trust_score, trust_computed_at, trust_version, retraction_reason,"
-  echo "  expires_at, demotion_reason, reactivated_at, thread_id."
-  echo
-  echo "$combined"
-  exit 1
-fi
+source = allowlist_source.read_text(encoding="utf-8")
+match = re.search(
+    r"const\s+CLAIM_UPDATE_ALLOWED_COLUMNS\s*:\s*&\[\s*&str\s*\]\s*=\s*&\[(.*?)\];",
+    source,
+    re.S,
+)
+if not match:
+    print(f"Claim immutability lint: missing CLAIM_UPDATE_ALLOWED_COLUMNS in {allowlist_source}", file=sys.stderr)
+    sys.exit(2)
 
-echo "All UPDATE statements against intelligence_claims target lifecycle columns only."
+ALLOWED = set(re.findall(r'"([a-z0-9_]+)"', match.group(1)))
+if not ALLOWED:
+    print(f"Claim immutability lint: empty CLAIM_UPDATE_ALLOWED_COLUMNS in {allowlist_source}", file=sys.stderr)
+    sys.exit(2)
+
+
+def is_ident_continue(ch: str) -> bool:
+    return ch == "_" or ch.isalnum()
+
+
+def is_boundary(text: str, idx: int) -> bool:
+    return idx < 0 or idx >= len(text) or not is_ident_continue(text[idx])
+
+
+def keyword_at(text: str, idx: int, keyword: str) -> bool:
+    lower = text.lower()
+    end = idx + len(keyword)
+    return lower.startswith(keyword, idx) and is_boundary(text, idx - 1) and is_boundary(text, end)
+
+
+def skip_ws(text: str, idx: int) -> int:
+    while idx < len(text) and (text[idx].isspace() or text[idx] == "\\"):
+        idx += 1
+    return idx
+
+
+def parse_identifier(text: str, idx: int):
+    idx = skip_ws(text, idx)
+    if idx >= len(text):
+        return None, idx
+
+    ch = text[idx]
+    if ch in ('"', "`"):
+        end = text.find(ch, idx + 1)
+        if end == -1:
+            return None, idx
+        return text[idx + 1:end].lower(), end + 1
+
+    if ch == "[":
+        end = text.find("]", idx + 1)
+        if end == -1:
+            return None, idx
+        return text[idx + 1:end].lower(), end + 1
+
+    if ch == "_" or ch.isalpha():
+        end = idx + 1
+        while end < len(text) and is_ident_continue(text[end]):
+            end += 1
+        return text[idx:end].lower(), end
+
+    return None, idx
+
+
+def find_keyword(text: str, keyword: str, start: int):
+    lower = text.lower()
+    idx = lower.find(keyword, start)
+    while idx != -1:
+        if keyword_at(text, idx, keyword):
+            return idx
+        idx = lower.find(keyword, idx + len(keyword))
+    return None
+
+
+def top_level_clause_starts(text: str, idx: int) -> bool:
+    return any(keyword_at(text, idx, kw) for kw in ("where", "returning", "order", "limit"))
+
+
+def skip_expression(text: str, idx: int) -> int:
+    depth = 0
+    quote = None
+    while idx < len(text):
+        if quote is None and depth == 0 and top_level_clause_starts(text, idx):
+            return idx
+
+        ch = text[idx]
+        if quote is not None:
+            idx += 1
+            if ch == quote:
+                if quote == "'" and idx < len(text) and text[idx] == "'":
+                    idx += 1
+                else:
+                    quote = None
+            continue
+
+        if ch in ("'", '"', "`"):
+            quote = ch
+            idx += 1
+        elif ch == "[":
+            quote = "]"
+            idx += 1
+        elif ch == "(":
+            depth += 1
+            idx += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+            idx += 1
+        elif ch == "," and depth == 0:
+            return idx + 1
+        else:
+            idx += 1
+    return idx
+
+
+def parse_set_columns(text: str, idx: int):
+    columns = []
+    while idx < len(text):
+        idx = skip_ws(text, idx)
+        if idx >= len(text) or top_level_clause_starts(text, idx):
+            break
+
+        column, next_idx = parse_identifier(text, idx)
+        if column is None:
+            idx += 1
+            continue
+
+        next_idx = skip_ws(text, next_idx)
+        if next_idx < len(text) and text[next_idx] == ".":
+            qualified, qualified_next = parse_identifier(text, next_idx + 1)
+            if qualified is not None:
+                column = qualified
+                next_idx = skip_ws(text, qualified_next)
+
+        if next_idx >= len(text) or text[next_idx] != "=":
+            idx = next_idx + 1
+            continue
+
+        columns.append(column)
+        idx = skip_expression(text, next_idx + 1)
+
+    return columns
+
+
+def parse_update_columns(text: str, start: int):
+    idx = skip_ws(text, start + len("update"))
+    if keyword_at(text, idx, "or"):
+        _, idx = parse_identifier(text, skip_ws(text, idx + len("or")))
+        idx = skip_ws(text, idx)
+
+    first, idx = parse_identifier(text, idx)
+    if first is None:
+        return []
+
+    idx = skip_ws(text, idx)
+    table = first
+    if idx < len(text) and text[idx] == ".":
+        second, second_idx = parse_identifier(text, idx + 1)
+        if second is not None:
+            table = second
+            idx = second_idx
+
+    if table != "intelligence_claims":
+        return []
+
+    set_idx = find_keyword(text, "set", idx)
+    if set_idx is None:
+        return []
+    return parse_set_columns(text, set_idx + len("set"))
+
+
+def strip_rust_comments(text: str) -> str:
+    out = []
+    i = 0
+    n = len(text)
+    state = "code"
+    raw_end = None
+    block_depth = 0
+
+    while i < n:
+        if state == "code":
+            if text.startswith("//", i):
+                newline = text.find("\n", i)
+                if newline == -1:
+                    break
+                out.append("\n")
+                i = newline + 1
+            elif text.startswith("/*", i):
+                state = "block_comment"
+                block_depth = 1
+                out.append("  ")
+                i += 2
+            elif text[i] == "r":
+                j = i + 1
+                while j < n and text[j] == "#":
+                    j += 1
+                if j < n and text[j] == '"':
+                    hashes = text[i + 1:j]
+                    raw_end = '"' + hashes
+                    out.append(text[i:j + 1])
+                    i = j + 1
+                    state = "raw_string"
+                else:
+                    out.append(text[i])
+                    i += 1
+            elif text[i] == '"':
+                state = "string"
+                out.append(text[i])
+                i += 1
+            elif text[i] == "'":
+                state = "char"
+                out.append(text[i])
+                i += 1
+            else:
+                out.append(text[i])
+                i += 1
+        elif state == "string":
+            out.append(text[i])
+            if text[i] == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+            elif text[i] == '"':
+                i += 1
+                state = "code"
+            else:
+                i += 1
+        elif state == "raw_string":
+            if raw_end is not None and text.startswith(raw_end, i):
+                out.append(raw_end)
+                i += len(raw_end)
+                raw_end = None
+                state = "code"
+            else:
+                out.append(text[i])
+                i += 1
+        elif state == "char":
+            out.append(text[i])
+            if text[i] == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+            elif text[i] == "'":
+                i += 1
+                state = "code"
+            else:
+                i += 1
+        elif state == "block_comment":
+            if text.startswith("/*", i):
+                block_depth += 1
+                out.append("  ")
+                i += 2
+            elif text.startswith("*/", i):
+                block_depth -= 1
+                out.append("  ")
+                i += 2
+                if block_depth == 0:
+                    state = "code"
+            else:
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+
+    return "".join(out)
+
+
+def normalized_source(path: pathlib.Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".rs":
+        text = strip_rust_comments(text)
+    return (
+        text
+        .replace("\\\n", " ")
+        .replace("\\n", " ")
+        .replace('\\"', '"')
+    )
+
+
+def iter_files():
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.as_posix().endswith("tests/dos7_d4_lint_test.rs"):
+                continue
+            if path.suffix in (".rs", ".sql"):
+                yield path
+
+
+violations = []
+update_re = re.compile(r"\bUPDATE\s+(?:OR\s+\w+\s+)?(?:[\"`\[]?intelligence_claims[\"`\]]?)\b", re.I)
+
+for path in iter_files():
+    text = normalized_source(path)
+    for match in update_re.finditer(text):
+        window = text[match.start(): match.start() + 8000]
+        statement_end = window.find(");")
+        statement = window if statement_end == -1 else window[:statement_end]
+        if "dos7-allowed:" in statement:
+            continue
+
+        columns = parse_update_columns(text, match.start())
+        denied = sorted({column for column in columns if column not in ALLOWED})
+        if denied:
+            line = text.count("\n", 0, match.start()) + 1
+            violations.append((str(path), line, ", ".join(denied)))
+
+if violations:
+    print("UPDATE on non-allowlisted intelligence_claims columns is forbidden.")
+    print("Allowed columns are parsed from services/claims.rs::CLAIM_UPDATE_ALLOWED_COLUMNS:")
+    print("  " + ", ".join(sorted(ALLOWED)))
+    print("Use /* dos7-allowed: ... */ only for documented one-time migration/backfill exceptions.")
+    print()
+    for path, line, columns in sorted(set(violations)):
+        print(f"{path}:{line}: non-allowlisted SET column(s): {columns}")
+    sys.exit(1)
+
+print("All UPDATE statements against intelligence_claims target allowlisted mutable columns only.")
+PY

--- a/src-tauri/scripts/check_claim_immutability_allowlist.sh
+++ b/src-tauri/scripts/check_claim_immutability_allowlist.sh
@@ -67,17 +67,11 @@ def parse_identifier(text: str, idx: int):
         return None, idx
 
     ch = text[idx]
-    if ch in ('"', "`"):
-        end = text.find(ch, idx + 1)
-        if end == -1:
-            return None, idx
-        return text[idx + 1:end].lower(), end + 1
+    if ch in ('"', "`", "'"):
+        return parse_quoted_identifier(text, idx, ch)
 
     if ch == "[":
-        end = text.find("]", idx + 1)
-        if end == -1:
-            return None, idx
-        return text[idx + 1:end].lower(), end + 1
+        return parse_quoted_identifier(text, idx, "]")
 
     if ch == "_" or ch.isalpha():
         end = idx + 1
@@ -85,6 +79,22 @@ def parse_identifier(text: str, idx: int):
             end += 1
         return text[idx:end].lower(), end
 
+    return None, idx
+
+
+def parse_quoted_identifier(text: str, idx: int, close: str):
+    ident = []
+    cursor = idx + 1
+    while cursor < len(text):
+        ch = text[cursor]
+        cursor += 1
+        if ch == close:
+            if cursor < len(text) and text[cursor] == close:
+                ident.append(ch)
+                cursor += 1
+                continue
+            return "".join(ident).lower(), cursor
+        ident.append(ch)
     return None, idx
 
 
@@ -138,6 +148,56 @@ def skip_expression(text: str, idx: int) -> int:
     return idx
 
 
+def parse_assignment_target(text: str, idx: int):
+    column, next_idx = parse_identifier(text, idx)
+    if column is None:
+        return None, idx
+
+    next_idx = skip_ws(text, next_idx)
+    if next_idx < len(text) and text[next_idx] == ".":
+        qualified, qualified_next = parse_identifier(text, next_idx + 1)
+        if qualified is not None:
+            column = qualified
+            next_idx = skip_ws(text, qualified_next)
+
+    return column, next_idx
+
+
+def parse_row_value_targets(text: str, idx: int):
+    idx = skip_ws(text, idx)
+    if idx >= len(text) or text[idx] != "(":
+        return None
+
+    cursor = idx + 1
+    columns = []
+    while cursor < len(text):
+        cursor = skip_ws(text, cursor)
+        if cursor < len(text) and text[cursor] == ")":
+            if not columns:
+                return None
+            cursor += 1
+            break
+
+        column, next_idx = parse_assignment_target(text, cursor)
+        if column is None:
+            return None
+        columns.append(column)
+
+        cursor = skip_ws(text, next_idx)
+        if cursor < len(text) and text[cursor] == ",":
+            cursor += 1
+            continue
+        if cursor < len(text) and text[cursor] == ")":
+            cursor += 1
+            break
+        return None
+
+    cursor = skip_ws(text, cursor)
+    if cursor < len(text) and text[cursor] == "=":
+        return columns, cursor + 1
+    return None
+
+
 def parse_set_columns(text: str, idx: int):
     columns = []
     while idx < len(text):
@@ -145,17 +205,17 @@ def parse_set_columns(text: str, idx: int):
         if idx >= len(text) or top_level_clause_starts(text, idx):
             break
 
-        column, next_idx = parse_identifier(text, idx)
+        row_value = parse_row_value_targets(text, idx)
+        if row_value is not None:
+            row_columns, value_idx = row_value
+            columns.extend(row_columns)
+            idx = skip_expression(text, value_idx)
+            continue
+
+        column, next_idx = parse_assignment_target(text, idx)
         if column is None:
             idx += 1
             continue
-
-        next_idx = skip_ws(text, next_idx)
-        if next_idx < len(text) and text[next_idx] == ".":
-            qualified, qualified_next = parse_identifier(text, next_idx + 1)
-            if qualified is not None:
-                column = qualified
-                next_idx = skip_ws(text, qualified_next)
 
         if next_idx >= len(text) or text[next_idx] != "=":
             idx = next_idx + 1
@@ -310,7 +370,12 @@ def iter_files():
 
 
 violations = []
-update_re = re.compile(r"\bUPDATE\s+(?:OR\s+\w+\s+)?(?:[\"`\[]?intelligence_claims[\"`\]]?)\b", re.I)
+IDENT = r"(?:[\"`']?[A-Za-z_][A-Za-z0-9_]*[\"`']?|\[[^\]]+\])"
+CLAIMS_TABLE = r"(?:[\"`']?intelligence_claims[\"`']?|\[intelligence_claims\])"
+update_re = re.compile(
+    rf"\bUPDATE\s+(?:OR\s+\w+\s+)?(?:{IDENT}\s*\.\s*)?{CLAIMS_TABLE}(?=\W|$)",
+    re.I,
+)
 
 for path in iter_files():
     text = normalized_source(path)

--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -207,29 +207,11 @@ pub fn purge_aged_emails(db: &ActionDb, days: i64) -> Result<usize, DbError> {
         // purge. Run BEFORE the DELETE so we can still join against
         // `emails` to identify which email_ids are aging out.
         if claims_table_present {
-            // L2 cycle-6 fix #1: restrict the UPDATE to rows whose
-            // subject_ref is valid JSON BEFORE evaluating
-            // json_extract — SQLite's WHERE-clause AND chain doesn't
-            // reliably short-circuit, so a malformed historical
-            // subject_ref would otherwise raise "malformed JSON"
-            // mid-purge and roll the whole transaction back. The
-            // valid-rows subquery materializes the safe set first.
-            conn.execute(
-                "UPDATE intelligence_claims /* dos7-allowed: lifecycle column update for Email-subject purge */ \
-                 SET claim_state = 'withdrawn', \
-                     retraction_reason = coalesce(retraction_reason, 'subject_purged') \
-                 WHERE id IN ( \
-                     SELECT ic.id FROM intelligence_claims ic \
-                     WHERE json_valid(ic.subject_ref) = 1 \
-                       AND ic.claim_state IN ('active', 'tombstoned', 'dormant') \
-                       AND lower(json_extract(ic.subject_ref, '$.kind')) = 'email' \
-                       AND json_extract(ic.subject_ref, '$.id') IN ( \
-                           SELECT email_id FROM emails \
-                           WHERE resolved_at IS NOT NULL \
-                             AND resolved_at < datetime('now', ?1) \
-                       ) \
-                 )",
-                params![cutoff],
+            // L2 cycle-6 fix #1: the helper restricts the UPDATE to rows whose
+            // subject_ref is valid JSON before evaluating json_extract, so
+            // malformed historical subject_ref values do not abort the purge.
+            crate::services::claims::withdraw_email_subject_claims_for_aged_resolved_emails(
+                db, &cutoff,
             )
             .map_err(|e| {
                 DbError::Migration(format!("purge_aged_emails: withdraw email claims: {e}"))
@@ -603,23 +585,12 @@ pub fn purge_source(db: &ActionDb, source: DataSource) -> Result<PurgeReport, Db
                     // committed stale Email tombstones after the
                     // source rows were gone.
                     if table_exists(tx, "intelligence_claims") {
-                        // L2 cycle-6 fix #1: filter via subquery so
-                        // json_extract is only evaluated on rows
-                        // whose subject_ref is valid JSON. See
-                        // purge_aged_emails for the same pattern.
-                        tx.conn_ref().execute(
-                            "UPDATE intelligence_claims /* dos7-allowed: lifecycle column update for data-source purge */ \
-                             SET claim_state = 'withdrawn', \
-                                 retraction_reason = coalesce(retraction_reason, 'subject_purged') \
-                             WHERE id IN ( \
-                                 SELECT ic.id FROM intelligence_claims ic \
-                                 WHERE json_valid(ic.subject_ref) = 1 \
-                                   AND ic.claim_state IN ('active', 'tombstoned', 'dormant') \
-                                   AND lower(json_extract(ic.subject_ref, '$.kind')) = 'email' \
-                                   AND json_extract(ic.subject_ref, '$.id') IN \
-                                       (SELECT email_id FROM emails) \
-                             )",
-                            [],
+                        // L2 cycle-6 fix #1: the helper filters via subquery
+                        // so json_extract is only evaluated on rows whose
+                        // subject_ref is valid JSON. See purge_aged_emails for
+                        // the same pattern.
+                        crate::services::claims::withdraw_email_subject_claims_for_existing_emails(
+                            tx,
                         )
                         .map_err(|e| format!("withdraw email claims before purge failed: {e}"))?;
                     }

--- a/src-tauri/src/prepare/meeting_context.rs
+++ b/src-tauri/src/prepare/meeting_context.rs
@@ -1548,7 +1548,7 @@ fn find_recent_summaries(
         }
     }
 
-    matches.sort_by_key(|item| std::cmp::Reverse(item.0));
+    matches.sort_by_key(|matched| std::cmp::Reverse(matched.0));
     matches.into_iter().take(limit).map(|(_, p)| p).collect()
 }
 

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -2945,6 +2945,55 @@ pub fn withdraw_all_tombstones_of_type(
     )
 }
 
+/// Withdraw Email-subject claims for resolved emails that are about to be
+/// purged by the age-based lifecycle job. The email rows must still exist so
+/// the subquery can identify the claim subjects safely.
+pub fn withdraw_email_subject_claims_for_aged_resolved_emails(
+    db: &ActionDb,
+    cutoff_modifier: &str,
+) -> Result<usize, rusqlite::Error> {
+    execute_claims_update_sqlite(
+        db.conn_ref(),
+        "UPDATE intelligence_claims \
+         SET claim_state = 'withdrawn', \
+             retraction_reason = coalesce(retraction_reason, 'subject_purged') \
+         WHERE id IN ( \
+             SELECT ic.id FROM intelligence_claims ic \
+             WHERE json_valid(ic.subject_ref) = 1 \
+               AND ic.claim_state IN ('active', 'tombstoned', 'dormant') \
+               AND lower(json_extract(ic.subject_ref, '$.kind')) = 'email' \
+               AND json_extract(ic.subject_ref, '$.id') IN ( \
+                   SELECT email_id FROM emails \
+                   WHERE resolved_at IS NOT NULL \
+                     AND resolved_at < datetime('now', ?1) \
+               ) \
+         )",
+        params![cutoff_modifier],
+    )
+}
+
+/// Withdraw Email-subject claims for all currently-present email rows before a
+/// connector source purge deletes those rows.
+pub fn withdraw_email_subject_claims_for_existing_emails(
+    db: &ActionDb,
+) -> Result<usize, rusqlite::Error> {
+    execute_claims_update_sqlite(
+        db.conn_ref(),
+        "UPDATE intelligence_claims \
+         SET claim_state = 'withdrawn', \
+             retraction_reason = coalesce(retraction_reason, 'subject_purged') \
+         WHERE id IN ( \
+             SELECT ic.id FROM intelligence_claims ic \
+             WHERE json_valid(ic.subject_ref) = 1 \
+               AND ic.claim_state IN ('active', 'tombstoned', 'dormant') \
+               AND lower(json_extract(ic.subject_ref, '$.kind')) = 'email' \
+               AND json_extract(ic.subject_ref, '$.id') IN \
+                   (SELECT email_id FROM emails) \
+         )",
+        [],
+    )
+}
+
 pub fn withdraw_tombstones_for(
     db: &ActionDb,
     filter: WithdrawTombstoneFilter<'_>,

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -347,20 +347,16 @@ fn parse_set_columns(sql: &str, mut cursor: usize) -> Vec<String> {
             break;
         }
 
-        let Some((mut column, mut next)) = parse_identifier(sql, cursor) else {
+        if let Some((row_columns, value_start)) = parse_row_value_set_target(sql, cursor) {
+            columns.extend(row_columns);
+            cursor = skip_expression(sql, value_start);
+            continue;
+        }
+
+        let Some((column, next)) = parse_assignment_target(sql, cursor) else {
             cursor += next_char_len(sql, cursor);
             continue;
         };
-
-        next = skip_ws(sql, next);
-        if sql[next..].starts_with('.') {
-            let qualified_start = skip_ws(sql, next + 1);
-            if let Some((qualified_column, qualified_next)) = parse_identifier(sql, qualified_start)
-            {
-                column = qualified_column;
-                next = skip_ws(sql, qualified_next);
-            }
-        }
 
         if !sql[next..].starts_with('=') {
             cursor = next + next_char_len(sql, next);
@@ -372,6 +368,62 @@ fn parse_set_columns(sql: &str, mut cursor: usize) -> Vec<String> {
     }
 
     columns
+}
+
+fn parse_assignment_target(sql: &str, cursor: usize) -> Option<(String, usize)> {
+    let (mut column, mut next) = parse_identifier(sql, cursor)?;
+
+    next = skip_ws(sql, next);
+    if sql[next..].starts_with('.') {
+        let qualified_start = skip_ws(sql, next + 1);
+        if let Some((qualified_column, qualified_next)) = parse_identifier(sql, qualified_start) {
+            column = qualified_column;
+            next = skip_ws(sql, qualified_next);
+        }
+    }
+
+    Some((column, next))
+}
+
+fn parse_row_value_set_target(sql: &str, cursor: usize) -> Option<(Vec<String>, usize)> {
+    let mut cursor = skip_ws(sql, cursor);
+    if !sql[cursor..].starts_with('(') {
+        return None;
+    }
+
+    cursor += 1;
+    let mut columns = Vec::new();
+    while cursor < sql.len() {
+        cursor = skip_ws(sql, cursor);
+        if sql[cursor..].starts_with(')') {
+            if columns.is_empty() {
+                return None;
+            }
+            cursor += 1;
+            break;
+        }
+
+        let (column, next) = parse_assignment_target(sql, cursor)?;
+        columns.push(column);
+
+        cursor = skip_ws(sql, next);
+        if sql[cursor..].starts_with(',') {
+            cursor += 1;
+            continue;
+        }
+        if sql[cursor..].starts_with(')') {
+            cursor += 1;
+            break;
+        }
+        return None;
+    }
+
+    cursor = skip_ws(sql, cursor);
+    if sql[cursor..].starts_with('=') {
+        Some((columns, cursor + 1))
+    } else {
+        None
+    }
 }
 
 fn skip_expression(sql: &str, mut cursor: usize) -> usize {
@@ -426,7 +478,7 @@ fn parse_identifier(sql: &str, cursor: usize) -> Option<(String, usize)> {
     let ch = sql[cursor..].chars().next()?;
 
     match ch {
-        '"' | '`' => parse_quoted_identifier(sql, cursor, ch, ch),
+        '\'' | '"' | '`' => parse_quoted_identifier(sql, cursor, ch, ch),
         '[' => parse_quoted_identifier(sql, cursor, '[', ']'),
         _ if is_ident_start(ch) => {
             let mut end = cursor + ch.len_utf8();
@@ -458,6 +510,11 @@ fn parse_quoted_identifier(
         let ch = sql[idx..].chars().next().expect("idx in bounds");
         idx += ch.len_utf8();
         if ch == close {
+            if sql[idx..].starts_with(close) {
+                ident.push(ch);
+                idx += close.len_utf8();
+                continue;
+            }
             return Some((ident.to_ascii_lowercase(), idx));
         }
         ident.push(ch);
@@ -2999,6 +3056,39 @@ mod tests {
     }
 
     #[test]
+    fn claim_update_allowlist_rejects_single_quoted_immutable_column() {
+        let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET 'source_asof' = ?1,
+                 claim_state = 'dormant'
+             WHERE id = ?2";
+
+        let err = check_claim_update_allowlist(sql)
+            .expect_err("single-quoted immutable column must reject");
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns) if columns == "source_asof"
+        ));
+    }
+
+    #[test]
+    fn claim_update_allowlist_rejects_row_value_immutable_column() {
+        let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET (claim_state, trust_score, subject_ref) =
+                 ('dormant', ?1, ?2)
+             WHERE id = ?3";
+
+        assert_eq!(
+            claim_update_columns(sql),
+            vec!["claim_state", "trust_score", "subject_ref"]
+        );
+        let err = check_claim_update_allowlist(sql).expect_err("row-value subject_ref must reject");
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns) if columns == "subject_ref"
+        ));
+    }
+
+    #[test]
     fn claim_update_allowlist_rejects_identity_columns_even_with_allowed_where_filters() {
         let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
              SET dedup_key = ?1
@@ -3011,6 +3101,67 @@ mod tests {
             err,
             ClaimError::ImmutableColumnUpdate(ref columns) if columns == "dedup_key"
         ));
+    }
+
+    #[test]
+    fn execute_claims_update_rejects_immutable_columns_before_sqlite() {
+        let db = test_db();
+        let err = execute_claims_update(
+            db.conn_ref(),
+            "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET subject_ref = ?999
+             WHERE id = ?1",
+            params!["would-hit-sqlite-bind-error"],
+        )
+        .expect_err("immutable column must reject before SQLite execution");
+
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns) if columns == "subject_ref"
+        ));
+    }
+
+    #[test]
+    fn execute_claims_update_allows_lifecycle_and_trust_columns() {
+        let db = test_db();
+        insert_fixture_claim(
+            &db,
+            "claim-allowed-update",
+            SUBJECT,
+            "risk",
+            "Allowed wrapper update",
+            ClaimState::Active,
+            SurfacingState::Active,
+        );
+
+        let updated = execute_claims_update(
+            db.conn_ref(),
+            "UPDATE intelligence_claims
+             SET claim_state = 'dormant',
+                 surfacing_state = 'dormant',
+                 demotion_reason = ?1,
+                 trust_score = ?2,
+                 trust_computed_at = ?3,
+                 trust_version = ?4
+             WHERE id = ?5",
+            params!["unit_test", 0.42_f64, TS, 3_i64, "claim-allowed-update"],
+        )
+        .expect("allowlisted lifecycle/trust columns should execute");
+
+        assert_eq!(updated, 1);
+        assert_eq!(
+            read_lifecycle_columns(&db, "claim-allowed-update"),
+            (
+                "dormant".to_string(),
+                "dormant".to_string(),
+                Some("unit_test".to_string()),
+                None
+            )
+        );
+        assert_eq!(
+            read_trust_columns(&db, "claim-allowed-update"),
+            (Some(0.42), Some(TS.to_string()), Some(3))
+        );
     }
 
     fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -172,7 +172,7 @@ pub enum ClaimError {
 pub type ClaimsError = ClaimError;
 pub type TrustVersion = i64;
 
-// DOS-7 amendment D: assertion columns are insert-only. These are the only
+// amendment D: assertion columns are insert-only. These are the only
 // intelligence_claims columns the claim service may mutate in-place.
 const CLAIM_UPDATE_ALLOWED_COLUMNS: &[&str] = &[
     "claim_state",
@@ -186,7 +186,7 @@ const CLAIM_UPDATE_ALLOWED_COLUMNS: &[&str] = &[
     "trust_computed_at",
     "trust_version",
     "thread_id",
-    // DOS-294 typed feedback adds derived review state; it is mutable
+    // typed feedback adds derived review state; it is mutable
     // metadata, not assertion identity.
     "verification_state",
     "verification_reason",

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, OnceLock};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use parking_lot::Mutex;
-use rusqlite::{params, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Params};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -157,6 +157,8 @@ pub enum ClaimError {
     },
     #[error("tombstone PRE-GATE: claim is tombstoned and cannot be re-committed")]
     TombstonedPreGate,
+    #[error("intelligence_claims UPDATE targets non-allowlisted columns: {0}")]
+    ImmutableColumnUpdate(String),
     #[error("transaction error: {0}")]
     Transaction(String),
     #[error("database error: {0}")]
@@ -169,6 +171,361 @@ pub enum ClaimError {
 
 pub type ClaimsError = ClaimError;
 pub type TrustVersion = i64;
+
+// DOS-7 amendment D: assertion columns are insert-only. These are the only
+// intelligence_claims columns the claim service may mutate in-place.
+const CLAIM_UPDATE_ALLOWED_COLUMNS: &[&str] = &[
+    "claim_state",
+    "surfacing_state",
+    "demotion_reason",
+    "reactivated_at",
+    "retraction_reason",
+    "expires_at",
+    "superseded_by",
+    "trust_score",
+    "trust_computed_at",
+    "trust_version",
+    "thread_id",
+    // DOS-294 typed feedback adds derived review state; it is mutable
+    // metadata, not assertion identity.
+    "verification_state",
+    "verification_reason",
+    "needs_user_decision_at",
+];
+
+fn execute_claims_update<P>(conn: &Connection, sql: &str, params: P) -> Result<usize, ClaimError>
+where
+    P: Params,
+{
+    check_claim_update_allowlist(sql)?;
+    Ok(conn.execute(sql, params)?)
+}
+
+fn execute_claims_update_sqlite<P>(
+    conn: &Connection,
+    sql: &str,
+    params: P,
+) -> rusqlite::Result<usize>
+where
+    P: Params,
+{
+    if check_claim_update_allowlist(sql).is_err() {
+        return Err(rusqlite::Error::InvalidQuery);
+    }
+    conn.execute(sql, params)
+}
+
+fn check_claim_update_allowlist(sql: &str) -> Result<(), ClaimError> {
+    let mut forbidden: Vec<String> = claim_update_columns(sql)
+        .into_iter()
+        .filter(|column| !CLAIM_UPDATE_ALLOWED_COLUMNS.contains(&column.as_str()))
+        .collect();
+    forbidden.sort();
+    forbidden.dedup();
+
+    if forbidden.is_empty() {
+        Ok(())
+    } else {
+        Err(ClaimError::ImmutableColumnUpdate(forbidden.join(", ")))
+    }
+}
+
+fn claim_update_columns(sql: &str) -> Vec<String> {
+    let sql = strip_sql_comments(sql);
+    let lower = sql.to_ascii_lowercase();
+    let mut search_from = 0;
+
+    while let Some(relative_idx) = lower[search_from..].find("update") {
+        let update_idx = search_from + relative_idx;
+        if !is_keyword_at(&lower, update_idx, "update") {
+            search_from = update_idx + "update".len();
+            continue;
+        }
+
+        let mut cursor = skip_ws(&sql, update_idx + "update".len());
+        if is_keyword_at(&lower, cursor, "or") {
+            cursor = skip_ws(&sql, cursor + "or".len());
+            if let Some((_, next)) = parse_identifier(&sql, cursor) {
+                cursor = skip_ws(&sql, next);
+            }
+        }
+
+        let Some((first_ident, first_end)) = parse_identifier(&sql, cursor) else {
+            search_from = update_idx + "update".len();
+            continue;
+        };
+        cursor = skip_ws(&sql, first_end);
+
+        let (table_ident, table_end) = if sql[cursor..].starts_with('.') {
+            let next_start = skip_ws(&sql, cursor + 1);
+            match parse_identifier(&sql, next_start) {
+                Some((second_ident, second_end)) => (second_ident, second_end),
+                None => (first_ident, cursor),
+            }
+        } else {
+            (first_ident, cursor)
+        };
+
+        if table_ident != "intelligence_claims" {
+            search_from = update_idx + "update".len();
+            continue;
+        }
+
+        if let Some(set_idx) = find_keyword_from(&lower, "set", table_end) {
+            return parse_set_columns(&sql, set_idx + "set".len());
+        }
+
+        search_from = update_idx + "update".len();
+    }
+
+    Vec::new()
+}
+
+fn strip_sql_comments(sql: &str) -> String {
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut in_single_quote = false;
+
+    while let Some(ch) = chars.next() {
+        if in_single_quote {
+            out.push(ch);
+            if ch == '\'' {
+                if chars.peek() == Some(&'\'') {
+                    out.push(chars.next().expect("peeked quote"));
+                } else {
+                    in_single_quote = false;
+                }
+            }
+            continue;
+        }
+
+        if ch == '\'' {
+            in_single_quote = true;
+            out.push(ch);
+            continue;
+        }
+
+        if ch == '-' && chars.peek() == Some(&'-') {
+            out.push(' ');
+            chars.next();
+            for comment_ch in chars.by_ref() {
+                if comment_ch == '\n' {
+                    out.push('\n');
+                    break;
+                }
+                out.push(' ');
+            }
+            continue;
+        }
+
+        if ch == '/' && chars.peek() == Some(&'*') {
+            out.push(' ');
+            chars.next();
+            let mut previous = '\0';
+            for comment_ch in chars.by_ref() {
+                out.push(if comment_ch == '\n' { '\n' } else { ' ' });
+                if previous == '*' && comment_ch == '/' {
+                    break;
+                }
+                previous = comment_ch;
+            }
+            continue;
+        }
+
+        out.push(ch);
+    }
+
+    out
+}
+
+fn parse_set_columns(sql: &str, mut cursor: usize) -> Vec<String> {
+    let mut columns = Vec::new();
+
+    while cursor < sql.len() {
+        cursor = skip_ws(sql, cursor);
+        if cursor >= sql.len() || top_level_clause_starts(sql, cursor) {
+            break;
+        }
+
+        let Some((mut column, mut next)) = parse_identifier(sql, cursor) else {
+            cursor += next_char_len(sql, cursor);
+            continue;
+        };
+
+        next = skip_ws(sql, next);
+        if sql[next..].starts_with('.') {
+            let qualified_start = skip_ws(sql, next + 1);
+            if let Some((qualified_column, qualified_next)) = parse_identifier(sql, qualified_start)
+            {
+                column = qualified_column;
+                next = skip_ws(sql, qualified_next);
+            }
+        }
+
+        if !sql[next..].starts_with('=') {
+            cursor = next + next_char_len(sql, next);
+            continue;
+        }
+
+        columns.push(column);
+        cursor = skip_expression(sql, next + 1);
+    }
+
+    columns
+}
+
+fn skip_expression(sql: &str, mut cursor: usize) -> usize {
+    let mut depth = 0usize;
+    let mut quote: Option<char> = None;
+
+    while cursor < sql.len() {
+        if quote.is_none() && depth == 0 && top_level_clause_starts(sql, cursor) {
+            return cursor;
+        }
+
+        let ch = sql[cursor..].chars().next().expect("cursor in bounds");
+        if let Some(active_quote) = quote {
+            cursor += ch.len_utf8();
+            if ch == active_quote {
+                if active_quote == '\'' && sql[cursor..].starts_with('\'') {
+                    cursor += 1;
+                } else {
+                    quote = None;
+                }
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => {
+                quote = Some(ch);
+                cursor += ch.len_utf8();
+            }
+            '[' => {
+                quote = Some(']');
+                cursor += ch.len_utf8();
+            }
+            '(' => {
+                depth += 1;
+                cursor += ch.len_utf8();
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                cursor += ch.len_utf8();
+            }
+            ',' if depth == 0 => return cursor + 1,
+            _ => cursor += ch.len_utf8(),
+        }
+    }
+
+    cursor
+}
+
+fn parse_identifier(sql: &str, cursor: usize) -> Option<(String, usize)> {
+    let cursor = skip_ws(sql, cursor);
+    let ch = sql[cursor..].chars().next()?;
+
+    match ch {
+        '"' | '`' => parse_quoted_identifier(sql, cursor, ch, ch),
+        '[' => parse_quoted_identifier(sql, cursor, '[', ']'),
+        _ if is_ident_start(ch) => {
+            let mut end = cursor + ch.len_utf8();
+            while end < sql.len() {
+                let next = sql[end..].chars().next().expect("end in bounds");
+                if is_ident_continue(next) {
+                    end += next.len_utf8();
+                } else {
+                    break;
+                }
+            }
+            Some((sql[cursor..end].to_ascii_lowercase(), end))
+        }
+        _ => None,
+    }
+}
+
+fn parse_quoted_identifier(
+    sql: &str,
+    cursor: usize,
+    open: char,
+    close: char,
+) -> Option<(String, usize)> {
+    debug_assert_eq!(sql[cursor..].chars().next(), Some(open));
+    let mut ident = String::new();
+    let mut idx = cursor + open.len_utf8();
+
+    while idx < sql.len() {
+        let ch = sql[idx..].chars().next().expect("idx in bounds");
+        idx += ch.len_utf8();
+        if ch == close {
+            return Some((ident.to_ascii_lowercase(), idx));
+        }
+        ident.push(ch);
+    }
+
+    None
+}
+
+fn skip_ws(sql: &str, mut cursor: usize) -> usize {
+    while cursor < sql.len() {
+        let ch = sql[cursor..].chars().next().expect("cursor in bounds");
+        if ch.is_whitespace() || ch == '\\' {
+            cursor += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    cursor
+}
+
+fn next_char_len(sql: &str, cursor: usize) -> usize {
+    sql[cursor..]
+        .chars()
+        .next()
+        .map(char::len_utf8)
+        .unwrap_or(1)
+}
+
+fn find_keyword_from(sql_lower: &str, keyword: &str, start: usize) -> Option<usize> {
+    let mut search_from = start;
+    while let Some(relative_idx) = sql_lower[search_from..].find(keyword) {
+        let idx = search_from + relative_idx;
+        if is_keyword_at(sql_lower, idx, keyword) {
+            return Some(idx);
+        }
+        search_from = idx + keyword.len();
+    }
+    None
+}
+
+fn top_level_clause_starts(sql: &str, cursor: usize) -> bool {
+    let lower = sql.to_ascii_lowercase();
+    ["where", "returning", "order", "limit"]
+        .iter()
+        .any(|keyword| is_keyword_at(&lower, cursor, keyword))
+}
+
+fn is_keyword_at(sql_lower: &str, idx: usize, keyword: &str) -> bool {
+    sql_lower[idx..].starts_with(keyword)
+        && is_keyword_boundary(sql_lower, idx.checked_sub(1))
+        && is_keyword_boundary(sql_lower, Some(idx + keyword.len()))
+}
+
+fn is_keyword_boundary(sql: &str, idx: Option<usize>) -> bool {
+    match idx {
+        None => true,
+        Some(i) if i >= sql.len() => true,
+        Some(i) => !sql[i..].chars().next().is_some_and(is_ident_continue),
+    }
+}
+
+fn is_ident_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_ident_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
 
 // ---------------------------------------------------------------------------
 // Per-key commit lock (ADR-0113 R2)
@@ -1350,7 +1707,8 @@ pub fn commit_claim(
             insert_claim_row(tx, &claim)?;
             project_legacy_state_for_claim(ctx, tx, &claim)?;
 
-            tx.conn_ref().execute(
+            execute_claims_update(
+                tx.conn_ref(),
                 "UPDATE intelligence_claims
                  SET claim_state = 'dormant',
                      surfacing_state = 'dormant',
@@ -1572,7 +1930,8 @@ pub fn withdraw_claim(
             || claim.surfacing_state != SurfacingState::Dormant
             || claim.retraction_reason.as_deref() != Some(reason)
         {
-            tx.conn_ref().execute(
+            execute_claims_update(
+                tx.conn_ref(),
                 "UPDATE intelligence_claims
                  SET claim_state = 'withdrawn',
                      surfacing_state = 'dormant',
@@ -1653,7 +2012,8 @@ pub fn record_claim_feedback(
 
         match (verification_changed, lifecycle_changed) {
             (true, true) => {
-                tx.conn_ref().execute(
+                execute_claims_update(
+                    tx.conn_ref(),
                     "UPDATE intelligence_claims
                      SET verification_state = ?1,
                          verification_reason = ?2,
@@ -1676,7 +2036,8 @@ pub fn record_claim_feedback(
                 )?;
             }
             (true, false) => {
-                tx.conn_ref().execute(
+                execute_claims_update(
+                    tx.conn_ref(),
                     "UPDATE intelligence_claims
                      SET verification_state = ?1,
                          verification_reason = ?2,
@@ -1691,7 +2052,8 @@ pub fn record_claim_feedback(
                 )?;
             }
             (false, true) => {
-                tx.conn_ref().execute(
+                execute_claims_update(
+                    tx.conn_ref(),
                     "UPDATE intelligence_claims
                      SET claim_state = ?1,
                          surfacing_state = ?2,
@@ -1942,7 +2304,8 @@ pub fn update_claim_trust(
 
     let trust_computed_at = ctx.clock.now().to_rfc3339();
     let trust_score = trust_score_db_value(trust_score);
-    let updated = db.conn_ref().execute(
+    let updated = execute_claims_update(
+        db.conn_ref(),
         "UPDATE intelligence_claims
          SET trust_score = ?1,
              trust_computed_at = ?2,
@@ -2513,7 +2876,8 @@ pub fn withdraw_all_tombstones_of_type(
     claim_type: &str,
     retraction_reason: &str,
 ) -> Result<usize, rusqlite::Error> {
-    db.conn_ref().execute(
+    execute_claims_update_sqlite(
+        db.conn_ref(),
         "UPDATE intelligence_claims /* dos7-allowed: bulk withdrawal helper */ \
          SET claim_state = 'withdrawn', \
              surfacing_state = 'dormant', \
@@ -2532,7 +2896,8 @@ pub fn withdraw_tombstones_for(
         return Ok(0);
     };
 
-    db.conn_ref().execute(
+    execute_claims_update_sqlite(
+        db.conn_ref(),
         "UPDATE intelligence_claims /* dos7-allowed: lifecycle withdrawal helper */ \
          SET claim_state = 'withdrawn', \
              surfacing_state = 'dormant', \
@@ -2572,6 +2937,81 @@ mod tests {
 
     const TS: &str = "2026-05-02T12:00:00+00:00";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
+
+    #[test]
+    fn claim_update_allowlist_accepts_lifecycle_trust_and_feedback_columns() {
+        let sql = "UPDATE intelligence_claims
+             SET claim_state = 'dormant',
+                 surfacing_state = 'dormant',
+                 trust_score = ?1,
+                 trust_computed_at = ?2,
+                 trust_version = ?3,
+                 verification_state = ?4,
+                 verification_reason = ?5,
+                 needs_user_decision_at = ?6
+             WHERE text = ?7 AND claim_type = ?8";
+
+        assert_eq!(
+            claim_update_columns(sql),
+            vec![
+                "claim_state",
+                "surfacing_state",
+                "trust_score",
+                "trust_computed_at",
+                "trust_version",
+                "verification_state",
+                "verification_reason",
+                "needs_user_decision_at",
+            ]
+        );
+        assert!(check_claim_update_allowlist(sql).is_ok());
+    }
+
+    #[test]
+    fn claim_update_allowlist_rejects_non_leading_immutable_column() {
+        let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET claim_state = 'dormant',
+                 subject_ref = ?1
+             WHERE id = ?2";
+
+        let err = check_claim_update_allowlist(sql).expect_err("subject_ref must be rejected");
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns) if columns == "subject_ref"
+        ));
+    }
+
+    #[test]
+    fn claim_update_allowlist_rejects_quoted_immutable_columns() {
+        let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET [created_at] = ?1,
+                 `text` = ?2,
+                 \"source_asof\" = ?3
+             WHERE id = ?4";
+
+        let err =
+            check_claim_update_allowlist(sql).expect_err("quoted immutable columns must reject");
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns)
+                if columns == "created_at, source_asof, text"
+        ));
+    }
+
+    #[test]
+    fn claim_update_allowlist_rejects_identity_columns_even_with_allowed_where_filters() {
+        let sql = "UPDATE intelligence_claims /* dos7-allowed: parser regression fixture */
+             SET dedup_key = ?1
+             WHERE claim_type = ?2
+               AND text = ?3
+               AND subject_ref = ?4";
+
+        let err = check_claim_update_allowlist(sql).expect_err("dedup_key must be rejected");
+        assert!(matches!(
+            err,
+            ClaimError::ImmutableColumnUpdate(ref columns) if columns == "dedup_key"
+        ));
+    }
 
     fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
         (

--- a/src-tauri/src/services/claims_backfill.rs
+++ b/src-tauri/src/services/claims_backfill.rs
@@ -1832,7 +1832,7 @@ mod tests {
         // immutability lint).
         db.conn_ref()
             .execute(
-                "UPDATE intelligence_claims \
+                "UPDATE intelligence_claims /* dos7-allowed: test-only rekey fixture */ \
                  SET dedup_key = 'rekeyed-shape:acct-retry:dismissed_item:risks', \
                      item_hash = 'runtime-canonical-hash' \
                  WHERE id LIKE 'm9-acct-retry-%'",

--- a/src-tauri/src/services/meetings.rs
+++ b/src-tauri/src/services/meetings.rs
@@ -2467,26 +2467,20 @@ pub async fn restore_meeting_entity(
                     .map_err(|e| e.to_string())?;
                 // Restore must withdraw the shadow tombstone claims so PRE-GATE /
                 // claim-backed readers don't keep suppressing the entity.
-                // dos7-allowed: claim lifecycle column update — claim_state/surfacing_state/retraction_reason are restore-flow lifecycle writes.
-                db.conn_ref()
-                    .execute(
-                        "UPDATE intelligence_claims /* dos7-allowed: claim lifecycle column update */ \
-                         SET claim_state = 'withdrawn', \
-                             surfacing_state = 'dormant', \
-                             retraction_reason = 'restored_by_user' \
-                         WHERE id IN ( \
-                             SELECT ic.id FROM intelligence_claims ic \
-                             WHERE ic.claim_state = 'tombstoned' \
-                               AND json_valid(ic.subject_ref) = 1 \
-                               AND lower(json_extract(ic.subject_ref, '$.kind')) = 'meeting' \
-                               AND json_extract(ic.subject_ref, '$.id') = ?1 \
-                               AND ic.claim_type IN ('meeting_entity_dismissed', 'linking_dismissed') \
-                               AND coalesce(ic.field_path, '') = coalesce(?2, '') \
-                               AND ic.text = ?3 \
-                         )",
-                        rusqlite::params![meeting_id_s, entity_type_s, entity_id_s],
+                for claim_type in ["meeting_entity_dismissed", "linking_dismissed"] {
+                    crate::services::claims::withdraw_tombstones_for(
+                        db,
+                        crate::services::claims::WithdrawTombstoneFilter {
+                            subject_kind: "meeting",
+                            subject_id: &meeting_id_s,
+                            claim_type,
+                            text: Some(&entity_id_s),
+                            field_path: Some(&entity_type_s),
+                            retraction_reason: "restored_by_user",
+                        },
                     )
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| format!("withdraw {claim_type} claim failed: {e}"))?;
+                }
                 db.conn_ref()
                     .execute(
                         "UPDATE linked_entities_raw SET source = 'rule:restored' \

--- a/src-tauri/src/signals/bus.rs
+++ b/src-tauri/src/signals/bus.rs
@@ -411,6 +411,7 @@ pub fn get_learned_reliability(
         Ok(Some((alpha, beta, update_count))) if update_count >= 5 => {
             super::sampling::sample_reliability(alpha, beta)
         }
+        Ok(Some(_)) => 0.5,
         _ => 0.5,
     }
 }

--- a/src-tauri/tests/dos7_d4_lint_test.rs
+++ b/src-tauri/tests/dos7_d4_lint_test.rs
@@ -542,7 +542,7 @@ fn lint_immutability_catches_forbidden_column_beyond_grep_window() {
 #[test]
 fn lint_immutability_allows_allowlisted_multiline_columns() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");
+    std::fs::create_dir_all(tmp.path().join("src/services")).expect("mkdir src/services");
     let good_sql = "fn good(conn: &Connection) {
         conn.execute(
             \"UPDATE intelligence_claims
@@ -558,7 +558,8 @@ fn lint_immutability_allows_allowlisted_multiline_columns() {
              params,
         ).unwrap();
     }";
-    std::fs::write(tmp.path().join("src/good_update.rs"), good_sql).expect("write good fixture");
+    std::fs::write(tmp.path().join("src/services/claims.rs"), good_sql)
+        .expect("write good fixture");
 
     let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
     let output = std::process::Command::new("bash")
@@ -569,6 +570,105 @@ fn lint_immutability_allows_allowlisted_multiline_columns() {
     assert!(
         output.status.success(),
         "lint must PASS on allowlisted mutable columns even with immutable WHERE filters. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_immutability_allows_marked_backfill_exception() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src/services")).expect("mkdir src/services");
+    let forbidden = "source".to_string() + "_" + "asof";
+    let backfill_sql = format!(
+        "fn backfill(conn: &Connection) {{\n\
+         conn.execute(\n\
+         \"UPDATE intelligence_claims /* dos7-allowed: backfill fixture repairs legacy audit data */ \\\n\
+          SET {forbidden} = ?1 \\\n\
+          WHERE id = ?2\",\n\
+         params,\n\
+         ).unwrap();\n\
+         }}\n"
+    );
+    std::fs::write(
+        tmp.path().join("src/services/source_asof_backfill.rs"),
+        backfill_sql,
+    )
+    .expect("write marked backfill fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        output.status.success(),
+        "lint must PASS on a documented migration/backfill dos7-allowed exception. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_immutability_rejects_runtime_dos7_marker_on_forbidden_set() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src/services")).expect("mkdir src/services");
+    let forbidden = "subject".to_string() + "_" + "ref";
+    let bad_sql = format!(
+        "fn bad(conn: &Connection) {{\n\
+         conn.execute(\n\
+         \"UPDATE intelligence_claims /* dos7-allowed: fake runtime exemption */ \\\n\
+          SET {forbidden} = ?1 \\\n\
+          WHERE id = ?2\",\n\
+         params,\n\
+         ).unwrap();\n\
+         }}\n"
+    );
+    std::fs::write(tmp.path().join("src/services/meetings.rs"), bad_sql)
+        .expect("write bad runtime marker fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        !output.status.success(),
+        "lint must FAIL on a runtime dos7-allowed marker hiding a forbidden SET target. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_immutability_rejects_direct_runtime_update_outside_claim_service() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src/db")).expect("mkdir src/db");
+    let bad_sql = "fn bad(conn: &Connection) {
+        conn.execute(
+            \"UPDATE intelligence_claims
+             SET claim_state = 'withdrawn'
+             WHERE id = ?1\",
+             params,
+        ).unwrap();
+    }";
+    std::fs::write(tmp.path().join("src/db/data_lifecycle.rs"), bad_sql)
+        .expect("write direct runtime update fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        !output.status.success(),
+        "lint must FAIL on direct runtime intelligence_claims UPDATE outside the claim service. \
          stdout: {}, stderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/src-tauri/tests/dos7_d4_lint_test.rs
+++ b/src-tauri/tests/dos7_d4_lint_test.rs
@@ -440,6 +440,68 @@ fn lint_immutability_catches_quoted_subject_ref_in_multi_column_set() {
 }
 
 #[test]
+fn lint_immutability_catches_single_quoted_subject_ref_set() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");
+    let forbidden = "subject".to_string() + "_" + "ref";
+    let bad_sql = format!(
+        "let _ = conn.execute(\n\
+         \"UPDATE intelligence_claims SET claim_state = ?1, '{forbidden}' = ?2 WHERE id = ?3\",\n\
+         params,\n\
+         );\n"
+    );
+    std::fs::write(tmp.path().join("src/bad_single_quoted.rs"), bad_sql)
+        .expect("write single-quoted bad fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        !output.status.success(),
+        "lint must FAIL on SQLite single-quoted forbidden identifier in SET target. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_immutability_catches_forbidden_column_in_row_value_set() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");
+    let forbidden = "source".to_string() + "_" + "asof";
+    let bad_sql = format!(
+        "fn bad(conn: &Connection) {{\n\
+         conn.execute(\n\
+         \"UPDATE intelligence_claims \\\n\
+          SET (claim_state, trust_score, {forbidden}) = \\\n\
+              (?1, ?2, ?3) \\\n\
+          WHERE id = ?4\",\n\
+         params,\n\
+         ).unwrap();\n\
+         }}\n"
+    );
+    std::fs::write(tmp.path().join("src/bad_row_value.rs"), bad_sql)
+        .expect("write row-value bad fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        !output.status.success(),
+        "lint must FAIL on row-value SET with a forbidden target. stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
 fn lint_immutability_catches_forbidden_column_beyond_grep_window() {
     let tmp = tempfile::tempdir().expect("tempdir");
     std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");

--- a/src-tauri/tests/dos7_d4_lint_test.rs
+++ b/src-tauri/tests/dos7_d4_lint_test.rs
@@ -439,6 +439,80 @@ fn lint_immutability_catches_quoted_subject_ref_in_multi_column_set() {
     );
 }
 
+#[test]
+fn lint_immutability_catches_forbidden_column_beyond_grep_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");
+    let bad_sql = "fn bad(conn: &Connection) {
+        conn.execute(
+            \"UPDATE intelligence_claims
+             SET claim_state = ?1,
+                 surfacing_state = ?2,
+                 demotion_reason = ?3,
+                 reactivated_at = ?4,
+                 retraction_reason = ?5,
+                 expires_at = ?6,
+                 superseded_by = ?7,
+                 trust_score = ?8,
+                 created_at = ?9
+             WHERE id = ?10\",
+             params,
+        ).unwrap();
+    }";
+    std::fs::write(tmp.path().join("src/bad_long_update.rs"), bad_sql)
+        .expect("write long bad fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        !output.status.success(),
+        "lint must FAIL on forbidden SET target beyond a bounded grep window. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lint_immutability_allows_allowlisted_multiline_columns() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir src");
+    let good_sql = "fn good(conn: &Connection) {
+        conn.execute(
+            \"UPDATE intelligence_claims
+             SET claim_state = ?1,
+                 surfacing_state = ?2,
+                 trust_score = ?3,
+                 trust_computed_at = ?4,
+                 trust_version = ?5,
+                 verification_state = ?6,
+                 verification_reason = ?7,
+                 needs_user_decision_at = ?8
+             WHERE text = ?9 AND claim_type = ?10\",
+             params,
+        ).unwrap();
+    }";
+    std::fs::write(tmp.path().join("src/good_update.rs"), good_sql).expect("write good fixture");
+
+    let lint_path = repo_root().join("src-tauri/scripts/check_claim_immutability_allowlist.sh");
+    let output = std::process::Command::new("bash")
+        .arg(&lint_path)
+        .current_dir(tmp.path())
+        .output()
+        .expect("run lint");
+    assert!(
+        output.status.success(),
+        "lint must PASS on allowlisted mutable columns even with immutable WHERE filters. \
+         stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 /// L2 cycle-20 fix #2: prove the legacy dismissal pairing lint
 /// catches `UPDATE briefing_callouts SET other = ?, dismissed_at = ?`
 /// when `dismissed_at` is not the first SET target. Same blind


### PR DESCRIPTION
## Summary

W0-F per v1.4.1 wave plan. Replaces the brittle grep-based DOS-7 amendment D immutability lint with a parser-backed scanner integrated into the `services/claims.rs` mutation gate.

## Changes

- Parser-backed claim immutability scanner replacing grep
- Shared allowlist in `services/claims.rs`
- Integrated allowlist check into update execution paths
- Allowed/disallowed parser + lint regression tests
- Mechanical clippy fixes for `-D warnings`

## Test plan

- ✅ `cargo fmt --check`
- ✅ `bash src-tauri/scripts/check_claim_immutability_allowlist.sh`
- ✅ `cargo clippy -- -D warnings`
- ✅ `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)