### PR TITLE
design: marketing home mock + content rewrite doc

### DIFF
--- a/.docs/design/reference/marketing/HOME-CONTENT-v1.md
+++ b/.docs/design/reference/marketing/HOME-CONTENT-v1.md
@@ -1,0 +1,257 @@
+# Home Content — v1 Draft
+
+This is the content rewrite for the Home page, written before any visual design.
+Read it as prose and reading order. Implementation structure (sections, columns,
+cards) comes later in the HTML mock.
+
+Source-of-truth references:
+- `.docs/design/product/MISSION.md`
+- `.docs/design/product/PRODUCT-THESIS.md`
+- `.docs/design/product/PHILOSOPHY.md`
+- `.docs/design/product/PRINCIPLES.md`
+
+The locked headline is **"Start from what matters."** Everything else is up for revision.
+
+---
+
+## Why this rewrite
+
+The current Home page is well-written but tries to do too many things at once. It runs through eight sections — hero, demo card, the-enemy, outcomes grid, three-band proof rail, "not another slot" cards, ideas teaser, beta CTA — and by the end the reader has heard seven different angles on the product. None of them get to land fully.
+
+The canon (MISSION, PRODUCT-THESIS, PHILOSOPHY) is tighter. It picks fewer points and lets them carry their own weight. This rewrite tries to do the same:
+
+- **One positioning idea up front:** memory plus judgement, not just storage.
+- **A vivid moment instead of an abstract claim:** the Killer Moment from PHILOSOPHY (the mystery 30-min meeting) — the most concrete passage in the canon, currently absent from Home.
+- **Trust as the differentiator,** because that's the wedge per PRODUCT-THESIS — not feature parity, not productivity, not AI-quality. Trust.
+- **Cut the outcomes grid.** It dilutes. The Killer Moment makes the same point with one image instead of four bullet rows.
+- **Cut the three-band proof rail** ("A working app / A portable context surface / A personal graph") — proof points belong on Demo and Ideas, not Home. Home is the door, not the tour.
+- **Keep the foundation-line teaser**, but recast as "a few statements carry the whole product" rather than a feature grid in disguise.
+- **End on Beta + finis marker.** Same as today.
+
+Net: 7-8 sections collapse to **6 sections**, each dense, each landing one idea.
+
+---
+
+## Voice notes
+
+The canon's voice is **editorial, declarative, slightly literary**. Short sentences. Plain words with weight. No SaaS hype vocabulary ("seamless", "powerful", "leverage"). No marketing throat-clearing.
+
+Examples that set the tone (lifted from canon):
+- "Magic, not machinery."
+- "The system operates. You leverage."
+- "Your brain shouldn't have a landlord."
+- "The moat is the discipline, not the data."
+- "Pick up where you are, not where you left off."
+
+Cadence: a clear thesis line, a small turn, a fact, a small turn, a closing image. Reads like a magazine column, not an SDR email.
+
+---
+
+## Open questions for James
+
+1. ~~**Killer-moment placement.**~~ — Cut. James: "feels really fake and unnecessary."
+2. ~~**Daily Briefing preview card.**~~ — Yes, on Home. Render it like the app, modeled on `.docs/design/reference/surfaces/briefing-d-spine.html`. (Decided.)
+3. ~~**"Trust as a feature" section.**~~ — Keep. James: "great headline." (Decided.)
+4. ~~**"What it is not" cards.**~~ — Cut entirely. James: "we don't need to talk about what it is not, that's typical AI contrast speak." (Decided.)
+5. **Foundation-line cards.** Today there are 3 (intelligence personal / context when it matters / brain landlord). Should the Home grid show all 7 published Idea-page lines, or curate to 3? My instinct: 3 is right; 7 dilutes again.
+6. **Hero CTA.** Today: "Watch the demo" + "Join the beta". Keep both? Reverse order? Just one (the stronger one)?
+
+## Standing rule (recorded in memory)
+
+**Marketing copy is outcomes-first, not features.** No "what it is not" / contrast cards / feature lists. Lift the canon's positions, never its prose. When uncertain, ask: "if a reader stops here, what changed for them?" If the answer is "they learned what we built," rewrite.
+
+This rule has now been applied. v2 below replaces v1.
+
+---
+
+## Proposed Home content (v2 — outcomes-first)
+
+Every section answers: *what changes for the reader?* Mechanism-language ("provenance attached", "claims persist", "structured intelligence") translated into reader-time experience ("you can act on what it tells you", "you stop second-guessing"). Where the canon's prose was load-bearing, I lifted the *position* and rewrote the words.
+
+### 1 — Hero
+
+> *No kicker — "DailyOS" already sits in the FolioBar pub label, repeating it as a hero eyebrow is redundant. Hero opens directly with the headline.*
+
+**Headline (display, serif, large):** Start from what matters.
+
+**Standfirst (serif, generous size, slight italic on the second sentence):**
+DailyOS keeps up with your work so you walk in prepared for every meeting, decision, and follow-up. The thread you need is already pulled. The next move is already in front of you.
+
+**Buttons:** [See it work] [Get on the list]
+
+> *Changes:* third paragraph cut (was redundant with the standfirst). CTA labels reframed as reader-actions ("see it work" / "get on the list") rather than feature-objects ("watch the demo" / "join the beta").
+
+---
+
+### 2 — Daily Briefing slate
+
+> *App-faithful preview, modeled on `.docs/design/reference/surfaces/briefing-d-spine.html`. Renders as an actual instance of the chrome (FolioBar accent, MeetingSpineItem rhythm, Pill colours), not a screenshot. Generic placeholder customer names (Acme, Globex, Northwind) per the d-spine reference and CLAUDE.md.*
+
+**Eyebrow (small, uppercase, mono):** A morning, picked up
+
+**Single line above the slate (serif, italic):**
+Your 9am opens to this — a day already understood, not a blank canvas.
+
+**Slate content (representative — exact pacing locked in HTML mock):**
+- Mini-folio header: TUESDAY, OCTOBER 14 · MEMORY + JUDGEMENT · the brand mark
+- Lead headline (serif): *Four meetings today, two with customers. The Acme renewal at 10:00 is the one to nail.*
+- Compressed day-chart strip — 2-3 visible meeting bars
+- 2 MeetingSpineItem entries: 10:00 Acme renewal (in progress, sage pill "Briefing fresh") + 2:00 Northwind partner sync (terracotta pill "No briefing yet")
+- 1 "Moving" row: Acme — Renewal moved forward — Health 71 +3
+- Finis-marker spacer
+
+**Single line below the slate:**
+You did not assemble any of this. Your morning starts with reading, not gathering.
+
+> *The slate is the page's only concrete proof. Its job is to make the abstract positioning physical without resorting to marketing prose. The line above frames it as outcome ("you open to this"), the line below confirms it ("you didn't assemble it").*
+
+---
+
+### 3 — The flip
+
+**Eyebrow:** The flip
+
+**Headline:** Stop being the integration layer.
+
+**Body:**
+
+Every other tool wants you to maintain it before it helps you. Tag the notes. Update the CRM. Clean the task list. Then prompt the AI to reason over the mess you just spent your morning preparing.
+
+You stop doing all that. You walk in with a thread already pulled, an account history already current, an action list that doesn't need babysitting. The work that used to happen between meetings happens for you, before them.
+
+**Pull-out (italic, set off):** Your morning starts with reading, not gathering.
+
+> *Outcome-led. Headline IS the reader's outcome. Body describes user-time, not system-time. "Magic, not machinery" cut from here — better placed elsewhere or held back, and "your morning starts with reading, not gathering" is the more concrete pullout.*
+
+---
+
+### 4 — Trust as a feature
+
+**Eyebrow:** Trust
+
+**Headline:** You can act on what it tells you.
+
+**Body:**
+
+Every other AI for work confidently hands you something plausible-but-wrong, stripped of context, forgetful of the correction you just made. You spend your day verifying its basics.
+
+You stop doing that. You see why something surfaced, where it's certain and where it isn't, and what would change its mind. Corrections you make stay made — not just for the next prompt, but for the way it reads your work tomorrow.
+
+**Pull-out:** Trust is a product behaviour, not a disclaimer.
+
+> *Headline IS the outcome. Body opens on the reader's pain (verifying basics), pivots to what changes (you stop). Pull-out preserves the canon's wedge phrase, demoted from headline to coda.*
+>
+> *Visual hint for the mock:* a small **trust-band Pill** ("Likely current" / "Use with caution" / "Needs verification") could sit inline next to a phrase, anchoring the abstract claim in a real-product affordance.
+
+---
+
+### 5 — Ownership
+
+**Eyebrow:** Ownership
+
+**Headline:** Your brain should not have a landlord.
+
+**Body:**
+
+Your professional context — your relationships, your judgement patterns, the lessons you carry — is irreducibly personal. It loses value the moment it's shared.
+
+It stays on your machine. You can take it with you. You can read it without DailyOS open. Any AI tool you trust can read it too. If you walk away one day, you walk away with everything you built.
+
+**Pull-out:** The moat is the discipline, not the data.
+
+> *Outcome rewrite. "Open formats every AI tool can read" → "any AI tool you trust can read it too." "Sync to whatever you trust" → "you can take it with you." Same substance, reader-time framing.*
+
+---
+
+### 6 — The foundation lines
+
+**Eyebrow:** Ideas
+
+**Headline:** A few statements carry the whole product.
+
+**Body:**
+
+Each is a page on its own. Read one and the rest follow.
+
+**Cards (3 — link to existing `/ideas/...` slugs):**
+
+— **Personal.** *DailyOS makes intelligence personal.*
+The category is not more AI at work. It is intelligence that knows your world.
+
+— **Timing.** *Your context, when it matters most.*
+Preparation beats engagement. Ready beats fast.
+
+— **The system's fault.** *The guilt is not laziness. It is the system's fault.*
+Every productivity tool failed you for the same reason. Here is what changes.
+
+> *Three cards. Each card description is reader-outcome flavour ("knows your world", "ready beats fast", "what changes"). Open question 5 still standing — happy to expand to more, but my read is 3 hits hardest.*
+
+---
+
+### 7 — Beta
+
+**Eyebrow:** Public beta coming soon
+
+**Headline:** A real demo, not a roadmap tour.
+
+**Body:**
+
+DailyOS is in private beta. The first invites go to colleagues who want to see a working system, not a deck. Public beta opens later this year — leave your email and we'll write to you directly when it does.
+
+**Button:** [Get on the list →]
+
+> *Outcome version. Lead with what the reader gets ("a real demo" + a direct-write follow-up) instead of an instruction.*
+
+---
+
+### 8 — End mark
+
+Three centered asterisks (the FinisMarker pattern from the app reference).
+
+Then, one line, centered, in the serif:
+> *Start from what matters.*
+
+---
+
+### 9 — Footer
+
+> *Standard corporate chrome — same shape as Studio Write's. Repo URL is `github.com/jamesgiroux/daily-operating-system` per the local repo's `public` remote. Press email stays Automattic.*
+
+**Layout:** Two-column flex on desktop; stacks on narrow.
+
+**Left (small, sans):**
+© 2026 DailyOS · An Automattic experiment, not an official product · [Radical Speed Month 2026](https://bsky.app/profile/automattic.com/post/3mkavah2m2k2w) · Press: [press@automattic.com](mailto:press@automattic.com)
+
+**Right (link row, small caps or small mono):**
+Blog · [GitHub](https://github.com/jamesgiroux/daily-operating-system) · X (TBD if there's a handle yet) · RSS
+
+> *Open question 7:* is there an X handle for DailyOS yet, or do we drop the X link for now? Same question for any other channel (Bluesky? LinkedIn?) — easier to add than remove.
+
+---
+
+## Section count + density
+
+| # | Section              | Lift                                | Status         |
+|---|----------------------|-------------------------------------|----------------|
+| 1 | Hero                 | Locked headline + tightened lede    | v2 — outcome   |
+| 2 | Daily Briefing slate | App-faithful preview                | New            |
+| 3 | The flip             | Replaces "the enemy" + outcomes grid | v2 — outcome  |
+| 4 | Trust as a feature   | Canonical wedge per PRODUCT-THESIS  | v2 — outcome   |
+| 5 | Ownership            | Compress + lift "moat is discipline"| v2 — outcome   |
+| 6 | The foundation lines | Re-curate to 3 cards w/ outcome subs| v2             |
+| 7 | Beta                 | A real demo, not a roadmap tour     | v2 — outcome   |
+| 8 | End mark             | Keep                                | —              |
+| 9 | Footer               | Standard corporate chrome           | New            |
+
+Net: 9 sections. 5 short (hero, end-mark, beta, footer, slate-frame), 4 carrying long-form prose (slate, flip, trust, ownership). Same reading rhythm as the d-spine reference: dense passages with breathing room between.
+
+---
+
+## What to react to first
+
+If you only react to one thing, react to:
+1. **Open questions 1-6** above.
+2. **Whether the trust section earns its place on Home** or belongs elsewhere.
+3. **Whether to keep the Daily Briefing preview slate** (existing) or let the prose carry the proof.
+
+Once those three are settled, the rest is wording polish, which I'll do as a v2 of this doc.

--- a/.docs/design/reference/marketing/home.html
+++ b/.docs/design/reference/marketing/home.html
@@ -1,0 +1,570 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>DailyOS · Personal intelligence on your machine.</title>
+  <meta name="description" content="Personal intelligence on your machine. DailyOS knows your work — what's true, what's stale, and what to surface now. Wherever you work.">
+
+  <link rel="stylesheet" href="../_shared/fonts.css">
+  <link rel="stylesheet" href="../_shared/styles/design-tokens.css">
+
+  <!-- App chrome — both the page top FolioBar and the embedded preview window -->
+  <link rel="stylesheet" href="../_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../_shared/styles/FolioBar.module.css">
+
+  <!-- d-spine vocabulary for the briefing rendered inside the preview -->
+  <link rel="stylesheet" href="../_shared/styles/MeetingSpineItem.module.css">
+  <link rel="stylesheet" href="../_shared/styles/Pill.module.css">
+  <link rel="stylesheet" href="../_shared/styles/editorial-briefing.module.css">
+
+  <!-- Dropdown paint reused from the account-detail surface -->
+  <link rel="stylesheet" href="../_shared/styles/FolioReportsDropdown.module.css">
+
+  <style>
+    /* =============================================================================
+       DailyOS · Home (experiment)
+
+         1. Centered hero with one promise + signup
+         2. Faithful app preview at canonical app dimensions
+         3. Finis marker
+         4. Footer
+       ============================================================================= */
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; }
+    body {
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Page-top FolioBar — site context tweak */
+    body > .MagazinePageLayout_magazinePage > .FolioBar_folio {
+      padding-left: 32px;
+    }
+
+
+    /* ─── Pages dropdown — reuses FolioReportsDropdown paint ────────────── */
+    .FolioReportsDropdown_dropdown { display: none; }
+    .FolioReportsDropdown_wrapper:hover .FolioReportsDropdown_dropdown,
+    .FolioReportsDropdown_wrapper:focus-within .FolioReportsDropdown_dropdown {
+      display: block;
+    }
+    a.FolioReportsDropdown_item { text-decoration: none; }
+    .FolioReportsDropdown_item:last-child { border-bottom: none; }
+
+
+    /* ─── Page container ────────────────────────────────────────────────── */
+    .page {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: calc(var(--page-margin-top) + var(--space-3xl)) var(--space-2xl) var(--space-2xl);
+    }
+    @media (max-width: 720px) {
+      .page { padding: calc(var(--page-margin-top) + var(--space-xl)) var(--space-md) var(--space-xl); }
+    }
+
+
+    /* ─── 1. Hero — centered ────────────────────────────────────────────── */
+    .hero {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: var(--space-3xl) 0;
+      text-align: center;
+    }
+    .hero__headline {
+      font-family: var(--font-serif);
+      font-size: clamp(48px, 7vw, 84px);
+      font-weight: 400;
+      letter-spacing: -0.025em;
+      line-height: 1.04;
+      color: var(--color-text-primary);
+      margin: 0 0 var(--space-lg);
+    }
+    .hero__headline-period { color: var(--color-spice-turmeric); }
+
+    .hero__narrative {
+      font-family: var(--font-serif);
+      font-size: clamp(18px, 1.9vw, 22px);
+      font-weight: 300;
+      font-style: italic;
+      line-height: 1.55;
+      color: var(--color-text-secondary);
+      margin: 0 auto var(--space-2xl);
+      max-width: 580px;
+    }
+
+
+    /* ─── Signup ────────────────────────────────────────────────────────── */
+    .signup__form {
+      display: flex;
+      gap: var(--space-sm);
+      max-width: 460px;
+      margin: 0 auto;
+      align-items: stretch;
+    }
+    .signup__input {
+      flex: 1 1 auto;
+      min-width: 0;
+      padding: 12px 14px;
+      border: 1px solid var(--color-rule-heavy);
+      border-radius: var(--radius-editorial-md);
+      background: var(--color-paper-warm-white);
+      font-family: var(--font-sans);
+      font-size: 14px;
+      color: var(--color-text-primary);
+      transition: border-color var(--transition-normal);
+    }
+    .signup__input::placeholder { color: var(--color-text-tertiary); }
+    .signup__input:focus { outline: none; border-color: var(--color-spice-turmeric); }
+    .signup__button {
+      flex: 0 0 auto;
+      padding: 12px 20px;
+      border: 1px solid var(--color-text-primary);
+      border-radius: var(--radius-editorial-md);
+      background: var(--color-text-primary);
+      color: var(--color-paper-cream);
+      font-family: var(--font-sans);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all var(--transition-normal);
+      white-space: nowrap;
+    }
+    .signup__button:hover {
+      background: var(--color-spice-turmeric);
+      border-color: var(--color-spice-turmeric);
+      color: var(--color-text-primary);
+    }
+    .signup__note {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      color: var(--color-text-tertiary);
+      margin: var(--space-md) 0 0;
+    }
+    @media (max-width: 480px) {
+      .signup__form { flex-direction: column; }
+    }
+
+
+    /* ─── 2. App preview — faithful render at canonical dimensions ───────
+       Internal proportions match the actual app: 40px FolioBar, 80px left
+       padding (traffic-light region), 120px page-padding-horizontal,
+       100px MarginGrid label gutter, 76px hero headline, full-scale
+       MeetingSpineItem rows. The whole frame is then proportionally
+       scaled to fit the page width.
+       ─────────────────────────────────────────────────────────────────── */
+
+    /* Stage holds the actual rendered layout space; the inner frame is the
+       1280×800 app rendered in full and scaled by --preview-scale. */
+    :root {
+      --preview-w: 1280px;
+      --preview-h: 800px;
+      /* Scale derives from viewport minus page horizontal padding (48px ×2 desktop). */
+      --preview-scale: min(0.92, calc((100vw - 96px) / 1280));
+    }
+    @media (max-width: 720px) {
+      :root {
+        --preview-scale: min(0.92, calc((100vw - 32px) / 1280));
+      }
+    }
+
+    .preview {
+      margin: var(--space-2xl) auto;
+      width: calc(var(--preview-w) * var(--preview-scale));
+      height: calc(var(--preview-h) * var(--preview-scale));
+      position: relative;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .preview__frame {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: var(--preview-w);
+      height: var(--preview-h);
+      transform: scale(var(--preview-scale));
+      transform-origin: top left;
+      border-radius: 14px;
+      overflow: hidden;
+      background: var(--color-paper-cream);
+      box-shadow:
+        0 0 0 1px rgba(30, 37, 48, 0.08),
+        0 16px 40px -12px rgba(30, 37, 48, 0.18),
+        0 40px 100px -28px rgba(30, 37, 48, 0.22);
+      isolation: isolate;
+    }
+
+    /* Override FolioBar inside the preview: scoped, not viewport-fixed */
+    .preview__frame .FolioBar_folio {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 5;
+      /* Keep the canonical 80px left padding for traffic-light region */
+    }
+
+    /* macOS traffic-light dots — sit in the FolioBar's left padding region */
+    .preview__traffic {
+      position: absolute;
+      top: 14px;
+      left: 16px;
+      z-index: 6;
+      display: flex;
+      gap: 8px;
+    }
+    .preview__traffic span {
+      display: block;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+    .preview__traffic-close { background: #ff5f57; }
+    .preview__traffic-min   { background: #febc2e; }
+    .preview__traffic-max   { background: #28c840; }
+
+    /* Override AtmosphereLayer inside the preview: contained */
+    .preview__frame .AtmosphereLayer_atmosphere {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Inside the preview, MagazinePageLayout_pageContainer renders normally
+       at canonical sizes. The 40px FolioBar at top is cleared by the
+       canonical --page-margin-top. */
+    .preview__frame .MagazinePageLayout_pageContainer {
+      margin-top: calc(var(--page-margin-top) + var(--space-md));
+      max-width: 1180px;
+    }
+
+
+    /* d-spine inline styles — copied verbatim from briefing-d-spine.html so
+       the rendered briefing inside the preview matches the app reference. */
+    .dspine-sharp { color: var(--color-spice-turmeric); }
+    .dspine-section-heading {
+      margin: 0;
+      font-family: var(--font-serif);
+      font-size: 32px;
+      font-weight: 400;
+      line-height: 1.15;
+      color: var(--color-text-primary);
+    }
+    .dspine-section-summary {
+      max-width: 660px;
+      margin: var(--space-xs) 0 var(--space-lg);
+      font-family: var(--font-serif);
+      font-size: 16px;
+      font-style: italic;
+      font-weight: 300;
+      line-height: 1.5;
+      color: var(--color-text-secondary);
+    }
+    .dspine-stack { display: grid; gap: 0; }
+
+
+    /* ─── 3. Finis marker ───────────────────────────────────────────────── */
+    .finis {
+      text-align: center;
+      padding: var(--space-3xl) 0 var(--space-xl);
+      color: var(--color-text-tertiary);
+    }
+    .finis__marks {
+      display: inline-flex;
+      gap: var(--space-md);
+      justify-content: center;
+      opacity: 0.55;
+    }
+
+
+    /* ─── 4. Footer ─────────────────────────────────────────────────────── */
+    .footer {
+      max-width: 760px;
+      margin: 0 auto;
+      border-top: 1px solid var(--color-rule-heavy);
+      padding: var(--space-xl) 0 var(--space-2xl);
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: var(--space-lg);
+      align-items: end;
+    }
+    .footer__copy {
+      font-family: var(--font-sans);
+      font-size: 12px;
+      line-height: 1.6;
+      color: var(--color-text-tertiary);
+      margin: 0;
+      max-width: 560px;
+    }
+    .footer__copy a {
+      color: var(--color-text-secondary);
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
+    }
+    .footer__copy a:hover { color: var(--color-text-primary); }
+    .footer__links {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      gap: var(--space-md);
+    }
+    .footer__links a {
+      color: var(--color-text-secondary);
+      text-decoration: none;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.10em;
+      text-transform: uppercase;
+    }
+    .footer__links a:hover { color: var(--color-spice-turmeric); }
+    @media (max-width: 640px) {
+      .footer { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="MagazinePageLayout_magazinePage">
+
+  <!-- Page atmosphere -->
+  <div class="AtmosphereLayer_atmosphere AtmosphereLayer_turmeric">
+    <div class="AtmosphereLayer_watermark AtmosphereLayer_watermarkTurmeric">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="100%" height="100%" aria-hidden="true">
+        <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+      </svg>
+    </div>
+  </div>
+
+  <!-- Page-top FolioBar -->
+  <header class="FolioBar_folio">
+    <div class="FolioBar_folioLeft">
+      <a class="FolioBar_folioHomeLink" href="./home.html">
+        <svg class="FolioBar_folioMark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18" aria-hidden="true">
+          <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+        </svg>
+      </a>
+      <span class="FolioBar_folioPub">DailyOS</span>
+    </div>
+    <div class="FolioBar_folioCenter">SUNDAY, MAY 10, 2026</div>
+    <div class="FolioBar_folioRight">
+      <div class="FolioReportsDropdown_wrapper">
+        <button type="button" class="FolioReportsDropdown_button" aria-haspopup="true">Pages ▾</button>
+        <div class="FolioReportsDropdown_dropdown" role="menu">
+          <a class="FolioReportsDropdown_item" role="menuitem" href="./demo.html">Demo</a>
+          <a class="FolioReportsDropdown_item" role="menuitem" href="./manifesto.html">Manifesto</a>
+          <a class="FolioReportsDropdown_item" role="menuitem" href="./ideas.html">Ideas</a>
+          <a class="FolioReportsDropdown_item" role="menuitem" href="./join-beta.html">Join Beta</a>
+          <a class="FolioReportsDropdown_item" role="menuitem" href="./blog.html">Blog</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+
+  <main class="page">
+
+    <!-- ── 1. Hero ──────────────────────────────────────────────────────── -->
+    <section class="hero">
+      <h1 class="hero__headline">Personal intelligence on your machine<span class="hero__headline-period">.</span></h1>
+      <p class="hero__narrative">It knows your work — what's true, what's stale, and what to surface now. Wherever you work. Private beta now, public beta later this year.</p>
+
+      <form class="signup__form" action="#" method="post" novalidate>
+        <input class="signup__input" type="email" name="email" placeholder="you@email.com" required aria-label="Email address">
+        <button class="signup__button" type="submit">Get notified →</button>
+      </form>
+      <p class="signup__note">We'll write when public beta opens. No newsletter.</p>
+    </section>
+
+
+    <!-- ── 2. App preview — faithful render at app dimensions, scaled ──── -->
+    <div class="preview" aria-label="DailyOS, Tuesday October 14: a working daily briefing">
+      <div class="preview__frame">
+
+        <!-- macOS traffic-light dots (in the FolioBar's reserved left padding) -->
+        <div class="preview__traffic" aria-hidden="true">
+          <span class="preview__traffic-close"></span>
+          <span class="preview__traffic-min"></span>
+          <span class="preview__traffic-max"></span>
+        </div>
+
+        <!-- AtmosphereLayer (contained inside the window) -->
+        <div class="AtmosphereLayer_atmosphere AtmosphereLayer_turmeric">
+          <div class="AtmosphereLayer_watermark AtmosphereLayer_watermarkTurmeric">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="100%" height="100%" aria-hidden="true">
+              <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+            </svg>
+          </div>
+        </div>
+
+        <!-- App FolioBar -->
+        <header class="FolioBar_folio">
+          <div class="FolioBar_folioLeft">
+            <span class="FolioBar_folioMark">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18" aria-hidden="true">
+                <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+              </svg>
+            </span>
+            <nav class="FolioBar_folioBreadcrumbs" aria-label="Breadcrumb">
+              <span class="FolioBar_folioBreadcrumbCurrent">Daily Briefing</span>
+            </nav>
+          </div>
+          <div class="FolioBar_folioCenter">TUESDAY, OCTOBER 14, 2026</div>
+          <div class="FolioBar_folioRight">
+            <div class="FolioBar_folioReadiness">
+              <span class="FolioBar_folioStat FolioBar_folioStatSage">
+                <span class="FolioBar_folioDot FolioBar_folioDotSage"></span>3 briefings ready
+              </span>
+              <span class="FolioBar_folioStat FolioBar_folioStatTerracotta">
+                <span class="FolioBar_folioDot FolioBar_folioDotTerracotta"></span>1 needs prep
+              </span>
+            </div>
+            <button class="FolioBar_folioSearch" type="button" aria-label="Open search">⌘K</button>
+          </div>
+        </header>
+
+        <!-- Page container -->
+        <main class="MagazinePageLayout_pageContainer">
+
+          <!-- Hero section -->
+          <section class="editorial-briefing_hero">
+            <h1 class="editorial-briefing_heroHeadline">Four meetings today, two with customers. <span class="dspine-sharp">The Acme renewal at 10:00 is the one to nail.</span></h1>
+            <div class="editorial-briefing_focusCapacity">
+              3h available · 2 deep work blocks · light afternoon after 2:00
+            </div>
+          </section>
+
+          <!-- Schedule section with MarginGrid -->
+          <section class="editorial-briefing_scheduleSection">
+            <div class="editorial-briefing_marginGrid">
+              <div class="editorial-briefing_marginLabel">
+                Today
+                <span class="editorial-briefing_marginLabelCount">4 meetings</span>
+              </div>
+              <div class="editorial-briefing_marginContent">
+                <div class="editorial-briefing_sectionRule"></div>
+                <h2 class="dspine-section-heading">Today's schedule</h2>
+                <p class="dspine-section-summary">2 customer · 1 partner · 1 internal. The day is shaped around one renewal and one partner call.</p>
+
+                <div class="dspine-stack">
+
+                  <article class="MeetingSpineItem_item MeetingSpineItem_internal MeetingSpineItem_past">
+                    <div class="MeetingSpineItem_timeColumn">
+                      <span class="MeetingSpineItem_time">9:00</span>
+                      <span class="MeetingSpineItem_duration">30m · ended</span>
+                    </div>
+                    <div class="MeetingSpineItem_body">
+                      <div class="MeetingSpineItem_eyebrow">
+                        <span class="MeetingSpineItem_glyph" aria-hidden="true"></span>
+                        <span class="MeetingSpineItem_entityName">Internal · Engineering</span>
+                        <span class="MeetingSpineItem_rule" aria-hidden="true"></span>
+                      </div>
+                      <div class="MeetingSpineItem_titleRow">
+                        <h3 class="MeetingSpineItem_title">Eng standup</h3>
+                      </div>
+                      <p class="MeetingSpineItem_context">Routine. Auth migration is a day late; nothing for you to do unless 4 PM forecast moves.</p>
+                      <div class="MeetingSpineItem_footer">
+                        <span>5 attendees</span>
+                        <span class="MeetingSpineItem_separator" aria-hidden="true"></span>
+                        <span class="Pill_pill Pill_compact Pill_eucalyptus"><span class="Pill_dot" aria-hidden="true"></span>Notes captured</span>
+                      </div>
+                    </div>
+                  </article>
+
+                  <article class="MeetingSpineItem_item MeetingSpineItem_customer MeetingSpineItem_inProgress">
+                    <div class="MeetingSpineItem_timeColumn">
+                      <span class="MeetingSpineItem_time">10:00</span>
+                      <span class="MeetingSpineItem_duration">45m</span>
+                      <span class="MeetingSpineItem_stateTag MeetingSpineItem_stateTagNow">Now</span>
+                    </div>
+                    <div class="MeetingSpineItem_body">
+                      <div class="MeetingSpineItem_eyebrow">
+                        <span class="MeetingSpineItem_glyph" aria-hidden="true"></span>
+                        <span class="MeetingSpineItem_entityName">Acme Corp · Renewal</span>
+                        <span class="MeetingSpineItem_rule" aria-hidden="true"></span>
+                      </div>
+                      <div class="MeetingSpineItem_titleRow">
+                        <h3 class="MeetingSpineItem_title">Acme renewal — pricing and tier 3</h3>
+                      </div>
+                      <p class="MeetingSpineItem_context">Decisions on tier 3 pricing. The buyer wants final terms language before legal goes deep on MSA.</p>
+                      <div class="MeetingSpineItem_footer">
+                        <span>4 attendees</span>
+                        <span class="MeetingSpineItem_separator" aria-hidden="true"></span>
+                        <span class="Pill_pill Pill_compact Pill_sage"><span class="Pill_dot" aria-hidden="true"></span>Briefing fresh</span>
+                      </div>
+                    </div>
+                  </article>
+
+                  <article class="MeetingSpineItem_item MeetingSpineItem_partner">
+                    <div class="MeetingSpineItem_timeColumn">
+                      <span class="MeetingSpineItem_time">2:00</span>
+                      <span class="MeetingSpineItem_duration">60m</span>
+                    </div>
+                    <div class="MeetingSpineItem_body">
+                      <div class="MeetingSpineItem_eyebrow">
+                        <span class="MeetingSpineItem_glyph" aria-hidden="true"></span>
+                        <span class="MeetingSpineItem_entityName">Northwind Traders · Partner</span>
+                        <span class="MeetingSpineItem_rule" aria-hidden="true"></span>
+                      </div>
+                      <div class="MeetingSpineItem_titleRow">
+                        <h3 class="MeetingSpineItem_title">Northwind partner sync</h3>
+                      </div>
+                      <p class="MeetingSpineItem_context">First touch since their lead left. Replacement has not briefed in. Health dropped 16 points in 30 days.</p>
+                      <div class="MeetingSpineItem_footer">
+                        <span>6 attendees</span>
+                        <span class="MeetingSpineItem_separator" aria-hidden="true"></span>
+                        <span class="Pill_pill Pill_compact Pill_terracotta"><span class="Pill_dot" aria-hidden="true"></span>No briefing yet</span>
+                      </div>
+                    </div>
+                  </article>
+
+                </div>
+              </div>
+            </div>
+          </section>
+
+        </main>
+      </div>
+    </div>
+
+
+    <!-- ── 3. Finis marker ──────────────────────────────────────────────── -->
+    <div class="finis" aria-hidden="true">
+      <div class="finis__marks">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="14" height="14"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="14" height="14"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="14" height="14"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+      </div>
+    </div>
+
+
+    <!-- ── 4. Footer ────────────────────────────────────────────────────── -->
+    <footer class="footer">
+      <p class="footer__copy">
+        © 2026 DailyOS · An Automattic experiment, not an official product · <a href="https://bsky.app/profile/automattic.com/post/3mkavah2m2k2w" target="_blank" rel="noopener">Radical Speed Month 2026</a> · Press: <a href="mailto:press@automattic.com">press@automattic.com</a>
+      </p>
+      <ul class="footer__links">
+        <li><a href="./blog.html">Blog</a></li>
+        <li><a href="https://github.com/jamesgiroux/daily-operating-system" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="./feed.xml">RSS</a></li>
+      </ul>
+    </footer>
+
+  </main>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `.docs/design/reference/marketing/` with a static HTML mock of the DailyOS marketing home and the content-first doc that drove the rewrite.

- **`home.html`** — single-page mock: centered hero (category-led headline + signup form), faithful app preview rendered at canonical app dimensions (1280×800 with macOS window chrome + traffic-light dots), finis marker, footer. Page-top FolioBar uses `FolioReportsDropdown` paint from the account-detail surface for the Pages nav.
- **`HOME-CONTENT-v1.md`** — content-first rewrite doc grounded in `.docs/design/product/` canon; tracks iteration history and open questions.

The mock loads the same `_shared/` chrome modules as the d-spine briefing reference (`FolioBar`, `AtmosphereLayer`, `MeetingSpineItem`, `Pill`, `editorial-briefing`, `MagazinePageLayout`) — no parallel design vocabulary. The marketing surface and the app surface share fonts, tokens, and section rhythm verbatim.

Iterated through several aesthetic directions (Lapham's-Quarterly editorial, Studio-Write minimal) and landed on app-faithful d-spine vocabulary per James's pivot. Headline currently centers Personal Intelligence as the category claim per the post outline at `.docs/learnings/2026-05-10-personal-intelligence-what-comes-after-the-second-brain.md`. Still in iteration — particularly the differentiation question vs Claude/Codex/Mem.

Not in this PR: parallel work in the WP Studio build at `~/Studio/dailyos/wp-content/themes/dailyos/` (chrome sync script, patched chrome.js, functions.php, templates, favicons) — that directory isn't under git.

## Test plan

- [ ] Open `.docs/design/reference/marketing/home.html` via `file://` — chrome (FolioBar, AtmosphereLayer, atmosphere watermark) renders
- [ ] Hover/focus the "Pages ▾" dropdown in the page-top FolioBar — items render with `FolioReportsDropdown` paint
- [ ] Scroll the page top-to-bottom — finis marker and footer visible after the preview
- [ ] Resize narrow — app preview scales proportionally, no horizontal overflow
- [ ] Compare to `.docs/design/reference/surfaces/briefing-d-spine.html` — typographic + chrome vocabulary matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)