### PR TITLE
DOS-379 W0-D: fail-closed on unknown stakeholder entity_id

### DIFF
--- a/src-tauri/src/calendar_merge.rs
+++ b/src-tauri/src/calendar_merge.rs
@@ -110,7 +110,7 @@ pub fn merge_meetings(briefing: Vec<Meeting>, live: &[CalendarEvent], tz: &Tz) -
     }
 
     // Sort by time string (lexicographic on "H:MM AM/PM" works for display order)
-    result.sort_by_key(|a| sort_time_key(&a.time));
+    result.sort_by_key(|item| sort_time_key(&item.time));
 
     result
 }

--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -730,6 +730,20 @@ mod tests {
     fn purge_source_removes_tagged_rows_and_preserves_user_rows() {
         let db = test_db();
         seed_person(&db, "p1", None);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO accounts (id, name, updated_at)
+                 VALUES ('a1', 'Glean Account', '2026-05-03T12:00:00+00:00')",
+                [],
+            )
+            .expect("seed glean account");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO accounts (id, name, updated_at)
+                 VALUES ('a2', 'User Account', '2026-05-03T12:00:00+00:00')",
+                [],
+            )
+            .expect("seed user account");
 
         db.link_person_to_account_with_source("a1", "p1", "champion", "glean")
             .expect("seed glean stakeholder");

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -2180,13 +2180,6 @@ mod tests {
                 updated_at TEXT NOT NULL,
                 archived INTEGER DEFAULT 0
             );
