### PR TITLE
DOS-264 W2-F: contract-first operations array

### DIFF
--- a/.docs/architecture/OPERATIONS.md
+++ b/.docs/architecture/OPERATIONS.md
@@ -1,0 +1,40 @@
+# Operations Contract
+
+DailyOS operations are the kebab-case contract view over the ADR-0102 abilities
+runtime. The source of truth is `src-tauri/src/operations/mod.rs::OPERATIONS`.
+It does not replace `AbilityRegistry`; operation executors dispatch into the
+existing ability bridge or into explicitly local internal maintenance code.
+
+## Phase 1 Shape
+
+Each `OperationDef` declares:
+
+- `name`: stable kebab-case operation name.
+- `description`: human-readable tool description.
+- `remote`: explicit exposure flag. `true` operations may appear in MCP-style
+  remote tool discovery; `false` operations are local-only.
+- `category`: `Read`, `Transform`, `Publish`, or `Maintenance`.
+- `input_schema` and `output_schema`: checked-in JSON schemas included at
+  compile time.
+- `requires_scope`: optional external scope label.
+- `executor`: typed `OperationExecutor`.
+
+Phase 1 registers two proofs:
+
+- `get-entity-context`: `Read`, `remote=true`, dispatches to the existing
+  `get_entity_context` ability through `TauriAbilityBridge`.
+- `internal-debug-dump`: `Maintenance`, `remote=false`, returns local diagnostic
+  counts and is intentionally omitted from `mcp_tool_list()`.
+
+## Enforcement
+
+The `operation_def!` macro requires an explicit `remote` field and verifies the
+executor has the `OperationExecutor` signature. `build.rs` checks the operation
+source on every build: names must be kebab-case, schema files referenced through
+`include_str!` must exist, executor names must match their category prefix, and
+the Tauri surface must expose only `operations::invoke_operation` for operation
+dispatch.
+
+MCP discovery uses `mcp_tool_list()`, which filters to `remote=true` operations.
+The round-trip test asserts that every advertised tool maps back to an operation
+and that `remote=false` operations are excluded.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 
 fn main() {
     emit_build_git_sha();
+    validate_operations_contract();
     tauri_build::build()
 }
 
@@ -100,4 +101,198 @@ fn git_dir(manifest_dir: &Path) -> Option<PathBuf> {
     } else {
         manifest_dir.join(path)
     })
