### PR TITLE
fix(fence): add .githooks/ to L2 + L3 fenced-prefixes

### DIFF
--- a/.github/workflows/l2-review.yml
+++ b/.github/workflows/l2-review.yml
@@ -96,6 +96,7 @@ jobs:
             ".github/scripts/"
             ".github/actions/"
             ".claude/git-hooks/"
+            ".githooks/"
           )
 
           hits=()

--- a/.github/workflows/l3-review.yml
+++ b/.github/workflows/l3-review.yml
@@ -123,6 +123,7 @@ jobs:
           )
           FENCED_PREFIXES=(
             ".github/actions/l3-reviewer-job/"
+            ".githooks/"
           )
           FENCED_GLOBS=(
             ".github/reviewer-prompts/l3-*.md"


### PR DESCRIPTION
## Summary

Modifications to `.githooks/*` (pre-commit, pre-push, commit-msg) bypass the local PII scan, stub-detection, ADR-0101 boundary, and L2 acknowledgment gates. They warrant the same self-modification trust boundary as workflow files and reviewer prompts.

Adds `.githooks/` to L2's `FENCED_PREFIXES` and L3's `FENCED_PREFIXES`. Any future PR that modifies `.githooks/*` will trip the fence — admin override required, same bootstrap pattern as #232, #246, #248, #249.

Closes the fence-coverage gap noted on PR #249.

## §4 Security

\`security_auditor_invoked: true\`

- [x] Adds a new trust boundary? — **yes** (extends existing fence to cover .githooks/)
- [x] Modifies `.github/workflows/*`? — **yes** (l2-review.yml, l3-review.yml)
- All other triggers: **no**

## Test plan

- [ ] PR will trip L2's config-fence (it modifies l2-review.yml). Admin override expected.
- [ ] After merge, modifying `.githooks/*` in any subsequent PR will trip the fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)