### PR TITLE
ci: split test workflow into policy / rust / frontend jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Install ripgrep (rg)
+        # Required by scripts that some cargo tests shell out to
+        # (e.g. tests/dos412_render_policy_lint_test.rs invokes
+        # scripts/check_render_policy_coverage.sh which uses `rg`).
+        # macOS runners don't ship rg by default; Ubuntu does.
+        run: brew install ripgrep
+
       - name: Cache Rust dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -13,41 +13,12 @@ on:
       - trunk
 
 jobs:
-  test:
-    runs-on: macos-latest
+  policy:
+    name: CI / policy
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Install ripgrep (rg)
-        run: brew install ripgrep
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: macos-cargo-v2-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            macos-cargo-v2-
-
-      - name: Install frontend dependencies
-        run: pnpm install
 
       - name: Fail on committed OAuth secrets
         run: |
@@ -55,14 +26,6 @@ jobs:
             echo "Committed Google OAuth secret pattern detected."
             exit 1
           fi
-
-      - name: Create sidecar stub for Tauri externalBin validation
-        run: |
-          mkdir -p src-tauri/binaries
-          TARGET=$(rustc -vV | awk '/^host:/ { print $2 }')
-          touch "src-tauri/binaries/dailyos-mcp-$TARGET"
-          # Force Cargo to re-run build.rs so it sees the stub binary
-          touch src-tauri/build.rs
 
       - name: Enforce service-layer mutation boundary
         run: ./scripts/check_service_layer_boundary.sh
@@ -86,6 +49,48 @@ jobs:
         continue-on-error: true
         run: src-tauri/scripts/check_dos301_legacy_projection_writers.sh
 
+  rust:
+    name: CI / rust
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: macos-cargo-v2-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            macos-cargo-v2-
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Create sidecar stub for Tauri externalBin validation
+        run: |
+          mkdir -p src-tauri/binaries
+          TARGET=$(rustc -vV | awk '/^host:/ { print $2 }')
+          touch "src-tauri/binaries/dailyos-mcp-$TARGET"
+          # Force Cargo to re-run build.rs so it sees the stub binary
+          touch src-tauri/build.rs
+
       - name: Run Rust clippy (production targets)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-features --lib --bins -- -D warnings
 
@@ -108,6 +113,25 @@ jobs:
 
       - name: Run Rust dependency audit (high+)
         run: cargo audit --file audit.toml
+
+  frontend:
+    name: CI / frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install frontend dependencies
+        run: pnpm install
 
       - name: Run frontend tests
         run: pnpm test


### PR DESCRIPTION
## Summary

Renames the workflow from \"Test\" to \"CI\" and splits the single overloaded job into three intent-named jobs.

| Job | Runner | Contents |
|---|---|---|
| `CI / policy` | `ubuntu-latest` | secret scan, service-layer boundary, no-let-underscore, write-fence, ability surface drift, durable source comments, legacy projection writer tracker |
| `CI / rust` | `macos-latest` | clippy, hermetic harness, cargo test, cargo audit |
| `CI / frontend` | `ubuntu-latest` | pnpm test + pnpm audit |

**No step logic changes** — every existing step is preserved, just regrouped. The `brew install ripgrep` step is dropped because Ubuntu's runner ships `rg` preinstalled.

## Why

- **Diagnosability**: PRs surface three independent statuses instead of one opaque `test` check. When CI fails, the failing job name names the actual concern (\"policy\" vs \"frontend\" vs \"rust\") instead of forcing a click into logs.
- **Cost**: policy and frontend move from macOS (~$0.08/min) to Ubuntu (~$0.008/min) — ~10x cut on those workloads.
- **Risk-managed**: rust stays on macOS for now. trybuild stderr files and Tauri-bound tests can be platform-sensitive, and verifying Ubuntu compatibility is its own task. Not taken on here.

## Test plan

- [ ] All three jobs run on this PR
- [ ] `CI / policy` passes (it's running the same scripts as before, just on Ubuntu)
- [ ] `CI / rust` passes (untouched logic, still on macOS)
- [ ] `CI / frontend` passes (untouched logic, just relocated)
- [ ] Verify on a PR that intentionally violates one policy script (e.g., a comment with DOS-### in it) — that PR should fail \`CI / policy\` only, with rust and frontend still able to run/pass independently

## Branch protection follow-up

Required-check name on dev is currently \`test\`. After this merges, branch protection needs updating to require \`CI / policy\`, \`CI / rust\`, \`CI / frontend\` instead. Otherwise:
- New PRs will report three checks but none will be required → no merge gate
- OR the \`test\` required check will block all PRs (no workflow posts that name anymore)

Coordinate the protection update with this merge — there's a brief window either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)