+}
+
+fn validate_operations_contract() {
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"));
+    let operations_mod = manifest_dir.join("src/operations/mod.rs");
+    let lib_rs = manifest_dir.join("src/lib.rs");
+
+    println!("cargo:rerun-if-changed={}", operations_mod.display());
+    println!("cargo:rerun-if-changed={}", lib_rs.display());
+
+    let Ok(source) = fs::read_to_string(&operations_mod) else {
+        return;
+    };
+    let lib_source = fs::read_to_string(&lib_rs).unwrap_or_default();
+
+    let blocks = operation_def_blocks(&source);
+    if blocks.is_empty() {
+        panic!("operations contract must declare at least one operation_def! entry");
+    }
+
+    let schema_base = operations_mod
+        .parent()
+        .expect("src/operations/mod.rs has a parent");
+    let mut names = Vec::new();
+    for block in blocks {
+        if !block.contains("remote:") {
+            panic!("operation_def! entries must declare the explicit `remote` field");
+        }
+
+        let name = field_string_literal(&block, "name")
+            .unwrap_or_else(|| panic!("operation_def! entry is missing string `name`"));
+        if !is_kebab_case(&name) {
+            panic!("operation `{name}` must use kebab-case");
+        }
+        names.push(name);
+
+        let category = field_ident(&block, "category")
+            .unwrap_or_else(|| panic!("operation_def! entry is missing `category`"));
+        let executor = field_path(&block, "executor")
+            .unwrap_or_else(|| panic!("operation_def! entry is missing `executor`"));
+        let executor_name = executor.rsplit("::").next().unwrap_or(&executor);
+        let expected_prefix = format!("{}_", category.to_ascii_lowercase());
+        if !executor_name.starts_with(&expected_prefix) {
+            panic!(
+                "operation category `{category}` must use an executor whose name starts with `{expected_prefix}`"
+            );
+        }
+
+        for field in ["input_schema", "output_schema"] {
+            let schema = include_str_path(&block, field).unwrap_or_else(|| {
+                panic!(
+                    "operation `{}` is missing include_str! for `{field}`",
+                    names.last().unwrap()
+                )
+            });
+            let schema_path = schema_base.join(&schema);
+            println!("cargo:rerun-if-changed={}", schema_path.display());
+            if !schema_path.is_file() {
+                panic!(
+                    "operation `{}` references missing schema file `{}`",
+                    names.last().unwrap(),
+                    schema_path.display()
+                );
+            }
+        }
+    }
+
+    if !operation_command_is_generic_only(&source) {
+        panic!("operations module must expose exactly one Tauri command: invoke_operation");
+    }
+    if !lib_source.contains("operations::invoke_operation") {
+        panic!("Tauri generate_handler! must expose operations::invoke_operation");
+    }
+
+    for name in names {
+        let snake = name.replace('-', "_");
+        for disallowed in [format!("commands::{snake}"), format!("operations::{snake}")] {
+            if generate_handler_contains(&lib_source, &disallowed) && snake != "invoke_operation" {
+                panic!(
+                    "operation `{name}` must be exposed through operations::invoke_operation, not `{disallowed}`"
+                );
+            }
+        }
+    }
+}
+
+fn operation_def_blocks(source: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+    let marker = "operation_def!";
+
+    while let Some(relative_start) = source[offset..].find(marker) {
+        let start = offset + relative_start;
+        let Some(open_relative) = source[start..].find('{') else {
+            break;
+        };
+        let open = start + open_relative;
+        let mut depth = 0usize;
+        let mut end = None;
+        for (relative_index, ch) in source[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        end = Some(open + relative_index + ch.len_utf8());
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(block_end) = end else {
+            break;
+        };
+        blocks.push(source[open + 1..block_end - 1].to_string());
+        offset = block_end;
+    }
+
+    blocks
+}
+
+fn field_string_literal(block: &str, field: &str) -> Option<String> {
+    let value = field_value(block, field)?;
+    let value = value.trim();
+    let rest = value.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+fn field_ident(block: &str, field: &str) -> Option<String> {
+    let value = field_value(block, field)?;
+    Some(
+        value
+            .trim()
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+            .collect(),
+    )
+    .filter(|value: &String| !value.is_empty())
+}
+
+fn field_path(block: &str, field: &str) -> Option<String> {
+    let value = field_value(block, field)?;
+    Some(
+        value
+            .trim()
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_' || *ch == ':')
+            .collect(),
+    )
+    .filter(|value: &String| !value.is_empty())
+}
+
+fn include_str_path(block: &str, field: &str) -> Option<String> {
+    let value = field_value(block, field)?;
+    let include = value.find("include_str!")?;
+    let rest = &value[include..];
+    let first_quote = rest.find('"')?;
+    let after_quote = &rest[first_quote + 1..];
+    let second_quote = after_quote.find('"')?;
+    Some(after_quote[..second_quote].to_string())
+}
+
+fn field_value<'a>(block: &'a str, field: &str) -> Option<&'a str> {
+    let marker = format!("{field}:");
+    let start = block.find(&marker)? + marker.len();
+    let rest = &block[start..];
+    let end = rest.find('\n').unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+fn is_kebab_case(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+        && !value.contains("--")
+        && value.contains('-')
+}
+
+fn operation_command_is_generic_only(source: &str) -> bool {
+    source.matches("#[tauri::command]").count() == 1
+        && source.contains("pub async fn invoke_operation")
+}
+
+fn generate_handler_contains(source: &str, handler: &str) -> bool {
+    source
+        .lines()
+        .map(str::trim)
+        .any(|line| line == format!("{handler},") || line == handler)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ mod migrations;
 mod notification;
 pub mod oauth;
 pub mod observability;
+pub mod operations;
 mod parser;
 pub mod people;
 pub mod prepare;
@@ -616,6 +617,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // Abilities
             commands::invoke_ability,
+            operations::invoke_operation,
             // sensitivity reveal audit
             commands::reveal_sensitive_claim_text,
             // Core

--- a/src-tauri/src/operations/mod.rs
+++ b/src-tauri/src/operations/mod.rs
@@ -1,0 +1,241 @@
+//! Contract-first operations registry.
+//!
+//! Phase 1 keeps abilities as the single execution source while publishing a
+//! kebab-case operation contract for external surfaces.
+#![allow(
+    clippy::let_underscore_must_use,
+    reason = "tauri::command macro emits internal Result glue that discards generated metadata"
+)]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::abilities::AbilityRegistry;
+use crate::bridges::tauri::TauriAbilityBridge;
+use crate::bridges::{BridgeSurfaceError, ConfirmationToken};
+use crate::state::AppState;
+
+pub type OperationFuture = Pin<Box<dyn Future<Output = OperationResult> + Send>>;
+pub type OperationResult = Result<serde_json::Value, BridgeSurfaceError>;
+pub type OperationExecutor = fn(OperationInvocation) -> OperationFuture;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum OperationCategory {
+    Read,
+    Transform,
+    Publish,
+    Maintenance,
+}
+
+#[derive(Clone, Copy)]
+pub struct OperationDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub remote: bool,
+    pub category: OperationCategory,
+    pub input_schema: &'static str,
+    pub output_schema: &'static str,
+    pub requires_scope: Option<&'static str>,
+    pub executor: OperationExecutor,
+}
+
+#[derive(Clone)]
+pub struct OperationInvocation {
+    pub state: Arc<AppState>,
+    pub input_json: serde_json::Value,
+    pub dry_run: bool,
+    pub confirmation: Option<ConfirmationToken>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpOperationTool {
+    pub name: String,
+    pub description: String,
+    pub category: OperationCategory,
+    pub input_schema: serde_json::Value,
+    pub output_schema: serde_json::Value,
+    pub requires_scope: Option<String>,
+}
+
+macro_rules! operation_def {
+    (
+        name: $name:literal,
+        description: $description:literal,
+        remote: $remote:expr,
+        category: $category:ident,
+        input_schema: $input_schema:expr,
+        output_schema: $output_schema:expr,
+        requires_scope: $requires_scope:expr,
+        executor: $executor:path $(,)?
+    ) => {{
+        const _: OperationExecutor = $executor;
+        OperationDef {
+            name: $name,
+            description: $description,
+            remote: $remote,
+            category: OperationCategory::$category,
+            input_schema: $input_schema,
+            output_schema: $output_schema,
+            requires_scope: $requires_scope,
+            executor: $executor,
+        }
+    }};
+}
+
+pub const OPERATIONS: &[OperationDef] = &[
+    operation_def! {
+        name: "get-entity-context",
+        description: "Read claim-backed context entries for an account, project, person, or meeting.",
+        remote: true,
+        category: Read,
+        input_schema: include_str!("schemas/get-entity-context.input.schema.json"),
+        output_schema: include_str!("schemas/get-entity-context.output.schema.json"),
+        requires_scope: Some("entity:read"),
+        executor: read_get_entity_context_executor,
+    },
+    operation_def! {
+        name: "internal-debug-dump",
+        description: "Return local diagnostic counts for the operation registry and app runtime.",
+        remote: false,
+        category: Maintenance,
+        input_schema: include_str!("schemas/internal-debug-dump.input.schema.json"),
+        output_schema: include_str!("schemas/internal-debug-dump.output.schema.json"),
+        requires_scope: None,
+        executor: maintenance_internal_debug_dump_executor,
+    },
+];
+
+pub fn operation_by_name(name: &str) -> Option<&'static OperationDef> {
+    OPERATIONS.iter().find(|operation| operation.name == name)
+}
+
+pub fn mcp_tool_list() -> Vec<McpOperationTool> {
+    OPERATIONS
+        .iter()
+        .filter(|operation| operation.remote)
+        .map(|operation| McpOperationTool {
+            name: operation.name.to_string(),
+            description: operation.description.to_string(),
+            category: operation.category,
+            input_schema: parse_schema(operation.name, "input", operation.input_schema),
+            output_schema: parse_schema(operation.name, "output", operation.output_schema),
+            requires_scope: operation.requires_scope.map(str::to_string),
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub async fn invoke_operation(
+    state: State<'_, Arc<AppState>>,
+    operation_name: String,
+    input_json: serde_json::Value,
+    dry_run: Option<bool>,
+    confirmation: Option<ConfirmationToken>,
+) -> OperationResult {
+    if state.lock_state.lock().is_locked {
+        return Err(BridgeSurfaceError::AbilityUnavailable);
+    }
+
+    let operation =
+        operation_by_name(&operation_name).ok_or(BridgeSurfaceError::AbilityUnavailable)?;
+    (operation.executor)(OperationInvocation {
+        state: state.inner().clone(),
+        input_json,
+        dry_run: dry_run.unwrap_or(false),
+        confirmation,
+    })
+    .await
+}
+
+fn read_get_entity_context_executor(invocation: OperationInvocation) -> OperationFuture {
+    Box::pin(async move {
+        let registry = AbilityRegistry::global_checked()
+            .map_err(|_| BridgeSurfaceError::AbilityUnavailable)?;
+        let response = TauriAbilityBridge::new(registry)
+            .invoke(
+                invocation.state.as_ref(),
+                "get_entity_context",
+                invocation.input_json,
+                invocation.dry_run,
+                invocation.confirmation.as_ref(),
+            )
+            .await?;
+        serde_json::to_value(response).map_err(|_| BridgeSurfaceError::AbilityUnavailable)
+    })
+}
+
+fn maintenance_internal_debug_dump_executor(invocation: OperationInvocation) -> OperationFuture {
+    Box::pin(async move {
+        let snapshot = invocation.state.context_snapshot();
+        let data_summary = invocation
+            .state
+            .db_read(crate::privacy::get_data_summary)
+            .await
+            .ok();
+        let latency_rollups = serde_json::to_value(crate::latency::get_rollups())
+            .map_err(|_| BridgeSurfaceError::AbilityUnavailable)?;
+
+        Ok(serde_json::json!({
+            "schemaVersion": 1,
+            "operationCount": OPERATIONS.len(),
+            "remoteOperationCount": OPERATIONS.iter().filter(|operation| operation.remote).count(),
+            "contextProvider": snapshot.provider_name(),
+            "contextRemote": snapshot.is_remote(),
+            "dataSummary": data_summary,
+            "latencyRollups": latency_rollups,
+        }))
+    })
+}
+
+fn parse_schema(operation: &str, side: &str, schema: &str) -> serde_json::Value {
+    serde_json::from_str(schema).unwrap_or_else(|error| {
+        panic!("invalid {side} schema for operation `{operation}`: {error}");
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_registry_round_trip_mcp_tool_list_excludes_remote_false_operations() {
+        let tools = mcp_tool_list();
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"get-entity-context"));
+        assert!(!names.contains(&"internal-debug-dump"));
+
+        for tool in tools {
+            let operation = operation_by_name(&tool.name).expect("tool maps back to operation");
+            assert!(operation.remote);
+            assert_eq!(tool.description, operation.description);
+            assert_eq!(tool.category, operation.category);
+            assert!(tool.input_schema.is_object());
+            assert!(tool.output_schema.is_object());
+        }
+    }
+
+    #[test]
+    fn operations_use_kebab_case_names() {
+        for operation in OPERATIONS {
+            assert!(
+                operation
+                    .name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'),
+                "operation `{}` must be kebab-case",
+                operation.name
+            );
+            assert!(operation.name.contains('-'));
+        }
+    }
+}

--- a/src-tauri/src/operations/schemas/get-entity-context.input.schema.json
+++ b/src-tauri/src/operations/schemas/get-entity-context.input.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GetEntityContextInput",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "entity_type", "entity_id", "depth"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "entity_type": {
+      "type": "string",
+      "enum": ["account", "project", "person", "meeting"]
+    },
+    "entity_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "depth": {
+      "type": "string",
+      "enum": ["shallow", "standard", "deep"]
+    }
+  }
+}

