### PR TITLE
DOS-265 W2-G: declarative claim-field → edge-type map

### DIFF
--- a/.docs/architecture/CLAIM-EDGES.md
+++ b/.docs/architecture/CLAIM-EDGES.md
@@ -1,0 +1,69 @@
+# Claim Edges
+
+`claim_edges` is a provenance-preserving projection from committed claims into
+entity graph edges. It is not a new operational linking writer. W2-G only adds
+the declarative frontmatter map compiler under `services::claims::link_map`.
+
+## Data Model
+
+`claim_edges` stores:
+
+- `from_entity_id`, `to_entity_id`, `edge_type`: the directed graph edge.
+- `origin_claim_id`: the immutable claim that produced the edge.
+- `link_source`: one of `frontmatter_map`, `manual`, or `extracted`.
+- `weight`, `confidence`: ranking inputs for downstream graph readers.
+- `superseded_by`, `tombstoned_at`: edge lifecycle fields.
+- `created_at`: copied from the origin claim commit time.
+
+`claim_edges_active` returns rows where `superseded_by IS NULL` and
+`tombstoned_at IS NULL`.
+
+`backlinks` is a convenience view keyed by `to_entity_id` for "what points at
+this entity?" readers.
+
+## Frontmatter Map
+
+`CLAIM_LINK_MAP` is a const slice of `LinkRule`:
+
+- `field`: exact `intelligence_claims.field_path` match.
+- `edge_type`: persisted edge type.
+- `direction`: `Forward` means subject -> linked entity; `Incoming` means
+  linked entity -> subject.
+- `fanout`: false keeps only the first target; true emits one edge per target.
+- `subject_type`: subject-kind filter. Rules do not fire for other subject
+  kinds.
+
+## Map Table
+
+| subject_type | field | edge_type | direction | fanout |
+| --- | --- | --- | --- | --- |
+| `CanonicalSubjectType::Meeting` | `account` | `mentions_account` | `EdgeDirection::Forward` | `false` |
+| `CanonicalSubjectType::Meeting` | `project` | `mentions_project` | `EdgeDirection::Forward` | `false` |
+| `CanonicalSubjectType::Account` | `stakeholders` | `has_stakeholder` | `EdgeDirection::Forward` | `true` |
+| `CanonicalSubjectType::Person` | `linked_entities` | `has_stakeholder` | `EdgeDirection::Incoming` | `true` |
+
+The compiler reads target IDs from JSON strings, arrays, or objects containing
+common ID fields (`id`, `entity_id`, `person_id`, `account_id`, `project_id`,
+`meeting_id`) and falls back to comma, semicolon, or newline separated text.
+
+## Lifecycle
+
+`commit_claim` writes claim edges in the same SQLite transaction as the origin
+claim insert.
+
+When a claim explicitly supersedes another claim, active edges from the old
+claim are marked with `superseded_by = <replacement claim id>`.
+
+When a tombstone claim lands for the same subject, claim type, and field path,
+active edges for matching prior claims are marked with `tombstoned_at`. This is
+the edge-level counterpart to the ADR-0113 tombstone pre-gate: re-enrichment of
+the same field cannot silently resurrect old edges into `claim_edges_active`.
+
+Withdrawn or tombstoned feedback lifecycle transitions also mark the affected
+claim's edges with `tombstoned_at`.
+
+## Extension Point
+
+Future work can add field mappings through the `frontmatter_link_map!` macro and
+the `ClaimLinkMap` trait without adding new claim-type variants. Claim-type
+taxonomy changes remain out of scope for W2-G and land in W4.

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -751,6 +751,10 @@ const MIGRATIONS: &[Migration] = &[
         version: 147,
         sql: include_str!("migrations/147_invalidation_jobs.sql"),
     },
+    Migration::Sql {
+        version: 148,
+        sql: include_str!("migrations/148_dos_265_claim_edges.sql"),
+    },
 ];
 
 /// Create the `schema_version` table if it doesn't exist.

--- a/src-tauri/src/migrations/148_dos_265_claim_edges.sql
+++ b/src-tauri/src/migrations/148_dos_265_claim_edges.sql
@@ -1,0 +1,63 @@
+-- Claim-derived entity edges.
+--
+-- claim_edges is a provenance-preserving projection from committed claims.
+-- The only writer in this change is the declarative frontmatter map compiler
+-- in services::claims::link_map.
+
+CREATE TABLE IF NOT EXISTS claim_edges (
+    id              TEXT PRIMARY KEY,
+    from_entity_id  TEXT NOT NULL,
+    to_entity_id    TEXT NOT NULL,
+    edge_type       TEXT NOT NULL,
+    origin_claim_id TEXT NOT NULL REFERENCES intelligence_claims(id),
+    link_source     TEXT NOT NULL CHECK (link_source IN ('frontmatter_map', 'manual', 'extracted')),
+    weight          REAL NOT NULL DEFAULT 1.0,
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    superseded_by   TEXT,
+    tombstoned_at   TEXT,
+    created_at      TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claim_edges_active_unique
+    ON claim_edges(from_entity_id, to_entity_id, edge_type, origin_claim_id)
+    WHERE superseded_by IS NULL AND tombstoned_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_claim_edges_from_active
+    ON claim_edges(from_entity_id, edge_type)
+    WHERE superseded_by IS NULL AND tombstoned_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_claim_edges_to_active
+    ON claim_edges(to_entity_id, edge_type)
+    WHERE superseded_by IS NULL AND tombstoned_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_claim_edges_origin_claim
+    ON claim_edges(origin_claim_id);
+
+CREATE VIEW IF NOT EXISTS claim_edges_active AS
+    SELECT
+        id,
+        from_entity_id,
+        to_entity_id,
+        edge_type,
+        origin_claim_id,
+        link_source,
+        weight,
+        confidence,
+        superseded_by,
+        tombstoned_at,
+        created_at
+    FROM claim_edges
+    WHERE superseded_by IS NULL
+      AND tombstoned_at IS NULL;
+
+CREATE VIEW IF NOT EXISTS backlinks AS
+    SELECT
+        to_entity_id AS entity_id,
+        from_entity_id AS backlink_entity_id,
+        edge_type,
+        origin_claim_id,
+        link_source,
+        weight,
+        confidence,
+        created_at
+    FROM claim_edges_active;

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -43,6 +43,9 @@ use crate::db::{ActionDb, DbError};
 use crate::intelligence::canonicalization::{item_hash, ItemKind};
 use crate::services::context::ServiceContext;
 
+pub mod link_map;
+mod link_map_macro;
+
 // ---------------------------------------------------------------------------
 // Public types: proposal + committed shape
 // ---------------------------------------------------------------------------
@@ -1021,6 +1024,130 @@ fn insert_claim_row(tx: &ActionDb, claim: &IntelligenceClaim) -> Result<(), Clai
     Ok(())
 }
 