-             CREATE TABLE entities (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                entity_type TEXT NOT NULL DEFAULT 'account',
-                tracker_path TEXT,
-                updated_at TEXT NOT NULL
-             );
              CREATE TABLE meetings_history (
                 id TEXT PRIMARY KEY,
                 title TEXT NOT NULL,

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -735,7 +735,7 @@ const MIGRATIONS: &[Migration] = &[
         version: 144,
         apply: v144_audit_action_token::migrate_v144_audit_action_token,
     },
-    // DOS-379: fail-closed entity_members links by enforcing
+    // fail-closed entity_members links by enforcing
     // entity_members.entity_id -> entities(id).
     Migration::Sql {
         version: 145,

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -735,8 +735,8 @@ const MIGRATIONS: &[Migration] = &[
         version: 144,
         apply: v144_audit_action_token::migrate_v144_audit_action_token,
     },
-    // entity_members.entity_id FK rebuild against entities; preserves orphan
-    // memberships in entity_members_migration_145_orphans for manual repair.
+    // DOS-379: fail-closed entity_members links by enforcing
+    // entity_members.entity_id -> entities(id).
     Migration::Sql {
         version: 145,
         sql: include_str!("migrations/145_dos_379_entity_members_entity_fk.sql"),
@@ -2180,6 +2180,13 @@ mod tests {
                 updated_at TEXT NOT NULL,
                 archived INTEGER DEFAULT 0
             );
+             CREATE TABLE entities (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                entity_type TEXT NOT NULL DEFAULT 'account',
+                tracker_path TEXT,
+                updated_at TEXT NOT NULL
+             );
              CREATE TABLE meetings_history (
                 id TEXT PRIMARY KEY,
                 title TEXT NOT NULL,

--- a/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
+++ b/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
@@ -4,17 +4,13 @@
 PRAGMA foreign_keys = OFF;
 BEGIN;
 
--- Legacy project rows may predate the project -> entities mirror. Restore the
--- mirror before the FK rebuild so valid project memberships are retained.
+-- Legacy project rows may predate the project -> entities mirror. Restore every
+-- missing mirror before the FK rebuild so project entities remain canonical
+-- even when the legacy project currently has no members.
 INSERT OR IGNORE INTO entities (id, name, entity_type, tracker_path, updated_at)
 SELECT p.id, p.name, 'project', p.tracker_path, COALESCE(p.updated_at, datetime('now'))
 FROM projects p
-WHERE EXISTS (
-    SELECT 1
-    FROM entity_members em
-    WHERE em.entity_id = p.id
-)
-  AND NOT EXISTS (
+WHERE NOT EXISTS (
     SELECT 1
     FROM entities e
     WHERE e.id = p.id

--- a/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
+++ b/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
@@ -4,6 +4,53 @@
 PRAGMA foreign_keys = OFF;
 BEGIN;
 
+-- Legacy project rows may predate the project -> entities mirror. Restore the
+-- mirror before the FK rebuild so valid project memberships are retained.
+INSERT OR IGNORE INTO entities (id, name, entity_type, tracker_path, updated_at)
+SELECT p.id, p.name, 'project', p.tracker_path, COALESCE(p.updated_at, datetime('now'))
+FROM projects p
+WHERE EXISTS (
+    SELECT 1
+    FROM entity_members em
+    WHERE em.entity_id = p.id
+)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM entities e
+    WHERE e.id = p.id
+);
+
+-- Preserve any membership that still cannot satisfy the FK after the project
+-- mirror backfill. These rows cannot stay in entity_members once the FK is
+-- active, but they must remain queryable for manual repair instead of being
+-- silently discarded during upgrade.
+CREATE TABLE IF NOT EXISTS entity_members_migration_145_orphans (
+    entity_id TEXT NOT NULL,
+    person_id TEXT NOT NULL,
+    relationship_type TEXT DEFAULT 'associated',
+    reason TEXT NOT NULL,
+    surfaced_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (entity_id, person_id)
+);
+
+INSERT OR IGNORE INTO entity_members_migration_145_orphans (
+    entity_id,
+    person_id,
+    relationship_type,
+    reason
+)
+SELECT
+    em.entity_id,
+    em.person_id,
+    em.relationship_type,
+    'missing_entity_after_project_mirror_backfill'
+FROM entity_members em
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM entities e
+    WHERE e.id = em.entity_id
+);
+
 CREATE TABLE entity_members_new (
     entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
     person_id TEXT NOT NULL,
@@ -24,6 +71,8 @@ DROP TABLE entity_members;
 ALTER TABLE entity_members_new RENAME TO entity_members;
 
 CREATE INDEX IF NOT EXISTS idx_entity_members_person ON entity_members(person_id);
+CREATE INDEX IF NOT EXISTS idx_entity_members_migration_145_orphans_person
+ON entity_members_migration_145_orphans(person_id);
 
 COMMIT;
 PRAGMA foreign_keys = ON;

--- a/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
+++ b/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
@@ -1,51 +1,8 @@
--- entity_members.entity_id must reference a real profile-agnostic
+-- DOS-379: entity_members.entity_id must reference a real profile-agnostic
 -- entity. Rebuild is required because SQLite cannot add an FK in place.
 
 PRAGMA foreign_keys = OFF;
 BEGIN;
-
--- Legacy project rows may predate the project -> entities mirror. Restore every
--- missing mirror before the FK rebuild so project entities remain canonical
--- even when the legacy project currently has no members.
-INSERT OR IGNORE INTO entities (id, name, entity_type, tracker_path, updated_at)
-SELECT p.id, p.name, 'project', p.tracker_path, COALESCE(p.updated_at, datetime('now'))
-FROM projects p
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM entities e
-    WHERE e.id = p.id
-);
-
--- Preserve any membership that still cannot satisfy the FK after the project
--- mirror backfill. These rows cannot stay in entity_members once the FK is
--- active, but they must remain queryable for manual repair instead of being
--- silently discarded during upgrade.
-CREATE TABLE IF NOT EXISTS entity_members_migration_145_orphans (
-    entity_id TEXT NOT NULL,
-    person_id TEXT NOT NULL,
-    relationship_type TEXT DEFAULT 'associated',
-    reason TEXT NOT NULL,
-    surfaced_at TEXT NOT NULL DEFAULT (datetime('now')),
-    PRIMARY KEY (entity_id, person_id)
-);
-
-INSERT OR IGNORE INTO entity_members_migration_145_orphans (
-    entity_id,
-    person_id,
-    relationship_type,
-    reason
-)
-SELECT
-    em.entity_id,
-    em.person_id,
-    em.relationship_type,
-    'missing_entity_after_project_mirror_backfill'
-FROM entity_members em
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM entities e
-    WHERE e.id = em.entity_id
-);
 
 CREATE TABLE entity_members_new (
     entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
@@ -67,8 +24,6 @@ DROP TABLE entity_members;
 ALTER TABLE entity_members_new RENAME TO entity_members;
 
 CREATE INDEX IF NOT EXISTS idx_entity_members_person ON entity_members(person_id);
-CREATE INDEX IF NOT EXISTS idx_entity_members_migration_145_orphans_person
-ON entity_members_migration_145_orphans(person_id);
 
 COMMIT;
 PRAGMA foreign_keys = ON;

--- a/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
+++ b/src-tauri/src/migrations/145_dos_379_entity_members_entity_fk.sql
@@ -1,4 +1,4 @@
--- DOS-379: entity_members.entity_id must reference a real profile-agnostic
+-- entity_members.entity_id must reference a real profile-agnostic
 -- entity. Rebuild is required because SQLite cannot add an FK in place.
 
 PRAGMA foreign_keys = OFF;

--- a/src-tauri/src/services/derived_state.rs
+++ b/src-tauri/src/services/derived_state.rs
@@ -674,6 +674,8 @@ pub(crate) fn rebuild_stakeholder_insights_cache_for_entity_inner(
     entity_id: &str,
     entity_type: &str,
 ) -> Result<(), ProjectionErrorClass> {
+    validate_stakeholder_entity_pair(tx, entity_id, entity_type)?;
+
     let person_ids = stakeholder_person_ids_for_entity(tx, entity_id)?;
     let mut claims = Vec::new();
     for person_id in person_ids {
@@ -729,6 +731,43 @@ pub(crate) fn rebuild_stakeholder_insights_cache_for_entity_inner(
         .map_err(classify_sql_error)?;
 
     Ok(())
+}
+
+fn validate_stakeholder_entity_pair(
+    tx: &ActionDb,
+    entity_id: &str,
+    entity_type: &str,
+) -> Result<(), ProjectionErrorClass> {
+    if entity_type == "account" {
+        let is_account: bool = tx
+            .conn_ref()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM accounts WHERE id = ?1)",
+                rusqlite::params![entity_id],
+                |row| row.get(0),
+            )
+            .map_err(classify_sql_error)?;
+        return if is_account {
+            Ok(())
+        } else {
+            Err(ProjectionErrorClass::ValidationError)
+        };
+    }
+
+    let actual_type = tx
+        .conn_ref()
+        .query_row(
+            "SELECT entity_type FROM entities WHERE id = ?1",
+            rusqlite::params![entity_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(classify_sql_error)?;
+
+    match actual_type.as_deref() {
+        Some(actual_type) if actual_type == entity_type => Ok(()),
+        _ => Err(ProjectionErrorClass::ValidationError),
+    }
 }
 
 fn stakeholder_person_ids_for_entity(
@@ -1843,6 +1882,47 @@ mod tests {
         .unwrap();
 
         assert_cache_contains(&db, account_id, "confirmed engagement visible");
+    }
+
+    #[test]
+    fn stakeholder_cache_rebuild_rejects_unknown_entity_id() {
+        let db = test_db();
+        let (clock, rng, ext) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &ext);
+
+        let err = rebuild_stakeholder_insights_cache_for_entity_inner(
+            &ctx,
+            &db,
+            "missing-entity",
+            "project",
+        )
+        .expect_err("unknown entity_id should be rejected");
+
+        assert_eq!(err, ProjectionErrorClass::ValidationError);
+    }
+
+    #[test]
+    fn stakeholder_cache_rebuild_rejects_entity_type_mismatch() {
+        let db = test_db();
+        db.conn_ref()
+            .execute(
+                "INSERT INTO entities (id, name, entity_type, updated_at)
+                 VALUES ('project-type-mismatch', 'Project Type Mismatch', 'project', ?1)",
+                params![TS],
+            )
+            .unwrap();
+        let (clock, rng, ext) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &ext);
+
+        let err = rebuild_stakeholder_insights_cache_for_entity_inner(
+            &ctx,
+            &db,
+            "project-type-mismatch",
+            "account",
+        )
+        .expect_err("entity_id/entity_type mismatch should be rejected");
+
+        assert_eq!(err, ProjectionErrorClass::ValidationError);
     }
 
     #[test]

--- a/src-tauri/src/services/people.rs
+++ b/src-tauri/src/services/people.rs
@@ -241,7 +241,9 @@ fn stakeholder_entity_type_for_id(db: &ActionDb, entity_id: &str) -> Result<Stri
         )
         .optional()
         .map_err(|e| format!("lookup stakeholder entity type: {e}"))
-        .map(|entity_type| entity_type.unwrap_or_else(|| "project".to_string()))
+        .and_then(|entity_type| {
+            entity_type.ok_or_else(|| format!("unknown stakeholder entity_id: {entity_id}"))
+        })
 }
 
 /// Get full detail for a person (person + signals + entities + recent meetings).
@@ -577,6 +579,22 @@ pub fn create_person(
     }
 
     Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+
+    #[test]
+    fn stakeholder_entity_type_for_id_rejects_unknown_entity_id() {
+        let db = test_db();
+
+        let err = stakeholder_entity_type_for_id(&db, "missing-entity")
+            .expect_err("unknown entity_id should be rejected");
+
+        assert!(err.contains("unknown stakeholder entity_id"));
+    }
 }
 
 /// Archive or unarchive a person with signal emission.

--- a/src-tauri/tests/dos379_entity_members_fk_test.rs
+++ b/src-tauri/tests/dos379_entity_members_fk_test.rs
@@ -120,6 +120,56 @@ fn migration_145_preserves_project_memberships_and_surfaces_unrecoverable_orphan
     );
 }
 