--- a/src-tauri/src/operations/schemas/get-entity-context.output.schema.json
+++ b/src-tauri/src/operations/schemas/get-entity-context.output.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GetEntityContextOperationOutput",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "invocation_id",
+    "ability_name",
+    "ability_version",
+    "schema_version",
+    "data",
+    "rendered_provenance",
+    "diagnostics"
+  ],
+  "properties": {
+    "invocation_id": { "type": "string" },
+    "ability_name": { "type": "string", "const": "get_entity_context" },
+    "ability_version": { "type": "string" },
+    "schema_version": { "type": "integer", "const": 1 },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "entityType", "entityId", "title", "content", "createdAt", "updatedAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "entityType": { "type": "string" },
+          "entityId": { "type": "string" },
+          "title": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          },
+          "content": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          },
+          "createdAt": { "type": "string" },
+          "updatedAt": { "type": "string" }
+        }
+      }
+    },
+    "rendered_provenance": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/src-tauri/src/operations/schemas/internal-debug-dump.input.schema.json
+++ b/src-tauri/src/operations/schemas/internal-debug-dump.input.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InternalDebugDumpInput",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/src-tauri/src/operations/schemas/internal-debug-dump.output.schema.json
+++ b/src-tauri/src/operations/schemas/internal-debug-dump.output.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InternalDebugDumpOutput",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "operationCount",
+    "remoteOperationCount",
+    "contextProvider",
+    "contextRemote",
+    "dataSummary",
+    "latencyRollups"
+  ],
+  "properties": {
+    "schemaVersion": { "type": "integer", "const": 1 },
+    "operationCount": { "type": "integer" },
+    "remoteOperationCount": { "type": "integer" },
+    "contextProvider": { "type": "string" },
+    "contextRemote": { "type": "boolean" },
+    "dataSummary": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["accounts", "people", "projects", "meetings", "actions", "insights", "signals", "emails"],
+          "properties": {
+            "accounts": { "type": "integer" },
+            "people": { "type": "integer" },
+            "projects": { "type": "integer" },
+            "meetings": { "type": "integer" },
+            "actions": { "type": "integer" },
+            "insights": { "type": "integer" },
+            "signals": { "type": "integer" },
+            "emails": { "type": "integer" }
+          }
+        }
+      ]
+    },
+    "latencyRollups": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- OperationDef + OPERATIONS const slice at src-tauri/src/operations/mod.rs
- invoke_operation Tauri command + mcp_tool_list() returning remote=true subset
- Two operations migrated as proof: get-entity-context + internal-debug-dump
- Proc-macro/build-script enforcement of explicit remote field
- Doc at .docs/architecture/OPERATIONS.md

## Test plan
- [x] preflight all 12 gates green
- [ ] CI green on dev
- [ ] L2 reviewers approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)