### PR TITLE
ci: rust 1.95 unnecessary_sort_by in bridges/types.rs

### DIFF
--- a/src-tauri/src/bridges/types.rs
+++ b/src-tauri/src/bridges/types.rs
@@ -411,7 +411,7 @@ fn write_canonical_json(value: &serde_json::Value, out: &mut Vec<u8>) {
         serde_json::Value::Object(object) => {
             out.push(b'{');
             let mut entries = object.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(left, _)| *left);
             for (index, (key, item)) in entries.into_iter().enumerate() {
                 if index > 0 {
                     out.push(b',');


### PR DESCRIPTION
## Summary

One-line fix-forward. The other session's commit \`637f5615\` cherry-picked the W0-G branch's clippy fixes for the 9 \`unnecessary_sort_by\` / \`collapsible_match\` sites Rust 1.95.0 surfaced. One site at \`src/bridges/types.rs:414\` was missed — it wasn't on W0-G's branch.

\`\`\`
- entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+ entries.sort_by_key(|(left, _)| *left);
\`\`\`

## Why

PR #234 (CI workflow split) is currently red on \`CI / rust\` because of this single remaining site. Confirmed locally: \`cargo clippy --workspace --all-features --lib --bins -- -D warnings\` passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)