+#[test]
+fn migration_145_mirrors_zero_member_legacy_projects() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    setup_v144_migration_state(&conn);
+
+    conn.execute(
+        "INSERT INTO projects (id, name, tracker_path, updated_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "project-zero-members",
+            "Legacy Zero Member Project",
+            "/projects/zero-members",
+            "2026-05-08T13:00:00Z"
+        ],
+    )
+    .expect("seed zero-member project row without entity mirror");
+
+    let applied = run_migrations(&conn).expect("apply migration 145");
+    assert_eq!(applied, 1);
+
+    let mirrored_entity: (String, String, Option<String>) = conn
+        .query_row(
+            "SELECT name, entity_type, tracker_path
+             FROM entities
+             WHERE id = ?1",
+            params!["project-zero-members"],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("zero-member legacy project should be mirrored into entities");
+    assert_eq!(
+        mirrored_entity,
+        (
+            "Legacy Zero Member Project".to_string(),
+            "project".to_string(),
+            Some("/projects/zero-members".to_string())
+        )
+    );
+
+    let member_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM entity_members
+             WHERE entity_id = ?1",
+            params!["project-zero-members"],
+            |row| row.get(0),
+        )
+        .expect("count zero-member project memberships");
+    assert_eq!(member_count, 0);
+}
+
 fn setup_v144_migration_state(conn: &Connection) {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS schema_version (

--- a/src-tauri/tests/dos379_entity_members_fk_test.rs
+++ b/src-tauri/tests/dos379_entity_members_fk_test.rs
@@ -29,3 +29,153 @@ fn migration_145_enforces_entity_members_entity_id_fk() {
     )
     .expect_err("orphan entity_members.entity_id should be rejected");
 }
+
+#[test]
+fn migration_145_preserves_project_memberships_and_surfaces_unrecoverable_orphans() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    setup_v144_migration_state(&conn);
+
+    conn.execute(
+        "INSERT INTO projects (id, name, tracker_path, updated_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "project-without-entity",
+            "Legacy Project",
+            "/projects/legacy",
+            "2026-05-08T12:00:00Z"
+        ],
+    )
+    .expect("seed project row without entity mirror");
+    conn.execute(
+        "INSERT INTO entity_members (entity_id, person_id, relationship_type)
+         VALUES (?1, ?2, ?3)",
+        params!["project-without-entity", "person-project", "member"],
+    )
+    .expect("seed recoverable project membership");
+    conn.execute(
+        "INSERT INTO entity_members (entity_id, person_id, relationship_type)
+         VALUES (?1, ?2, ?3)",
+        params!["missing-entity", "person-orphan", "reviewer"],
+    )
+    .expect("seed unrecoverable membership");
+
+    let applied = run_migrations(&conn).expect("apply migration 145");
+    assert_eq!(applied, 1);
+
+    let recovered_relationship: String = conn
+        .query_row(
+            "SELECT relationship_type
+             FROM entity_members
+             WHERE entity_id = ?1 AND person_id = ?2",
+            params!["project-without-entity", "person-project"],
+            |row| row.get(0),
+        )
+        .expect("project membership should survive migration");
+    assert_eq!(recovered_relationship, "member");
+
+    let recovered_entity: (String, String, Option<String>) = conn
+        .query_row(
+            "SELECT name, entity_type, tracker_path
+             FROM entities
+             WHERE id = ?1",
+            params!["project-without-entity"],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("missing project entity mirror should be backfilled");
+    assert_eq!(
+        recovered_entity,
+        (
+            "Legacy Project".to_string(),
+            "project".to_string(),
+            Some("/projects/legacy".to_string())
+        )
+    );
+
+    let active_orphan_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM entity_members
+             WHERE entity_id = ?1 AND person_id = ?2",
+            params!["missing-entity", "person-orphan"],
+            |row| row.get(0),
+        )
+        .expect("count active orphan rows");
+    assert_eq!(active_orphan_count, 0);
+
+    let surfaced_orphan: (String, String) = conn
+        .query_row(
+            "SELECT relationship_type, reason
+             FROM entity_members_migration_145_orphans
+             WHERE entity_id = ?1 AND person_id = ?2",
+            params!["missing-entity", "person-orphan"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("unrecoverable membership should be surfaced for triage");
+    assert_eq!(
+        surfaced_orphan,
+        (
+            "reviewer".to_string(),
+            "missing_entity_after_project_mirror_backfill".to_string()
+        )
+    );
+}
+
+fn setup_v144_migration_state(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO schema_version (version) VALUES (144);
+
+        CREATE TABLE IF NOT EXISTS meetings (id TEXT PRIMARY KEY);
+        CREATE TABLE IF NOT EXISTS meeting_prep (id TEXT PRIMARY KEY);
+        CREATE TABLE IF NOT EXISTS meeting_transcripts (id TEXT PRIMARY KEY);
+        CREATE TABLE IF NOT EXISTS account_stakeholders (
+            id TEXT PRIMARY KEY,
+            data_source TEXT
+        );
+        CREATE TABLE IF NOT EXISTS entity_assessment (
+            id TEXT PRIMARY KEY,
+            health_json TEXT,
+            org_health_json TEXT,
+            dimensions_json TEXT,
+            success_plan_signals_json TEXT
+        );
+        CREATE TABLE IF NOT EXISTS entity_quality (
+            id TEXT PRIMARY KEY,
+            health_score REAL,
+            health_trend TEXT,
+            coherence_score REAL,
+            coherence_flagged INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS person_relationships (
+            id TEXT PRIMARY KEY,
+            rationale TEXT
+        );
+        CREATE TABLE IF NOT EXISTS email_signals (
+            id TEXT PRIMARY KEY,
+            source TEXT
+        );
+        CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS entities (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'account',
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS entity_members (
+            entity_id TEXT NOT NULL,
+            person_id TEXT NOT NULL,
+            relationship_type TEXT DEFAULT 'associated',
+            PRIMARY KEY (entity_id, person_id)
+        );",
+    )
+    .expect("create v144 migration fixture state");
+}

--- a/src-tauri/tests/dos379_entity_members_fk_test.rs
+++ b/src-tauri/tests/dos379_entity_members_fk_test.rs
@@ -1,0 +1,31 @@
+use dailyos_lib::migration_test_api::run_migrations;
+use rusqlite::{params, Connection};
+
+#[test]
+fn migration_145_enforces_entity_members_entity_id_fk() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    run_migrations(&conn).expect("apply migrations");
+
+    let fk_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM pragma_foreign_key_list('entity_members')
+             WHERE \"table\" = 'entities'
+               AND \"from\" = 'entity_id'
+               AND \"to\" = 'id'
+               AND on_delete = 'CASCADE'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inspect entity_members foreign keys");
+    assert_eq!(fk_count, 1);
+
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
+        .expect("enable FK enforcement");
+    conn.execute(
+        "INSERT INTO entity_members (entity_id, person_id, relationship_type)
+         VALUES (?1, ?2, 'member')",
+        params!["missing-entity", "person-1"],
+    )
+    .expect_err("orphan entity_members.entity_id should be rejected");
+}

--- a/src-tauri/tests/dos412_migration_144_idempotency_test.rs
+++ b/src-tauri/tests/dos412_migration_144_idempotency_test.rs
@@ -195,9 +195,18 @@ fn setup_migration_runner_state(conn: &Connection) {
             id TEXT PRIMARY KEY,
             source TEXT
         );
+        CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS entities (
             id TEXT PRIMARY KEY,
-            entity_type TEXT NOT NULL DEFAULT 'project'
+            name TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'account',
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
         );
         CREATE TABLE IF NOT EXISTS entity_members (
             entity_id TEXT NOT NULL,

--- a/src-tauri/tests/dos412_migration_144_idempotency_test.rs
+++ b/src-tauri/tests/dos412_migration_144_idempotency_test.rs
@@ -28,7 +28,7 @@ fn migration_144_rebuilds_prior_audit_schemas_to_canonical_shape() {
         let conn = Connection::open_in_memory().expect("open in-memory database");
         setup_starting_state(&conn, state);
 
-        apply_pending_v144(&conn, state.label());
+        apply_pending_from_v143(&conn, state.label());
         assert_canonical_reveal_audit_schema(&conn, state.label());
         assert_legacy_data_preserved(&conn, state.label());
 
@@ -57,7 +57,7 @@ fn migration_144_repairs_partial_prior_action_column_without_index() {
     .expect("create partial prior action column state");
     setup_migration_runner_state(&conn);
 
-    apply_pending_v144(&conn, "partial_action_column");
+    apply_pending_from_v143(&conn, "partial_action_column");
 
     assert_canonical_reveal_audit_schema(&conn, "partial_action_column");
     assert_legacy_data_preserved(&conn, "partial_action_column");
@@ -77,7 +77,7 @@ fn retry_after_partial_prior_state_preserves_tokens() {
     .expect("create partial prior action token state");
     setup_migration_runner_state(&conn);
 
-    apply_pending_v144(&conn, "partial_prior_token");
+    apply_pending_from_v143(&conn, "partial_prior_token");
 
     assert_canonical_reveal_audit_schema(&conn, "partial_prior_token");
     assert_eq!(reveal_audit_row_count(&conn), 1);
@@ -103,13 +103,13 @@ fn idempotency_when_already_canonical() {
     let before_columns = reveal_audit_columns(&conn);
     let before_index_sql = reveal_action_index_sql(&conn);
 
-    apply_pending_v144(&conn, "already_canonical");
+    apply_pending_from_v143(&conn, "already_canonical");
 
     assert_eq!(reveal_audit_columns(&conn), before_columns);
     assert_eq!(reveal_action_index_sql(&conn), before_index_sql);
     assert_eq!(reveal_audit_row_count(&conn), 1);
     assert_eq!(single_reveal_action_id(&conn), "abc-123");
-    assert!(schema_version(&conn) >= 144);
+    assert_eq!(schema_version(&conn), 145);
 }
 
 fn setup_starting_state(conn: &Connection, state: StartingState) {
@@ -197,16 +197,7 @@ fn setup_migration_runner_state(conn: &Connection) {
         );
         CREATE TABLE IF NOT EXISTS entities (
             id TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            entity_type TEXT NOT NULL DEFAULT 'account',
-            tracker_path TEXT,
-            updated_at TEXT NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS projects (
-            id TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            tracker_path TEXT,
-            updated_at TEXT
+            entity_type TEXT NOT NULL DEFAULT 'project'
         );
         CREATE TABLE IF NOT EXISTS entity_members (
             entity_id TEXT NOT NULL,
@@ -218,17 +209,17 @@ fn setup_migration_runner_state(conn: &Connection) {
     .expect("create migration runner fixture state");
 }
 
-fn apply_pending_v144(conn: &Connection, label: &str) {
+fn apply_pending_from_v143(conn: &Connection, label: &str) {
     let applied = run_migrations(conn)
         .unwrap_or_else(|error| panic!("{label}: migration runner failed: {error}"));
-    assert!(
-        applied >= 1,
-        "{label}: at least v144 should have applied (got {applied})"
+    assert_eq!(
+        applied, 2,
+        "{label}: v144 and v145 should be the pending migrations"
     );
-    assert!(
-        schema_version(conn) >= 144,
-        "{label}: schema version should be at v144 or later (got {})",
-        schema_version(conn)
+    assert_eq!(
+        schema_version(conn),
+        145,
+        "{label}: latest schema version should be recorded"
     );
 }
 

--- a/src-tauri/tests/dos412_render_policy_test.rs
+++ b/src-tauri/tests/dos412_render_policy_test.rs
@@ -159,7 +159,7 @@ fn sensitivity_reveal_audit_migration_repairs_current_audit_bucket_v143() {
     ))
     .expect("idempotency migration applies");
     setup_migration_runner_state(&conn);
-    run_pending_v144(&conn);
+    run_pending_from_v143(&conn);
 
     let columns = reveal_audit_columns(&conn);
 
@@ -189,7 +189,7 @@ fn sensitivity_reveal_audit_migration_repairs_legacy_reveal_session_v143() {
     )
     .expect("legacy reveal session idempotency migration applies");
     setup_migration_runner_state(&conn);
-    run_pending_v144(&conn);
+    run_pending_from_v143(&conn);
 
     let columns = reveal_audit_columns(&conn);
 
@@ -242,16 +242,7 @@ fn setup_migration_runner_state(conn: &Connection) {
         );
         CREATE TABLE IF NOT EXISTS entities (
             id TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            entity_type TEXT NOT NULL DEFAULT 'account',
-            tracker_path TEXT,
-            updated_at TEXT NOT NULL
-        );
-        CREATE TABLE IF NOT EXISTS projects (
-            id TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            tracker_path TEXT,
-            updated_at TEXT
+            entity_type TEXT NOT NULL DEFAULT 'project'
         );
         CREATE TABLE IF NOT EXISTS entity_members (
             entity_id TEXT NOT NULL,
@@ -263,9 +254,9 @@ fn setup_migration_runner_state(conn: &Connection) {
     .expect("create migration runner fixture state");
 }
 
-fn run_pending_v144(conn: &Connection) {
+fn run_pending_from_v143(conn: &Connection) {
     let applied = run_migrations(conn).expect("action token migration applies");
-    assert!(applied >= 1);
+    assert_eq!(applied, 2);
 }
 
 fn reveal_audit_columns(conn: &Connection) -> Vec<String> {

--- a/src-tauri/tests/dos412_render_policy_test.rs
+++ b/src-tauri/tests/dos412_render_policy_test.rs
@@ -240,9 +240,18 @@ fn setup_migration_runner_state(conn: &Connection) {
             id TEXT PRIMARY KEY,
             source TEXT
         );
+        CREATE TABLE IF NOT EXISTS projects (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
+        );
         CREATE TABLE IF NOT EXISTS entities (
             id TEXT PRIMARY KEY,
-            entity_type TEXT NOT NULL DEFAULT 'project'
+            name TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'account',
+            tracker_path TEXT,
+            updated_at TEXT NOT NULL
         );
         CREATE TABLE IF NOT EXISTS entity_members (
             entity_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary

W0-D per v1.4.1 wave plan. Closes the silent-fallback path on unknown `entity_id` and adds a schema FK to enforce id-validity at write time.

## Changes

- `services/people.rs::stakeholder_entity_type_for_id` rejects unknown `entity_id` instead of falling back to `project`
- New migration **v145** rebuilds `entity_members` with FK `entity_id -> entities(id) ON DELETE CASCADE`
- `services/derived_state.rs::rebuild_stakeholder_insights_cache_for_entity` pair-validates `entity_id` against `entity_type`
- DOS-379 regression tests added
- Migration v145 fixtures updated

## Test plan

- ✅ `cargo fmt -- --check`
- ✅ `cargo clippy -- -D warnings`
- ✅ `cargo test` (full library + integration suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)