+fn insert_claim_edges(tx: &ActionDb, claim: &IntelligenceClaim) -> Result<(), ClaimError> {
+    let edges = link_map::compile_edges_from_claim(claim);
+    if edges.is_empty() || !claim_edges_table_exists(tx)? {
+        return Ok(());
+    }
+
+    for edge in edges {
+        tx.conn_ref().execute(
+            "INSERT OR IGNORE INTO claim_edges (
+                id, from_entity_id, to_entity_id, edge_type, origin_claim_id,
+                link_source, weight, confidence, superseded_by, tombstoned_at, created_at
+             ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, ?9
+             )",
+            params![
+                &edge.id,
+                &edge.from_entity_id,
+                &edge.to_entity_id,
+                &edge.edge_type,
+                &edge.origin_claim_id,
+                edge.link_source,
+                edge.weight,
+                edge.confidence,
+                &claim.created_at,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn claim_edges_table_exists(tx: &ActionDb) -> Result<bool, ClaimError> {
+    Ok(tx
+        .conn_ref()
+        .query_row(
+            "SELECT 1
+             FROM sqlite_master
+             WHERE type = 'table'
+               AND name = 'claim_edges'
+             LIMIT 1",
+            [],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn mark_claim_edges_superseded_by_claim(
+    tx: &ActionDb,
+    origin_claim_id: &str,
+    replacement_claim_id: &str,
+) -> Result<(), ClaimError> {
+    if !claim_edges_table_exists(tx)? {
+        return Ok(());
+    }
+
+    tx.conn_ref().execute(
+        "UPDATE claim_edges
+         SET superseded_by = ?1
+         WHERE origin_claim_id = ?2
+           AND superseded_by IS NULL
+           AND tombstoned_at IS NULL",
+        params![replacement_claim_id, origin_claim_id],
+    )?;
+    Ok(())
+}
+
+fn mark_claim_edges_tombstoned(
+    tx: &ActionDb,
+    origin_claim_id: &str,
+    tombstoned_at: &str,
+) -> Result<(), ClaimError> {
+    if !claim_edges_table_exists(tx)? {
+        return Ok(());
+    }
+
+    tx.conn_ref().execute(
+        "UPDATE claim_edges
+         SET tombstoned_at = ?1
+         WHERE origin_claim_id = ?2
+           AND superseded_by IS NULL
+           AND tombstoned_at IS NULL",
+        params![tombstoned_at, origin_claim_id],
+    )?;
+    Ok(())
+}
+
+fn mark_claim_edges_tombstoned_for_identity(
+    tx: &ActionDb,
+    subject: &SubjectRef,
+    claim_type: &str,
+    field_path: Option<&str>,
+    tombstoned_at: &str,
+) -> Result<(), ClaimError> {
+    if !claim_edges_table_exists(tx)? {
+        return Ok(());
+    }
+
+    let Some(kind) = subject_kind_label(subject) else {
+        return Ok(());
+    };
+    let Some(id) = subject_id_for_lookup(subject) else {
+        return Ok(());
+    };
+    let field = field_path.unwrap_or("");
+
+    tx.conn_ref().execute(
+        "UPDATE claim_edges
+         SET tombstoned_at = ?1
+         WHERE superseded_by IS NULL
+           AND tombstoned_at IS NULL
+           AND origin_claim_id IN (
+               SELECT ic.id
+               FROM intelligence_claims ic
+               WHERE ic.claim_type = ?2
+                 AND coalesce(ic.field_path, '') = coalesce(?3, '')
+                 AND json_valid(ic.subject_ref) = 1
+                 AND lower(json_extract(ic.subject_ref, '$.kind')) = lower(?4)
+                 AND json_extract(ic.subject_ref, '$.id') = ?5
+           )",
+        params![tombstoned_at, claim_type, field, kind, id],
+    )?;
+    Ok(())
+}
+
 fn project_legacy_state_for_claim(
     ctx: &ServiceContext<'_>,
     tx: &ActionDb,
@@ -1688,6 +1815,11 @@ pub fn commit_claim(
 
     with_claim_transaction(db, |tx| {
         let now = ctx.clock.now().to_rfc3339();
+        let claim_metadata_json = link_map::metadata_with_structured_field(
+            proposal.metadata_json.as_deref(),
+            proposal.field_path.as_deref(),
+            &proposal.text,
+        );
         if proposal.tombstone.is_some() && proposal.supersedes.is_some() {
             return Err(ClaimError::InvalidSupersession(
                 "tombstone commits cannot also supersede another claim".to_string(),
@@ -1722,6 +1854,25 @@ pub fn commit_claim(
                     superseded.id
                 )));
             }
+            if pre_gate_blocking_tombstone_exists(
+                tx.conn_ref(),
+                &superseded_subject,
+                &superseded.claim_type,
+                superseded.field_path.as_deref(),
+                superseded.item_hash.as_deref().unwrap_or(""),
+                &superseded.text,
+                &now,
+            )? || pre_gate_blocking_tombstone_exists(
+                tx.conn_ref(),
+                &subject,
+                &proposal.claim_type,
+                proposal.field_path.as_deref(),
+                &computed_hash,
+                &canonical_text,
+                &now,
+            )? {
+                return Err(ClaimError::TombstonedPreGate);
+            }
 
             let new_id = proposal
                 .id
@@ -1743,7 +1894,7 @@ pub fn commit_claim(
                 observed_at: proposal.observed_at.clone(),
                 created_at: now.clone(),
                 provenance_json: proposal.provenance_json.clone(),
-                metadata_json: proposal.metadata_json.clone(),
+                metadata_json: claim_metadata_json.clone(),
                 claim_state: ClaimState::Active,
                 surfacing_state: SurfacingState::Active,
                 demotion_reason: None,
@@ -1763,6 +1914,7 @@ pub fn commit_claim(
             };
             insert_claim_row(tx, &claim)?;
             project_legacy_state_for_claim(ctx, tx, &claim)?;
+            insert_claim_edges(tx, &claim)?;
 
             execute_claims_update(
                 tx.conn_ref(),
@@ -1774,6 +1926,7 @@ pub fn commit_claim(
                  WHERE id = ?2",
                 params![&new_id, superseded_id],
             )?;
+            mark_claim_edges_superseded_by_claim(tx, superseded_id, &new_id)?;
 
             let contradiction_id = uuid::Uuid::new_v4().to_string();
             tx.conn_ref().execute(
@@ -1819,6 +1972,13 @@ pub fn commit_claim(
                     Some("same_meaning_merge"),
                     &now,
                 )?;
+                let mut edge_claim = existing.clone();
+                edge_claim.metadata_json = link_map::metadata_with_structured_field(
+                    edge_claim.metadata_json.as_deref(),
+                    proposal.field_path.as_deref(),
+                    &proposal.text,
+                );
+                insert_claim_edges(tx, &edge_claim)?;
                 tx.bump_for_subject(&subject)?;
                 return Ok(CommittedClaim::Reinforced {
                     claim: existing,
@@ -1860,7 +2020,7 @@ pub fn commit_claim(
                     observed_at: proposal.observed_at.clone(),
                     created_at: now.clone(),
                     provenance_json: proposal.provenance_json.clone(),
-                    metadata_json: proposal.metadata_json.clone(),
+                    metadata_json: claim_metadata_json.clone(),
                     claim_state: ClaimState::Active,
                     surfacing_state: SurfacingState::Active,
                     demotion_reason: None,
@@ -1880,6 +2040,7 @@ pub fn commit_claim(
                 };
                 insert_claim_row(tx, &contradicting)?;
                 project_legacy_state_for_claim(ctx, tx, &contradicting)?;
+                insert_claim_edges(tx, &contradicting)?;
 
                 let contradiction_id = uuid::Uuid::new_v4().to_string();
                 tx.conn_ref().execute(
@@ -1930,7 +2091,7 @@ pub fn commit_claim(
             observed_at: proposal.observed_at.clone(),
             created_at: now.clone(),
             provenance_json: proposal.provenance_json.clone(),
-            metadata_json: proposal.metadata_json.clone(),
+            metadata_json: claim_metadata_json,
             claim_state,
             surfacing_state,
             demotion_reason: None,
@@ -1951,6 +2112,17 @@ pub fn commit_claim(
 
         insert_claim_row(tx, &claim)?;
         project_legacy_state_for_claim(ctx, tx, &claim)?;
+        if proposal.tombstone.is_some() {
+            mark_claim_edges_tombstoned_for_identity(
+                tx,
+                &subject,
+                &proposal.claim_type,
+                proposal.field_path.as_deref(),
+                &now,
+            )?;
+        } else {
+            insert_claim_edges(tx, &claim)?;
+        }
         tx.bump_for_subject(&subject)?;
 
         if proposal.tombstone.is_some() {
@@ -1996,6 +2168,7 @@ pub fn withdraw_claim(
                  WHERE id = ?2",
                 params![reason, claim_id],
             )?;
+            mark_claim_edges_tombstoned(tx, claim_id, &ctx.clock.now().to_rfc3339())?;
             tx.bump_for_subject(&subject)?;
         }
 
@@ -2127,6 +2300,14 @@ pub fn record_claim_feedback(
                 )?;
             }
             (false, false) => {}
+        }
+
+        if matches!(
+            lifecycle_update.claim_state,
+            ClaimState::Tombstoned | ClaimState::Withdrawn
+        ) || lifecycle_update.surfacing_state == SurfacingState::Dormant
+        {
+            mark_claim_edges_tombstoned(tx, &input.claim_id, &now)?;
         }
 
         let repair_job_id =
@@ -3300,6 +3481,44 @@ mod tests {
             .expect("read temporal_scope")
     }
 
+    fn edge_proposal(text: &str) -> ClaimProposal {
+        let mut p = proposal(text);
+        p.field_path = Some("stakeholders".to_string());
+        p
+    }
+
+    fn active_claim_edges(db: &ActionDb) -> Vec<(String, String, String, String)> {
+        let mut stmt = db
+            .conn_ref()
+            .prepare(
+                "SELECT from_entity_id, to_entity_id, edge_type, origin_claim_id
+                 FROM claim_edges_active
+                 ORDER BY from_entity_id, to_entity_id, edge_type, origin_claim_id",
+            )
+            .expect("prepare active claim edge query");
+        stmt.query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .expect("query active claim edges")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("map active claim edges")
+    }
+
+    fn edge_lifecycle_for_origin(
+        db: &ActionDb,
+        origin_claim_id: &str,
+    ) -> (Option<String>, Option<String>) {
+        db.conn_ref()
+            .query_row(
+                "SELECT superseded_by, tombstoned_at
+                 FROM claim_edges
+                 WHERE origin_claim_id = ?1",
+                params![origin_claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read claim edge lifecycle")
+    }
+
     fn read_claim_sensitivity(db: &ActionDb, claim_id: &str) -> String {
         db.conn_ref()
             .query_row(
@@ -3798,6 +4017,220 @@ mod tests {
             claim.item_hash,
             Some(item_hash(ItemKind::Risk, &claim.text))
         );
+    }
+
+    #[test]
+    fn claim_edges_schema_exposes_active_and_backlinks_views() {
+        let db = test_db();
+        let object_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM sqlite_master
+                 WHERE name IN ('claim_edges', 'claim_edges_active', 'backlinks')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(object_count, 3);
+    }
+
+    #[test]
+    fn commit_claim_populates_frontmatter_edges_in_same_transaction() {
+        let db = test_db();
+        seed_account(&db);
+        seed_person(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let id =
+            inserted_claim_id(commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#)).unwrap());
+
+        assert_eq!(
+            active_claim_edges(&db),
+            vec![(
+                "acct-1".to_string(),
+                "person-1".to_string(),
+                "has_stakeholder".to_string(),
+                id
+            )]
+        );
+    }
+
+    #[test]
+    fn same_meaning_reinforcement_backfills_missing_frontmatter_edges() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let raw_targets = r#"["Person-MixedCase"]"#;
+        let canonical_text = canonicalize_for_dos280(raw_targets);
+        let subject_ref = compact_subject_ref_str(SUBJECT).expect("compact subject");
+        let hash = item_hash(item_kind_for_claim_type("risk"), &canonical_text);
+        let dedup_key = compute_dedup_key(&hash, &subject_ref, "risk", Some("stakeholders"));
+        let existing = IntelligenceClaim {
+            id: "claim-pre-edge".to_string(),
+            subject_ref,
+            claim_type: "risk".to_string(),
+            field_path: Some("stakeholders".to_string()),
+            topic_key: None,
+            text: canonical_text,
+            dedup_key,
+            item_hash: Some(hash),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: None,
+            source_asof: Some(TS.to_string()),
+            observed_at: TS.to_string(),
+            created_at: TS.to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            claim_state: ClaimState::Active,
+            surfacing_state: SurfacingState::Active,
+            demotion_reason: None,
+            reactivated_at: None,
+            retraction_reason: None,
+            expires_at: None,
+            superseded_by: None,
+            trust_score: None,
+            trust_computed_at: None,
+            trust_version: None,
+            thread_id: None,
+            temporal_scope: TemporalScope::State,
+            sensitivity: ClaimSensitivity::Internal,
+            verification_state: ClaimVerificationState::Active,
+            verification_reason: None,
+            needs_user_decision_at: None,
+        };
+        insert_claim_row(&db, &existing).expect("seed pre-edge claim");
+
+        let result = commit_claim(&ctx, &db, edge_proposal(raw_targets)).unwrap();
+        match result {
+            CommittedClaim::Reinforced { claim, .. } => assert_eq!(claim.id, existing.id),
+            other => panic!("expected same-meaning reinforcement, got {other:?}"),
+        }
+
+        assert_eq!(
+            active_claim_edges(&db),
+            vec![(
+                "acct-1".to_string(),
+                "Person-MixedCase".to_string(),
+                "has_stakeholder".to_string(),
+                "claim-pre-edge".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn supersede_marks_prior_claim_edges_superseded_by_replacement_claim() {
+        let db = test_db();
+        seed_account(&db);
+        seed_person(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let first_id =
+            inserted_claim_id(commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#)).unwrap());
+        let mut replacement = edge_proposal(r#"["person-2"]"#);
+        replacement.supersedes = Some(first_id.clone());
+        let replacement_id = inserted_claim_id(commit_claim(&ctx, &db, replacement).unwrap());
+
+        assert_eq!(
+            edge_lifecycle_for_origin(&db, &first_id),
+            (Some(replacement_id.clone()), None)
+        );
+        assert_eq!(
+            active_claim_edges(&db),
+            vec![(
+                "acct-1".to_string(),
+                "person-2".to_string(),
+                "has_stakeholder".to_string(),
+                replacement_id
+            )]
+        );
+    }
+
+    #[test]
+    fn tombstone_resurrection_keeps_edges_out_of_active_view() {
+        let db = test_db();
+        seed_account(&db);
+        seed_person(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let first_id =
+            inserted_claim_id(commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#)).unwrap());
+        let mut tombstone = edge_proposal("<keyless>");
+        tombstone.actor = "user".to_string();
+        tombstone.data_source = "user_input".to_string();
+        tombstone.tombstone = Some(TombstoneSpec {
+            retraction_reason: "user_removal".to_string(),
+            expires_at: None,
+        });
+        commit_claim(&ctx, &db, tombstone).unwrap();
+
+        let (_, tombstoned_at) = edge_lifecycle_for_origin(&db, &first_id);
+        assert!(tombstoned_at.is_some());
+        assert!(active_claim_edges(&db).is_empty());
+
+        let err = commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#))
+            .expect_err("field tombstone must block re-enrichment");
+        assert!(matches!(err, ClaimError::TombstonedPreGate));
+        assert!(active_claim_edges(&db).is_empty());
+    }
+
+    #[test]
+    fn tombstoned_field_blocks_explicit_supersession_edges() {
+        let db = test_db();
+        seed_account(&db);
+        seed_person(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let first_id =
+            inserted_claim_id(commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#)).unwrap());
+        let mut tombstone = edge_proposal("<keyless>");
+        tombstone.actor = "user".to_string();
+        tombstone.data_source = "user_input".to_string();
+        tombstone.tombstone = Some(TombstoneSpec {
+            retraction_reason: "user_removal".to_string(),
+            expires_at: None,
+        });
+        commit_claim(&ctx, &db, tombstone).unwrap();
+
+        assert!(active_claim_edges(&db).is_empty());
+
+        let mut replacement = edge_proposal(r#"["person-2"]"#);
+        replacement.supersedes = Some(first_id);
+        let err = commit_claim(&ctx, &db, replacement)
+            .expect_err("field tombstone must block explicit supersession");
+
+        assert!(matches!(err, ClaimError::TombstonedPreGate));
+        assert!(active_claim_edges(&db).is_empty());
+    }
+
+    #[test]
+    fn dormant_feedback_tombstones_claim_edges() {
+        let db = test_db();
+        seed_account(&db);
+        seed_person(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, edge_proposal(r#"["person-1"]"#)).unwrap());
+        assert_eq!(active_claim_edges(&db).len(), 1);
+
+        record_claim_feedback(
+            &ctx,
+            &db,
+            feedback_input(&claim_id, FeedbackAction::MarkOutdated),
+        )
+        .unwrap();
+
+        let (_, tombstoned_at) = edge_lifecycle_for_origin(&db, &claim_id);
+        assert!(tombstoned_at.is_some());
+        assert!(active_claim_edges(&db).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/services/claims/link_map.rs
+++ b/src-tauri/src/services/claims/link_map.rs
@@ -1,0 +1,492 @@
+//! Declarative claim field -> entity edge compiler.
+//!
+//! This module is intentionally narrow: it translates configured claim
+//! frontmatter-style fields into `claim_edges` rows. It does not add claim
+//! types or mutate operational entity-linking tables.
+
+use std::collections::HashSet;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::abilities::claims::CanonicalSubjectType;
+use crate::db::claim_invalidation::SubjectRef;
+use crate::db::claims::{ClaimState, IntelligenceClaim, SurfacingState};
+use crate::services::claims::subject_ref_from_json;
+
+pub const LINK_SOURCE_FRONTMATTER_MAP: &str = "frontmatter_map";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeDirection {
+    Forward,
+    Incoming,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkRule {
+    pub field: &'static str,
+    pub edge_type: &'static str,
+    pub direction: EdgeDirection,
+    pub fanout: bool,
+    pub subject_type: CanonicalSubjectType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimEdge {
+    pub id: String,
+    pub from_entity_id: String,
+    pub to_entity_id: String,
+    pub edge_type: String,
+    pub origin_claim_id: String,
+    pub link_source: &'static str,
+    pub weight: f64,
+    pub confidence: f64,
+}
+
+pub trait ClaimLinkMap {
+    fn rules(&self) -> &'static [LinkRule];
+}
+
+pub struct FrontmatterClaimLinkMap;
+
+impl ClaimLinkMap for FrontmatterClaimLinkMap {
+    fn rules(&self) -> &'static [LinkRule] {
+        CLAIM_LINK_MAP
+    }
+}
+
+crate::frontmatter_link_map! {
+    /// Declarative claim field -> edge type rules for frontmatter-style fields.
+    pub const CLAIM_LINK_MAP = [
+        {
+            field: "account",
+            edge_type: "mentions_account",
+            direction: EdgeDirection::Forward,
+            fanout: false,
+            subject_type: CanonicalSubjectType::Meeting,
+        },
+        {
+            field: "project",
+            edge_type: "mentions_project",
+            direction: EdgeDirection::Forward,
+            fanout: false,
+            subject_type: CanonicalSubjectType::Meeting,
+        },
+        {
+            field: "stakeholders",
+            edge_type: "has_stakeholder",
+            direction: EdgeDirection::Forward,
+            fanout: true,
+            subject_type: CanonicalSubjectType::Account,
+        },
+        {
+            field: "linked_entities",
+            edge_type: "has_stakeholder",
+            direction: EdgeDirection::Incoming,
+            fanout: true,
+            subject_type: CanonicalSubjectType::Person,
+        },
+    ];
+}
+
+pub const FRONTMATTER_LINK_MAP: &[LinkRule] = CLAIM_LINK_MAP;
+
+pub fn compile_edges_from_claim(claim: &IntelligenceClaim) -> Vec<ClaimEdge> {
+    if claim.claim_state != ClaimState::Active || claim.surfacing_state != SurfacingState::Active {
+        return Vec::new();
+    }
+
+    let Some(field_path) = claim.field_path.as_deref() else {
+        return Vec::new();
+    };
+    let Some(rule) = CLAIM_LINK_MAP.iter().find(|rule| rule.field == field_path) else {
+        return Vec::new();
+    };
+
+    let Ok(subject_value) = serde_json::from_str::<Value>(&claim.subject_ref) else {
+        return Vec::new();
+    };
+    let Ok(subject) = subject_ref_from_json(&subject_value) else {
+        return Vec::new();
+    };
+    let Some((subject_type, subject_id)) = subject_type_and_id(&subject) else {
+        return Vec::new();
+    };
+    if subject_type != rule.subject_type {
+        return Vec::new();
+    }
+
+    let mut targets = target_entity_ids_for_claim(claim, rule.field);
+    if !rule.fanout {
+        targets.truncate(1);
+    }
+
+    let mut seen = HashSet::new();
+    targets
+        .into_iter()
+        .filter(|target_id| !target_id.is_empty() && target_id != &subject_id)
+        .filter_map(|target_id| {
+            let (from_entity_id, to_entity_id) = match rule.direction {
+                EdgeDirection::Forward => (subject_id.clone(), target_id),
+                EdgeDirection::Incoming => (target_id, subject_id.clone()),
+            };
+            let key = (
+                from_entity_id.clone(),
+                to_entity_id.clone(),
+                rule.edge_type.to_string(),
+            );
+            if !seen.insert(key) {
+                return None;
+            }
+
+            let edge_type = rule.edge_type.to_string();
+            Some(ClaimEdge {
+                id: edge_id(&claim.id, &from_entity_id, &to_entity_id, &edge_type),
+                from_entity_id,
+                to_entity_id,
+                edge_type,
+                origin_claim_id: claim.id.clone(),
+                link_source: LINK_SOURCE_FRONTMATTER_MAP,
+                weight: 1.0,
+                confidence: claim.trust_score.unwrap_or(1.0),
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn metadata_with_structured_field(
+    metadata_json: Option<&str>,
+    field_path: Option<&str>,
+    original_text: &str,
+) -> Option<String> {
+    let Some(field_path) = field_path else {
+        return metadata_json.map(ToOwned::to_owned);
+    };
+    if !CLAIM_LINK_MAP.iter().any(|rule| rule.field == field_path) {
+        return metadata_json.map(ToOwned::to_owned);
+    }
+
+    let mut root = metadata_json
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| match value {
+            Value::Object(map) => Some(map),
+            _ => None,
+        })
+        .unwrap_or_default();
+    let field_value = serde_json::from_str::<Value>(original_text)
+        .unwrap_or_else(|_| Value::String(original_text.to_string()));
+
+    match root.get_mut("fields") {
+        Some(Value::Object(fields)) => {
+            fields.entry(field_path.to_string()).or_insert(field_value);
+        }
+        _ => {
+            let mut fields = Map::new();
+            fields.insert(field_path.to_string(), field_value);
+            root.insert("fields".to_string(), Value::Object(fields));
+        }
+    }
+    root.entry("original_text".to_string())
+        .or_insert_with(|| Value::String(original_text.to_string()));
+
+    Some(Value::Object(root).to_string())
+}
+
+fn subject_type_and_id(subject: &SubjectRef) -> Option<(CanonicalSubjectType, String)> {
+    match subject {
+        SubjectRef::Account { id } => Some((CanonicalSubjectType::Account, id.clone())),
+        SubjectRef::Meeting { id } => Some((CanonicalSubjectType::Meeting, id.clone())),
+        SubjectRef::Person { id } => Some((CanonicalSubjectType::Person, id.clone())),
+        SubjectRef::Project { id } => Some((CanonicalSubjectType::Project, id.clone())),
+        SubjectRef::Email { id } => Some((CanonicalSubjectType::Email, id.clone())),
+        SubjectRef::Multi(_) | SubjectRef::Global => None,
+    }
+}
+
+fn target_entity_ids_for_claim(claim: &IntelligenceClaim, field: &str) -> Vec<String> {
+    claim
+        .metadata_json
+        .as_deref()
+        .and_then(|metadata| target_entity_ids_from_metadata(metadata, field))
+        .unwrap_or_else(|| target_entity_ids(&claim.text))
+}
+
+fn target_entity_ids_from_metadata(metadata_json: &str, field: &str) -> Option<Vec<String>> {
+    let metadata = serde_json::from_str::<Value>(metadata_json).ok()?;
+    let Value::Object(root) = metadata else {
+        return None;
+    };
+
+    if let Some(Value::Object(fields)) = root.get("fields") {
+        if let Some(value) = fields.get(field) {
+            let targets = target_entity_ids_from_value(value);
+            if !targets.is_empty() {
+                return Some(targets);
+            }
+        }
+    }
+
+    if let Some(value) = root.get(field) {
+        let targets = target_entity_ids_from_value(value);
+        if !targets.is_empty() {
+            return Some(targets);
+        }
+    }
+
+    root.get("original_text")
+        .map(target_entity_ids_from_value)
+        .filter(|targets| !targets.is_empty())
+}
+
+fn target_entity_ids(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        let mut out = Vec::new();
+        collect_target_ids(&value, &mut out);
+        return stable_dedup(out);
+    }
+
+    stable_dedup(
+        trimmed
+            .split([',', '\n', ';'])
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+    )
+}
+
+fn target_entity_ids_from_value(value: &Value) -> Vec<String> {
+    match value {
+        Value::String(raw) => target_entity_ids(raw),
+        _ => {
+            let mut out = Vec::new();
+            collect_target_ids(value, &mut out);
+            stable_dedup(out)
+        }
+    }
+}
+
+fn collect_target_ids(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(s) if !s.trim().is_empty() => out.push(s.trim().to_string()),
+        Value::Array(items) => {
+            for item in items {
+                collect_target_ids(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for key in [
+                "id",
+                "entity_id",
+                "account_id",
+                "project_id",
+                "person_id",
+                "meeting_id",
+            ] {
+                if let Some(Value::String(s)) = map.get(key) {
+                    if !s.trim().is_empty() {
+                        out.push(s.trim().to_string());
+                    }
+                }
+            }
+
+            for key in [
+                "ids",
+                "entity_ids",
+                "linked_entities",
+                "accounts",
+                "projects",
+                "people",
+                "stakeholders",
+                "meetings",
+                "value",
+            ] {
+                if let Some(nested) = map.get(key) {
+                    collect_target_ids(nested, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn stable_dedup(values: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.clone()))
+        .collect()
+}
+
+fn edge_id(
+    origin_claim_id: &str,
+    from_entity_id: &str,
+    to_entity_id: &str,
+    edge_type: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(origin_claim_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(from_entity_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(to_entity_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(edge_type.as_bytes());
+    format!("ce-{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abilities::feedback::ClaimVerificationState;
+    use crate::db::claims::{ClaimSensitivity, TemporalScope};
+
+    fn subject_for(subject_type: CanonicalSubjectType, id: &str) -> String {
+        let kind = subject_type.as_str();
+        serde_json::json!({ "kind": kind, "id": id }).to_string()
+    }
+
+    fn fixture_claim(rule: &LinkRule, text: &str) -> IntelligenceClaim {
+        IntelligenceClaim {
+            id: format!("claim-{}", rule.field),
+            subject_ref: subject_for(rule.subject_type, "subject-1"),
+            claim_type: "risk".to_string(),
+            field_path: Some(rule.field.to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            dedup_key: "dedup".to_string(),
+            item_hash: Some("hash".to_string()),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: None,
+            source_asof: None,
+            observed_at: "2026-05-02T12:00:00+00:00".to_string(),
+            created_at: "2026-05-02T12:00:00+00:00".to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            claim_state: ClaimState::Active,
+            surfacing_state: SurfacingState::Active,
+            demotion_reason: None,
+            reactivated_at: None,
+            retraction_reason: None,
+            expires_at: None,
+            superseded_by: None,
+            trust_score: Some(0.73),
+            trust_computed_at: None,
+            trust_version: None,
+            thread_id: None,
+            temporal_scope: TemporalScope::State,
+            sensitivity: ClaimSensitivity::Internal,
+            verification_state: ClaimVerificationState::Active,
+            verification_reason: None,
+            needs_user_decision_at: None,
+        }
+    }
+
+    #[test]
+    fn claim_link_map_direction_property_holds_for_each_entry() {
+        assert!(!CLAIM_LINK_MAP.is_empty(), "link map must not be vacuous");
+
+        for rule in CLAIM_LINK_MAP {
+            let claim = fixture_claim(rule, r#"["target-1"]"#);
+            let edges = compile_edges_from_claim(&claim);
+            assert_eq!(edges.len(), 1, "expected one edge for {rule:?}");
+            let edge = &edges[0];
+            assert_eq!(edge.origin_claim_id, claim.id);
+            assert_eq!(edge.edge_type, rule.edge_type);
+            assert_eq!(edge.link_source, LINK_SOURCE_FRONTMATTER_MAP);
+
+            match rule.direction {
+                EdgeDirection::Forward => {
+                    assert_eq!(edge.from_entity_id, "subject-1");
+                    assert_eq!(edge.to_entity_id, "target-1");
+                }
+                EdgeDirection::Incoming => {
+                    assert_eq!(edge.from_entity_id, "target-1");
+                    assert_eq!(edge.to_entity_id, "subject-1");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn subject_type_filter_rejects_wrong_subject_kind() {
+        let rule = CLAIM_LINK_MAP
+            .iter()
+            .find(|rule| rule.subject_type != CanonicalSubjectType::Email)
+            .unwrap();
+        let mut claim = fixture_claim(rule, r#"["target-1"]"#);
+        claim.subject_ref = subject_for(CanonicalSubjectType::Email, "email-1");
+
+        assert!(compile_edges_from_claim(&claim).is_empty());
+    }
+
+    #[test]
+    fn fanout_controls_target_cardinality() {
+        let fanout_rule = CLAIM_LINK_MAP.iter().find(|rule| rule.fanout).unwrap();
+        let single_rule = CLAIM_LINK_MAP.iter().find(|rule| !rule.fanout).unwrap();
+
+        assert_eq!(
+            compile_edges_from_claim(&fixture_claim(fanout_rule, r#"["a","b","a"]"#)).len(),
+            2
+        );
+        assert_eq!(
+            compile_edges_from_claim(&fixture_claim(single_rule, r#"["a","b"]"#)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn target_ids_prefer_structured_fields_and_preserve_case() {
+        let rule = CLAIM_LINK_MAP
+            .iter()
+            .find(|rule| rule.field == "stakeholders")
+            .unwrap();
+        let mut fields = Map::new();
+        fields.insert(
+            rule.field.to_string(),
+            serde_json::json!(["Person-MixedCase"]),
+        );
+        let mut root = Map::new();
+        root.insert("fields".to_string(), Value::Object(fields));
+
+        let mut claim = fixture_claim(rule, r#"["person-mixedcase"]"#);
+        claim.metadata_json = Some(Value::Object(root).to_string());
+
+        let edges = compile_edges_from_claim(&claim);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].to_entity_id, "Person-MixedCase");
+    }
+
+    #[test]
+    fn target_ids_fall_back_to_original_text_when_structured_field_missing() {
+        let rule = CLAIM_LINK_MAP
+            .iter()
+            .find(|rule| rule.field == "stakeholders")
+            .unwrap();
+        let mut claim = fixture_claim(rule, r#"["person-fallback"]"#);
+        claim.metadata_json = Some(
+            serde_json::json!({
+                "fields": {},
+                "original_text": r#"["Person-Fallback"]"#
+            })
+            .to_string(),
+        );
+
+        let edges = compile_edges_from_claim(&claim);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].to_entity_id, "Person-Fallback");
+    }
+
+    #[test]
+    fn claim_link_map_trait_exposes_frontmatter_rules() {
+        let provider = FrontmatterClaimLinkMap;
+        assert_eq!(provider.rules(), CLAIM_LINK_MAP);
+        assert_eq!(FRONTMATTER_LINK_MAP, CLAIM_LINK_MAP);
+    }
+}

--- a/src-tauri/src/services/claims/link_map_macro.rs
+++ b/src-tauri/src/services/claims/link_map_macro.rs
@@ -1,0 +1,30 @@
+#[macro_export]
+macro_rules! frontmatter_link_map {
+    (
+        $(#[$meta:meta])*
+        $vis:vis const $name:ident = [
+            $(
+                {
+                    field: $field:literal,
+                    edge_type: $edge_type:literal,
+                    direction: $direction:path,
+                    fanout: $fanout:literal,
+                    subject_type: $subject_type:path $(,)?
+                }
+            ),* $(,)?
+        ];
+    ) => {
+        $(#[$meta])*
+        $vis const $name: &[$crate::services::claims::link_map::LinkRule] = &[
+            $(
+                $crate::services::claims::link_map::LinkRule {
+                    field: $field,
+                    edge_type: $edge_type,
+                    direction: $direction,
+                    fanout: $fanout,
+                    subject_type: $subject_type,
+                },
+            )*
+        ];
+    };
+}

--- a/src-tauri/tests/dos265_link_map_macro_shape_test.rs
+++ b/src-tauri/tests/dos265_link_map_macro_shape_test.rs
@@ -1,0 +1,6 @@
+#[test]
+fn frontmatter_link_map_macro_shape_rejects_missing_required_keys() {
+    std::env::set_var("DAILYOS_SRC_TAURI", env!("CARGO_MANIFEST_DIR"));
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.rs");
+}

--- a/src-tauri/tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.rs
+++ b/src-tauri/tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.rs
@@ -1,0 +1,51 @@
+mod abilities {
+    pub mod claims {
+        #[derive(Clone, Copy)]
+        pub enum CanonicalSubjectType {
+            Meeting,
+        }
+    }
+}
+
+mod services {
+    pub mod claims {
+        pub mod link_map {
+            use crate::abilities::claims::CanonicalSubjectType;
+
+            pub enum EdgeDirection {
+                Forward,
+                Incoming,
+            }
+
+            pub struct LinkRule {
+                pub field: &'static str,
+                pub edge_type: &'static str,
+                pub direction: EdgeDirection,
+                pub fanout: bool,
+                pub subject_type: CanonicalSubjectType,
+            }
+        }
+    }
+}
+
+include!(concat!(
+    env!("DAILYOS_SRC_TAURI"),
+    "/src/services/claims/link_map_macro.rs"
+));
+
+use services::claims::link_map::EdgeDirection;
+
+frontmatter_link_map! {
+    pub const TRYBUILD_FRONTMATTER_LINK_MAP = [
+        {
+            field: "account",
+            edge_type: "trybuild_mentions_account",
+            direction: EdgeDirection::Forward,
+            fanout: false,
+        },
+    ];
+}
+
+fn main() {
+    let _ = abilities::claims::CanonicalSubjectType::Meeting;
+}

--- a/src-tauri/tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.stderr
+++ b/src-tauri/tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.stderr
@@ -1,0 +1,16 @@
+error: no rules expected `}`
+  --> tests/trybuild/frontmatter_link_map_shape_missing_subject_type_fails.rs:45:9
+   |
+45 |         },
+   |         ^ no rules expected this token in macro call
+   |
+  ::: src/services/claims/link_map_macro.rs
+   |
+   | macro_rules! frontmatter_link_map {
+   | --------------------------------- when calling this macro
+   |
+note: while trying to match `subject_type`
+  --> src/services/claims/link_map_macro.rs
+   |
+   |                     subject_type: $subject_type:path $(,)?
+   |                     ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- services/claims/link_map.rs with EdgeDirection (Forward, Incoming), LinkRule, CLAIM_LINK_MAP const
- compile_edges_from_claim respects subject_type filter, fanout, edge direction
- claim_edges schema + claim_edges_active VIEW + backlinks VIEW
- commit_claim populates edges in same tx; supersede + tombstone correctly mark
- Property test per CLAIM_LINK_MAP entry; tombstone resurrection test; trybuild macro shape test
- Extension mechanism only (no new claim variants — those land in W4)
- .docs/architecture/CLAIM-EDGES.md with the map table printed

## L2
- 4 cycles to APPROVE on cycle-4
- Codex adversarial cycle-4: APPROVE — no LITERAL ADR-0113 acceptance blocker

## Test plan
- [x] cargo clippy --workspace --lib --bins -- -D warnings clean
- [x] preflight all 12 gates green
- [ ] CI green on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)