### PR TITLE
DOS-546 v1.4.2: 9 L0 packets at unanimous APPROVE (W3-W5)

### DIFF
--- a/.docs/plans/dos-546/v1.4.2-project/DOS-589-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/DOS-589-L0-packet.md
@@ -1,0 +1,850 @@
+# W4-B-signals L0 packet - signal subscriber + scope-filter dispatcher
+
+Date: 2026-05-13 (V1)
+Project: v1.4.2 - Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: W4-B-signals (stage-1 sibling under DOS-546 v1.4.2)
+Issue: DOS-589 (signal subscriber + scope-filter dispatch)
+Sibling: DOS-567 (W4-B: three-view consistency concurrency contract)
+Status: L0 prep
+
+This packet captures the substrate-side dispatcher plan for DOS-589. The Linear issue remains the canonical execution record; this packet hardens the implementation contract where the issue leaves decisions open or where W4-B V9 supersedes older wording.
+
+DOS-589 is pure Rust substrate work. It is not WP/PHP work. It consumes `version_events` rows written by DOS-567's W4-B outbox after commit and delivers ordered, scope-filtered events to subscribers that are already authorized to see the underlying claim or composition.
+
+W4-B V9 is the upstream contract inherited here:
+
+- W4-B V9 section 5 defines `ClaimVersionEvent`, `CompositionVersionEvent`, and `CorrectionRef`.
+- W4-B V9 section 15 defines the dedicated `version_events` table, `event_seq INTEGER PRIMARY KEY AUTOINCREMENT`, UUIDv4 cursor, and replay clause `WHERE event_seq > ? ORDER BY event_seq`.
+- W4-B V9 section 16 defines the class-level scope-filter rule.
+- W4-B V9 section 17 defines `wp_user_id` session binding for SurfaceClient requests.
+- W4-B V9 section 37 pins `src-tauri/src/bridges/surface_client.rs` as the canonical `/v1/surface/*` route module.
+
+One drift is intentional in this packet: Linear DOS-589 still says `signal_events` in its scope and acceptance text. W4-B V9 supersedes that wording for this issue. DOS-589 dispatches from `version_events`, not the legacy ADR-0080 `signal_events` table.
+
+## Changelog
+
+- **V3.2 (2026-05-13):** Cycle 4 codex confirmation pass — closed one literal acceptance violation:
+  - §16 (SurfaceClient session expiry handling, V2 NEW) renumbered to §13.5 to preserve §13 → §14 → §15 ordering required by L0 closure acceptance criterion ("All 15 sections remain present in order"). V2 inserted §16 between §13 and §14 which created `13 → 16 → 14 → 15`. V3.2 keeps the content unchanged; only the section index changes.
+  - V2 changelog reference to "§16" updated to "§13.5".
+  - All trust-boundary and substrate-contract findings already closed in V3.1 — section ordering was the residual literal-acceptance gap.
+
+- **V3.1 (2026-05-13):** Cycle 3 codex confirmation pass — closed one stale-contract drift after V3 §3 cursor envelope landed:
+  - §10 reconnect flow rewritten as envelope-first: dispatcher decodes envelope → reads embedded `subscription_id` → looks up `subscriber_local_key` + checkpoint by `subscription_id` (durable key, not cursor) → recomputes HMAC → on mismatch returns "no events" indistinguishably without resolving cursor_uuid. V2 said "lookup subscription_id via cursor → event_seq → checkpoint" which reintroduced the cursor-as-lookup-authority path that V3 §3 explicitly removed.
+  - Added explicit rule: if envelope is unverifiable, `from_cursor` is ignored entirely; no implicit subscription allocation tied to a foreign cursor.
+
+- **V3 (2026-05-13):** Cycle 2 fold — codex BLOCK. Material changes:
+  - **CRITICAL fix (codex C2):** §3 cursor envelope shape. V2 conflated "HMAC-as-cursor" with "UUIDv4-as-row-PK" — codex correctly flagged this contradicts W4-B V9 §15 (which fixes the `version_events.cursor` PK as UUIDv4). V3: the W4-B UUIDv4 PK is preserved verbatim; on-wire cursor is a base64 envelope `{cursor_uuid: UUIDv4, subscription_id: UUIDv4, mac: HMAC-SHA256(subscriber_local_key, cursor_uuid || subscription_id)}`. Envelope is the transport-layer authenticity check; row identity remains the UUIDv4. Resolution: decode → lookup subscriber_local_key by subscription_id → recompute MAC → on match, resolve cursor_uuid to event_seq via W4-B V9 §15 PK lookup.
+  - **HIGH fix (codex C2):** §4 + Q4 — `SubscribeAck.current_cursor` rewritten as subscriber-visible cursor (most recent event whose `scope_permits_*_read` predicate returns true under current scopes, or `null`). V2 said "global latest is acceptable since UUIDv4 is opaque"; codex correctly noted that returning ANY reachable cursor in a global-latest scheme is still an existence-oracle signal. V3: internal `event_seq_at_subscribe` high-water mark is dispatcher-private and never surfaces; subscribers see only permitted-event cursors.
+  - **MEDIUM fix (codex C2):** §5 `scope_permits_composition_read` predicate now takes `composition_version` and authorizes against the FROZEN claim_refs at that exact version, not the most recent reflection. Prevents a race where a subsequent version drops the actor's only permitted claim_ref but the dispatcher still delivers the earlier event's notification using current reflection.
+
+- **V2 (2026-05-13):** Cycle 1 fold — eng + devex CONDITIONAL APPROVE; /cso CONDITIONAL (2 CRITICAL + 3 HIGH + 3 MEDIUM + 2 LOW); codex BLOCK (1 CRITICAL + 3 HIGH + 2 MEDIUM + 1 LOW). Material changes:
+  - **CRITICAL fix (codex):** §3 replay cursor semantics rewritten. V1 conflated "internal scan position" with "client-visible cursor" — out-of-scope rows trapped subscribers in infinite loop OR leaked via cursor advancement. V2 distinguishes: internal `last_scanned_event_seq` (durable, ratchets through ALL event_seqs regardless of scope; prevents replay loops) vs client-visible `cursor` (UUIDv4, references only PERMITTED events the subscriber actually received; prevents existence-oracle leak).
+  - **HIGH fix (codex):** §5 composition event scope-gating no longer relies on `affected_claim_ids` (which W4-B V9 §5 does not provide). V2 adds `scope_permits_composition_read(actor, composition_id)` predicate — DOS-589-owned, queries `composition_versions` + composition's known claim_refs. No W4-B amendment needed.
+  - **HIGH fix (codex):** Replay/live race ordering. On Subscribe with `from_cursor`, dispatcher captures high-water `event_seq_at_subscribe`. Replay runs through that high-water. Live events with `event_seq > high_water` BUFFER on the subscriber's outbound queue until replay completes. After replay close, buffered events drain in order.
+  - **HIGH fix (codex):** Durable checkpoint identity §10/§11 now keyed by `(subscription_id, actor, scopes_digest, subject_filter_digest)`. `subscription_id` is server-allocated per Subscribe call. Concurrent same-actor connections don't poison each other.
+  - **CRITICAL fix (cso C1):** §4 — scope set re-resolved from CURRENT authenticated actor for each row, not snapshotted at subscribe or replay-start. Per-row scope rebind catches mid-replay scope tightening.
+  - **CRITICAL fix (cso C2):** Cursor HMAC binding. Client-visible cursor is `HMAC(per-subscriber-key, event_seq)`. Foreign cursor → bridge resolves cursor to event_seq; HMAC mismatch returns identical "no events" envelope (not differentiated from "valid but no events"). Cross-actor cursor capture cannot probe event_seq lifetime.
+  - **HIGH fix (cso H1):** §7 backpressure event delivered ONLY to affected subscriber. `dropped_event_count` counts events in subscriber's permitted set; never includes filtered-away rows. No cross-subscriber backpressure metric on any SurfaceClient route.
+  - **HIGH fix (cso H2):** §8 transport — push channel inherits per-frame HMAC matching W2-B contract; transport choice deferred but integrity property locked.
+  - **HIGH fix (cso H3):** §8 wp_user_id binding for SubscribeRequest — body-asserted rejected if not matching session-bound; dispatcher never reads from body without bridge validation.
+  - **MEDIUM (cso M1):** §4 predicate evaluation + payload projection inside consistent claim-read-policy snapshot (per-claim-version-bound read).
+  - **Eng P1-A:** §9 + §11 — dispatch reader takes SELECT snapshot ordered by event_seq; advances checkpoint to `min(committed_event_seq_observed)`. Never advances past lower-seq row not yet observed.
+  - **Eng P1-B:** §4 + Q4 — `current_cursor` = global latest event_seq cursor; scope evaluation deferred to first replay/push (acceptable since cursor opaque UUIDv4).
+  - **Eng P2-B:** §8 heartbeat semantics — dispatcher-emits on `heartbeat_ms` interval; subscriber-miss detection in transport adapter; heartbeat does NOT advance cursor.
+  - **Eng P3-A:** backpressure thresholds pinned `soft=256, hard=1024` per-subscriber-queue events.
+  - **Eng P3-B:** migration slot reservation v176-v179 (after W4-B v170, W4-C v171-v174, W4-E v175).
+  - **Eng P3-C:** CI invariant — dispatcher routes/methods NEVER live in `signals/bus.rs`.
+  - **Devex P1-1 dashmap:** §13 + What-W4-B-Signals-Authors net-new — `DashMap<SubscriptionId, SubscriberHandle>` (lock-free shard) + `DashMap<SubscriberDigest, SubscriptionId>` (reconnect) + bounded `tokio::sync::mpsc::channel`. NOT `tokio::Mutex<HashMap>`.
+  - **Devex P2-1 module placement:** §13 — `src-tauri/src/services/version_dispatcher.rs` + `services/version_events.rs`. Reserves `signals/` for ADR-0080.
+  - **Devex P2-2 Tauri entrypoint:** `commands/version_dispatcher.rs`; `tauri::ipc::Channel<DispatchedEvent>` per subscription (NOT `Window::emit`). Channel close = auto-unsubscribe.
+  - **Devex P2-3 session expiry:** §13.5 NEW (originally numbered §16 in V2; renumbered V3.2 to preserve ordering) — SurfaceClient session expiry triggers immediate unsubscribe, drain queue without dispatching, require new SubscribeRequest with fresh wp_user_id binding.
+  - **Devex P2-4 backpressure discipline:** §7 — `tokio::sync::mpsc::channel` bounded; reserved slots for `claim.write_rejected`/`claim.corrected`.
+  - **Devex P2-5 replay cap:** server caps LIMIT to `MAX_REPLAY_BATCH = 500`; `ReplayResponse.has_more = true` when capped.
+
+- **V1 (2026-05-13):** Initial L0 packet for DOS-589. Mirrors W4-B V9 section shape, inherits W4-B V9 sections 5/15/16/17/37, resolves dispatcher decisions, maps each Linear acceptance criterion to directional decisions and negative fixtures, and names the CI invariants needed to prevent scope-filter bypass.
+
+## Status snapshot
+
+- DOS-589 is the delivery half of W4-B-signals.
+- DOS-567 owns version assignment, outbox row schema, cursor allocation, and atomic insert into `version_events`.
+- DOS-589 owns subscriber state, dispatch loop, scope-filtered delivery, replay, backpressure, and dispatcher-facing routes.
+- Current `src-tauri/src/signals/bus.rs` is an ADR-0080 SQLite event-log emitter for `signal_events`.
+- Current `signals/bus.rs` is not a pub/sub dispatcher.
+- It has no subscriber registry.
+- It has no dispatch loop.
+- It has no `scope_permits_claim_read(subscriber, claim_id)` predicate.
+- It has no per-subscriber outbound queues.
+- It has no replay cursor resolution over `version_events`.
+- It has no `subscription.backpressure` event.
+- Current `src-tauri/src/bridges/surface_client.rs` exists and already owns SurfaceClient authorization/rate-limit substrate.
+- Current `src-tauri/src/surface_runtime/mod.rs` supports signed `/v1/surface/*` route dispatch.
+- Current signed route allowlist includes `/v1/surface/invoke`, `/v1/surface/feedback`, `/v1/surface/abilities`, and `/v1/surface/keyring`.
+- DOS-589 adds dispatcher routes to that signed SurfaceClient route surface.
+- W4-B V9 section 37 makes `bridges/surface_client.rs` the canonical route module for those routes.
+- DOS-589 gates W4-C dispatcher consumers.
+- W4-C expects invalidation when signed/tamper cache entries are stale after a version event.
+- DOS-589 gates W4-A renderer cache-bust.
+- W4-A expects mounted block render state to refresh without polling when claim/composition versions move.
+- DOS-589 gates W5-A retry-after-event.
+- W5-A expects 423/409 retry loops to wait on cursor events rather than tight polling.
+- DOS-589 is blocked by DOS-567 because the dispatcher needs W4-B V9 section 15 `version_events`.
+- DOS-589 blocks DOS-569, DOS-572, and DOS-573 because those consumers need push delivery.
+- No design review is required for L0 because this packet is substrate-only and has no user-facing UI.
+
+## Pre-work confirmed (substrate reuse audit)
+
+**Headline finding:** DOS-589 is net-new pub/sub infrastructure over an inherited event log. It should reuse the existing SurfaceClient bridge, actor/scopes types, and W4-B `version_events` contract, but it should not extend the legacy ADR-0080 `signal_events` emitter into a correctness dispatcher.
+
+### Existing `src-tauri/src/signals/bus.rs`
+
+- The module header describes "Signal event CRUD and source tier weights (ADR-0080)."
+- `SignalEvent` is documented as a row from the `signal_events` table.
+- `emit_signal_event(...)` returns `SignalEmitOutcome { id, coalesced }`.
+- The bus has coalescing state and rate-limited claim attempt heuristics.
+- The bus writes generic `signal_events` rows.
+- The bus is useful for legacy intelligence signals and propagation.
+- The bus is not an ordered subscriber dispatcher.
+- There is no `Subscriber`, `Subscription`, `SubscribeRequest`, or `SubscribeAck` type.
+- There is no registry keyed by `(actor, scopes, subject_filter)`.
+- There is no outbound queue per subscriber.
+- There is no replay loop using `event_seq`.
+- There is no post-commit watcher over `version_events`.
+- There is no scope predicate for claim-read authorization.
+- Conclusion: DOS-589 should create a dedicated dispatcher module rather than overloading `signals/bus.rs` with two different meanings of "signal."
+
+### Existing `src-tauri/src/migrations/018_signal_bus.sql`
+
+- `signal_events` is a generic ADR-0080 table with `id`, `entity_type`, `entity_id`, `signal_type`, `source`, `value`, `confidence`, `decay_half_life_days`, `created_at`, and `superseded_by`.
+- The schema has no `event_seq`.
+- The schema has no UUIDv4 cursor contract.
+- The schema has no claim/composition XOR constraint.
+- The schema has no W4-B event-kind enum.
+- The schema has no correction event-log pointer.
+- Therefore it cannot satisfy W4-B V9 section 15 replay and payload contracts without weakening them.
+
+### Inherited `version_events` table from W4-B V9 section 15
+
+- `event_seq INTEGER PRIMARY KEY AUTOINCREMENT` is the replay-order source of truth.
+- `cursor TEXT NOT NULL UNIQUE` is a UUIDv4 opaque cursor.
+- `event_kind` is constrained to W4-B event kinds.
+- Exactly one of `claim_id` or `composition_id` is present.
+- `previous_version` and `current_version` carry watermark movement.
+- `correction_event_log_id` points to the durable body for `CorrectionRef`.
+- `mutation_id` ties rows back to `mutation_attempts` when relevant.
+- `created_at` and `actor_kind` support audit and consumer diagnostics.
+- Replay clause is `SELECT * FROM version_events WHERE event_seq > ? ORDER BY event_seq LIMIT ?`.
+- Cursor resolution is `SELECT event_seq FROM version_events WHERE cursor = ?`.
+- DOS-589 consumes these rows after W4-B commits.
+- DOS-589 does not define or migrate this table.
+
+### Existing actor/scope substrate
+
+- `abilities-runtime/src/abilities/registry.rs` defines `Actor::SurfaceClient { instance, scopes }`.
+- `ScopeSet` is typed, sorted, and non-empty for SurfaceClient actors.
+- `SurfaceScope` is string-backed and allowlist-aware.
+- `AbilityPolicy.required_scopes` exists for ability invocation gating.
+- These types provide the subscriber identity and scope material for dispatcher authorization.
+- DOS-589 still needs a claim-specific read predicate because ability-level required scopes are not enough to prove a subscriber may read a particular `claim_id`.
+
+### Existing `src-tauri/src/bridges/surface_client.rs`
+
+- The file exists in the target worktree.
+- It already contains `SurfaceClientBridge`, rate-limit budgets, request class limits, and authorization plumbing.
+- W4-B V9 section 37 promotes this module as the canonical owner for `/v1/surface/*` routes.
+- DOS-589 dispatcher routes land here, not in a new route-owner module.
+- Surface runtime signed-route dispatch must add DOS-589 routes to the supported route allowlist.
+
+### Phase 0 artifact 02 subscription contract
+
+- `.docs/plans/dos-546/phase-0/02-concurrency-contract.md` lines 595-616 define `SubscribeRequest` and `SubscribeAck`.
+- Lines 624-650 define backpressure semantics and the `subscription.backpressure` event.
+- Lines 658-683 define replay request/response semantics.
+- DOS-589 should implement the Phase 0 shape with W4-B V9 `version_events` as the backing log.
+- Any transport-specific choice must preserve those transport-independent semantics.
+
+## What DOS-589 authors net-new
+
+| Surface | Status today | DOS-589 authoring scope |
+|---|---|---|
+| `signals/version_dispatcher.rs` or equivalent substrate module | Missing | Dispatcher service over `version_events` |
+| `SubscribeRequest` / `SubscribeAck` Rust wire types | Missing | Exact Phase 0 artifact 02 lines 595-616 shape |
+| `ReplayRequest` / `ReplayResponse` Rust wire types | Missing | Phase 0 artifact 02 lines 668-683 plus W4-B V9 cursor-to-event_seq resolution |
+| `BackpressureEvent` Rust wire type | Missing | Phase 0 artifact 02 lines 640-649 |
+| Subscriber registry keyed by `(actor, scopes, subject_filter)` | Missing | In-memory live handles plus persisted checkpoint rows |
+| Persistent reconnect checkpoint | Missing | Durable last-seen cursor/event_seq by subscriber identity and subject filter |
+| Dispatch loop | Missing | Post-commit reader over `version_events` ordered by `event_seq` |
+| `scope_permits_claim_read(subscriber, claim_id)` | Missing | Mandatory delivery predicate for every claim-bound event |
+| Composition-to-claim expansion | Missing | Dispatcher maps composition events to affected claims where payload supplies them, then applies claim predicate |
+| Subject filter matcher | Missing | Supports claim, composition, and subject filters from Phase 0 |
+| Per-subscriber outbound queue | Missing | Bounded queue with backpressure emission and replay-required state |
+| Scope-filtered replay endpoint | Missing | Streams only permitted rows in event_seq order |
+| `GET /v1/surface/event-log/{event_log_id}` route | Missing as DOS-589 route work | Scope-filtered `CorrectionRef` event-log body fetch through `bridges/surface_client.rs` |
+| Tauri command subscription channel | Missing | User/Agent actor transport for native app consumers |
+| HTTP loopback subscription route | Missing | SurfaceClient transport through signed `/v1/surface/*` route surface |
+| CI bypass gate | Missing | Tests/lint proving every delivery path calls the scope predicate |
+
+**Module placement:** the implementation should keep durable/domain logic in `services/` per repository rule. Route handlers and Tauri commands call service methods; they do not write subscriber state or mutate dispatcher rows directly.
+
+**Suggested module split:**
+
+- `src-tauri/src/services/version_dispatcher.rs` - registry, dispatch loop, replay, predicates, persistence.
+- `src-tauri/src/signals/version_events.rs` - typed decoding helpers for W4-B V9 sections 5/15 rows, if not already created by DOS-567.
+- `src-tauri/src/bridges/surface_client.rs` - HTTP loopback route handlers and signed SurfaceClient request/response projection.
+- `src-tauri/src/commands.rs` or existing Tauri command owner - native app subscription entrypoint for User/Agent actors.
+- `src-tauri/tests/dos589_fixture_*.rs` - negative fixtures and replay/backpressure tests.
+
+## Directional decisions resolved at L0
+
+### section 1. Pub/sub model: push first, replay as the correctness backstop
+
+DOS-589 implements push delivery, not client polling. This follows Phase 0 artifact 02 lines 587-593.
+
+The dispatcher continuously advances through committed `version_events` rows and pushes rows to active subscribers with bounded queues.
+
+Replay remains mandatory because push transport is lossy across process pause, network loss, and backpressure.
+
+Correctness is in the event log plus replay, not in the live socket.
+
+A subscriber that misses live delivery reconnects with its last-seen cursor and receives ordered, deduplicated replay.
+
+### section 2. Subscriber persistence: live handles in memory, durable subscription checkpoint in SQLite
+
+The registry has an in-memory live handle keyed by `subscription_id` for connected transports.
+
+The registry has a durable checkpoint keyed by `(actor, scopes_digest, subject_filter_digest)` for reconnect continuity.
+
+The durable row stores `subscription_id`, actor kind/instance, scopes digest, canonical subject filter, timestamps, last acked cursor, last acked `event_seq`, and backpressure state.
+
+The durable row does not store raw customer names, domains, or subject labels.
+
+Rationale: replay reconstructs missed rows from `version_events`, while a purely in-memory registry fails reconnect persistence.
+
+### section 3. Replay strategy: `event_seq` is order; cursor is address (V2 REWRITE per codex CRITICAL)
+
+V1 conflated internal scan position with the client-visible cursor. V2 distinguishes them:
+
+- **`last_scanned_event_seq` (internal, durable, per-subscriber):** ratchets forward through ALL event_seqs scanned, regardless of scope. Stored in `subscription_checkpoints` table. Prevents infinite replay loops on out-of-scope rows.
+- **`cursor_uuid` (W4-B V9 §15 PRIMARY KEY, UUIDv4):** the row identifier in `version_events`. Stays as the canonical event address.
+- **`cursor_envelope` (client-visible, V3 per codex C2 CRITICAL):** the actual on-wire cursor is a structured envelope `{cursor_uuid: UUIDv4, subscription_id: UUIDv4, mac: bytes32}` — the UUIDv4 IS the row PK from W4-B V9 §15 (preserved verbatim); the HMAC binds the envelope to the subscription. V2 conflated "HMAC-as-cursor" with "UUIDv4-as-row-key"; V3 separates them: row identity uses UUIDv4 (W4-B contract preserved), envelope authenticity uses HMAC over the envelope contents.
+
+**Cursor envelope construction (V3 per codex C2 CRITICAL):** every client-visible cursor is serialized as a base64-encoded envelope: `cursor_envelope = base64({ "cursor_uuid": <UUIDv4>, "subscription_id": <UUIDv4>, "mac": HMAC-SHA256(subscriber_local_key, cursor_uuid || subscription_id) })`. The `subscriber_local_key` is generated per-subscription at Subscribe time and stored alongside the durable checkpoint. On reconnect with `from_cursor`, dispatcher:
+1. Decodes the envelope.
+2. Looks up `subscriber_local_key` by `subscription_id`.
+3. Recomputes the expected HMAC over `cursor_uuid || subscription_id`.
+4. On HMAC mismatch OR unknown subscription_id, returns "no events" indistinguishably from "valid cursor but no permitted events in the requested range."
+5. On HMAC match, resolves the UUIDv4 to event_seq via `SELECT event_seq FROM version_events WHERE cursor = ?` — the W4-B V9 §15 row lookup, unchanged.
+
+Foreign cursor capture cannot probe event_seq lifetime; cursor authenticity does NOT alter the W4-B V9 cursor schema (UUIDv4 PK preserved); the HMAC is a transport-layer envelope check, not a substrate schema change.
+
+**Replay query semantics:**
+- Replay reads via `SELECT * FROM version_events WHERE event_seq > ? ORDER BY event_seq LIMIT ?`.
+- `WHERE event_seq > last_scanned_event_seq` ensures scan ratchets through ALL rows; out-of-scope rows are filtered but `last_scanned` still advances.
+- `MAX_REPLAY_BATCH = 500` cap; `ReplayResponse.has_more = true` when capped; client iterates with returned `next_cursor`.
+- `ReplayResponse.next_cursor` is the last DELIVERED (permitted) event's cursor — NOT the last scanned event_seq.
+
+**Cursor resolution:**
+- `SELECT event_seq FROM version_events WHERE cursor = ?` resolves the envelope's `cursor_uuid` to its event_seq (the W4-B V9 §15 PK column).
+- HMAC over `(cursor_uuid || subscription_id)` validates the envelope belongs to the requesting subscriber.
+- Unknown cursor (no row found) → return Phase 0 `replay-expired` envelope.
+- Unknown cursor is NEVER treated as "from beginning."
+- Deduplication is by event_seq: the row at the supplied cursor is not replayed.
+
+**Replay/live race barrier (V2 NEW per codex HIGH):**
+- On Subscribe (or replay request) with `from_cursor`, dispatcher captures `event_seq_at_subscribe = SELECT MAX(event_seq) FROM version_events` as a high-water mark.
+- Replay runs through that high-water mark.
+- Live events with `event_seq > event_seq_at_subscribe` are BUFFERED on the subscriber's outbound queue but NOT delivered until replay completes (signaled by `ReplayResponse.has_more = false`).
+- After replay close, buffered live events drain in order. No live event with `event_seq < event_seq_at_subscribe` can arrive after replay close (post-COMMIT ordering enforced by W4-B V9 §15 outbox).
+
+### section 4. Scope-filter at dispatch and replay, not only at subscribe (V2 — per-row scope re-resolution per cso CRITICAL-1)
+
+Subscription acceptance verifies actor and route shape, but final claim visibility is late-bound at each individual delivery.
+
+**Per-row scope re-resolution (V2 critical rule):** scope set is resolved from the CURRENT authenticated actor for each row, NOT snapshotted at subscribe or replay-start. The dispatcher's delivery loop:
+
+```rust
+for row in version_events_batch {
+    let current_scopes = resolve_session_scopes(subscriber.session_token)?;
+    if !scope_permits_claim_read(&current_scopes, &row.claim_id)? {
+        continue;  // ratchet last_scanned forward; do NOT advance client-visible cursor
+    }
+    deliver(row, subscriber)?;
+}
+```
+
+This catches mid-replay scope tightening, mid-replay session re-pairing with narrower scopes, and post-Subscribe scope revocation. If a subscriber's session is invalidated mid-replay, the next row's `resolve_session_scopes` returns the new (or empty) scope set; out-of-scope rows are skipped from that row forward.
+
+**Predicate consistency (cso MEDIUM-1):** `scope_permits_claim_read` is referentially transparent for `(actor, claim_id, claim_state, claim_version)`. Predicate evaluation + payload projection occur inside a consistent claim-read-policy snapshot via versioned read against `claim_version`. Two concurrent dispatcher workers reading the same row see the same predicate result.
+
+**Existence-oracle defense:** cross-scope claim events produce ZERO delivery. The dispatcher does NOT send redacted push/replay notifications for out-of-scope claim events — even a notification that "an event happened" reveals existence.
+
+**`current_cursor` semantics (V3 REWRITE per codex C2 HIGH):** V2 said `SubscribeAck.current_cursor` is the global latest event_seq cursor; codex correctly flagged this contradicts the §4 existence-oracle defense (returning ANY cursor reachable by global latest = signal that an event exists even if out-of-scope). V3:
+- `SubscribeAck.current_cursor` is a SUBSCRIBER-VISIBLE cursor: the most recent event whose `scope_permits_*_read` predicate returns true under the subscriber's CURRENT scopes, OR `null` if none.
+- Internally, the dispatcher maintains `event_seq_at_subscribe = SELECT MAX(event_seq) FROM version_events` as a high-water mark for the replay/live race barrier (§3) — this state is internal and never surfaced to the subscriber.
+- The two values may diverge (global high-water is ahead of subscriber-visible cursor); that divergence is the explicit oracle defense. Subscribers see only events they are permitted to see; they cannot infer the existence of out-of-scope events from `current_cursor`.
+
+### section 5. Composition events gated by `scope_permits_composition_read` (V2 REWRITE per codex HIGH)
+
+V1 relied on `affected_claim_ids` carried in `CompositionVersionEvent`. W4-B V9 §5's actual `CompositionVersionEvent` payload has only `composition_id`, `previous_version`, `current_version`, `cursor`, `reason` — NO `affected_claim_ids`. V2 fix: DOS-589 owns its own composition-scope predicate, no W4-B amendment required.
+
+**`scope_permits_composition_read(actor, composition_id, composition_version)` predicate (DOS-589-owned, V3 versioned per codex C2 MEDIUM):**
+
+V2 resolved claim_refs from "the most recent ability output," which authorizes the WRONG version: the dispatcher must authorize against the claim_refs of the version that was actually published in this event, not whatever the most recent composition reflection happens to carry. V3 pins the version explicitly.
+
+```rust
+/// Returns true if the actor's scope set permits reading the composition
+/// AT THE EXACT VERSION mutated in this event — i.e., at least one of the
+/// composition_version's frozen claim_refs is permitted by the actor's scopes.
+fn scope_permits_composition_read(
+    actor: &Actor::SurfaceClient,
+    composition_id: &CompositionDocId,
+    composition_version: i64,
+) -> Result<bool> {
+    // Resolve the FROZEN claim_refs for this exact composition_version.
+    // W4-B V9 §8 composition_versions row carries
+    // generated_by_invocation_id for the version; the substrate
+    // resolves the version-frozen claim_refs (not the most recent
+    // reflection). For each claim_ref, run scope_permits_claim_read.
+    let claim_refs = composition_version_frozen_claim_refs(
+        composition_id,
+        composition_version,
+    )?;
+    Ok(claim_refs.iter().any(|cr| scope_permits_claim_read(actor, &cr.claim_id)))
+}
+```
+
+**Delivery rule:**
+- For a `CompositionVersionEvent { composition_id, current_version, .. }`, dispatcher calls `scope_permits_composition_read(actor, composition_id, current_version)`.
+- If returns true: deliver the event (version-only payload — no claim list).
+- If returns false: zero delivery (existence-oracle defense per §4).
+- The version-frozen authorization prevents a race where a subsequent version drops the actor's only permitted claim_ref but the dispatcher would still deliver the earlier event's notification using current reflection.
+
+**No `affected_claim_ids` in event payload:** the payload remains version-only (`{composition_id, previous_version, current_version, cursor, reason}`). Subscribers re-invoke the producing ability to get the scope-filtered Composition. The W4-B V9 contract is preserved; the per-event affected-claim leak vector is eliminated.
+
+### section 6. CorrectionRef fetch route shares the inline 409 projection rule
+
+`CorrectionRef.event_log_id` is a bearer pointer.
+
+W4-B V9 section 16 says direct-key fetches by `event_log_id` are scope-gated just like inline correction payloads.
+
+DOS-589 implements `GET /v1/surface/event-log/{event_log_id}` in `src-tauri/src/bridges/surface_client.rs` per W4-B V9 section 37.
+
+The route resolves `event_log_id` to the underlying claim and calls the same scope predicate used by inline 409 correction projection.
+
+Out-of-scope returns redacted envelope only when the caller already has an in-scope reason to know the event exists; otherwise it returns 404.
+
+The route never returns a claim body to an out-of-scope caller.
+
+### section 7. Backpressure semantics: bounded queue, explicit event, replay-required recovery (V2 — thresholds + side-channel defense)
+
+Every connected subscriber has a bounded outbound queue: `tokio::sync::mpsc::channel(1024)`. Thresholds (V2 NEW per eng P3-A + devex P2-4):
+
+- **Soft threshold = 256 events** in queue → dispatcher emits `subscription.backpressure` event (delivered only to the affected subscriber per cso H1), keeps enqueueing.
+- **Hard cap = 1024 events** → dispatcher stops enqueueing ordinary live events for that subscriber and marks `replay_required = true` on the subscription. Subscriber must reconnect with `from_cursor` to resume.
+
+**Reserved slots for correctness events:** `claim.write_rejected` and `claim.corrected` are NEVER dropped — they bypass the hard cap via a reserved slot in the channel (or a "must deliver" sub-channel). Coalescing rules: multiple `claim.updated` events may coalesce only when latest `claim_version` and `event_seq` remain correct per Phase 0 lines 630-636.
+
+**Backpressure-as-side-channel defense (V2 per cso H1):**
+- `subscription.backpressure` event delivered ONLY to the affected subscriber.
+- `dropped_event_count` counts events already filtered to subscriber's permitted set — NEVER includes filtered-away rows.
+- No cross-subscriber backpressure metric is exposed on any SurfaceClient route. No aggregate queue depth API.
+- CI invariant: no route returns aggregate queue depth keyed by subscription_id.
+
+**Mutation isolation:**
+- Backpressure must NOT block W4-B mutation commits (per §12 failure isolation).
+- A slow subscriber's queue overflow is its own problem; the substrate writer always commits.
+
+### section 8. Transport: Tauri command channel for User/Agent, signed HTTP loopback for SurfaceClient (V2 — HMAC + wp_user_id + heartbeat pins)
+
+**Tauri command channel** serves native app `Actor::User` and `Actor::Agent` consumers via `tauri::ipc::Channel<DispatchedEvent>` per subscription (per devex P2-2). Channel close = auto-unsubscribe.
+
+**Signed HTTP loopback** serves `Actor::SurfaceClient` consumers. Routes land under `/v1/surface/*` in `src-tauri/src/bridges/surface_client.rs` per W4-B V9 §37.
+
+**Per-frame HMAC integrity (V2 per cso H2):** the push channel (SSE/WebSocket — choice deferred at L0) inherits per-frame HMAC matching W2-B's bridge contract. Subscribe request is signed; subscribe response stream frames carry HMAC envelopes too. Transport-level integrity property is locked at L0; transport choice (SSE vs WebSocket) is implementation discretion.
+
+**`wp_user_id` binding for SubscribeRequest (V2 per cso H3):** if `SubscribeRequest` body carries `wp_user_id`, the bridge precondition `validate_session_bound_wp_user_id` (per W4-B V9 §17) validates against the paired session before dispatcher state is created. Mismatch returns 403 `wrong_user`; no subscription_id is allocated, no checkpoint row is written. Fixture `dos589_fixture_signal_subscribe_wp_user_binding.rs`.
+
+**Heartbeat semantics (V2 NEW per eng P2-B):** dispatcher emits heartbeat on `heartbeat_ms` interval (per `SubscribeAck.heartbeat_ms` from Phase 0 line 612). Subscriber-side miss detection lives in the transport adapter, NOT the service. Heartbeat does NOT advance cursor (it's a liveness signal only).
+
+**L0 contract:**
+- Forces route owner (`bridges/surface_client.rs`), service contract (transport-neutral interface), and Phase 0 wire semantics.
+- Defers WebSocket vs SSE choice.
+- The service API must be transport-neutral enough to support either.
+
+### section 9. Post-COMMIT delivery only
+
+The dispatcher never reads uncommitted mutation state.
+
+W4-B V9 section 15 owns atomic insert of `version_events` inside the mutation transaction.
+
+DOS-589 begins work only after that transaction commits.
+
+Polling `version_events` by `event_seq` is acceptable.
+
+An in-process notification after W4-B commit is acceptable if it still reads the committed row.
+
+Both options must preserve event_seq order.
+
+### section 10. Subscriber identity key and digesting (V2 — per-subscription_id keyed per codex HIGH)
+
+V1 keyed durable checkpoints by `(actor, scopes_digest, subject_filter_digest)` only. That conflated concurrent connections from the same actor (e.g., two browser tabs with same SurfaceClient session) — checkpoint advancement from one tab could starve the other.
+
+**V2 canonical subscriber key (durable):** `(subscription_id, actor_kind, actor_instance, scopes_digest, subject_filter_digest)`.
+
+- `subscription_id` is server-allocated UUIDv4 at Subscribe time, returned in `SubscribeAck.subscription_id`. Per-Subscribe-call, not per-actor.
+- Concurrent same-actor Subscribes allocate distinct subscription_ids and maintain independent checkpoints.
+- The user-facing shorthand `(actor, scopes, subject_filter)` remains in the Linear acceptance and SubscribeRequest body for filter selection; the subscription_id is the durable key.
+
+**Reconnect with `from_cursor` (V3 REWRITE per codex C3 HIGH):** V2 said reconnect looks up the subscription_id via `cursor → event_seq → checkpoint`. Codex correctly flagged this contradicts §3 V3: it would resolve cursor identity BEFORE authenticating the envelope HMAC, reintroducing the "cursor-as-lookup-authority" path. V3 ordering is envelope-first:
+
+1. Subscriber sends `from_cursor = <envelope>` (the base64 envelope per §3 V3).
+2. Dispatcher decodes the envelope → reads embedded `subscription_id`.
+3. Dispatcher looks up `subscriber_local_key` and the durable checkpoint by `subscription_id` (the durable key, not the cursor).
+4. Dispatcher recomputes the HMAC over `cursor_uuid || subscription_id`; on mismatch OR unknown `subscription_id`, returns the indistinguishable "no events" envelope per §3 V3 — NEVER resolves `cursor_uuid` to `event_seq`.
+5. On HMAC match, dispatcher resolves `cursor_uuid` to `event_seq` via the W4-B V9 §15 PK lookup, then continues with the §3 replay query.
+6. If the subscriber has no checkpoint AND the envelope is otherwise unverifiable, the request is treated as a fresh Subscribe (no implicit allocation tied to a foreign cursor) — `from_cursor` is ignored, the subscriber must re-Subscribe to receive a fresh `subscription_id` + `subscriber_local_key`.
+
+The cursor is NEVER the lookup authority for the subscription. The `subscription_id` embedded in the envelope IS the lookup key, and the HMAC is what authenticates the envelope's right to make that lookup.
+
+**Digest computation:**
+- `scopes_digest` = SHA256 of sorted scope strings joined by `\n`.
+- `subject_filter_digest` = SHA256 of canonical JSON for requested subjects.
+- Both digests are computed at Subscribe time and stored in `subscription_checkpoints`.
+
+**Durable storage rules:**
+- May include opaque claim/composition IDs needed for matching.
+- MUST NOT include real customer names, domains, emails, or account details.
+- The per-subscription HMAC key for cursor binding (§3) is stored alongside the checkpoint.
+
+### section 11. Cursor acknowledgment and checkpoint timing
+
+The dispatcher advances a subscriber checkpoint only after the event is accepted by transport or serialized into a replay response.
+
+For live push, the service should prefer explicit ack when transport supports it.
+
+If v1.4.2 transport lacks per-event ack, checkpoint advances on enqueue only for events replayable from the prior cursor.
+
+For replay, `ReplayResponse.next_cursor` is the last event included in the response.
+
+`ReplayResponse.next_cursor` is not the newest global cursor.
+
+### section 12. Failure isolation
+
+A slow subscriber cannot block W4-B mutation commit.
+
+A slow subscriber cannot block other subscribers.
+
+A slow subscriber cannot block replay for another subscriber.
+
+A slow subscriber cannot block CorrectionRef fetch for a permitted caller.
+
+Each subscriber queue is isolated.
+
+Dispatcher errors are logged or audited with safe IDs and request IDs, not customer content.
+
+### section 13. Runtime and service ownership (V2 — module placement + concurrency primitives pinned)
+
+**Module placement (V2 per devex P2-1):**
+- `src-tauri/src/services/version_dispatcher.rs` — owns subscription registry, dispatch loop, checkpoint persistence, scope-predicate evaluation.
+- `src-tauri/src/services/version_events.rs` — typed decoders for `ClaimVersionEvent`, `CompositionVersionEvent`, `CorrectionRef` from W4-B V9 §15 outbox rows.
+- `src-tauri/src/commands/version_dispatcher.rs` — Tauri command entrypoint (per devex P2-2).
+- `src-tauri/src/bridges/surface_client.rs` — SurfaceClient HTTP routes (per W4-B V9 §37).
+
+**RESERVED `signals/` for ADR-0080 only** (per devex P2-1): no DOS-589 code lives under `signals/`. CI invariant per eng P3-C: version dispatcher routes/methods MUST NOT live in `signals/bus.rs`.
+
+**Concurrency primitives (V2 per devex P1-1):**
+- Live subscription registry: `DashMap<SubscriptionId, SubscriberHandle>` — lock-free sharded reads; dispatcher hot path scans per-event registry on subject filter + scope predicate.
+- Reconnect lookup index: `DashMap<SubscriberDigest, SubscriptionId>` — supports reconnect-with-cursor flow per §10.
+- Per-subscriber outbound queue: bounded `tokio::sync::mpsc::channel(1024)` — backpressure thresholds per §7.
+- Durable subscription_checkpoints: SQLite via service layer; never written from command/route handlers.
+- NOT `tokio::Mutex<HashMap<..>>` (serializes dispatch); NOT `parking_lot::Mutex` (blocks under contention).
+- "No `std::sync::Mutex` across await points" — async-aware Tokio primitives only.
+
+**Boundaries:**
+- All persistent mutations go through `services/version_dispatcher.rs`.
+- Route handlers in `bridges/surface_client.rs` validate signed session, build `Actor::SurfaceClient`, call service, serialize response.
+- Tauri command handlers build `Actor::User`/`Actor::Agent`, call service, emit through Tauri `ipc::Channel`.
+- No command handler writes subscriber checkpoints directly.
+- No route handler writes event-log state directly.
+- `signals/bus.rs` (legacy ADR-0080 emitter) is NOT modified by W4-B-signals work.
+
+### section 13.5. SurfaceClient session expiry handling (V2 NEW per devex P2-3; renumbered V3.2 per codex C4 to preserve §13→§14→§15 ordering)
+
+When a SurfaceClient session expires or is invalidated:
+
+1. Bridge layer detects expiry (any signed request with expired token → 401).
+2. Dispatcher receives session-expired signal (in-process notification from bridge OR auto-detected on next delivery attempt).
+3. Live handle for the subscription_id is immediately removed from the in-memory registry.
+4. Outbound queue is drained without dispatching remaining events.
+5. The durable `subscription_checkpoints` row survives — reconnect with fresh session and `from_cursor` is supported.
+6. New SubscribeRequest with fresh `wp_user_id` binding is required to resume.
+7. Audit emits `subscription.expired` event (operator-visible, NOT subscriber-visible per cso H1 backpressure-as-side-channel rule).
+8. Fixture `dos589_fixture_session_expiry.rs` exercises: subscribe → mid-stream session invalidate → no further deliveries → reconnect with fresh session + last-seen cursor → resume.
+
+### section 14. Intelligence Loop fit
+
+DOS-589 does not create new claims, but it is part of the claim lifecycle runtime.
+
+It must preserve subject attribution via claim/composition IDs.
+
+It must preserve temporal ordering via `event_seq`.
+
+It must preserve lifecycle state via event kind.
+
+It must preserve feedback/retry handoff via `CorrectionRef`.
+
+It must preserve trust and existence defense through scope-filtered delivery.
+
+The dispatcher is incomplete if it only renders frontend notifications; runtime consumers must receive the events needed to keep derived state current.
+
+### section 15. Linear issue drift resolution
+
+Linear DOS-589 says "Dispatcher consumes `signal_events` rows" and "Implement pub/sub layer that consumes `signal_events`."
+
+That was true before W4-B V9 introduced the dedicated `version_events` table.
+
+For implementation, W4-B V9 section 15 wins.
+
+DOS-589 dispatches from `version_events`.
+
+DOS-589 orders by `event_seq`.
+
+DOS-589 resolves cursor to `event_seq`.
+
+DOS-589 preserves W4-B V9 section 5 payload schema.
+
+The legacy `signal_events` table remains out of scope except as historical context for why `signals/bus.rs` is not enough.
+
+## Acceptance criteria lifted into DOS-589
+
+### Implementation acceptance
+
+1. **Subscribe/SubscribeAck wire shape.**
+   - Source: Phase 0 artifact 02 lines 595-616.
+   - Directional decision: section 1, section 8.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`, `src-tauri/src/bridges/surface_client.rs`.
+   - Negative fixture: `dos589_fixture_signal_replay_cursor.rs`.
+   - Test condition: `SubscribeRequest` accepts `surface_client_id`, `surface`, `streams`, `subjects`, optional `from_cursor`, and optional `max_batch_size`; `SubscribeAck` returns `ok`, `subscription_id`, `heartbeat_ms`, optional `replay_from`, and `current_cursor`.
+
+2. **Subscriber registry keyed on `(actor, scopes, subject_filter)`, persistent across reconnects.**
+   - Source: Linear DOS-589 acceptance.
+   - Directional decision: section 2, section 10, section 11.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`, W4-B-successor migration if DOS-589 needs a persisted table.
+   - Negative fixture: `dos589_fixture_signal_replay_cursor.rs`.
+   - Test condition: Reconnect with equivalent actor, sorted scopes, and canonical subject filter recovers the durable checkpoint and subscription identity.
+
+3. **Dispatcher consumes `version_events` rows after W4-B commit.**
+   - Source: W4-B V9 section 15 superseding Linear stale `signal_events` wording.
+   - Directional decision: section 3, section 9, section 15.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`, W4-B row decoder.
+   - Negative fixture: `dos589_fixture_signal_replay_cursor.rs`.
+   - Test condition: Dispatcher never observes rolled-back version rows and emits only committed rows in `event_seq` order.
+
+4. **`scope_permits_claim_read(subscriber, claim_id)` gates every delivery.**
+   - Source: W4-B V9 section 16 and Linear DOS-589 acceptance.
+   - Directional decision: section 4, section 5, section 12.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`, claim projection/read service.
+   - Negative fixture: `dos589_fixture_signal_scope_leak.rs`.
+   - Test condition: Out-of-scope subscriber receives zero event, zero redacted event, and zero existence hint for that claim_id.
+
+5. **`CorrectionRef.event_log_id` lookup endpoint is scope-filtered identically to inline 409.**
+   - Source: W4-B V9 section 5, section 16, section 37 and Linear DOS-589 acceptance.
+   - Directional decision: section 6, section 8, section 13.
+   - File targets: `src-tauri/src/bridges/surface_client.rs`, `src-tauri/src/services/version_dispatcher.rs`.
+   - Negative fixture: `dos589_fixture_correction_ref_replay_scope_leak.rs`.
+   - Test condition: Out-of-scope fetch returns redacted envelope or 404 and never returns claim body.
+
+6. **`subscription.backpressure` event when outbound queue exceeds threshold.**
+   - Source: Phase 0 artifact 02 lines 624-650 and Linear DOS-589 acceptance.
+   - Directional decision: section 7, section 12.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`.
+   - Negative fixture: `dos589_fixture_signal_backpressure.rs`.
+   - Test condition: Slow subscriber triggers backpressure event and W4-B mutation commit path is not blocked.
+
+7. **Replay-from-cursor streams missed events in order, scope-filtered, with cursor-to-event_seq resolution.**
+   - Source: W4-B V9 section 15 and Phase 0 artifact 02 lines 658-683.
+   - Directional decision: section 3, section 4, section 11.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`, `src-tauri/src/bridges/surface_client.rs`.
+   - Negative fixture: `dos589_fixture_signal_replay_cursor.rs`, `dos589_fixture_signal_scope_leak.rs`.
+   - Test condition: Replay resolves cursor to event_seq, queries `event_seq > ? ORDER BY event_seq`, filters every row, and returns `next_cursor`.
+
+8. **Reconnect resilience: ordered, deduplicated, scope-filtered replay from last-seen cursor.**
+   - Source: Linear DOS-589 acceptance and Phase 0 artifact 02 reconnection section.
+   - Directional decision: section 2, section 3, section 4, section 11.
+   - File targets: `src-tauri/src/services/version_dispatcher.rs`.
+   - Negative fixture: `dos589_fixture_signal_replay_cursor.rs`.
+   - Test condition: Drop and reconnect with last delivered cursor yields no duplicate of that cursor row and delivers all permitted later rows in order.
+
+### Acceptance cross-reference matrix
+
+| AC | Directional decision(s) | Required negative fixture(s) |
+|---|---|---|
+| AC1 Subscribe/SubscribeAck wire shape | section 1, section 8 | `dos589_fixture_signal_replay_cursor.rs` |
+| AC2 Subscriber registry keyed on `(actor, scopes, subject_filter)`, persistent across reconnects | section 2, section 10, section 11 | `dos589_fixture_signal_replay_cursor.rs` |
+| AC3 Dispatcher consumes `version_events` rows after W4-B commit | section 3, section 9, section 15 | `dos589_fixture_signal_replay_cursor.rs` |
+| AC4 `scope_permits_claim_read(subscriber, claim_id)` gates every delivery | section 4, section 5, section 12 | `dos589_fixture_signal_scope_leak.rs` |
+| AC5 `CorrectionRef.event_log_id` lookup endpoint is scope-filtered identically to inline 409 | section 6, section 8, section 13 | `dos589_fixture_correction_ref_replay_scope_leak.rs` |
+| AC6 `subscription.backpressure` event when outbound queue exceeds threshold | section 7, section 12 | `dos589_fixture_signal_backpressure.rs` |
+| AC7 Replay-from-cursor streams missed events in order, scope-filtered, with cursor-to-event_seq resolution | section 3, section 4, section 11 | `dos589_fixture_signal_replay_cursor.rs`, `dos589_fixture_signal_scope_leak.rs` |
+| AC8 Reconnect resilience: ordered, deduplicated, scope-filtered replay from last-seen cursor | section 2, section 3, section 4, section 11 | `dos589_fixture_signal_replay_cursor.rs` |
+
+## Negative fixtures (`src-tauri/tests/dos589_fixture_<name>.rs`)
+
+### `dos589_fixture_signal_scope_leak.rs`
+
+Purpose: prove the dispatcher never creates an existence oracle for claim-bound events.
+
+Setup:
+
+- Seed two claims with different required read scopes.
+- Seed W4-B-style `version_events` rows for both claims.
+- Register one subscriber with scopes permitting only the first claim.
+- Register another subscriber with scopes permitting only the second claim.
+- Run live dispatch and replay from an earlier cursor.
+
+Assertions:
+
+- Each subscriber receives only events for permitted claims.
+- Out-of-scope claim events are absent, not redacted.
+- Queue metrics do not include per-claim denied counts visible to the subscriber.
+- Replay does not leak out-of-scope rows that live dispatch suppressed.
+- The test fails if any delivery path serializes before calling `scope_permits_claim_read`.
+
+Failure mode caught:
+
+- Filtering at subscribe time only.
+- Redacted push notifications that reveal claim existence.
+- Replay path bypassing live dispatch filter.
+- Composition event leaking affected out-of-scope claim IDs.
+
+### `dos589_fixture_correction_ref_replay_scope_leak.rs`
+
+Purpose: prove direct event-log body fetch follows the same scope rule as inline 409 correction payload.
+
+Setup:
+
+- Seed a W4-B `version_events` row with `correction_event_log_id`.
+- Seed durable correction body containing claim-bound content.
+- Build a permitted `Actor::SurfaceClient { scopes }`.
+- Build an out-of-scope `Actor::SurfaceClient { scopes }`.
+- Request `GET /v1/surface/event-log/{event_log_id}` through the SurfaceClient bridge.
+
+Assertions:
+
+- Permitted actor receives the correction body projected through the same claim read service as inline 409.
+- Out-of-scope actor receives 404 or redacted envelope.
+- Out-of-scope actor never receives claim text, field values, provenance body, or subject metadata.
+- Route lives under `bridges/surface_client.rs`.
+- `wp_user_id` session binding check runs before event-log fetch when a request carries `wp_user_id`.
+
+Failure mode caught:
+
+- Treating `event_log_id` as sufficient authorization.
+- Scope-filtering inline 409 but not replay/fetch.
+- Placing route logic outside the canonical SurfaceClient bridge.
+
+### `dos589_fixture_signal_backpressure.rs`
+
+Purpose: prove bounded queues fail closed into replay without blocking substrate commits.
+
+Setup:
+
+- Configure a small outbound queue threshold.
+- Register a subscriber whose transport does not drain.
+- Insert a burst of committed `version_events` rows.
+- Run dispatcher until threshold is exceeded.
+
+Assertions:
+
+- Dispatcher emits `subscription.backpressure` with `subscription_id`, `cursor`, `replay_required`, and `replay_from`.
+- The subscriber is marked replay-required.
+- Ordinary events stop enqueueing after the hard bound.
+- `claim.write_rejected` and `claim.corrected` are not coalesced away.
+- W4-B mutation/outbox write path completes independently of subscriber queue state.
+- A replay from `replay_from` recovers ordered permitted events.
+
+Failure mode caught:
+
+- Unbounded queue memory growth.
+- Slow subscriber blocking the dispatcher or mutation commit path.
+- Backpressure without a usable replay cursor.
+- Coalescing correctness events away.
+
+### `dos589_fixture_signal_replay_cursor.rs`
+
+Purpose: prove cursor replay is ordered, deduplicated, and reconnect-safe.
+
+Setup:
+
+- Seed `version_events` rows with monotonic `event_seq` and UUIDv4 cursors.
+- Register a subscriber with claim/composition/subject filters.
+- Deliver rows through live dispatch.
+- Drop connection after acknowledging a known cursor.
+- Insert more committed rows.
+- Reconnect with `from_cursor` set to the last-seen cursor.
+
+Assertions:
+
+- Dispatcher resolves cursor to event_seq.
+- Replay query uses `WHERE event_seq > ? ORDER BY event_seq`.
+- The row at `from_cursor` is not duplicated.
+- Later permitted rows arrive in event_seq order.
+- Out-of-scope rows between permitted rows are skipped without changing order of delivered rows.
+- `ReplayResponse.next_cursor` equals the last delivered permitted event cursor.
+- Unknown/expired cursor returns replay-expired shape, not silent full replay.
+
+Failure mode caught:
+
+- Cursor lexical ordering.
+- Timestamp ordering.
+- Duplicate replay of last-seen row.
+- Replay path skipping scope filter.
+- Treating unknown cursor as "start from zero."
+
+## CI invariants
+
+1. **Scope predicate call gate.**
+   - Add a test or lint that every function serializing `ClaimVersionEvent`, `CompositionVersionEvent` with affected claims, `ReplayResponse`, or `CorrectionRef` body calls the scope-filter service.
+   - Preferred shape: a narrow AST or grep gate over dispatcher module allowlists, similar in spirit to W4-B V9 acceptance section 33.
+   - The gate should fail on new dispatcher delivery functions that bypass `scope_permits_claim_read`.
+
+2. **Existence-oracle regression gate.**
+   - `dos589_fixture_signal_scope_leak.rs` must cover live dispatch and replay.
+   - `dos589_fixture_correction_ref_replay_scope_leak.rs` must cover direct event-log fetch.
+   - Both must assert absence, not only redaction, for push/replay delivery.
+
+3. **Version log ordering gate.**
+   - Tests must assert `event_seq` ordering.
+   - Tests must reject cursor lexical ordering and timestamp ordering.
+   - The replay SQL in service code should be easy to locate and should match W4-B V9 section 15.
+
+4. **Post-COMMIT boundary gate.**
+   - Dispatcher tests should inject a rolled-back mutation transaction or failed event insert and prove no delivery occurs.
+   - If implementation uses in-process notification, notification must happen after commit and still read from SQLite.
+
+5. **Route owner gate.**
+   - SurfaceClient dispatcher routes must live in `src-tauri/src/bridges/surface_client.rs`.
+   - `src-tauri/src/surface_runtime/mod.rs` may route to that bridge, but should not own dispatcher domain logic.
+
+6. **No direct DB writes from handlers.**
+   - Command handlers and route adapters call service methods only.
+   - Subscriber checkpoint updates go through `services/version_dispatcher.rs`.
+
+7. **No PII in fixtures.**
+   - Tests use generic IDs and examples only.
+   - No real customer domains, company names, email addresses, or account details.
+
+8. **Standard gate remains required before implementation closes.**
+   - `cargo clippy -- -D warnings`.
+   - `cargo test`.
+   - `pnpm tsc --noEmit`.
+
+## Interlocks with W4-B + W4-C + W4-A + W5-A
+
+| Consumer | What it expects from DOS-589 | DOS-589 guarantee |
+|---|---|---|
+| DOS-567 / W4-B outbox | Delivery begins only after `version_events` commit | Dispatcher reads committed rows by `event_seq`; no mutation transaction coupling |
+| DOS-567 / W4-B event schema | W4-B V9 section 5 payloads are preserved | Dispatcher decodes and forwards `ClaimVersionEvent`, `CompositionVersionEvent`, and `CorrectionRef` without changing schema semantics |
+| DOS-567 / W4-B replay contract | W4-B V9 section 15 cursor/event_seq split is honored | Cursor resolves to event_seq; replay uses `WHERE event_seq > ? ORDER BY event_seq` |
+| DOS-569 / W4-C tamper | Cache invalidation fires only for permitted affected claims/compositions | Dispatcher delivers cache-bust events to W4-C subscribers without leaking unrelated claim existence |
+| DOS-569 / W4-C scope rule | W4-B V9 section 16 direct-key fetches are scope-gated | `GET /v1/surface/event-log/{event_log_id}` uses same predicate as inline 409 |
+| DOS-572 / W4-A renderer | Mounted block state receives cache-bust without polling | Subscribe/SubscribeAck plus replay provides current cursor and missed events |
+| DOS-572 / W4-A renderer | Backpressure puts blocks into refreshing/replay state | `subscription.backpressure` includes replay cursor and replay-required flag |
+| DOS-573 / W5-A feedback router | 423/409 retry-after-event can wait on cursor | Dispatcher resolves retry cursor to event_seq and pushes terminal event or supports replay |
+| DOS-573 / W5-A feedback router | Cross-scope feedback subscribers learn nothing | Out-of-scope claim events receive zero delivery |
+| Tauri native surface | User/Agent subscribers can consume runtime events | Tauri command channel uses same service and scope predicate |
+| SurfaceClient loopback | WP Studio subscribers can consume runtime events | Signed `/v1/surface/*` route uses `bridges/surface_client.rs` and session-bound actor/scopes |
+
+## What DOS-589 explicitly does NOT own
+
+- W4-B outbox row schema.
+- W4-B `version_events` migration.
+- W4-B `event_seq` and cursor generation.
+- W4-B version assignment.
+- W4-B `ClaimVersionEvent`, `CompositionVersionEvent`, and `CorrectionRef` schema definition.
+- W4-B mutation transaction and post-rollback `mutation_aborted` guarantees.
+- W4-C Ed25519 projection signing.
+- W4-C tamper cache storage.
+- W4-C quarantine behavior.
+- W4-A Gutenberg block renderer UI.
+- W4-A cache-bust rendering policy beyond delivery of events.
+- W5-A feedback routing and correction UX.
+- WP-side JavaScript subscription client.
+- PHP route implementation.
+- Product/design UI copy.
+- Legacy ADR-0080 `signal_events` propagation.
+- Generic intelligence signal scoring.
+- Multi-process distributed dispatcher leadership.
+- Retention policy beyond the Phase 0 minimum replay assumption unless implementation needs a migration.
+
+## Open questions
+
+| ID | Question | Proposed L0 resolution |
+|---|---|---|
+| Q1 | Does DOS-589 need a new migration for durable subscriber checkpoints? | Yes if no existing table can hold `(actor, scopes_digest, subject_filter_digest, last_event_seq, last_cursor)`. Keep it small and dispatcher-specific. |
+| Q2 | Is subscriber persistence durable table or config file? | SQLite table. It is runtime state tied to DB event_seq, so DB is the right authority. |
+| Q3 | Does backpressure persist across reconnects? | Persist replay-required state and last safe cursor; do not persist the outbound queue. |
+| Q4 | Does `current_cursor` in `SubscribeAck` mean global latest or subscriber-visible latest? | Subscriber-visible latest after scope filtering. Global latest can create an existence/timing oracle. |
+| Q5 | What is the exact transport for SurfaceClient push? | L0 does not force WebSocket vs SSE. It forces route owner, service contract, and Phase 0 wire semantics. |
+| Q6 | How is `scope_permits_claim_read` implemented if no helper exists? | DOS-589 authors it in the service layer using existing claim projection/read services and `Actor::SurfaceClient { scopes }`; do not use ad-hoc string checks in route handlers. |
+| Q7 | How should composition-only events without affected claims be filtered? | Use composition/subject read predicate when available; otherwise require affected claim expansion before delivering claim-bound content. |
+| Q8 | Should out-of-scope CorrectionRef fetch return 404 or redacted envelope? | Use redacted envelope only when the caller already learned the event exists through an in-scope synchronous path; otherwise 404 to avoid oracle. |
+| Q9 | Does DOS-589 update Linear issue text from `signal_events` to `version_events`? | L0 closure should comment/update Linear so implementation follows W4-B V9 section 15. |
+| Q10 | Does this require design review? | No. Pure Rust substrate; no UI or user-facing prose. |
+
+## Linear dependency edges
+
+- DOS-589 is a sibling of DOS-567 under DOS-546 v1.4.2.
+- DOS-589 is blocked by DOS-567.
+- DOS-567 provides W4-B V9 section 5 payload schemas.
+- DOS-567 provides W4-B V9 section 15 `version_events` schema and outbox atomicity.
+- DOS-567 provides W4-B V9 section 16 scope-filter class rule.
+- DOS-567 provides W4-B V9 section 17 `wp_user_id` session-binding rule.
+- DOS-567 provides W4-B V9 section 37 route owner rule.
+- DOS-589 blocks DOS-569.
+- DOS-589 blocks DOS-572.
+- DOS-589 blocks DOS-573.
+- DOS-569 depends on DOS-589 for W4-C tamper cache invalidation delivery.
+- DOS-572 depends on DOS-589 for W4-A renderer cache-bust delivery.
+- DOS-573 depends on DOS-589 for W5-A retry-after-event delivery.
+- DOS-589 should be linked as related to DOS-546 project execution.
+- DOS-589 should carry a Linear comment noting that `version_events` supersedes stale `signal_events` wording in the original issue body.
+
+## L0 reviewer panel - required runners
+
+- `/plan-eng-review` - required. Focus: service/module boundary, replay correctness, failure isolation, and migration/checkpoint shape.
+- `/cso` - required. Focus: scope-filter bypass, direct-key `event_log_id` fetch, existence-oracle defense, session-bound actor/scopes.
+- `/plan-devex-review` - required. Focus: route owner clarity, transport-neutral API, testability, and implementation handoff to W4-C/W4-A/W5-A consumers.
+- `/codex challenge` - required. Focus: adversarial replay ordering, cursor semantics, backpressure edge cases, and Linear/W4-B contract drift.
+- `/plan-design-review` - not required. Focus: pure substrate, no visual surface, no copy/interaction design.
+
+Reviewer convergence target:
+
+- eng APPROVE
+- cso APPROVE
+- devex APPROVE
+- codex APPROVE
+
+Conditional approvals must be folded into a successor packet version before implementation starts.
+
+## Acceptance for L0 closure
+
+This packet is L0-ready when:
+
+1. All 15 sections remain present in order.
+2. W4-B V9 references are preserved by section number: 5, 15, 16, 17, and 37.
+3. Linear DOS-589 acceptance criteria are restated as testable implementation items.
+4. Every acceptance criterion cross-references a directional decision and at least one negative fixture.
+5. The packet explicitly resolves the `signal_events` vs `version_events` drift in favor of W4-B V9 section 15.
+6. The packet keeps DOS-589 scoped to pure Rust substrate.
+7. The packet says route adapters do not mutate DB state directly.
+8. Negative fixtures cover live dispatch, replay, CorrectionRef fetch, and backpressure.
+9. CI invariants include a class-wide scope-filter bypass gate.
+10. Interlocks with DOS-567, DOS-569, DOS-572, and DOS-573 are explicit.
+11. L0 reviewer panel is eng + cso + devex + codex, with no design review.
+12. Linear dependency edges are posted or confirmed.
+13. Any L0 reviewer findings are folded into V2+ changelog entries.
+14. The output file remains uncommitted until the user explicitly asks for a commit.
+15. Implementation starts only after unanimous L0 approval or explicit L6 override.
+
+DOS-589 implementation may start after L0 closes and DOS-567's `version_events` schema/outbox guarantee is available. W4-C, W4-A, and W5-A should not depend on ad-hoc polling while waiting for this issue; their cache/retry consumers should bind to this dispatcher contract.

--- a/.docs/plans/dos-546/v1.4.2-project/W3-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W3-L0-packet.md
@@ -1,0 +1,202 @@
+# W3 L0 packet — host boundary + open decisions
+
+Date: 2026-05-13 (V4)
+Project: v1.4.2 — Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 3 (DOS-563 W3-0, DOS-564 W3-A, DOS-565 W3-B, DOS-566 W3-C)
+
+This packet captures the cross-cutting W3 decisions resolved at L0 so that W3-0 stays narrow and W3-A/B/C contracts are unambiguous when parallel agents fan out. The Linear issue descriptions remain the canonical execution contracts; this packet supersedes them only where it makes explicit a decision they leave open.
+
+## Changelog
+
+- **V4 (2026-05-13):** Cycle 3 reviewer panel — eng + devex + cso all APPROVE; codex CONDITIONAL with 3 textual findings (transport-neutrality mapping under non-default transports, handshake-per-invoke vs handshake-at-pairing ambiguity, marker-as-heuristic clarification). 2-reviewer class signal on stdio mapping (codex + cso). V4 folds all 3 as textual tightening; no structural changes.
+- **V3 (2026-05-13):** Cycle 2 reviewer panel — eng + devex + cso all APPROVE; codex CONDITIONAL with 3 new findings. V3 folds all 3: loosens MCP transport pin to invariants-only (transport class deferred to W3-0 adapter choice per DOS-566 contract), strikes the credential-retrieval OR in favor of the DOS-565 contract (manage_options-gated WP filter, no WP persistence), defines the prior-pairing marker shape at W3-A activation.
+- **V2 (2026-05-13):** Folded L0 reviewer findings — eng (3), devex (4), cso (5), codex (5 of which 1 overlaps with cso). After consolidation all four reviewers are CONDITIONAL. Adds: namespace-vacancy + reservation invariant for W3-A; credential state machine + HMAC redaction wrapper for W3-B; MCP transport pinning + invariant-not-assertion for default-MCP enumeration + drift-fixture for W3-C; supply-chain pinning, prod-vs-dev split, WP version fixture matrix, transport-class gating clause for W3-0→W3-B. Renamed `mcp_server_name` audit field to `mcp_exposure_path`. Renderer/detector handoff named explicitly.
+- **V1 (2026-05-13):** Initial draft.
+
+## Status snapshot
+
+- W2 closed clean 2026-05-12 — loopback transport, HMAC, pairing+4-path recovery, rate-limit matrix all merged.
+- W3 milestone seeded with four issues (DOS-563/564/565/566). Internal staging: W3-0 → W3-A → (W3-B ∥ W3-C).
+- v1.4.2 supersedes the parked v1.4.10 entity-intelligence project; first WordPress proof is one substrate-authored composition rendered as one dynamic Gutenberg block, not full entity surfaces.
+
+## Pre-work confirmed
+
+- WP skills installed: `automattic/agent-skills@wp-plugin-development`, `wp-block-development`, `wp-wpcli-and-ops`, `wp-block-themes`. The `ollie` block-theme skill is already present and may be relevant for W3-A WP Abilities tools workflow + W5-B magazine theme.
+- Studio CLI (`wp-studio` npm, v1.9.0) installed and working. `studio site create --blueprint <path>` confirmed available.
+- Studio app upgraded to 1.9.0 (was 1.6.3); config migration complete.
+
+## Studio site posture
+
+- **Primary W3-W6 implementation + W6-B validation target:** `DailyOS Dev` at `~/Studio/dailyos-dev`, port 8884, PHP 8.4, WP latest. Created clean 2026-05-13.
+- **Stock-content control site:** `~/Studio/dailyos` (marketing-site WP install, autoStart on) — used as a stock-content control so we can prove the DailyOS plugin doesn't break a generic Studio site with unrelated content. Not the implementation target.
+- **Decision rule:** any negative fixture or W6-B clean-machine evidence must run against `~/Studio/dailyos-dev` or a fresh `studio site create`. Evidence against the marketing site is invalid because pre-existing content contaminates baselines.
+
+## Studio Blueprint posture
+
+Validated 2026-05-13. Studio Blueprints (introduced 1.6.0, local resource fix in 1.7.8) are JSON files conforming to the WordPress Playground blueprint schema, with steps including `installPlugin`, `installTheme`, `wp-cli`, `runPHP`, `setSiteOptions`, `defineWpConfigConsts`. Local zips referenced as `vfs` resources work since 1.7.8. The DailyOS bundle (plugin + theme + pairing setup) maps cleanly onto a single blueprint.
+
+- **W6-B bootstrap mechanism:** `studio site create --blueprint <path>`. No need to script around Studio.
+- **Blueprint authorship lives in W6**, not W3. W3 produces the plugin + theme + custom MCP server; W6 packages them into a blueprint and validates clean-machine install.
+
+## Studio native MCP — host vs site layer
+
+Probed 2026-05-13. `studio mcp` exposes 24 hardcoded tools, all host-layer (site lifecycle, WP.com push/pull, `wp_cli` passthrough, scaffold/validate helpers, preview management). No `resources` or `prompts` capability, no extension point, no way to register DailyOS abilities into Studio's MCP.
+
+This resolves a W3-C open question definitively:
+
+- **Studio MCP and DailyOS plugin MCP are at different layers, not competing.** Studio MCP manages local sites; DailyOS plugin MCP exposes DailyOS abilities running against the substrate. Both can coexist on the same machine.
+- **DOS-566 plan stands.** DailyOS ships its own MCP server using `wordpress/mcp-adapter` (or W3-0 chooses an equivalent), with explicit allowlist + low-cap WP user + SurfaceClient scope enforcement.
+- **Host-boundary invariant:** Studio's `wp_cli` and `site_import/export` tools can mutate the WP DB independently of DailyOS scope enforcement. DailyOS treats those mutations as **out-of-band edits** — they hit the W4-B watermark contract + W4-C tamper detection, and surface in trust-band rendering as `use_with_caution` / `needs_verification`. They are never silently promoted to canonical substrate.
+- **Acknowledged DX papercut (V2):** developers exercising the standard Studio dev loop with `studio mcp wp_cli` will sometimes see `use_with_caution` states on DailyOS-rendered content. This is intentional behavior routed through W4-B watermark + W4-C tamper detection — not a W3-C ask. A future surface affordance can offer "this was my edit" attribution; v1.4.2 detects, renders, and does not silently promote.
+
+## Production vs Studio dev (V2)
+
+`wp-studio` CLI, `studio mcp`, and Studio Blueprints are dev-loop and clean-machine-validation tooling. They are **not** production WordPress operations tooling.
+
+Banned from any production runbook, deployment guide, or end-user instruction:
+
+- `studio mcp wp_cli` passthrough — Studio host-layer tool, dev-only.
+- `studio site export/import` — Studio site-lifecycle, not a production migration tool.
+- Any `wp-studio` CLI command that mutates site state at runtime (`wp_cli`, `runPHP`, blueprint re-apply).
+
+Production WordPress operations reference standard WP-CLI, standard plugin install flows, and standard WordPress.org plugin/theme distribution. The DailyOS plugin readme (W3-B authorship) and W6 install documentation inherit this rule by reference rather than re-deriving it.
+
+## Directional decisions resolved at L0
+
+These are not deferred to W3-0 spike; they are inputs to it.
+
+1. **WPGraphQL — out of v1.4.2 critical path.** Any GraphQL usage is reference/prior-art only, read-only WP-local, and cannot bypass SurfaceClient/HMAC/nonce/scope. W3-0 confirms this in writing; no implementation work.
+2. **Remote Data Blocks — reference/borrow patterns only.** Editor UX and server-rendered block patterns are inspiration; DailyOS runtime remains canonical, RDB is not vendored or forked into the plugin.
+3. **WordPress MCP Adapter — directional default: depend on it as a library, with explicit fallback.** W3-0 confirms whether to take a direct dependency, pin a fork, or implement adapter-style patterns inline. The custom DailyOS MCP server registers using the adapter's pattern; ability logic does not move to PHP. **(V2)** Pin a specific known-good adapter release in the W6-B blueprint. Exit strategy: if the adapter ships a breaking change OR stalls (no commit ≥6 months), the v1.4.x project owning the next blueprint refresh evaluates vendor/fork. The pin is a v1.4.x contract, not a forever choice.
+4. **PHP runtime transport — directional default: WordPress HTTP API** wrapped in `DailyOS_Runtime_Client`, with tests proving exact-byte canonicalization to match the W2 HMAC contract. **(V2)** Gating clause: **if W3-0 finds the WP HTTP API insufficient for HMAC byte-exactness (e.g. body-stream re-read corrupts canonical bytes), W3-B start is gated on the transport-class decision being recorded in this packet (V3) before implementation.** A late-breaking transport switch from WP HTTP API → cURL after W3-A merges is non-trivial and must not happen mid-stream.
+5. **WP/PHP minimums — WordPress 6.9+, PHP 8.1+.** **(V2)** "WP latest" is insufficient as a compatibility target. The Abilities API is documented as WP 6.9+ only. W6-B validates on **two pinned WP fixtures**: exact WP 6.9.x minimum AND the current `WP latest` at v1.4.2 release. Both fixtures must pass activation, ability registration, and MCP exposure tests. Compatibility shim work is in scope only if a real consumer needs WP 6.7/6.8.
+6. **Studio MCP composition — not pursued.** DailyOS abilities are exposed exclusively through the DailyOS plugin MCP server (DOS-566). Studio's native MCP is treated as a host-layer peer.
+7. **Studio CLI ergonomics — adopt `wp-studio` npm CLI for headless flows.** Bundled `studio-cli.sh` in Studio.app is `preview`-only. The npm CLI (`studio`) is the canonical headless interface and is the W6-B clean-machine validation driver. **(V2)** Pin `wp-studio` to a specific known-good version in the W6-B blueprint metadata. Same exit strategy as MCP Adapter (item 3) applies if Studio CLI ships a breaking change between W3 start and v1.4.2 release.
+
+## Host-boundary acceptance criteria (lifted into W3-A/B/C)
+
+These criteria are derived from the W3–W6 Studio-first WordPress prior-art reuse packet (2026-05-12), the workspace-boundary decision (2026-05-12), and the L0 reviewer panel (2026-05-13). They are conditions of L1/L2 passing for the named issues, not aspirations.
+
+### W3-A (DOS-564) plugin skeleton
+
+- MUST NOT introduce: local-site management UI, connector marketplace, OAuth/provider credential storage, generic MCP toolkit browsing, routine builder UI, markdown/block sync engine, Jetpack/Woo admin chrome.
+- **(V2)** MUST NOT register `WP_CLI::add_command` entries that shadow or duplicate Studio host-layer surfaces (`site_create`, `site_list`, `site_start`, `site_stop`, `site_delete`, `site_push`, `site_pull`, `preview_*`, `scaffold_theme`, `validate_blocks`, `need_for_speed`, `rank_me_up`, `wp_cli` passthrough). DailyOS WP-CLI commands are scoped to plugin diagnostics + DailyOS-specific operations (e.g. `wp dailyos status`, `wp dailyos repair-projection`).
+- MAY register: DailyOS Gutenberg blocks (W4 surface), DailyOS abilities via WP Abilities API, pairing/status diagnostics, settings page (read-side until W3-B).
+- **(V2) Reserve DailyOS-owned WP namespaces:** option keys prefixed `dailyos_`, post-type prefixes `dailyos_`, role name `dailyos_substrate`, user-meta prefix `dailyos_`. Namespace reservation is a W3-A activation contract that W4-C will sign + verify.
+- **(V2) Namespace-vacancy invariant at first activation:** activation MUST refuse to adopt pre-existing `dailyos_*` option keys, DailyOS-prefixed post-types, the `dailyos_substrate` role, or DailyOS-prefixed user-meta if any pre-exist with no recorded prior pairing. Diagnostic-with-recovery-path UX, never silent inheritance. Negative fixture seeded into phase-0 artifact 12.
+- **(V3 + V4) Prior-pairing marker — concrete:** "recorded prior pairing" means a non-secret marker stored in `wp_options.dailyos_pairing_marker` containing `runtime_instance_id`, `site_nonce_hash`, `projection_version`. The marker is non-secret by design: its contents do not authenticate anyone, only attest that *some* prior DailyOS pairing existed on this site. **(V4) The marker is a namespace-vacancy heuristic only — runtime-reported state is the authoritative trust source. Marker-match NEVER bypasses runtime pairing, signature, or scope checks; it only informs the activation-stage decision about whether the WP namespace was previously claimed.** An attacker with WP DB write can forge the marker fields, but cannot forge the runtime's view of `runtime_instance_id` or `projection_version`; the runtime-state comparison is the load-bearing check. Activation logic:
+  - Marker absent AND `dailyos_*` namespace clean → legitimate fresh install. Activate.
+  - Marker absent AND `dailyos_*` namespace not clean → hostile pre-existing state. Refuse activation with diagnostic; recovery is the `wp dailyos repair-namespace` CLI helper (one of the explicit W3-A WP-CLI commands listed under the `WP_CLI::add_command` MUST NOT exception list).
+  - Marker present AND matches the paired runtime's reported state → legitimate re-activation (reinstall, upgrade, re-pair). Proceed.
+  - Marker present AND mismatches runtime state → quarantine; require explicit admin repair via the same CLI helper.
+
+  Negative fixtures covering all four paths seeded into phase-0 artifact 12.
+- **(V2) Projection envelope shape pinned at W3-A:** every W3-A-authored storage row destined for W4-C signature carries: `dailyos_canonical_id`, `dailyos_signature`, `dailyos_source_runtime` (runtime instance ID), `dailyos_projection_version`. W4-A renderers and W4-C verifiers consume this envelope as the contract.
+- **(V2) Plugin source grep gates — concrete:** W3-A authors a regex set in `wp/dailyos/scripts/grep-gates.json` covering:
+  - Raw `$wpdb->query`/`$wpdb->insert`/`$wpdb->update`/`$wpdb->delete` outside service wrappers under `wp/dailyos/includes/services/`.
+  - Filesystem writes outside `wp-content/uploads/dailyos/` scope.
+  - Known secret-persistence patterns: `update_option.*hmac`, `set_transient.*hmac`, `update_post_meta.*hmac`, `update_user_meta.*hmac`, `wp_localize_script.*hmac`, similar variants for `bearer`/`session_key`/`pairing_token`.
+  CI job runs against `wp/dailyos/**` on every PR; deliberate-violation negative fixture in phase-0 artifact 12 proves the gate triggers.
+
+### W3-B (DOS-565) runtime client + HMAC + pairing UI
+
+- Browser JS never calls the Rust runtime directly. JS → WP REST/admin → PHP signer → `127.0.0.1:<runtime_port>`.
+- Per-session HMAC key is request-time secret material only. Negative grep gates: no key in `wp_options`, transients, post meta, block attributes, JS preload state, page HTML, logs, diagnostic dumps.
+- **(V2 + V3 + V4) Credential state machine:** pairing produces session material (per W2-C contract); session material is held in-process via a `DailyOS_Session_Credential` value object whose lifetime is the request only. **Cross-request retrieval (per DOS-565 contract, V3 + V4 disambiguation):** the W2-C single-use handshake happens **once at pairing time** (or on rotation events below) — NOT per invoke. The handshake issues a per-session credential held by the runtime. Per WP request, the `manage_options`-gated `dailyos_wp_bridge_session_key` WP filter pulls a runtime-resident *reference* to that already-issued credential. The credential lifetime is tied to the W2-C session, not to individual WP requests; admin AJAX, page renders, and block invocations in the same paired session share the same credential. No WP-side persistence of secret material — ever. Rotation: on re-pair, runtime restart, scope change, or revoke — each rotation event invalidates the prior credential and issues a fresh W2-C handshake. Revoke: WP-side flag flips → next request fails closed with typed error. State transitions tested in W3-B unit + integration. **(V3 note):** a bearer-token retrieval branch was considered in V2 and struck — if needed in the future, it lands as a W3-0 / packet V5 transport amendment with explicit lifetime, storage owner, replay behavior, and tests, not as a parallel option implementers must pick between.
+- **(V2) HMAC redaction wrapper:** `DailyOS_Session_Credential` and any `DailyOS_Hmac_Key` value object expose `__debugInfo`, `__toString`, and `jsonSerialize` overrides returning a redacted token (e.g. `***REDACTED***`). Unit tests assert `print_r`, `var_dump`, `json_encode`, and a deliberate `WP_DEBUG_LOG`-line emit of the object yield redacted output, not the secret bytes. Belongs in W3-B; gates on PHP opcode cache / `var_export` debug paths / fatal-error stack dumps capturing in-memory values.
+- Pairing/revoke/re-pair handle runtime restart, stale pairing code, concurrent-admin pairing flows with typed user-facing errors that do not leak runtime internals.
+- Settings page exposes instance ID, granted scopes, endpoint version, last-use timestamp; never the HMAC key, bearer token, or runtime port.
+- Pairing UI uses WordPress admin nonces for admin form CSRF only. DailyOS user-presence nonces are separate and are not introduced in W3-B.
+
+### W3-C (DOS-566) custom MCP server
+
+- Default WP MCP server (if any host plugin enables one) MUST NOT enumerate `dailyos/*` tools or schemas.
+- **(V2)** "Must not enumerate" is enforced as an invariant, not asserted as prose: DailyOS ability registration sets `mcp_exposure` metadata on every `wp_register_ability()` call; the `mcp_exposure: None` default makes abilities invisible to any generic MCP-adapter enumerator. **Negative fixture:** instantiate a generic MCP adapter against the local WP, enumerate, assert zero `dailyos/*` tools surface unless explicit allowlist is loaded. Belongs in phase-0 artifact 12.
+- DailyOS-namespaced MCP server enumerates only allowlisted abilities from `tools/dailyos-abilities.json`: `mcp_exposure: Invocable | MetadataOnly`. `None` is absent.
+- `MetadataOnly` exposure never returns invoke schema and never permits invocation.
+- Read-mostly default: allowlist defaults to Read/Transform categories. Publish/Maintenance abilities require explicit ADR/issue promotion.
+- Dedicated low-capability WP user (`dailyos_substrate` role) created at activation; WP capability alone is never sufficient. Permission callbacks check both WP capability AND DailyOS SurfaceClient scopes before invocation.
+- **(V2) Capability + scope drift fixture:** pin the `dailyos_substrate` role's capability map AND the resolved SurfaceClient scope set in `wp/dailyos/tests/fixtures/role-capabilities.json` + `tests/fixtures/surfaceclient-scopes.json`. CI diff-checks both; drift fails the build. Prevents silent capability creep via `add_cap` or scope-set widening.
+- Audit emits `mcp_exposure_path` (Invocable vs MetadataOnly enumeration result), `wp_user_id`, `ability_name`, scope-check result via the W1-A0 SurfaceClient audit helper. **(V2)** Renamed from `mcp_server_name` per eng review — the server-name field was constant under the "DailyOS abilities exclusively through DailyOS plugin MCP" decision and carried no forensic value; the exposure-path distinction is the actually-useful signal.
+- **(V2 + V3) MCP transport invariants:** the DailyOS MCP server uses whatever transport the W3-0 adapter decision selects (likely REST under `/wp-json/dailyos/v1/mcp/*`, but the adapter may choose SSE, streamable HTTP, or stdio bridge — DOS-566 contract gives W3-0 this choice). Independent of transport choice, the following invariants apply unconditionally:
+  - Authentication via the dedicated `dailyos_substrate` WP user (not anonymous, not `manage_options`).
+  - No public unauthenticated enumeration — tool listing requires authenticated session.
+  - Rate limits inherited from the W2-D `SurfaceClientBridge` matrix (per-instance, per-user, per-site, per-ability, per-scope-class).
+  - Bind scope: same-origin only; cross-origin MCP discovery refused.
+
+  **(V3):** the specific transport + adapter compatibility is recorded by W3-0 in a packet V5 amendment if the adapter pattern alters the default REST assumption. V2 over-constrained by pinning REST; V3 corrects to invariants-only.
+
+  **(V4) Transport-neutrality mapping requirement:** if W3-0 selects a non-default transport (SSE, streamable HTTP, stdio bridge), the V5 amendment MUST explicitly map each of the four invariants above to that transport. Reference mappings:
+  - **REST (default):** auth via WP REST nonce / cookie / app password for `dailyos_substrate` user; no anon enum = no permission callback for guests; rate-limit identity = `wp_user_id` + IP; bind = same-origin via `Origin`/`Host` header allowlist.
+  - **SSE:** auth same as REST at connection open; no anon enum = connection refused without session; rate-limit identity = `wp_user_id` + connection; bind = `Origin` header allowlist of paired runtime URLs.
+  - **stdio bridge:** auth = process spawned by the paired DailyOS runtime (process-parentage check + runtime-signed handshake nonce on first frame); no anon enum = no MCP frames before runtime auth; rate-limit identity = runtime-instance-id passed in handshake; bind = process boundary, no network listener.
+
+  Adapters that cannot map all four invariants are rejected at the W3-0 decision stage. The mapping requirement is documentation, not implementation work for W3-C — implementation follows W3-0's chosen adapter.
+- **Host MCP coexistence invariant:** Studio's native `wp_cli` MCP tool can mutate the WP DB. DailyOS-side handling: any WP DB row that differs from the runtime's signed projection (per W4-C) renders in degraded/tamper state; this is the same path used for direct WP admin edits and DB restores. **(V2) Renderer/detector handoff named explicitly:** W4-A renderer reads tamper/quarantine state from the W4-C projection ledger and degrades the trust band accordingly. **W3-C does not own UI degradation;** W3-C's audit emission carries the divergence signal, and W4-A/C consume it.
+
+## Workspace-boundary release-gate invariants
+
+From the 2026-05-12 workspace boundary decision. These are additive release-gate items, not new code:
+
+- DailyOS canonical workspace remains `DailyOS/` (per-user, source ledger, claims, provenance). WordPress DB is a projection surface. No code path in W3-A/B/C may promote a WP DB row, a markdown file edit, or a Studio site-import into canonical substrate state.
+- WordPress, including local Studio sites, may become a source for future signal ingestion. v1.4.2 does not ship that ingestion path; v1.4.6 owns it.
+- DailyOS-authored projections must be distinguishable from human-authored WordPress content at the source-ingestion layer (v1.4.6 contract). v1.4.2's contribution is making this distinction renderable via projection signatures (W4-C) so that v1.4.6 has a substrate to consume.
+
+## Linear dependency edges (formalize)
+
+Currently described only in prose. Add as Linear blocker relations:
+
+- DOS-563 (W3-0) blocks DOS-564 (W3-A).
+- DOS-564 (W3-A) blocks DOS-565 (W3-B).
+- DOS-564 (W3-A) blocks DOS-566 (W3-C).
+- DOS-563 (W3-0) blocks DOS-565 (W3-B) and DOS-566 (W3-C) transitively; explicit edges optional.
+
+W3-B and W3-C run in parallel after W3-A merges. **(V2)** W3-B's start is additionally gated on the W3-0 PHP-transport decision being recorded in this packet (V3) if the WP HTTP API canonicalization concern surfaces — see Directional decision item 4.
+
+## What W3-0 (DOS-563) still owns after this packet
+
+This packet shrinks W3-0 scope to the items still genuinely ambiguous:
+
+1. **MCP Adapter dependency posture:** direct dependency, pinned fork, or pattern-only. Default lean: direct dependency, pinned to a known-good release.
+2. **rsm-second-brain mapping:** which exact files/patterns we borrow for bootstrap, domain layout, REST/service split, asset manifest guard, AI-log evidence. The "borrow architecture, not substrate semantics" rule is fixed; the file-level mapping is research output.
+3. **A8C-internal prior-art sweep:** if/when GitHub auth resolves, scan WooCommerce MCP/Abilities work, Big Sky plugin, wp-admin-rpg, claude-code-vip for additional reusable shape. Internal-code findings summarize shape only — no proprietary code in Linear.
+4. **PHP transport edge cases:** what (if anything) breaks WP HTTP API exact-byte canonicalization at the HMAC-signed boundary; whether body-stream re-reads are safe. **(V2)** If WP HTTP API fails byte-exactness, W3-0 records the transport-class switch decision in a packet V3 amendment; W3-B does not start until this is locked.
+5. **Studio Blueprint authoring spike for W6-B:** the actual blueprint JSON shape that bundles plugin zip + theme zip + WP-CLI bootstrap + pairing onboarding admin notice. Output is a v0 blueprint that W6-B can validate, not a finished one.
+6. **(V2) WP version pin:** confirm the exact WP 6.9.x minimum target (likely the latest 6.9 point release at v1.4.2 release time) and document the "current latest" target. Both fixtures land in the W6-B blueprint test matrix.
+
+## L0 reviewer panel — results (V2)
+
+Reviewers run 2026-05-13. All four reviewers CONDITIONAL after consolidation. Verdicts posted as comments on DOS-546:
+
+- **Eng:** 3 findings (P1 renderer handoff, P2 audit-field rename, P3 transport gating clause). All folded into V2.
+- **DevEx:** 3 P2 + 1 P3 (supply-chain pinning, prod-vs-dev split, missing WP_CLI MUST NOT, DX papercut ack). All folded into V2.
+- **CSO:** 2 HIGH + 2 MEDIUM + 1 LOW (concrete grep gates, namespace vacancy, HMAC redaction wrapper, capability+scope drift fixture, pairing nonce non-issue). All folded into V2.
+- **Codex (challenge mode):** 5 findings, BLOCK verdict (consolidated to CONDITIONAL — credential state machine overlaps CSO MEDIUM; MCP transport / invariant-vs-assertion / namespace + envelope reservation / WP version matrix all folded into V2).
+
+Two genuinely new W3-A scope items emerged from the panel and are now in the W3-A host-boundary criteria above: (a) reserve DailyOS WP namespaces + pin projection envelope shape, (b) namespace-vacancy check at activation.
+
+### Cycle 2 (2026-05-13, V2 packet under review)
+
+- **Eng:** APPROVE. All 3 V1 findings ADDRESSED; no new L0-blocking findings.
+- **DevEx:** APPROVE. All 4 V1 findings ADDRESSED; no new L0-blocking findings.
+- **CSO:** APPROVE. All 4 V1 findings ADDRESSED; no new L0-severity findings.
+- **Codex (challenge mode, full context — V2 packet + W3-A/B/C issue contracts inline):** CONDITIONAL. All 5 V1 findings ADDRESSED; 3 new findings — [HIGH] MCP transport over-constraint (V2 pinned REST when W3-0 owns adapter choice per DOS-566), [MEDIUM] credential retrieval OR conflicting with DOS-565 single-path contract, [LOW] prior-pairing marker undefined. All 3 folded into V3.
+
+### Cycle 3 (2026-05-13, V3 packet under review)
+
+- **Eng:** APPROVE. NO-REGRESSION on all three V3 changes; marker shape aligns 1:1 with W4-C projection envelope.
+- **DevEx:** APPROVE. NO-REGRESSION; high-frequency-invocation latency papercut named as future packet V5 amendment owned by W3-0 with required attributes spelled out.
+- **CSO:** APPROVE. NO-REGRESSION; sharp note that stdio "same-origin" means process-parentage (folded into V4 transport-neutrality mapping).
+- **Codex (challenge mode, full context):** CONDITIONAL. All 3 V2/V3 findings ADDRESSED; 3 new findings — [MEDIUM] transport-neutrality mapping under non-default transports, [MEDIUM] handshake-per-invoke vs handshake-at-pairing wording ambiguity, [LOW] marker-as-heuristic clarification. All 3 folded into V4 as textual tightening.
+
+## Acceptance for L0 closure
+
+This packet is L0-approved when:
+
+1. Devex + eng + cso unanimous APPROVE — confirmed in Cycle 3 against V3 (with V4 carrying their notes forward). **(V4)** Cycle 4 codex re-run is **required** to confirm V4 textual fold closes the 3 Cycle 3 wording findings. Eng / devex / cso don't need re-confirmation in Cycle 4 since V4 changes are pure textual tightening of surfaces they already approved. L0 closes when codex APPROVEs on V4.
+2. W3-A/B/C Linear issue descriptions updated to reference this packet by URL for the lifted criteria.
+3. Linear dependency edges added.
+4. Any reviewer-surfaced changes folded back into this doc, dated.
+
+W3-0 (DOS-563) may start in parallel with reviewer re-scheduling, scoped to the residual questions above. W3-A/B/C wait for L0 closure.

--- a/.docs/plans/dos-546/v1.4.2-project/W4-A-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-A-L0-packet.md
@@ -1,0 +1,840 @@
+# W4-A L0 packet - dailyos/account-overview Gutenberg block renderer
+
+## 1. Header
+
+Date: 2026-05-13
+Project: v1.4.2 - Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: W4-A, stage-3 renderer
+Issue: DOS-572
+Surface: WordPress Gutenberg dynamic block
+Block name: `dailyos/account-overview`
+Output path: `wp/dailyos/blocks/account-overview/`
+Primary runtime dependency: W3-B `DailyOS_Runtime_Client`
+Primary producer dependency: W4-A0 `AbilityOutput<Composition>`
+Primary projection dependency: W4-D `project_composition_for_surface(composition, ctx)`
+Primary trust-boundary dependencies: W4-B, W4-C, W4-E
+Downstream dependencies: W5-A feedback router, W5-B magazine theme, DOS-589 outbox delivery
+
+This packet captures the W4-A renderer contract resolved at L0.
+The Linear issue remains the canonical execution contract.
+This packet supersedes it only where the issue leaves a boundary implicit.
+The implementing agent should treat W4-A as thin PHP/JS rendering glue.
+The block must not become a second producer, trust scorer, signer, projector, nonce issuer, or feedback persistence layer.
+
+DailyOS product framing applies.
+The block renders account context with trust, provenance, and visible uncertainty.
+It must feel editorial under the DailyOS theme and remain legible under stock WordPress themes.
+It must not expose internal vocabulary in user-facing strings.
+
+## 2. Changelog
+
+- **V3.2 (2026-05-13):** Cycle 4 codex confirmation pass — two contract drifts closed:
+  - V2 changelog entry at line 47 marked SUPERSEDED BY V3 (V2 wp_cache + scope_set_hash mechanism replaced by V3 runtime-side cache + opaque cache_hint_token). The cached_projection-removal property is preserved; the V2 mechanism is replaced.
+  - §6.3.1 W3-B method signature + AC #13 now name `cache_hint_token` round-trip explicitly: optional 4th parameter on the PHP-side wrapper, return shape is `['projection' => ProjectedCompositionDTO, 'cache_hint_token' => string]`. This closes the contract anchor for the V3 §6.2 round-trip.
+
+- **V3.1 (2026-05-13):** Cycle 3 codex confirmation pass — class-wide sweep of remaining stale cache-class references after V3 named-section fix landed. Class fixes:
+  - §6.3 step 3: PHP no longer "checks `wp_cache`"; render.php calls the runtime on every render (PHP-side cache fully removed). Step 4 shows the runtime as cache authority with `cache_hint_token` round-trip.
+  - §6.3 audit-emission paragraph deduplicated; the duplicate V2-era paragraph that said "Cache hit → emit projection_cache_served audit (no runtime call)" removed — runtime is sole emitter.
+  - §6.7 editor preview/refresh rewritten: every preview render calls the runtime; cache lives substrate-side; failed refresh keeps DOM stale-marked without a PHP-side cached projection.
+  - AC #44 (editor reload) rewritten: success/failure paths describe `watermarks` + optional `cache_hint_token`; explicitly no `cached_projection` attribute exists; PHP serves no local cached projection.
+  - CI invariant #21 rewritten as a CI grep banning `cached_projection`/`actor_scope_fingerprint`/`actor_context_hint` attributes from `edit.js`/`render.php`.
+  - Open Question #6 resolved: runtime-side cache is canonical; no PHP-side cache and no WP transient; substrate is sole scope-identity authority.
+
+- **V3 (2026-05-13):** Cycle 2 fold — codex BLOCK verdict. Material changes:
+  - **CRITICAL fix (codex C2):** Acceptance criteria fully reconciled with V2 §6.2 — removed all residual `cached_projection` / `actor_context_hint` / `actor_scope_fingerprint` references from AC list, fixture names, and CI invariants. AC #45 reload expectation now describes `watermarks` + optional `cache_hint_token` (NO `cached_projection`). Fixture #34 renamed to `dos572_fixture_runtime_cache_hit_drops_raw_error.php`.
+  - **HIGH fix (codex C2):** AC #13-20 PHP render path tightened — PHP calls `DailyOS_Runtime_Client::project_composition_for_surface($composition_id, $composition_version, $actor_ctx)` directly; never receives `AbilityOutput<Composition>`, never reaches into W4-D directly. Eliminates AC-vs-§6.3 drift codex flagged.
+  - **HIGH fix (codex C2):** §6.2 cache layer moved RUNTIME-SIDE (V2 attempted a PHP `wp_cache` keyed by `scope_set_hash`; codex correctly flagged this as impossible because §6.12 forbids PHP from asserting scope identity — the substrate is the sole scope authority). V3: runtime owns the cache keyed by `(composition_id, composition_version, scope_set_canonical_id)` derived inside the substrate from the authenticated SurfaceClient session. Runtime returns an opaque `cache_hint_token` (non-secret, advisory only); PHP echoes it back so the runtime can short-circuit cache lookup. Block attribute schema (§6.1) carries `cache_hint_token` instead of `actor_scope_fingerprint` — no scope material in `post_content`.
+  - **Class-wide sweep:** all attribute discipline negative rules now also forbid scope-derived material (hashes, fingerprints, scope set identifiers). The post_content scope-leak class is closed at the schema layer, not by case-by-case patching.
+
+- **V2 (2026-05-13):** Cycle 1 fold — 5 reviewer panels (eng + cso + devex + ui-designer CONDITIONAL APPROVE, codex BLOCK). Material changes:
+  - **CRITICAL fix (codex C1; SUPERSEDED BY V3 — see V3.1 above):** `cached_projection` REMOVED from block attributes (was a scope-leak vector — block attributes serialize into publicly-readable `post_content`). V2 placed perf cache in PHP `wp_cache` keyed by `(composition_id, composition_version, scope_set_hash)`. Codex Cycle 2 BLOCK correctly flagged this approach as impossible since §6.12 forbids PHP from asserting scope identity (substrate is sole scope authority). V3 supersedes this: cache lives RUNTIME-SIDE; block attributes carry only `cache_hint_token` (opaque, advisory); no PHP-side cache, no scope-derived material in `post_content`. The cached_projection-removal property is preserved; the V2 wp_cache mechanism is REPLACED by the V3 runtime-side cache.
+  - **HIGH fix (codex):** §6.3 PHP→W4-D contract — PHP does NOT call W4-D directly. W3-B exposes new `DailyOS_Runtime_Client::project_composition_for_surface()` method wrapping the Rust API; PHP renders the DTO only.
+  - **HIGH fix (codex):** §6.7 enforcement_mode trust-gate — explicit rules per `enforce`/`shadow`/`disabled` plus tamper/rollback/missing-signature states. Trusted affordances only when `enforce` + verification + currentness all pass.
+  - **HIGH fix (codex):** §6.1 block.json `attributes` schema pinned verbatim with per-field types/defaults; explicitly no `cached_projection`, no claim text, no provenance.
+  - **/cso H1 (closed by C1):** cached_projection scope-revalidation — closed by dropping the attribute entirely.
+  - **/cso MEDIUM:** PHP escaping discipline ac + CI grep; audit emission split (`ability_invoked` vs `projection_cache_served`).
+  - **/cso LOW:** §6.12 renderer never asserts wp_user_id — only forwards SurfaceClient session token; substrate is sole authority.
+  - **Eng P1×3:** block-registration hook ownership pinned (`dailyos_register_blocks()` from `init`); stale banner version state surface pinned (`wp_options.dailyos_composition_versions[composition_id]`); W3-B method signature referenced via DOS-565 Linear, not hardcoded.
+  - **Eng P2:** server-render perf budget p95 ≤500ms cold / ≤200ms warm.
+  - **Devex P1×2:** build toolchain pinned (`@wordpress/scripts`); PHP testing harness pinned (`wp-env` + `Brain\Monkey`).
+  - **Devex P2:** W3-B contract §6.3.1; editor dev loop `wp-scripts start` HMR; account selection via `InspectorControls` + `ComboboxControl`; nonce helper from W4-E PHP layer.
+  - **UI-design P1×3:** §6.5 binds to `AboutThisIntelligencePanel` pattern; §6.6/§6.7 banners bind to `StaleReportBanner`/`ConsistencyFindingBanner` (or new `VerificationBanner` variant); §6.4 full `data-ds-*` attributes per `TrustBandBadge`.
+  - **UI-design P2×3:** editorial-vs-dashboard ac; FinisMarker; empty state §6.13.
+  - **UI-design P3:** copy revisions to magazine voice.
+
+- **V1 (2026-05-13):** Initial L0 plan packet for the first DailyOS Gutenberg block.
+- Captures dynamic block shape, file layout, render path, editor preview path, and fallback behavior.
+- Inherits W4-B V9 concurrency and version contracts, including `commit_composition`, `ClaimRef::with_field`, `Block.field_bindings`, `BridgeSurfaceError` precedence, `wp_user_id` session binding, SurfaceClient route ownership, and `version_events`.
+- Inherits W4-A0 V5 producer shape, claim-type to `BlockType` mapping, and trust-band fallback table.
+- Inherits W4-C V3 projection envelope, Ed25519 verification-on-read, quarantine rendering, and shadow-trust enforcement flag.
+- Inherits W4-D V3 composition-level projection API and unknown-block fallback rules.
+- Inherits W4-E V2 nonce issue/verify endpoints for feedback affordances.
+- Inherits W3-B runtime client and HMAC signer path.
+- Records that the current W4-A prep worktree has no `wp/dailyos` plugin directory yet.
+- Records that `src/styles/design-tokens.css` already ships the three trust-band color aliases.
+- Records that runtime components already expose `TrustBandBadge`, `TrustBand`, `ProvenanceTag`, and design-system metadata conventions.
+- Establishes no commit, no migration, and no new substrate schema ownership for W4-A.
+
+## 3. Status Snapshot
+
+- W4-A is W4 stage-3: a renderer after stage-1/stage-2 substrate contracts land.
+- W4-A is gated on W4-A0 merging because the renderer needs the real `AbilityOutput<Composition>` producer.
+- W4-A is gated on W4-C merging because signed projection state and quarantine rendering are trust-boundary inputs.
+- W4-A is gated on W4-D merging because the block consumes `ProjectedComposition`, not raw `Composition` blocks.
+- W4-A is gated on W4-E merging before feedback affordances are enabled.
+- W4-A is gated on W3-B merging because PHP must call the runtime through the existing HMAC-signed client.
+- W4-B V9 is a hard dependency for composition watermarks, `version_events`, and SurfaceClient session binding.
+- DOS-589 is an interlock for delivering version events into WordPress stale-detection state.
+- W5-A consumes W4-A save-handler attribute changes and edit-route metadata for feedback routing.
+- W5-B supplies the full DailyOS magazine theme shell; W4-A must still render safely without it.
+- The current target worktree contains `.docs/plans/dos-546/v1.4.2-project/` but no W4-A packet file yet.
+- The current target worktree contains no `wp/dailyos/` directory.
+- Therefore W4-A implementation will create the first block directory and likely the first concrete block registration path.
+- That creation does not authorize inventing a parallel plugin architecture.
+- W3-A/W3-B plugin registration conventions remain the owner for main plugin bootstrap.
+- W4-A only adds the account-overview block files and registration hook required for this block.
+- No database migration is planned for W4-A.
+- No Rust schema change is planned for W4-A.
+- No new ability is planned for W4-A.
+- No new `BlockType` is planned for W4-A.
+- No new trust-band vocabulary is planned for W4-A.
+
+## 4. Pre-work - substrate reuse audit + WP block conventions
+
+### Substrate reuse audit
+
+- `wp/dailyos/` does not exist in the target W4-A prep worktree.
+- W4-A should create `wp/dailyos/blocks/account-overview/` only when implementation begins.
+- W4-A should not create a broad plugin framework unless W3-A/W3-B did not already define one on merge.
+- W4-A must inspect merged W3-A/W3-B plugin bootstrap before coding.
+- Block registration must attach to the plugin owner established by W3-A/W3-B.
+- Existing DailyOS design tokens live in `src/styles/design-tokens.css`.
+- Existing trust aliases are `--color-trust-likely-current`, `--color-trust-use-with-caution`, and `--color-trust-needs-verification`.
+- Existing trust alpha aliases exist at 8, 10, 12, and 15 stops.
+- Existing design docs mirror those tokens in `.docs/design/tokens/color.md`.
+- Existing `TrustBandBadge` exposes the three visible wire bands.
+- Existing `TrustBandBadge` uses product labels `Likely current`, `Use with caution`, and `Needs verification`.
+- Existing `TrustBandBadge` exposes `data-ds-name`, `data-ds-tier`, and `data-ds-spec`.
+- Existing `TrustBand` composes trust, provenance, and freshness for native app surfaces.
+- Existing `ProvenanceTag` exposes design-system metadata and source display conventions.
+- Existing `MagazinePageLayout`, `FolioBar`, `FloatingNavIsland`, `AtmosphereLayer`, and `FinisMarker` define the DailyOS magazine shell.
+- WordPress rendering cannot import the React app components directly.
+- WordPress CSS should mirror token semantics and product copy rather than duplicating React internals.
+- Under the DailyOS theme, CSS variables should resolve to theme-provided shell tokens.
+- Under stock themes, W4-A must define safe local fallbacks for paper, text, rule, account, and trust colors.
+- No customer-specific data may appear in fixtures, snapshots, comments, or examples.
+
+### WordPress block conventions
+
+- The block uses WordPress block metadata in `block.json`.
+- The block uses `apiVersion: 3`.
+- The block is dynamic and server rendered.
+- `block.json` points `render` to `file:./render.php`.
+- `save.js` returns `null`.
+- PHP registration uses `register_block_type()` against the block directory or metadata.
+- Editor markup uses `useBlockProps()`.
+- Front-end PHP markup uses `get_block_wrapper_attributes()`.
+- Attributes are stored in the block comment delimiter, not in rendered HTML.
+- `supports.html` is false so generated HTML is not user-edited.
+- W4-A does not use InnerBlocks for DailyOS-authored child content in v1.
+- W4-A may allow adjacent free-form WordPress blocks through normal editor behavior.
+- W4-A does not store full ability output JSON in `post_content`.
+- W4-A does not store raw provenance envelopes in `post_content`.
+- W4-A does not store HMAC material, nonce material, or runtime secrets anywhere in attributes.
+- W4-A does not expose direct browser-to-runtime calls.
+- Browser JS calls WordPress REST or editor preview routes.
+- PHP calls the runtime through the W3-B client.
+- The editor preview must remain close to front-end output.
+- Registration and asset handles should follow WordPress metadata loading instead of manually enqueuing global assets.
+- Any REST preview endpoint must use WordPress capability checks plus DailyOS SurfaceClient scope checks.
+
+## 5. What W4-A authors net-new
+
+| Surface | Status | Authoring scope |
+|---|---|---|
+| `wp/dailyos/blocks/account-overview/block.json` | Missing | Metadata for `dailyos/account-overview`, attributes, dynamic render, editor/front assets |
+| `wp/dailyos/blocks/account-overview/render.php` | Missing | PHP render adapter from attributes to runtime invocation to projected HTML |
+| `wp/dailyos/blocks/account-overview/edit.js` | Missing | Gutenberg editor preview, account selection handoff, reload button, preview state |
+| `wp/dailyos/blocks/account-overview/save.js` | Missing | Null save for dynamic block |
+| `wp/dailyos/blocks/account-overview/style.scss` | Missing | Front-end editorial styling with DailyOS token fallbacks |
+| `wp/dailyos/blocks/account-overview/editor.scss` | Missing | Editor-only chrome, loading, preview, inspector affordances |
+| Block registration hook | Missing or pending W3 merge | Register this block via the plugin bootstrap using metadata |
+| Runtime invocation adapter | Missing | Use `DailyOS_Runtime_Client::invoke_ability()` from W3-B |
+| Projection render adapter | Missing | Render W4-D `ProjectedComposition` into Gutenberg-safe HTML |
+| Trust-band markup | Missing | Render visible band labels and `data-ds-trust-band` attributes |
+| Provenance side panel | Missing | Vanilla DOM island for field attribution detail already scope-filtered upstream |
+| Stale-projection banner | Missing | Compare attributes against DOS-589 delivered version state |
+| Tamper/quarantine banner | Missing | Render W4-C quarantine state without re-verifying signatures |
+| Editor preview route | Missing | Proxy preview through PHP/server render path; no direct runtime call from JS |
+| Feedback hook attributes | Missing | Persist save-handler observed changes for W5-A; no direct feedback write |
+| Negative fixtures | Missing | PHPUnit/JS fixtures named below |
+
+| Surface | W4-A ownership |
+|---|---|
+| New ability output shape | No - W4-A0 owns it |
+| `ProjectedComposition` shape | No - W4-D owns it |
+| Bridge error variants | No - W4-B/W4-C own them |
+| Projection envelope verification | No - W4-C owns it |
+| User-presence nonce lifecycle | No - W4-E owns it |
+| HMAC signing implementation | No - W3-B owns it |
+| Feedback persistence | No - W5-A owns it |
+| Theme shell implementation | No - W5-B owns it |
+| Outbox delivery substrate | No - DOS-589 owns it |
+
+## 6. Directional decisions resolved at L0
+
+### 6.1. Block metadata and registration
+
+- `block.json` uses `apiVersion: 3`.
+- `name` is `dailyos/account-overview`.
+- The block is dynamic.
+- `render` is `file:./render.php`.
+- `editorScript` points to `file:./edit.js`.
+- `style` points to the compiled `style.css`.
+- `editorStyle` points to the compiled `editor.css`.
+- `supports.html` is false.
+- `supports.reusable` stays false until duplicate composition identity is resolved.
+- `supports.inserter` is true for paired/editor users.
+- Registration happens in PHP via `register_block_type()`.
+- Registration must be attached to the existing DailyOS plugin bootstrap after W3-A/W3-B merge.
+- W4-A does not register a second plugin or namespace owner.
+- W4-A does not add a static `save()` markup contract.
+
+Block-registration hook ownership pinned: W3-A's plugin bootstrap reserves a `dailyos_register_blocks()` hook invoked from WordPress `init`. W4-A's first commit registers `dailyos/account-overview` inside that hook. W4-A start is gated on W3-A V-next having reserved the hook (else W4-A would invent a parallel registration path).
+
+Minimal metadata shape with **V2-pinned attribute schema** (codex HIGH — load-bearing for the saved contract):
+
+```json
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "dailyos/account-overview",
+  "title": "Account Overview",
+  "category": "dailyos",
+  "supports": {
+    "html": false,
+    "reusable": false,
+    "inserter": true
+  },
+  "attributes": {
+    "composition_id": { "type": "string" },
+    "composition_version": { "type": "integer", "default": 0 },
+    "block_id": { "type": "string" },
+    "account_id": { "type": "string" },
+    "watermarks": { "type": "object", "default": {} },
+    "cache_hint_token": { "type": "string", "default": "" },
+    "block_instance_id": { "type": "string" }
+  },
+  "render": "file:./render.php",
+  "editorScript": "file:./edit.js",
+  "style": "file:./style.css",
+  "editorStyle": "file:./editor.css"
+}
+```
+
+**Critical (codex C1 + V3 codex HIGH #3):** the `attributes` schema deliberately has NO `cached_projection` AND NO `actor_scope_fingerprint`. Block attributes serialize into `post_content` which is publicly-readable / portable — storing scope-filtered projection bodies OR scope-fingerprint there is a scope-leak vector. The schema carries only the watermarks needed to identify which composition this block instance refers to plus an opaque `cache_hint_token` (non-secret, opaque, runtime-derived). The actual `ProjectedComposition` is fetched fresh on every render via the runtime (per §6.3); the runtime maintains a server-side scope-bound cache that PHP NEVER interprets (per §6.2 V3). The `cache_hint_token` is what PHP echoes back to enable fast cache lookup; the substrate is the sole interpreter.
+
+### 6.2. Attribute set and cache watermarking (V2 REWRITE per codex C1)
+
+V1 allowed `cached_projection` in block attributes "for portability." Codex Cycle 1 CRITICAL flagged this as a claim-body leak vector: block attributes serialize into `post_content` which is publicly readable via WP REST and exportable. Storing scope-filtered projection bodies there leaks to any lower-scope render or REST consumer. V2 drops the cache from attributes entirely.
+
+**Attribute discipline rules:**
+
+- Block attributes carry ONLY: `composition_id`, `composition_version`, `block_id`, `account_id` (opaque subject ref), `watermarks` (the §6.6 stale-detection pair extracted per claim ref), optional `cache_hint_token` (opaque, runtime-issued; non-secret; §6.2 cache layer), optional `block_instance_id` for W5-A correlation.
+- **No `cached_projection` attribute.** Block attributes MUST NOT carry projected payload bytes, claim text, source excerpts, provenance envelopes, signing material, nonce values, OR any scope-derived material (no scope hashes, scope fingerprints, scope set identifiers).
+- `composition_id` is a string (UUID per W4-B V9 convention).
+- `composition_version` is integer-typed in the schema (per §6.1); WP serialization tolerates string→int but block.json `default: 0` enforces the type at deserialize.
+- `account_id` is an opaque subject reference; non-authoritative for actor binding (actor context derives from current WP user per §6.12).
+- `watermarks` is a structured object per Phase 0 artifact 02 lines 128-157: `{ claims: { [claim_id]: { claim_version }}, composition: { composition_version }}` — used solely for stale detection.
+- `cache_hint_token` is an opaque, non-secret string issued by the runtime on a successful project call. PHP echoes it back on the next call so the runtime can short-circuit cache lookup. PHP NEVER derives, interprets, or asserts anything from this token. The runtime treats the token as advisory and re-validates scope server-side on every call (see §6.2 cache layer).
+
+**Per-render fetch is canonical — cache lives RUNTIME-SIDE (V3 per codex C2 HIGH #3):**
+
+V2 attempted a PHP-side `wp_cache` keyed by `scope_set_hash = SHA256(Actor::SurfaceClient { scopes })`. Codex correctly flagged the impossibility: §6.12 forbids PHP from asserting scope identity (substrate is sole actor authority); PHP cannot compute the scopes hash without duplicating that authority. V3 moves the cache server-side:
+
+- `render.php` calls `DailyOS_Runtime_Client::project_composition_for_surface($composition_id, $composition_version, $actor_ctx)` (per §6.3.1) on EVERY render.
+- The RUNTIME (substrate side) maintains the cache, keyed by `(composition_id, composition_version, scope_set_canonical_id)` — where `scope_set_canonical_id` is derived inside the substrate from the authenticated SurfaceClient session (the substrate IS the scope authority).
+- The runtime returns a `ProjectedComposition` plus an opaque `cache_hint_token` (non-secret, opaque string).
+- PHP MAY echo the `cache_hint_token` back in subsequent calls so the runtime can short-circuit faster on cache hits, but PHP NEVER derives or interprets the token.
+- TTL is enforced server-side (60 seconds, matching W4-E nonce lifetime).
+- Cache invalidation on scope-set change happens server-side automatically — the substrate's `scope_set_canonical_id` changes when the actor's scopes change, miss-then-recompute is natural.
+- No PHP-side cache. No `actor_scope_fingerprint` in block attributes.
+
+Block attribute schema (per §6.1) carries no scope-fingerprint field. The runtime is the cache authority.
+
+**Audit emission split (V2 NEW per /cso M-2):**
+- Runtime cache miss → runtime emits `ability_invoked` (live producer call).
+- Runtime cache hit → runtime emits `projection_cache_served` (cache hit). Both carry `composition_id` + `composition_version` + actor.
+- PHP does NOT emit audit events directly; the runtime side is the only emitter (per §6.3 audit-intent drain).
+
+W4-B §3 watermarks make `composition_id` + `composition_version` the stale-detection pair; §6.6 reads from `wp_options.dailyos_composition_versions[composition_id]` (the DOS-589-published store) to detect stale.
+
+Attribute discipline NEGATIVE rules (CI-enforced per §9):
+- Attributes must not carry raw claim text.
+- Attributes must not carry full provenance envelopes.
+- Attributes must not carry signing material (signatures, key IDs, HMAC tokens).
+- Attributes must not carry nonce values.
+- Attributes must not carry projected payload bodies (the V1 `cached_projection` field is removed entirely).
+
+### 6.3. PHP render contract (V2 REWRITE per codex HIGH)
+
+V1 said PHP invokes the producer ability then "passes" the Composition to W4-D. That was unimplementable: W4-D is a Rust composition-level API; PHP cannot directly call it without reimplementing the projection rules. V2 routes through a single runtime-side method.
+
+**Canonical call chain:**
+
+1. `render.php` reads sanitized attributes (per §6.2 attribute schema), including the optional opaque `cache_hint_token`.
+2. `render.php` derives actor context from `wp_get_current_user()` and the paired SurfaceClient session (per §6.12).
+3. `render.php` calls **`DailyOS_Runtime_Client::project_composition_for_surface(composition_id, composition_version, actor_ctx, cache_hint_token?)`** on EVERY render — a NEW W3-B-exposed method (see §6.3.1) that wraps the Rust composition-level API end-to-end. PHP performs NO local cache check; the runtime is the cache authority (per §6.2 V3).
+4. The runtime side internally: looks up its server-side cache keyed by `(composition_id, composition_version, scope_set_canonical_id)` (substrate-derived scope identity); on hit, returns the cached `ProjectedComposition` + a refreshed `cache_hint_token` and emits a `projection_cache_served` audit. On miss, invokes W4-A0 producer ability → receives committed `AbilityOutput<Composition>` → calls W4-D `project_composition_for_surface(composition, ctx)` → drains `Vec<AuditIntent>` via `emit_surface_audit` (including `ability_invoked`) → caches the result → returns `ProjectedComposition` DTO + new `cache_hint_token` to PHP.
+5. `render.php` renders the `ProjectedComposition` DTO and stashes the returned `cache_hint_token` back to block attributes (advisory; never interpreted by PHP).
+
+**Critical rules (codex HIGH):**
+
+- PHP NEVER directly calls W4-D; the bridge layer wraps it.
+- PHP NEVER reimplements block-level helpers (per W4-D V3 V8 §1.1 those are `pub(crate)`).
+- PHP NEVER inspects raw unknown payloads.
+- PHP NEVER recomputes trust bands; W4-A0 emits them, W4-D preserves them, W4-A renders them.
+- PHP NEVER mints claim refs or mutates canonical DailyOS data.
+- The runtime call uses W3-B HMAC signing per W2-B contract; no hand-rolled canonicalization.
+- All projected text passes through `esc_html` or a documented `wp_kses` allowlist per /cso MEDIUM (CI invariant grep against unescaped `<?= $var ?>` patterns in render.php).
+
+### 6.3.1. W3-B contract this packet assumes (V2 NEW per devex P2)
+
+W4-A binds to W3-B's runtime client (DOS-565). V2 pins the assumed method signature; if W3-B ships with a different signature, W4-A V3 amends (no local shim):
+
+```php
+class DailyOS_Runtime_Client {
+    /**
+     * Composition-level projection for a SurfaceClient render path.
+     *
+     * Internally invokes the named producer ability (W4-A0), drains
+     * audit intents via emit_surface_audit, and returns a scope-filtered
+     * ProjectedComposition DTO together with a refreshed runtime-issued
+     * opaque cache_hint_token. PHP does NOT call W4-D directly.
+     *
+     * @param string      $composition_id        composition id (UUID; from block attribute)
+     * @param int         $composition_version   expected composition version (W4-B watermark)
+     * @param array       $actor_ctx             ['surface_client_id' => string, 'session_token' => string]
+     * @param string|null $cache_hint_token      optional opaque cache_hint_token from a prior render (per §6.2 V3); runtime treats as advisory, never client-asserted authority
+     * @return array      ['projection' => array (ProjectedComposition DTO per W4-D V3 §1.1), 'cache_hint_token' => string (opaque, base64; substrate-issued)]
+     * @throws DailyOS_Runtime_Error  on HMAC failure, 401/403/422/423/409/500 per W4-B V9 §6.5
+     */
+    public function project_composition_for_surface(
+        string $composition_id,
+        int $composition_version,
+        array $actor_ctx,
+        ?string $cache_hint_token = null
+    ): array;
+}
+```
+
+Ability-id namespace is `dailyos/account-overview` (slash-form) per W3-A V8 §37 namespace reservation. The runtime resolves which producer ability to invoke from `composition_id` → `composition_versions.generated_by_invocation_id` (W4-B V9 §8). PHP never names the ability — that's the runtime's job.
+
+W4-A's interlock with DOS-565: surface this method as an explicit obligation on the W3-B issue (Linear comment on DOS-565 once Linear MCP is reconnected).
+
+### 6.4. Trust-band rendering (V2 — bound to `TrustBandBadge` primitive)
+
+- Trust scoring lives upstream.
+- W4-A renders the band supplied by W4-A0/W4-D.
+- W4-A renders the visible three-band vocabulary.
+- The visible values are `likely_current`, `use_with_caution`, and `needs_verification`.
+- **Full Design System attribute set required (V2 per ui-design P1-3):** trust-band element carries `data-ds-tier="primitive"` + `data-ds-name="TrustBandBadge"` + `data-ds-spec="primitives/TrustBandBadge.md"` to preserve audit-tool targeting parity with the shipped React `TrustBandBadge` component. `data-ds-trust-band="<band>"` is supplementary state.
+- Markup example: `<span data-ds-tier="primitive" data-ds-name="TrustBandBadge" data-ds-spec="primitives/TrustBandBadge.md" data-ds-trust-band="likely_current">…</span>`
+- CSS maps those attributes to DailyOS trust tokens.
+- CSS uses `--color-trust-likely-current`.
+- CSS uses `--color-trust-use-with-caution`.
+- CSS uses `--color-trust-needs-verification`.
+- Stock themes receive safe fallback custom properties.
+- Missing or unknown band degrades to `needs_verification`.
+- W4-A does not expose `unscored` as a visible band.
+- W4-A does not promote a caution band to likely-current.
+- W4-A does not hide the band in compact or mobile layout.
+
+### 6.5. AboutThisIntelligencePanel (WordPress port) (V2 — bound to canonical pattern)
+
+V1 proposed a "vanilla DOM island"; ui-design P1-1 flagged that DailyOS already has the `AboutThisIntelligencePanel` pattern (`.docs/design/patterns/AboutThisIntelligencePanel.md`). V2 binds the WP side to that pattern instead of inventing a parallel surface.
+
+- Provenance is rendered as an inline affordance on fields or blocks with attribution.
+- Clicking or focusing the affordance opens a side panel.
+- The panel is a small vanilla DOM island in v1.
+- The panel does not require a shadcn-style React island.
+- The panel lazy-loads field attribution detail through a WordPress server route.
+- The server route calls the runtime through W3-B.
+- The runtime returns scope-filtered field attribution per W4-B §16 and W4-D projection context.
+- W4-A renders only the filtered result.
+- W4-A does not ask for broader data to fill the panel.
+- W4-A does not show hidden fields, hidden sources, revoked attribution, or dropped payload.
+- The panel must be keyboard reachable.
+- The panel must close on Escape and outside click.
+- The panel must not serialize detail into block attributes.
+- The panel must not preload all provenance into page HTML.
+- Product copy uses "About this" or equivalent DailyOS vocabulary.
+
+### 6.6. Stale-projection banner (V2 — bound to `StaleReportBanner` pattern)
+
+V2 binds to the canonical `StaleReportBanner` pattern (`.docs/design/patterns/StaleReportBanner.md`) rather than authoring inline banner HTML.
+
+- W4-A compares local `composition_version` to the latest substrate-reported version.
+- **Version state surface (V2 per eng P1-2):** the latest version reaches WordPress through DOS-589 delivery into **`wp_options.dailyos_composition_versions[composition_id]`** — a `dailyos_*`-prefixed option per W3-A V8 namespace reservation. W4-A reads this option key; does not poll substrate tables.
+- If local version is older, W4-A renders the banner.
+- **Pattern binding:** banner emits `data-ds-tier="pattern"` + `data-ds-name="StaleReportBanner"` + `data-ds-spec="patterns/StaleReportBanner.md"`. Inherits the pattern's editorial mark (rule-above, lowercase eyebrow, single-sentence body, finite link). No ad-hoc card or alarm chrome.
+- Banner appears above the affected account overview.
+- Banner does not block rendering of the freshly fetched projection (per §6.2 there is no attribute cache; the projection is the live runtime call).
+- Banner offers refresh when the viewer has permission.
+- Front end never claims stale content is fresh.
+- Editor Reload from runtime button clears stale state only after successful invocation.
+- If runtime is unreachable, current rendered content remains visibly marked stale.
+- Stale detection uses `composition_id` + `composition_version`.
+- Stale detection tolerates missing outbox state by treating as "unknown — refresh cautiously."
+
+User-facing copy (V2 — magazine voice per ui-design P3):
+
+```text
+Newer context has arrived. Refresh to bring this in.
+```
+
+### 6.7. Tamper and rollback banner + enforcement_mode trust-gate (V2 — codex HIGH + ui-design P1-2)
+
+V2 pins the W4-C `projection_signature_enforcement` mode as a HARD trust-affordance gate, plus binds the banner to canonical pattern naming.
+
+**Verification responsibility:**
+- Signature verification lives in W4-C; W4-A reacts to the result.
+- W4-A does NOT run Ed25519 verification, reconstruct canonical bytes, or compare signature IDs.
+
+**Enforcement-mode states (V2 NEW per codex HIGH):**
+
+| enforcement_mode | Verification + currentness PASS | Failure or unknown-key |
+|---|---|---|
+| `enforce` | Trusted affordances visible (provenance click-through, trust-band badges, click-bound feedback) | Suppress trusted affordances; render banner |
+| `shadow` | Bytes may render BUT trust affordances visibly DOWNGRADED (banner "Verification in progress" + no provenance click-through) | Same — never trusted, never alarming |
+| `disabled` | Same as shadow plus operator-facing notice | Same as shadow |
+
+**Banner pattern binding:** tamper and rollback banner is a variant of `ConsistencyFindingBanner` (`.docs/design/patterns/ConsistencyFindingBanner.md`), or a promoted-new `VerificationBanner` pattern (requires 4-way sync per `feedback_chrome_overlap_audit_before_new_pattern` — markdown spec + source CSS module + reference render + inventory). Emits `data-ds-tier="pattern"` + `data-ds-name="ConsistencyFindingBanner"` (or `VerificationBanner` if promoted) + `data-ds-spec="patterns/ConsistencyFindingBanner.md"`.
+
+**W4-C precedence rules (per W4-B V9 §6.5):**
+- `ProjectionTampered` (precedence 0) above stale-watermark (4-6).
+- `ProjectionVersionRollback` (precedence 1) above stale-watermark.
+- Tamper error path does NOT emit `correction.claim` payload.
+
+**Quarantine + ledger linking:**
+- If W4-C reports quarantine, W4-A renders the banner.
+- Banner links to safe ledger / quarantine detail only for authorized editors (`current_user_can('manage_options')` or operator role).
+- Public visitors see degraded trust state without raw diagnostic IDs.
+- W4-A NEVER exposes raw runtime errors, signature bytes, key IDs, or payload hashes in public HTML.
+
+User-facing copy (V2 — magazine voice per ui-design P3):
+
+```text
+Something about this account doesn't line up. Verify before acting.
+```
+
+### 6.8. Unknown block delegation
+
+- W4-A knows only the block types W4-A0 can emit today.
+- W4-A does not author additional block types.
+- If `ProjectedComposition` contains an unknown or fallback block, W4-A follows W4-D fallback rules.
+- W4-D owns nearest-known-type selection.
+- W4-D owns unknown-block caps.
+- W4-D owns raw-payload exclusion.
+- W4-D owns fallback trust-band capping.
+- W4-A renders the fallback DTO as supplied.
+- W4-A never renders raw payload values from an unknown block.
+- W4-A never logs dropped payload values.
+- W4-A never stores dropped payload values in attributes.
+- W4-A switch statements must have a fallback case that delegates to W4-D output, not to raw JSON.
+- W4-A may emit W4-D `AuditIntent` through the runtime-supported path.
+- Unknown-block fallback should log support diagnostics upstream via W4-D audit intent.
+
+### 6.9. Editor preview
+
+- `edit.js` renders the same composition shape as `render.php`.
+- `edit.js` uses `useBlockProps()`.
+- `edit.js` calls a WordPress API wrapper for preview.
+- The wrapper proxies to PHP/server render logic in preview mode.
+- Browser JS never calls the Rust runtime directly.
+- Browser JS never receives HMAC key material.
+- Browser JS never receives pairing secret material.
+- The preview route returns sanitized HTML or projected preview props.
+- Preview and front-end render share the same projection contract.
+- The Reload from runtime button re-invokes the ability through PHP.
+- Reload bypasses compatible cache only for the explicit refresh request.
+- Repeated clicks must not start parallel refresh storms.
+- A 200ms editorial shimmer on preview load is acceptable.
+- **Editor chrome isolation (V2 NEW per ui-design P2-5):** editor preview renders the block's editorial content only; magazine shell (`FolioBar`, `FloatingNavIsland`, `AtmosphereLayer`, `MagazinePageLayout`) does NOT appear inside the Gutenberg canvas. Gutenberg supplies its own chrome.
+- **Account selection UX (V2 NEW per devex P2):** the editor exposes `account_id` selection via `InspectorControls` + `ComboboxControl`, populated from a paginated REST search endpoint backed by W3-B. No slash-command or URL-param shortcut in v1.
+- **Build toolchain (V2 per devex P1):** `wp-scripts start --hot` for dev loop. `wp-scripts build` for production. `package.json` lives at `wp/dailyos/package.json` (or workspace root if W3-A consolidates).
+- Every preview render calls `DailyOS_Runtime_Client::project_composition_for_surface(...)` per §6.3; the runtime returns either a cache-served or live `ProjectedComposition` opaquely (PHP cannot distinguish, and need not). If the underlying composition version may have advanced (DOS-589 outbox check), the editor surfaces a refreshing indicator while the next render call completes.
+- Successful refresh updates `composition_id`, `composition_version`, `watermarks`, and optionally `cache_hint_token` block attributes. No `cached_projection` attribute exists (per §6.2 V2 — runtime owns the cache; block attributes do not store projection bodies).
+- Failed refresh keeps the prior rendered DOM visibly marked stale via the §6.6 banner pattern; PHP does NOT serve a local cached projection (there is no PHP-side cache per §6.2 V3). The "preserve last-known good" semantics live RUNTIME-SIDE: on upstream runtime failure, the substrate may serve its own cached `ProjectedComposition` if the cache entry remains valid for the actor's current scope set; otherwise the renderer surfaces the error envelope per §6.7.
+
+### 6.9.1. Empty state (V2 NEW per ui-design P2-3)
+
+When the produced Composition contains zero visible blocks (all claims sensitivity-filtered, no data yet, or all-quarantined), W4-A renders a silent posture per /cso class-level scope-filter rule:
+
+- Single editorial line: "No account context to show here."
+- No trust band on the empty state.
+- No banners.
+- No empty cards.
+- No "some content is restricted" indicator (per privacy-safe default — silence is the absence-signal).
+- `FinisMarker` rule below the message.
+- Block-level fixture `dos572_fixture_empty_projection_renders_silent.php` asserts no provenance-attribution traces leak.
+
+### 6.10. Magazine theme and stock-theme rendering
+
+- The DailyOS theme provides the full magazine shell in W5-B.
+- W4-A must work under that shell without fighting it.
+- W4-A must also render safely under stock WordPress themes.
+- `style.scss` should expose shell-aware CSS variables.
+- `style.scss` should define local fallbacks for page, ink, rule, account, and trust tokens.
+- The block should use editorial rows, rules, sections, and reading order.
+- The block should avoid dashboard card grids unless rendering a repeated item that genuinely needs a card.
+- The block should not assume `FolioBar` or `FloatingNavIsland` exist.
+- Under the DailyOS theme, the block may align with `MagazinePageLayout` width and typography.
+- Under stock themes, the block should remain self-contained, readable, and accessible.
+- The first viewport signal should be the account context, not internal diagnostics.
+- Color communicates trust, state, entity identity, or action.
+- Decorative color is out of scope.
+- Finite endings are preferred where the theme shell can support them.
+
+### 6.11. Feedback hook
+
+- W4-A exposes feedback affordances only when W4-E nonce issuance succeeds.
+- W4-A requests a nonce from the runtime before exposing a feedback action.
+- W4-A binds nonce request to the field route supplied by W4-D.
+- W4-A does not mint nonces locally.
+- W4-A does not persist feedback locally.
+- W4-A does not call claim mutation services.
+- W4-A does not implement W5-A routing.
+- W5-A observes save-handler attribute changes and edit-route metadata.
+- W4-A records enough block attribute delta to let W5-A identify click-bound feedback candidates.
+- Missing nonce means no feedback affordance.
+- Expired nonce means affordance refresh before action.
+- FeedbackTarget routes with zero claim refs do not expose claim correction affordances.
+- `ComputedFrom` and `DisplayOnly` routes do not become claim-feedback receivers.
+
+### 6.12. `wp_user_id` session binding (V2 — renderer is pure forwarder)
+
+Per /cso LOW Cycle 1: V1 had PHP `derive actor context from current_user` AND bridge validates session-bound `wp_user_id`. Two validation paths invite divergence. V2 eliminates the renderer-side derivation:
+
+- W4-A renderer NEVER asserts `wp_user_id`. It forwards only the SurfaceClient session token; the runtime substrate is the sole authority on actor identity.
+- The bridge precondition `validate_session_bound_wp_user_id` (per W4-B V8 §17) runs at request entry and binds `wp_user_id` from the paired session, NOT from any request body/header/query field.
+- The runtime side resolves the SurfaceClient session → bound `wp_user_id` → `Actor::SurfaceClient { instance, scopes }`.
+- If the SurfaceClient session is invalid or paired to a different `wp_user_id` than the current WP user, the bridge returns `403 wrong_user` BEFORE any further dispatch — no runtime invocation, no nonce issue, no projection detail, no feedback path. Per W4-B V9 §17 and §43 fixture.
+- `render.php` MAY use `wp_get_current_user()` to gate WHO sees an affordance (`current_user_can('edit_posts')` for editor-only links), but that is WP-side capability gating distinct from substrate actor binding.
+- Editor preview uses the same session-bound actor rule as front-end render.
+- Provenance side-panel detail (per §6.5) uses the same session-bound actor rule.
+
+## 7. Acceptance criteria
+
+1. The implementation creates exactly one Gutenberg block: `dailyos/account-overview`.
+2. The block is registered by PHP via `register_block_type()`.
+3. The block lives under `wp/dailyos/blocks/account-overview/`.
+4. The directory contains `block.json`.
+5. The directory contains `render.php`.
+6. The directory contains `edit.js`.
+7. The directory contains `save.js`.
+8. The directory contains `style.scss`.
+9. The directory contains `editor.scss`.
+10. `block.json` uses `apiVersion: 3`.
+11. `block.json` declares a dynamic PHP render path.
+12. `save.js` returns `null`.
+13. The PHP render path calls **`DailyOS_Runtime_Client::project_composition_for_surface($composition_id, $composition_version, $actor_ctx, $cache_hint_token = null)`** (per §6.3.1) — a single runtime-side method that internally invokes W4-A0 producer (or serves a cache hit per §6.2 V3 runtime-side cache), calls W4-D projector, drains audit intents, and returns BOTH the scope-filtered `ProjectedComposition` DTO and a refreshed opaque `cache_hint_token` (per the V3 round-trip).
+14. Runtime invocation uses the W3-B HMAC signer.
+15. No direct browser-to-runtime request exists.
+16. PHP NEVER receives raw `AbilityOutput<Composition>`; only the projected DTO.
+17. PHP NEVER calls W4-D directly (per V2 §6.3).
+18. PHP NEVER calls W4-D block-level helpers (those are `pub(crate)` per W4-D V3).
+19. The render path renders the returned `ProjectedComposition` DTO and no other shape.
+20. Audit intents are drained by the runtime side; PHP does not call substrate audit tables.
+21. Trust bands render visibly as `likely_current`, `use_with_caution`, and `needs_verification`.
+22. Trust-band CSS uses DailyOS trust tokens with stock-theme fallbacks.
+23. Missing or unknown trust band degrades to `needs_verification`.
+24. Provenance refs render inline where policy allows.
+25. Claim refs render inline where policy allows.
+26. Provenance click-through opens a side panel.
+27. Side-panel detail is scope-filtered per W4-B §16.
+28. Side-panel detail is lazy-loaded and not serialized into attributes.
+29. Block attributes include `composition_id`.
+30. Block attributes include `composition_version`.
+31. Block attributes include `watermarks` (the structured `{claims, composition}` watermark object per §6.2).
+32. Block attributes include `block_id` and optional `block_instance_id`. **Block attributes do NOT contain `cached_projection` or `actor_context_hint`** (per V2 §6.2 — those V1 fields were removed as scope-leak vectors).
+33. Watermarks detect stale projection using `composition_id` and `composition_version`.
+34. Stale projection displays a visible banner when local version lags delivered version state.
+35. Stale projection remains visibly marked if runtime is unreachable.
+36. Tamper state from W4-C displays a visible banner.
+37. Projection rollback state from W4-C displays a visible banner.
+38. W4-A reacts to W4-C verification state and does not re-verify signatures.
+39. Unknown block fallback delegates to W4-D rules.
+40. Unknown block fallback never renders raw payload.
+41. Editor preview renders the same projected composition as front-end render.
+42. Editor Reload from runtime re-invokes the ability.
+43. Editor reload updates composition attributes only after success.
+44. Editor Reload that succeeds updates `composition_id`, `composition_version`, `watermarks`, and optionally `cache_hint_token` block attributes (per §6.2 V2 — NO `cached_projection` attribute). Editor Reload that fails leaves block attributes unchanged AND keeps the prior rendered DOM visibly marked stale via §6.6 banner; PHP serves no local cached projection (no PHP-side cache per §6.2 V3).
+45. Feedback affordances appear only after W4-E nonce issue succeeds.
+46. Missing nonce suppresses the feedback affordance.
+47. W5-A can consume save-handler attribute changes for click-bound feedback.
+48. W4-A does not persist feedback.
+49. W4-A does not author additional block types.
+50. W4-A derives actor context from current WordPress user and paired session.
+51. W4-A inherits W4-B §17 wrong-user rejection.
+52. The block renders under the DailyOS theme.
+53. The block renders under stock WordPress themes.
+54. The block does not use customer-specific data in fixtures or snapshots.
+55. The block does not leak HMAC key material, nonce material, pairing secrets, raw runtime errors, or raw payload fields.
+56. PHPUnit fixtures cover PHP render and registration failures.
+57. JS fixtures cover editor preview parity and reload behavior.
+58. CI checks protect dynamic block registration, null save, and asset loading.
+59. L1 proof includes screenshots or rendered HTML under DailyOS theme and stock theme.
+60. L1 proof includes a stale banner case and a tamper banner case.
+
+## 8. Negative fixtures
+
+Negative fixtures are named here for implementation.
+Do not create the files during L0 prep.
+Use generic data only.
+
+1. **`dos572_fixture_stale_projection_banner.php`**
+2. Input: saved attributes contain an older `composition_version` than delivered version state.
+3. Expected: render includes stale banner and does not claim the view is current.
+4. **`dos572_fixture_signature_mismatch_banner.php`**
+5. Input: W4-C reports `ProjectionTampered`.
+6. Expected: render includes verification banner and no correction payload.
+7. **`dos572_fixture_unknown_block_falls_back.php`**
+8. Input: projected composition includes fallback block from W4-D.
+9. Expected: render uses fallback DTO and contains no raw unknown payload sentinel.
+10. **`dos572_fixture_missing_nonce_no_feedback_affordance.php`**
+11. Input: W4-E nonce issue fails or is absent.
+12. Expected: feedback action is not rendered.
+13. **`dos572_fixture_actor_scope_filters_field_attribution.php`**
+14. Input: actor lacks scope for one field attribution.
+15. Expected: side panel omits the field and shows no placeholder leak.
+16. **`dos572_fixture_stock_theme_renders_safe_shell.php`**
+17. Input: block rendered without DailyOS theme variables.
+18. Expected: safe fallback typography, color, and spacing apply.
+19. **`dos572_fixture_editor_preview_matches_frontend.js`**
+20. Input: editor preview and front-end render receive same projected composition.
+21. Expected: normalized markup/projection parity holds.
+22. **`dos572_fixture_block_registers_under_correct_namespace.php`**
+23. Input: plugin bootstrap registers blocks.
+24. Expected: `dailyos/account-overview` exists and no alternate namespace exists.
+25. **`dos572_fixture_runtime_invocation_uses_w3b_hmac_signer.php`**
+26. Input: render invokes the runtime.
+27. Expected: invocation goes through `DailyOS_Runtime_Client` signer, not raw HTTP.
+28. **`dos572_fixture_projection_version_rollback_banner.php`**
+29. Input: W4-C reports `ProjectionVersionRollback`.
+30. Expected: rollback banner wins over stale banner.
+31. **`dos572_fixture_wrong_user_rejected_before_preview.php`**
+32. Input: preview request carries mismatched asserted user.
+33. Expected: `403 wrong_user` before runtime invocation.
+34. **`dos572_fixture_runtime_cache_hit_drops_raw_error.php`**
+35. Input: runtime returns a `503` upstream error WITH a runtime-side cache hit on the prior compatible projection (server-side cache per §6.2 V3).
+36. Expected: PHP renders the runtime-served cached `ProjectedComposition`, no raw exception body, no claim/scope material in `post_content`.
+37. **`dos572_fixture_save_returns_null.js`**
+38. Input: block save invoked.
+39. Expected: saved output is null and contains no rendered DailyOS HTML.
+40. **`dos572_fixture_trust_band_unknown_degrades.php`**
+41. Input: projected block carries absent or unknown band.
+42. Expected: visible band is `needs_verification`.
+43. **`dos572_fixture_reload_updates_watermarks.js`**
+44. Input: editor Reload from runtime succeeds.
+45. Expected: attributes update `composition_id`, `composition_version`, `watermarks`, and (optionally) `cache_hint_token`. The `cached_projection` attribute MUST NOT be present (removed per §6.2 V2 — runtime owns the cache, not block attributes).
+
+## 9. CI invariants
+
+1. Block registration test asserts `dailyos/account-overview` exists.
+2. Block registration test asserts registration uses metadata from `block.json`.
+3. Static grep fails if `save.js` returns serialized DailyOS HTML.
+4. Static grep fails if block attributes include HMAC, secret, token, bearer, or raw nonce fields.
+5. Static grep fails if browser JS calls `127.0.0.1`, loopback runtime URLs, or runtime ports directly.
+6. Static grep fails if `edit.js` imports or reconstructs HMAC signer logic.
+7. PHP unit test asserts runtime invocation uses `DailyOS_Runtime_Client::invoke_ability`.
+8. PHP unit test asserts wrong-user precondition prevents runtime invocation.
+9. PHP unit test asserts `render.php` calls only composition-level W4-D projection.
+10. PHP unit test asserts raw unknown payload sentinel never appears in output.
+11. PHP unit test asserts raw runtime exception text never appears in output.
+12. PHP unit test asserts stale banner appears when delivered version is newer.
+13. PHP unit test asserts tamper banner has precedence over stale banner.
+14. PHP unit test asserts rollback banner has precedence over stale banner.
+15. PHP unit test asserts trust-band data attributes are emitted.
+16. PHP unit test asserts unknown trust band degrades to `needs_verification`.
+17. PHP unit test asserts provenance side-panel bootstrap contains no full attribution payload.
+18. JS test asserts preview calls WordPress API wrapper, not runtime.
+19. JS test asserts Reload from runtime debounces parallel refresh.
+20. JS test asserts successful reload updates watermark attributes.
+21. JS test asserts failed editor reload leaves block attributes unchanged and surfaces stale-marker DOM; static grep fails if `edit.js` or `render.php` introduces any `cached_projection`, `actor_scope_fingerprint`, or `actor_context_hint` attribute — the runtime is the sole projection-cache authority (per §6.2 V3).
+22. JS test asserts `save.js` returns null.
+23. Style test or snapshot asserts stock theme fallback variables exist.
+24. Style test or snapshot asserts DailyOS theme variables override fallbacks.
+25. Fixture test asserts no customer-specific strings in block fixtures.
+26. Fixture test asserts user-facing copy avoids internal process vocabulary.
+27. Accessibility test asserts provenance affordance is keyboard reachable.
+28. Accessibility test asserts side panel closes on Escape.
+29. Accessibility test asserts trust band remains perceivable without color alone.
+30. L1 evidence includes rendered front-end HTML and editor preview parity.
+
+## 10. Interlocks with W4 stage-2 + W5-A + DOS-589
+
+| Owner | W4-A consumes | W4-A obligation |
+|---|---|---|
+| W4-B | `commit_composition`, watermarks, `ClaimRef::with_field`, `Block.field_bindings`, error precedence, `version_events`, `wp_user_id` session binding, `surface_client.rs` ownership | Render watermarks and refs; do not assign or validate them locally |
+| W4-A0 | Committed `AbilityOutput<Composition>`, claim-type to `BlockType` mapping, trust-band fallback table | Invoke producer and render output; do not produce alternate composition shape |
+| W4-C | Signed projection envelope, ledger currentness, quarantine state, `ProjectionTampered`, `ProjectionVersionRollback`, shadow-trust flag | Render degraded/quarantine states; do not re-verify signatures |
+| W4-D | `project_composition_for_surface(composition, ctx)`, `ProjectedComposition`, fallback blocks, edit routes, audit intents | Consume composition-level API only; never raw unknown payload |
+| W4-E | Nonce issue/verify endpoints and tuple binding | Request nonce before feedback affordance; do not mint locally |
+| W3-B | `DailyOS_Runtime_Client`, HMAC signer, pairing UI, PHP-to-runtime transport | Use client; no raw HTTP signer in block code |
+| DOS-589 | Delivery of `version_events` into surface-observable stale state | Compare delivered composition version against attributes |
+| W5-A | Feedback router and save-handler attribute observation | Preserve enough edit-route/watermark attributes for routing |
+| W5-B | DailyOS magazine WordPress theme | Render shell-aware CSS while retaining stock-theme fallbacks |
+
+Interlock rules:
+
+1. W4-A starts after W4-A0, W4-C, W4-D, and W3-B contracts are merged or available in the implementation branch.
+2. Feedback affordances may ship disabled until W4-E is available.
+3. If W4-E is not merged, W4-A must render no feedback actions rather than a local placeholder.
+4. If DOS-589 is not merged, stale detection may use the runtime response but must mark outbox-driven stale checks as blocked.
+5. If W5-B is not merged, W4-A must still pass stock-theme rendering fixtures.
+6. If W5-A is not merged, W4-A must still persist the agreed attribute changes for later consumption.
+7. Any mismatch between W4-D `ProjectedComposition` and W4-A render needs a W4-D packet amendment, not a local W4-A DTO fork.
+
+## 11. What W4-A explicitly does NOT own
+
+- W4-A does not author the `ProjectedComposition` shape.
+- W4-A does not author W4-D fallback policy.
+- W4-A does not author unknown-block nearest-type scoring.
+- W4-A does not author raw-payload exclusion rules.
+- W4-A does not author `BridgeSurfaceError` variants.
+- W4-A does not author error precedence.
+- W4-A does not author `ProjectionTampered`.
+- W4-A does not author `ProjectionVersionRollback`.
+- W4-A does not author Ed25519 signature verification.
+- W4-A does not author projection envelope canonicalization.
+- W4-A does not author ledger currentness checks.
+- W4-A does not author quarantine persistence.
+- W4-A does not author W4-A0 ability output.
+- W4-A does not author claim-type to `BlockType` mapping.
+- W4-A does not author trust scoring.
+- W4-A does not author the trust-band fallback table.
+- W4-A does not author `commit_composition`.
+- W4-A does not author `ClaimRef::with_field`.
+- W4-A does not author `Block.field_bindings`.
+- W4-A does not author `version_events`.
+- W4-A does not author DOS-589 delivery.
+- W4-A does not author HMAC canonicalization.
+- W4-A does not author pairing UI.
+- W4-A does not author nonce issue or verify.
+- W4-A does not author feedback persistence.
+- W4-A does not author claim mutation services.
+- W4-A does not author additional block types.
+- W4-A does not author a custom MCP exposure path.
+- W4-A does not author the DailyOS WordPress theme.
+- W4-A does not own database migrations.
+- W4-A does not own Rust schema changes.
+- W4-A does not own customer-specific fixtures.
+
+## 12. Open questions
+
+1. **Side-panel UI.**
+2. Options: shadcn-style React island or vanilla DOM.
+3. Recommendation: vanilla DOM for v1 to stay frontend-light and avoid a second React runtime in WordPress.
+4. **Caching home — RESOLVED V3.**
+5. Resolution per codex C1 + C2: the projection cache lives RUNTIME-SIDE (substrate-owned), keyed by `(composition_id, composition_version, scope_set_canonical_id)`. Block attributes carry only the opaque `cache_hint_token` (advisory). No PHP-side cache. No WP transient. The substrate is the sole interpreter of cache state and the sole scope-identity authority per §6.12. See §6.2 V3.
+7. **Editor preview latency.**
+8. Question: accept a 200ms editorial shimmer on `edit.js` load?
+9. Recommendation: yes; prefer stable preview over flashing spinners.
+10. **Unknown-block support logging.**
+11. Question: should fallback log to substrate?
+12. Recommendation: yes, through W4-D `AuditIntent`, not W4-A string logs.
+13. **Duplicate blocks.**
+14. Question: can two blocks share one `composition_id`?
+15. Recommendation: allow only if W5-A can disambiguate feedback routes; otherwise force refresh or warn.
+16. **Public visitor provenance depth.**
+17. Question: how much field attribution should unauthenticated visitors see?
+18. Recommendation: W4-D actor context decides; W4-A renders only filtered output.
+19. **Block icon.**
+20. Question: which DailyOS mark appears in the inserter?
+21. Recommendation: reuse existing DailyOS mark from plugin/theme assets once W3/W5 settles asset ownership.
+22. **Preview response format.**
+23. Question: return sanitized HTML or projection props?
+24. Recommendation: sanitized HTML first for parity; projection props only if editor interactions need structured routes.
+25. **Theme variable contract.**
+26. Question: should W5-B provide every token or only shell aliases?
+27. Recommendation: W4-A defines local fallbacks and lets W5-B override.
+28. **Nonce prefetch.**
+29. Question: prefetch nonces for all visible fields?
+30. Recommendation: no; request on visible click/focus intent to keep nonce exposure small.
+
+## 13. Linear dependency edges
+
+- Blocks-on: DOS-589 (W4-A0 producer ability).
+- Blocks-on: DOS-? (W4-C projection signing and quarantine).
+- Blocks-on: DOS-? (W4-D fallback projector).
+- Blocks-on: DOS-? (W4-B concurrency and watermarks).
+- Blocks-on: DOS-? (W3-B runtime client and HMAC signer).
+- Soft blocks-on: DOS-? (W4-E nonce) for feedback affordances.
+- Blocks: DOS-? (W5-A feedback consumption).
+- Blocks: DOS-? (W5-B magazine theme).
+- Blocks: DOS-589 stale delivery consumers where WordPress projection state is part of verification.
+
+Dependency notes:
+
+- Exact W4-C/W4-D/W4-B/W3-B/W5 issue ids should be tightened by L0 reviewers if Linear already has them.
+- W4-A should not start implementation until the W3-B runtime client contract is merged or stable enough to call.
+- W4-A can draft block files before W4-E but cannot expose feedback actions without nonce issue.
+- W4-A can draft theme-neutral CSS before W5-B but must re-test under W5-B when available.
+- W4-A cannot substitute polling for DOS-589 stale delivery without a packet amendment.
+
+## 14. L0 reviewer panel - required runners
+
+- `/plan-eng-review` - substrate fit + WP boundary.
+- `/cso` - trust-boundary review for nonce, actor scope, signature verification chain, and secret leakage.
+- `/plan-devex-review` - block authoring DX, metadata conventions, preview route, and theme interop.
+- `/codex challenge` - adversarial pass against upstream contracts and "thin renderer" boundary.
+- `/codex consult` - second opinion on implementation plan and acceptance coverage.
+- `/plan-design-review` - magazine vs dashboard discipline, editorial tone, trust/provenance readability.
+
+Reviewer prompts should include:
+
+- This is the first DailyOS Gutenberg block.
+- The block is a dynamic WordPress block.
+- The block consumes committed `AbilityOutput<Composition>`.
+- The block renders `ProjectedComposition`.
+- The block must not recompute trust.
+- The block must not verify signatures.
+- The block must not mint nonces.
+- The block must not persist feedback.
+- The block must work under DailyOS and stock themes.
+- The block must keep user-facing copy in product vocabulary.
+
+## 15. Acceptance for L0 closure
+
+1. Packet exists at the required path.
+2. Packet length is between 600 and 800 lines.
+3. All 15 required sections are present and non-empty.
+4. Changelog records V1.
+5. Status snapshot states W4-A is stage-3 renderer work.
+6. Pre-work records the absence of `wp/dailyos/` in the prep worktree.
+7. Pre-work records WordPress dynamic block conventions.
+8. Net-new table covers the six required block files.
+9. Directional decisions include block metadata and PHP render path.
+10. Directional decisions include the required attribute set.
+11. Directional decisions include runtime invocation through W3-B.
+12. Directional decisions include trust-band rendering.
+13. Directional decisions include provenance side panel.
+14. Directional decisions include stale projection banner.
+15. Directional decisions include tamper and rollback banner.
+16. Directional decisions include unknown-block delegation.
+17. Directional decisions include editor preview.
+18. Directional decisions include magazine and stock-theme rendering.
+19. Directional decisions include feedback hook.
+20. Directional decisions include `wp_user_id` session binding.
+21. Acceptance criteria reflect every issue-level requirement.
+22. Negative fixtures include at least 10 names using the `dos572_fixture_` convention.
+23. CI invariants include PHP, JS, style, accessibility, and leakage checks.
+24. Interlocks reference W4-B, W4-A0, W4-C, W4-D, W4-E, W3-B, W5-A, W5-B, and DOS-589.
+25. Explicit non-ownership section prevents W4-A from taking upstream responsibilities.
+26. Open questions include recommendations, not just uncertainties.
+27. Linear dependency edges are recorded with placeholders where exact ids are unknown.
+28. L0 reviewer panel lists all six required runners.
+29. Packet contains no code-style example with issue-number leakage.
+30. Packet is ready for L0 reviewers to challenge.

--- a/.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md
@@ -1,0 +1,770 @@
+# W4-A0 L0 packet — `dailyos/account-overview` Composition-producing ability
+
+## Header
+
+Issue: DOS-568
+
+Project issue family: DOS-546
+
+Wave: 4 stage-2 producer
+
+Branch: `dos-546-w4-a0-l0-prep`
+
+Working tree: `/private/tmp/dailyos-w4-a0-l0-prep`
+
+Packet output: `.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md`
+
+Prepared: 2026-05-13
+
+Primary spec: `.docs/plans/dos-546/phase-0/14-gutenberg-block-account-overview.md`
+
+Structural model: `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md`
+
+Upstream contract: W4-B `commit_composition` and watermark substrate.
+
+Downstream consumer: W4-A renderer through `SurfaceClientBridge`.
+
+Ability name: `dailyos/account-overview`
+
+Ability category: `Read`
+
+Output: `AbilityOutput<Composition>`
+
+Mutation stance: no claim mutation; `MutatingProposal` does not apply.
+
+Composition finalization: consumes W4-B `commit_composition` once W4-B lands.
+
+Core acceptance: declare policy, compose from account claims, produce deterministic Composition, prove bridge invocation.
+
+Linear fetch note: `gh issue view https://linear.app/a8c/issue/DOS-568` is not a valid `gh issue` target in this environment; scope below is inferred from the supplied DOS-568 acceptance criteria plus the W4 wave plan.
+
+## Changelog
+
+- **V5 (2026-05-13):** Codex Cycle 4 caught two leftover "four" references in the prose around §2 after V4 patched the bullet list. V5 substitutes "three" and "three policy macro keys above" in both spots. No structural change.
+- **V4 (2026-05-13):** Codex Cycle 3 CONDITIONAL fold — one item: `mutates` is NOT a `#[ability]` macro key (the macro synthesizes it from detected mutation paths; declaring `mutates = []` errors as unknown attribute). §2 macro-key list updated to remove `mutates` and add explanatory paragraph; registry-projection test asserts empty mutates on the materialized descriptor. Items 2-4 (BlockType mapping, trust-band table, audit `wp_user_id`) already ADDRESSED in V3 per codex re-verification.
+- **V3 (2026-05-13):** Cycle 2 reviewer fold — 4 V3-fixable items closed. (a) **Macro fields are real** (eng + codex verified at `abilities-macro/src/lib.rs:795-798`); §2 §"Policy fields set through registry or policy-builder" section rewritten as §"Macro keys for `AbilityPolicy` fields" — `required_scopes`, `mcp_exposure`, `client_side_executable`, `mutates` declared directly via `#[ability]`, not separated. (b) **Claim-type → BlockType mapping pinned** to canonical enum at `composition.rs:298-309` via explicit table; `Custom` reserved for downstream abilities; CI exhaustiveness gate on new claim types. (c) **Trust-band fallback table pinned** by `(claim_state, source_asof freshness, trust_score present)` triple with explicit `likely_current` / `use_with_caution` / `needs_verification` / "excluded entirely" mapping; freshness_class per claim-type lives in `trust.rs`. (d) **Audit emission `wp_user_id` plumbing** (cso H1) — ac §55 expanded to require `actor.session.wp_user_id` plumbing into `AuditFields.wp_user_id`, with explicit CI assertion that `emit_surface_audit` returns `Ok(_)` (not `SurfaceClientMissingWpUserId`).
+- **V2 (2026-05-13):** Cycle 1 reviewer fold — eng + cso + devex CONDITIONAL APPROVE items and codex BLOCK items folded into closure requirements.
+- Adds hard `ClaimRef::with_field` / `Block.field_bindings` enforcement for rendered Source and FeedbackTarget fields, with ComputedFrom and DisplayOnly roles pinned.
+- Splits determinism into pure builder determinism and committed-output determinism so W4-A0 no longer contradicts W4-B's every-accepted-commit-advances-version rule.
+- Pins actual SurfaceClient scope enforcement as a closure condition in `src-tauri/src/bridges/surface_client.rs`; missing `read.account_overview` must reject before ability internals.
+- Pins ADR-0105 trust derivation, freshness caps, unknown `source_asof` warnings, and most-cautious block trust across Source and ComputedFrom bindings.
+- Adds W4-A0 invalidation behavior for DOS-589 claim/source/dismissal signals and re-composition through `commit_composition`.
+- Closes `commit_composition` ownership: W4-A0 builds `CompositionProposal`, calls the W4-B finalizer seam directly, and returns committed `AbilityOutput<Composition>`.
+- Closes `client_side_executable`: `false` is correct because the Gutenberg renderer invokes server-side through the PHP runtime SurfaceClient.
+- Keeps direct claim-reader use as required v1 path; `get_entity_context` composition is explicitly out until its SurfaceClient TODOs close.
+- Adds cso fixtures and gates for surface-scoped claim loading, sensitivity exclusion, and `emit_surface_audit(event_kind = ability_invoked)`.
+- Splits macro attribute keys from `AbilityPolicy` fields per actual `get_entity_context.rs:52` grammar.
+- Inherits W4-B V8: `bridges/surface_client.rs` canonical route module, wp_user_id session binding at bridge layer, and W4-D `project_composition_for_surface` interlock.
+- **V1 (2026-05-13):** Initial L0 Prep packet for DOS-568 / W4-A0.
+- Mirrors the W4-B packet section order requested for this work.
+- Carries W4-B contracts forward only where W4-A0 consumes them.
+- Explicitly marks `SurfaceClientBridge` concrete path as an open substrate-location question because this branch exposes generic bridge primitives but no concrete `SurfaceClientBridge` type.
+- Keeps net-new W4-A0 scope minimal: ability declaration, composition assembly, bridge contract proof, deterministic fixture.
+- Confirms ADR-0080, ADR-0102, ADR-0105, and ADR-0130 exist before citing them.
+- Treats the ability as Read despite consuming `commit_composition`: the domain read produces a composition from existing claims; W4-B owns watermark finalization and outbox semantics.
+- Pins `MutatingProposal` / `ClaimMutationTarget` as non-applicable for W4-A0 because this ability does not call `commit_claim`.
+- Adds negative fixtures for missing account id, unauthorized scope, empty claim set, and absent trust band.
+- Adds CI invariants for registry declaration, scope gate, seeded determinism, and bridge invocation contract.
+
+## Status snapshot
+
+- **L0 Prep state:** V2 packet folded from Cycle 1 reviewer findings; no implementation edits made.
+- **Branch confirmed:** `/private/tmp/dailyos-w4-a0-l0-prep` is on `dos-546-w4-a0-l0-prep`.
+- **Output-only safety:** this packet is the only intended write.
+- **Linear issue body:** not fetched through `gh`; `gh` rejected the Linear URL as an invalid GitHub issue target.
+- **Scope source:** DOS-568 acceptance criteria supplied in the task plus W4 wave plan lines 397-403.
+- **W4 stage status:** W4-A0 is stage-2 and starts after W4-B merges.
+- **W4-B dependency:** W4-B provides `commit_composition`, `CompositionVersionEvent`, `BridgeSurfaceError` precedence, and the outbox table.
+- **W4-B V8 dependency:** W4-B also provides `bridges/surface_client.rs`, `validate_session_bound_wp_user_id`, and the canonical W4-D projection interlock.
+- **Current branch reality:** `commit_composition` is not present in this W4-A0 prep worktree; W4-A0 implementation must either rebase after W4-B or target the merged W4-B API.
+- **Current branch reality:** `ClaimRef::with_field`, `FieldBinding`, and `BindingRole` are not present in this W4-A0 prep worktree; those are W4-B-owned surfaces.
+- **W4-B V8 inheritance:** `src-tauri/src/bridges/surface_client.rs` is the canonical SurfaceClient route module; Open Q1 is closed.
+- **Ability location decision:** new module under `src-tauri/abilities-runtime/src/abilities/account_overview.rs`.
+- **Renderer status:** W4-A renderer is downstream; W4-A0 should not implement block PHP/JS, cached projections, signatures, or fallback renderer rules.
+- **Trust status:** backend trust bands exist under `src-tauri/abilities-runtime/src/abilities/trust/` and provenance trust helpers exist under `src-tauri/abilities-runtime/src/abilities/provenance/trust.rs`.
+- **Frontend trust render status:** `src/lib/trust-band.ts`, `src/components/ui/TrustBandBadge.tsx`, and `src/components/intelligence/TrustBand.tsx` already normalize/render the canonical trust-band strings.
+- **Account-context status:** existing builders include `build_intelligence_context()` and `gather_account_context()`, but W4-A0 must use the direct claim-reader service path for v1 and must not compose `get_entity_context` until SurfaceClient TODOs close.
+- **Risk focus:** accidental renderer work, accidental new claim model, accidental direct DB read/write, bridge leakage on unauthorized scopes, missing field bindings, and over-including sensitive claims.
+
+## Pre-work confirmed substrate reuse audit
+
+**Headline finding:** W4-A0 should be a thin producer over already-landed substrate. It should not create a parallel account model, a parallel trust-band model, a renderer, a new transport, or a claim write path.
+
+### ADR existence check
+
+- Verified: `.docs/decisions/0080-signal-intelligence-architecture.md`
+- Verified: `.docs/decisions/0102-abilities-as-runtime-contract.md`
+- Verified: `.docs/decisions/0105-provenance-as-first-class-output.md`
+- Verified: `.docs/decisions/0130-surface-independent-composition-contract.md`
+- No unverified ADR number is used as an implementation authority in this packet.
+
+### W4-B contracts carried forward
+
+- `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` §3 defines `commit_composition`.
+- §3 signature carried forward: `commit_composition(ctx, db, proposal: CompositionProposal) -> Result<CommittedComposition, CompositionError>`.
+- §3 states `CompositionProposal` carries `composition_id`, `expected_composition_version`, and `composition`.
+- §3 states `CommittedComposition` returns server-assigned `composition_version`.
+- §3 authority rule: `composition_version` is assigned inside `commit_composition`, not trusted from the ability.
+- §3 idempotency rule: every accepted `commit_composition` advances the version.
+- §3 outbox rule: `CompositionVersionEvent` is inserted in the same transaction as the version mutation.
+- §3 concurrent producer rule: two producers for the same `composition_id` race through CAS; one succeeds, one gets `StaleVersion`.
+- `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` §5 defines the signal payload schema.
+- §5 carries `CompositionVersionEvent { event_kind, composition_id, previous_version, current_version, cursor, reason }`.
+- §5 assigns delivery and subscriber replay to DOS-589, not W4-A0.
+- `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` §6.5 defines bridge error precedence.
+- §6.5 precedence is inherited; W4-A0 does not add a new precedence ladder.
+- `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` §13 defines `MutatingProposal` and `ClaimMutationTarget`.
+- §13 is explicitly non-applicable to W4-A0 because W4-A0 is a Read ability and does not call `commit_claim`.
+- `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` §15 defines the `version_events` outbox table.
+- §15 outbox pattern is inherited only through `commit_composition`; W4-A0 does not write `version_events`.
+- W4-B acceptance criteria 3-5 apply to W4-A0 only as consumer obligations.
+- W4-B acceptance criterion 3: composition versions are assigned exclusively inside `commit_composition`.
+- W4-B acceptance criterion 4: `commit_composition` uses `BEGIN IMMEDIATE` transactional CAS.
+- W4-B acceptance criterion 5: `ClaimRef.field_path` and `Block.field_bindings` are W4-B substrate surfaces W4-A0 consumes.
+- W4-B acceptance criterion 10 is claim-mutation-only; W4-A0 must not implement or satisfy `MutatingProposal`.
+- W4-B acceptance criterion 11 is mutation-proposal-only; W4-A0 must not emit mutation proposal bindings.
+- W4-B acceptance criterion 12 is lock/CAS substrate; W4-A0 relies on it through W4-B.
+- W4-B acceptance criterion 13 is the three-Tx outbox protocol; W4-A0 consumes it by calling `commit_composition`.
+- W4-B V8 §37 is inherited: `src-tauri/src/bridges/surface_client.rs` is the canonical module for `/v1/surface/*` route ownership and SurfaceClient bridge tests.
+- W4-B V8 §17 is inherited at bridge layer: any request payload containing `wp_user_id` must match the W2-C session-bound value before dispatch; W4-A0 has no direct domain obligation because this Read ability input does not accept `wp_user_id`.
+- W4-B §16 scope-filter shape is inherited for W4-A0 claim loads: the SurfaceClient actor's scopes must drive surface projection before any claim body reaches composition assembly.
+- W4-B acceptance criterion 17 is consumer-critical: every feedback-eligible Source or FeedbackTarget reference must use `ClaimRef::with_field(claim_id, version, field_path)`.
+- W4-B acceptance criterion 5 is consumer-critical: every `Block` must populate `field_bindings`; `Vec::new()` is only a back-compat constructor default, not acceptable W4-A0 output for rendered intelligence blocks.
+
+### Ability runtime substrate
+
+- `src-tauri/abilities-runtime/src/abilities/registry.rs` has `AbilityCategory::Read`.
+- ADR-0102 describes Read abilities as no domain mutation in the call graph.
+- `registry.rs` carries `Actor::SurfaceClient { instance, scopes }`.
+- `registry.rs` carries `ActorKind::SurfaceClient`.
+- `registry.rs` carries `SurfaceScope` and `ScopeSet`.
+- `registry.rs` lines 432-480 define `AbilityPolicy` fields.
+- `AbilityPolicy` includes `allowed_actors`, `required_scopes`, `mcp_exposure`, and `client_side_executable`.
+- `AbilityPolicy::default()` keeps `mcp_exposure: None` and `client_side_executable: false`.
+- `AbilityPolicy::required_scopes_typed()` materializes `required_scopes` into typed scopes.
+- Registry build seeds the global scope allowlist from registered descriptors.
+- Registry invocation policy checks actor kind before dispatch.
+- Current bridge gap to close: `src-tauri/src/bridges/types.rs::resolve_pre_dispatch` checks `allowed_actors` and schema closure, but does not yet compare `Actor::SurfaceClient.scopes` against `descriptor.policy.required_scopes`.
+- W4-A0 closure condition: the actual `SurfaceClientBridge` path must enforce `read.account_overview` before ability internals, claim reads, or audit success emission run.
+- Existing macro examples: `get_entity_context` uses an ability declaration under `src-tauri/abilities-runtime/src/abilities/get_entity_context.rs`.
+- W4-A0 should follow the same module/import style instead of a custom registry path.
+
+### Composition substrate
+
+- `src-tauri/abilities-runtime/src/abilities/composition.rs` is the authoritative model.
+- Lines 1-21 document substrate-owned composition authorship and provenance-lives-once.
+- Lines 52-70 define `CompositionDocId`.
+- Lines 107-125 define `CompositionVersion`; current branch still uses `saturating_add`, but W4-B §4 replaces this with checked overflow behavior.
+- Lines 131-154 define `ClaimRef` with `claim_id` and `claim_version`.
+- W4-B adds `ClaimRef.field_path` / `ClaimRef::with_field()`; not present in this worktree.
+- Lines 252-287 define `ProvenanceRef`.
+- Lines 294-310 define `BlockType`, including `AccountOverview`.
+- Lines 367-378 define `CompositionMetadata`.
+- Lines 390-417 define `Section`.
+- Lines 419-520 define `Block`.
+- Lines 522-585 define `Composition`.
+- Lines 555-570 make `Composition::new` `pub(crate)`, matching ADR-0130 substrate-owned authorship.
+- Lines 667-671 define fallback trust cap `NeedsVerification`.
+- W4-A0 should construct `Composition` inside the abilities-runtime crate, not in Tauri commands or WP code.
+
+### Ability output and provenance substrate
+
+- `src-tauri/abilities-runtime/src/abilities/provenance/envelope.rs` lines 302-335 define `AbilityOutput<T>`.
+- `AbilityOutput<T>` carries `data`, `provenance`, `ability_version`, and `diagnostics`.
+- ADR-0102 Rule 5 says provenance lives exactly once on `AbilityOutput<T>`.
+- ADR-0130 §2 repeats that `Composition` is the domain output and blocks carry `ProvenanceRef`.
+- `src-tauri/abilities-runtime/src/abilities/provenance/builder.rs` applies field trust bands into `field_attributions`.
+- `src-tauri/abilities-runtime/src/abilities/provenance/trust.rs` exposes `claim_trust_band_from_score` and `most_cautious_trust_band`.
+- W4-A0 should use the existing provenance builder/envelope path, not embed provenance inside block attributes.
+
+### Account context and claim-reader substrate
+
+- `src-tauri/src/intelligence/prompts.rs` defines `IntelligenceContext` and `build_intelligence_context()`.
+- `build_intelligence_context()` lines 267-276 gather account/project context from DB and prior intelligence.
+- `build_intelligence_context()` lines 285-360 build account facts from account DB fields, products, team, and source refs.
+- `src-tauri/src/context_provider/local.rs` lines 1-4 explicitly wrap `build_intelligence_context()`.
+- `src-tauri/src/context_provider/local.rs` lines 59-68 delegate to `build_intelligence_context()`.
+- `src-tauri/src/prepare/meeting_context.rs` lines 274-283 define `gather_account_context()`.
+- `gather_account_context()` lines 319-423 reads recent captures, actions, meetings, products, account team, sourced facts, and technical footprint.
+- `gather_account_context()` is meeting-prep oriented and private; W4-A0 should not depend on its JSON shape unless it is deliberately promoted.
+- `src-tauri/abilities-runtime/src/services/context.rs` lines 830-842 define narrow read seams on `ServiceContext`.
+- `src-tauri/abilities-runtime/src/services/context.rs` lines 857-873 define `EntityContextClaimReadHandle`.
+- `src-tauri/abilities-runtime/src/services/context.rs` lines 1101-1119 expose `read_entity_context_claims()`.
+- `src-tauri/src/services/context.rs` wires that trait to `services::claims::load_entity_context_claims_active_for_surface`.
+- `src-tauri/src/services/claims.rs` lines 7904-7933 provide `load_claims_active` and `load_claims_active_for_surface`.
+- `src-tauri/src/services/claims.rs` lines 8058-8088 provide `load_entity_context_claims_active_for_surface`.
+- Preferred W4-A0 read path: use the narrow claim-reader seam in `ServiceContext` when inside an ability; do not pass raw DB handles into ability internals.
+
+### Claim model substrate
+
+- `src-tauri/abilities-runtime/src/types.rs` lines 40-74 define `IntelligenceClaim`.
+- `IntelligenceClaim` includes `subject_ref`, `claim_type`, `field_path`, `text`, `data_source`, `source_ref`, `source_asof`, `observed_at`, `provenance_json`, lifecycle states, `trust_score`, temporal scope, sensitivity, and verification fields.
+- `src-tauri/src/services/claims.rs` lines 3744-3785 read those columns from `intelligence_claims`.
+- `src-tauri/abilities-runtime/src/abilities/claims.rs` defines the claim taxonomy.
+- Claim metadata includes default temporal scope, sensitivity, freshness decay class, commit policy class, canonical subject types, and actor classes.
+- Account-relevant claim types already include `risk`, `win`, `entity_risk`, `entity_win`, `stakeholder_engagement`, `stakeholder_assessment`, `value_delivered`, `commitment`, and `company_context`.
+- W4-A0 should select and order from this claim substrate; it should not add new claim columns or new claim types for the first account overview.
+- If a claim type needed by the fixture is missing, that is an input-fixture adjustment or upstream claim-registry question, not W4-A0 scope.
+
+### Trust-band rendering substrate
+
+- Backend trust enum lives under `src-tauri/abilities-runtime/src/abilities/trust/types.rs`.
+- Backend trust compiler helpers live under `src-tauri/abilities-runtime/src/abilities/trust/mod.rs`.
+- Provenance trust helper `claim_trust_band_from_score()` maps score to `LikelyCurrent`, `UseWithCaution`, `NeedsVerification`, or `Unscored`.
+- `src/lib/trust-band.ts` lines 10-15 defines wire bands `likely_current`, `use_with_caution`, `needs_verification`, and `unscored`.
+- `src/lib/trust-band.ts` lines 41-55 normalizes/extracts trust bands from rendered provenance.
+- `src/lib/trust-band.ts` lines 66-104 partitions evidence by trust band.
+- `src/components/ui/TrustBandBadge.tsx` lines 6-27 defines visual labels for the three user-facing bands.
+- `src/components/intelligence/TrustBand.tsx` lines 59-96 composes badge, provenance tag, and freshness indicator.
+- W4-A0 output should carry canonical trust-band strings and field attribution; W4-A decides visual rendering.
+
+### SurfaceClientBridge substrate
+
+- W4-B V8 promotes `src-tauri/src/bridges/surface_client.rs` as the canonical route module for `/v1/surface/*` endpoints.
+- Open Q1 is closed: W4-A0 bridge contract tests target `bridges/surface_client.rs`, not an invented parallel module.
+- Existing generic bridge primitives still live under `src-tauri/src/bridges/types.rs`, `tauri.rs`, `mcp.rs`, `worker.rs`, and `eval.rs`.
+- `src-tauri/src/bridges/types.rs` lines 421-455 provide pre-dispatch actor/mode/schema checks.
+- The known gap is scope enforcement: `resolve_pre_dispatch` does not yet compare `Actor::SurfaceClient.scopes` with `descriptor.policy.required_scopes`.
+- W4-A0 does not paper over that gap inside the ability; L0 closure requires the real SurfaceClient bridge path to reject missing `read.account_overview` before `account_overview` code runs.
+- The bridge proof must spy on the claim-reader seam and assert it is not called on missing scope.
+- W4-B §17 `wp_user_id` session binding is inherited at request-entry layer; W4-A0 remains read-only and does not accept a `wp_user_id` domain field.
+- Successful SurfaceClient invocation must emit a surface audit event after commit, not before, because the audit row carries the assigned `composition_version`.
+
+### Intelligence Loop integration check
+
+1. Claim model: W4-A0 does not create new claim fields; it renders existing account claims through field-aware `ClaimRef` and `FieldBinding` roles.
+2. Provenance + trust: provenance remains on `AbilityOutput<Composition>`; blocks carry `ProvenanceRef`; trust bands come from existing provenance/trust helpers plus the V2 freshness cap algorithm.
+3. Signals + invalidation: W4-A0 consumes W4-B `CompositionVersionEvent` emission through `commit_composition` and declares the DOS-589 triggers that must re-run the producer.
+4. Runtime + surfaces: ability is invoked through registry/SurfaceClientBridge; Tauri/MCP consume the same `AbilityOutput<Composition>` without renderer-specific HTML.
+5. Feedback loop: W4-A0 preserves `(claim_id, claim_version, field_path)` for Source and FeedbackTarget fields so W5-A feedback can route corrections/dismissals to the claim substrate.
+
+## What W4-A0 authors net-new table
+
+| Surface | Net-new? | W4-A0 ownership |
+|---|---:|---|
+| `src-tauri/abilities-runtime/src/abilities/account_overview.rs` | Yes | New Read ability module with input/output types, composition assembly, tests. |
+| Ability declaration for `dailyos/account-overview` | Yes | Macro keys plus policy-builder fields: `allowed_actors: [User, SurfaceClient]`, `required_scopes: ["read.account_overview"]`, `mcp_exposure: Invocable`, `client_side_executable: false`. |
+| Composition block assembly | Yes | Create `CompositionKind::EntityPage`, subject account ref, mapped block types for risk/win/value/commitment/current-state claims, and field-aware bindings from existing claims. |
+| Provenance field attribution for blocks | Yes | Build/attach canonical provenance once on `AbilityOutput<Composition>` and point blocks at field paths. |
+| Field binding topology | Yes | Every block gets `Block.field_bindings`; Source and FeedbackTarget require `ClaimRef::with_field`, summaries use ComputedFrom, decorative/empty fields use DisplayOnly. |
+| Use of W4-B `commit_composition` | Yes, as consumer | Call the W4-B chokepoint or finalizer exactly once; never assign `composition_version` locally. |
+| Seeded deterministic fixture | Yes | Generic account fixture with stable clock, sorted claims, known trust bands, expected JSON snapshot. |
+| SurfaceClientBridge contract test | Yes | Prove renderer-style SurfaceClient actor with `read.account_overview` invokes and receives `AbilityOutput<Composition>`. |
+| Surface audit | Yes | Successful Invocable SurfaceClient calls emit `emit_surface_audit(event_kind = ability_invoked)` after commit with actor, account, composition, and claim-ref counts. |
+| New account claim type | No | Reuse existing claim registry. |
+| New trust-band enum | No | Reuse ADR-0105/W4 trust helpers and wire labels. |
+| New renderer | No | W4-A owns Gutenberg render code. |
+| New transport/HMAC/pairing | No | W2 owns transport and pairing. |
+| New fallback projection rules | No | W4-D owns unknown-block fallback. |
+| New signature/tamper logic | No | W4-C owns Ed25519 projection signing/verification. |
+| New feedback router | No | W5-A owns correction/dismissal routing. |
+| `MutatingProposal` implementation | No | W4-A0 is not a claim mutation producer. |
+| Direct DB writes | No | All writes, if any, go through W4-B `commit_composition`; ability reads through service seams. |
+| Signal dispatcher implementation | No | DOS-589 owns delivery; W4-A0 only declares invalidation triggers and re-invokes through its normal ability/finalizer path. |
+
+## Directional decisions
+
+### §1. Ability lives in `abilities-runtime`
+
+- W4-A0 lives at `src-tauri/abilities-runtime/src/abilities/account_overview.rs`.
+- Add `pub mod account_overview;` in `src-tauri/abilities-runtime/src/abilities/mod.rs`.
+- Register through the existing ability macro/inventory path, not a hand-written bridge map.
+- Use ability name `dailyos/account-overview` because the Gutenberg block spec names `dailyos/account-overview`.
+- If current macro only admits snake-case names, implementation must either use the canonical external name in descriptor metadata or update the macro deliberately with a registry test.
+- Do not place W4-A0 under `src-tauri/src/services/`; services provide data, abilities produce product output.
+- Do not place W4-A0 under `src-tauri/src/bridges/`; bridges invoke abilities, they do not author composition.
+
+### §2. Policy declaration is part of acceptance
+
+**Macro attribute keys, per `get_entity_context.rs:52`:**
+
+- `name = "dailyos/account-overview"` or a canonical external-name metadata mapping if the macro cannot accept slash names.
+- `category = Read`.
+- `version` and `schema_version` pinned in the ability declaration.
+- `allowed_actors = [User, SurfaceClient]` only if the macro supports `SurfaceClient`; otherwise the descriptor/policy builder must supply SurfaceClient and the registry test must prove the projection.
+- `allowed_modes = [Live]` unless the implementation deliberately adds Evaluate with fixture-backed behavior.
+- `requires_confirmation = false`.
+- `may_publish = false`.
+- `composes = []`; v1 uses direct claim-reader services and must not compose `get_entity_context` until that ability's SurfaceClient TODOs close.
+- `experimental = false`.
+- `signal_policy = { emits_on_output_change = [], coalesce = false }` unless the registry requires a composition-output-change signal hook.
+
+**Macro keys for `AbilityPolicy` fields** (V3 correction per eng + codex Cycle 2: these ARE macro keys at `abilities-macro/src/lib.rs:795-798`, NOT registry/policy-builder fields):
+
+- `required_scopes = ["read.account_overview"]` — declared directly on `#[ability]`.
+- `mcp_exposure = Invocable` — declared directly on `#[ability]`.
+- `client_side_executable = false` — declared directly on `#[ability]`.
+
+**`mutates` is NOT a macro key (V4 correction per codex Cycle 3):** the macro synthesizes `mutates` from detected mutation paths in the ability body (`detected.iter()` → `mutates_exprs` per `abilities-macro/src/lib.rs`). Declaring `mutates = []` as a `#[ability]` attribute fails compilation (unknown attribute). For W4-A0 (Read-only), the expectation is that the macro detector finds no mutation paths and synthesizes an empty `mutates` list automatically. The registry-projection test asserts `descriptor.policy.mutates.is_empty()` on the materialized descriptor — not on macro-key presence.
+
+V2's "policy-builder fields" framing was over-defensive — the macro grammar admits the three policy macro keys above (`required_scopes`, `mcp_exposure`, `client_side_executable`). V3 places them in the macro invocation alongside the other declared keys. The macro expansion materializes them into `AbilityPolicy` automatically; a registry-projection test asserts the values surface correctly on the `AbilityDescriptor`.
+
+**Behavioral notes:**
+
+- SurfaceClient scope enforcement is not satisfied by declaration alone; the actual bridge path must compare `Actor::SurfaceClient.scopes` with `descriptor.policy.required_scopes` before ability internals (this gap is in the substrate, not W4-A0's authoring obligation).
+- Phase 0 artifact 14 is compatible with `client_side_executable = false`: Gutenberg invokes server-side through the PHP runtime client, which authenticates as a SurfaceClient and calls the server ability.
+- The registry declaration test must fail if any of the three policy macro keys above drifts from its declared value.
+
+### §3. Composition shape for renderer
+
+- Return committed `AbilityOutput<Composition>`, not renderer HTML.
+- `Composition.kind`: `CompositionKind::EntityPage`.
+- `Composition.subject`: account entity ref for the requested account id.
+- `Composition.generated_by`: `dailyos/account-overview`.
+- `Composition.metadata.generated_by`: same ability name.
+- `Composition.metadata.composition_version`: `0` placeholder on proposal input; W4-B overwrites on commit.
+- `Composition.sections`: deterministic sections from claim groups.
+- Minimum viable section set:
+- `overview` section with an `AccountOverview` block.
+- `signals` section with mapped claim summary/evidence blocks when visible claims exist.
+- `empty` state section only when the account exists but no visible claims resolve.
+- **Claim-type to `BlockType` mapping (V3 pinned to canonical enum at `composition.rs:298-309`):**
+
+| Claim type | `BlockType` variant | Notes |
+|---|---|---|
+| `risk`, `entity_risk` | `BlockType::RiskCallout` | One block per active risk claim |
+| `win`, `entity_win` | `BlockType::ClaimSummary` | `attributes.intent = "win"` discriminator |
+| `value_delivered` | `BlockType::ClaimSummary` | `attributes.intent = "value"` discriminator |
+| `commitment` | `BlockType::ActionList` | Items aggregated by claim_id |
+| `stakeholder_engagement`, `stakeholder_assessment` | `BlockType::RelationshipMap` | One block per stakeholder identity |
+| `current_state`, `health_signal` | `BlockType::HealthSnapshot` | One block per account state snapshot |
+| `company_context`, other generic account claims | Folded into `BlockType::AccountOverview` (the account block itself) — NOT a new block |
+| Evidence text from claim sources | `BlockType::EvidenceList` | Only when block needs separate evidence list; otherwise inline |
+
+The mapping is implemented as a closed `match` over the substrate's claim_type taxonomy returning a known `BlockType` variant. CI invariant: exhaustiveness gate fails the build if a new claim type added to the substrate has no `BlockType` mapping declared. Unknown claim types FAIL the build, not silently drop to `BlockType::Custom { type_id }` — `Custom` is reserved for downstream-ability blocks not in W4-A0's taxonomy.
+- Every rendered claim reference for a Source or FeedbackTarget field uses `ClaimRef::with_field(claim_id, claim_version, field_path)`.
+- Every `Block` populates `Block.field_bindings`; no W4-A0 output block may rely on constructor default `Vec::new()`.
+- Source bindings identify directly rendered claim fields.
+- FeedbackTarget bindings identify fields eligible for correction/dismissal routing.
+- Computed summaries use `BindingRole::ComputedFrom` with all contributing field-aware refs.
+- Decorative, empty-state, separator, and copy-only fields use `BindingRole::DisplayOnly` and carry no feedback target.
+- Source and FeedbackTarget bindings reject `claim_ref.field_path = None` at build time or fixture assertion time.
+- Blocks carry `ProvenanceRef` into the top-level envelope.
+- Do not duplicate full provenance or raw source payloads in `Block.attributes`.
+- Do not emit substrate-authored HTML.
+- Do not include customer-specific strings in fixtures or snapshots.
+
+### §4. Existing trust-band helper feeds the Composition
+
+- Input eligibility runs before trust derivation: non-active, non-surfaced, tombstoned, superseded, withdrawn, dismissed, or sensitivity-excluded claims are not scored, counted, or rendered.
+- Use `src-tauri/abilities-runtime/src/abilities/provenance/trust.rs::claim_trust_band_from_score` for the initial per-claim band from `IntelligenceClaim.trust_score`.
+- For the user-facing three bands, output canonical strings: `likely_current`, `use_with_caution`, `needs_verification`.
+- `unscored` may exist only as internal/wire fallback; renderer-facing account-overview blocks must cap it to a visible caution band.
+- **Trust-band fallback table (V3 pinned per codex C2 V3-item-3):**
+
+| `claim_state` | `source_asof` freshness | `trust_score` present | Resolved band |
+|---|---|---|---|
+| `active` | < 7 days | yes | `likely_current` (use `claim_trust_band_from_score` directly) |
+| `active` | 7-30 days | yes | `use_with_caution` (cap on score-derived band) |
+| `active` | > 30 days OR unknown | any | `needs_verification` (cap on score-derived band) |
+| `active` | any | absent | `needs_verification` (never `likely_current` without a score) |
+| `tombstoned`, `superseded`, `withdrawn`, `dismissed`, or sensitivity > `read.account_overview` | — | — | Claim excluded entirely — no block, no ClaimRef, no count (per /cso H2) |
+
+Freshness-class durability is per-claim-type: fast-decay (e.g. `engagement_state`, `stakeholder_sentiment`) ages on the 7d/30d boundaries above; durable account facts (e.g. `company_context.industry`, `account.country`) skip the freshness cap entirely (treated as `likely_current` when active + scored). The exact per-claim-type freshness class lives in a `freshness_class` table inside `trust.rs` (W4-A0's first commit pins values for the current claim taxonomy; new claim types must declare a class at registration time via the same exhaustiveness gate as the BlockType mapping).
+- If a source is revoked or marked unreliable before composition, exclude the claim unless the claim substrate still exposes an active surfaced replacement.
+- Block trust is `most_cautious_trust_band` across every contributing Source and ComputedFrom binding.
+- DisplayOnly bindings do not strengthen trust.
+- FeedbackTarget bindings inherit the trust of the Source or ComputedFrom binding they point at; they do not independently raise the band.
+- Renderer mode (`full`, `compact`, `icon`) remains W4-A/UI scope; W4-A0 output is mode-independent.
+
+### §5. Determinism strategy
+
+- Split determinism into two fixtures: pure builder determinism and committed-output determinism.
+- Pure builder determinism does not call `commit_composition`.
+- Pure builder fixture compares the proposed `Composition` plus provenance after normalizing expected runtime-only envelope fields.
+- Committed-output determinism calls `commit_composition`, but each comparison run uses a cloned fixture DB or rolls back to the same pre-commit state.
+- Do not assert byte-stable output after two accepted commits to the same live DB; W4-B explicitly advances `composition_version` on every accepted commit.
+- Seed fixture with generic account id such as `acct-fixture-1`.
+- Use injected service clock, not `Utc::now()`.
+- Inject deterministic composition id, block ids, and stable invocation ids for fixture output.
+- Pass identical `expected_composition_version` into each committed-output comparison; bootstrap uses `0`.
+- Sort claims before composition assembly.
+- Primary sort: salience/trust policy bucket.
+- Secondary sort: claim type stable order.
+- Tertiary sort: `source_asof` descending with unknown last.
+- Final sort: `claim_id` lexicographic.
+- Use `BTreeMap` / `BTreeSet` where map iteration reaches output.
+- Derive deterministic block ids from `composition_id`, section key, claim id, and field path.
+- Normalize JSON snapshots before comparing.
+- Pin expected committed output after W4-B overwrites `composition_version` from the same cloned/rolled-back starting state.
+
+### §6. Error precedence inherits W4-B
+
+- Pre-dispatch unknown ability, actor denial, mode denial, schema closure, and reserved input fields continue to map to `AbilityUnavailable`.
+- SurfaceClient missing `read.account_overview` must be rejected by the actual `src-tauri/src/bridges/surface_client.rs` path before ability internals run.
+- The known `resolve_pre_dispatch` gap must be closed or bypassed only by the canonical SurfaceClient bridge adding equivalent required-scope enforcement.
+- Missing `account_id` is input validation after actor/scope admission; it should not reveal account existence.
+- Account not visible to the actor should map to a safe unavailable or validation surface consistent with the existing bridge policy.
+- Sensitivity tighter than `read.account_overview` is not an error; those claims are excluded from the composition entirely.
+- If `commit_composition` returns `Overflow`, W4-B §6.5 precedence maps composition overflow before stale composition.
+- If `commit_composition` returns `StaleVersion`, W4-B §6.5 maps `StaleComposition` as the composition-level 409.
+- W4-A0 must not introduce an alternate error envelope for stale composition.
+- W4-A0 must not catch W4-B errors and downgrade them to generic success-with-warning.
+
+### §7. Read ability plus `commit_composition`
+
+- W4-A0 remains `Read` because it reads account claims and returns composed intelligence.
+- The ability must not mutate claims, source rows, feedback rows, accounts, or external systems.
+- `MutatingProposal` is not implemented.
+- `ClaimMutationTarget` is not constructed.
+- `commit_claim` is not called.
+- The only write-adjacent behavior is W4-B composition watermark finalization.
+- W4-A0 builds a `CompositionProposal` with deterministic `composition_id`, `expected_composition_version`, and proposal `composition`.
+- Bootstrap call ergonomics are pinned: `expected_composition_version: 0` means first-ever commit under that `composition_id`.
+- Proposal input ergonomics are pinned: `Composition.metadata.composition_version: 0` is a placeholder and is not trusted.
+- W4-A0 calls the W4-B finalizer through a narrow service/finalizer seam directly from the ability path.
+- W4-A0 returns committed `AbilityOutput<Composition>` after W4-B assigns `composition_version`.
+- Treat `commit_composition` as substrate-owned Composition contract finalization, not a domain claim mutation.
+- L0 reviewers have closed Open Q8 with this ownership model; bridge wrapping a raw uncommitted Composition is not the v1 path.
+
+### §8. Claim selection is conservative
+
+- Use active, surfaced account claims only.
+- Use the surface-aware claim-reader seam with `Actor::SurfaceClient { scopes }` projection when invoked by the Gutenberg path.
+- Do not call non-surface claim loaders for SurfaceClient invocations.
+- Do not include dormant, tombstoned, withdrawn, superseded, contradicted, or surface-dismissed claims.
+- Respect sensitivity before composition assembly.
+- Claims requiring scopes tighter than `read.account_overview` are excluded entirely: no block, no `ClaimRef`, no `field_bindings`, no provenance field attribution, no count.
+- Do not expose raw source snippets in attributes.
+- Empty claim set returns a valid empty-state Composition, not a hard error.
+- Missing account id returns validation/unavailable, not empty Composition.
+- Missing trust band degrades visibly.
+
+### §9. SurfaceClientBridge proof is contract-level
+
+- W4-A0 does not implement the W4-A renderer.
+- W4-A0 must include a test that invokes the ability as a `SurfaceClient` actor with `read.account_overview` through `src-tauri/src/bridges/surface_client.rs`.
+- The proof must fail if dispatch goes through a helper that does not enforce `descriptor.policy.required_scopes`.
+- The missing-scope test asserts the claim-reader seam is not called.
+- The successful test asserts the bridge returns committed `AbilityOutput<Composition>`, not raw `Composition` data.
+- The successful test asserts `emit_surface_audit` runs after commit with `event_kind = "ability_invoked"`.
+- The successful audit detail carries actor, account_id, composition_id, composition_version, and claim_ref_count.
+- Direct claim-reader use is required for v1. Do not compose `get_entity_context` until its SurfaceClient TODOs close and a later packet deliberately promotes that dependency.
+- W4-B §17 `wp_user_id` precondition is verified at bridge layer only; W4-A0 does not add a domain-level `wp_user_id` field.
+
+### §10. Signal invalidation and cache-bust behavior
+
+- W4-A0 does not implement DOS-589 delivery, but its packet declares the signals that invalidate the account-overview composition.
+- Included claim version events invalidate any composition whose field bindings include the changed `(claim_id, claim_version, field_path)` lineage.
+- Account-subject claim changes invalidate account-overview composition for that account even when the changed claim was not previously rendered.
+- Tombstone, supersede, withdrawal, contradiction, and correction events invalidate affected account-overview compositions.
+- Surface dismissal changes invalidate only projections for the affected surface/account pair.
+- Source freshness changes, source revocation, and source reliability downgrades invalidate any block whose Source or ComputedFrom binding depends on that source.
+- Cache-bust marks the cached projection stale before any renderer fetch can reuse it as current.
+- Recomposition re-invokes W4-A0 through the same SurfaceClient-authorized path, rebuilds the proposal, and calls `commit_composition`.
+- Successful recomposition publishes a new composition version through W4-B's `commit_composition` outbox row.
+- DOS-589 owns fan-out, cursor replay, backpressure, and subscriber delivery; W4-A0 owns correct dependency declaration and deterministic rebuild behavior.
+
+## Acceptance criteria
+
+1. Ability module exists at `src-tauri/abilities-runtime/src/abilities/account_overview.rs`.
+2. Ability is registered in the abilities runtime registry/inventory path.
+3. Ability name is externally `dailyos/account-overview`.
+4. Ability category is `Read`.
+5. Ability returns committed `AbilityOutput<Composition>`.
+6. Macro declaration pins name, category, version, schema_version, allowed_actors, allowed_modes, confirmation, publish, composes, experimental, and signal_policy.
+7. Policy builder or registry pins `allowed_actors: [User, SurfaceClient]`.
+8. Policy builder or registry pins `required_scopes: ["read.account_overview"]`.
+9. Policy builder or registry pins `mcp_exposure: Invocable`.
+10. Policy builder or registry pins `client_side_executable: false`.
+11. Ability does not implement `MutatingProposal`.
+12. Ability does not construct `ClaimMutationTarget`.
+13. Ability does not call `commit_claim`.
+14. Ability does not write account, claim, feedback, source, or renderer state directly.
+15. Ability reads existing account claims through service/context reader seams.
+16. SurfaceClient claim loads route through `Actor::SurfaceClient { scopes }` projection per W4-B §16.
+17. CI grep gate rejects account-overview claim loads using non-surface variants in the SurfaceClient path.
+18. Ability composes from account claims already in the claim substrate.
+19. Ability uses existing trust-band helper(s) plus V2 freshness caps for claim/block trust.
+20. Ability uses existing provenance builder/envelope patterns.
+21. Composition blocks carry `ClaimRef` entries for rendered claims.
+22. Every rendered Source or FeedbackTarget claim ref uses `ClaimRef::with_field`.
+23. Source and FeedbackTarget bindings reject `claim_ref.field_path = None`.
+24. Every block populates `Block.field_bindings`.
+25. Summaries use `BindingRole::ComputedFrom`.
+26. Decorative and empty-state fields use `BindingRole::DisplayOnly`.
+27. Composition blocks carry `ProvenanceRef` entries into the canonical output envelope.
+28. Composition does not duplicate full provenance envelopes in block attributes.
+29. Composition does not include raw source snippets in block attributes.
+30. Composition uses canonical trust-band strings.
+31. Unknown `source_asof` emits a provenance warning and caps trust.
+32. Stale `source_asof` caps trust by freshness class.
+33. Block trust is most-cautious across Source and ComputedFrom bindings.
+34. Claims tighter than `read.account_overview` are excluded entirely: no block, no ClaimRef, no count.
+35. Empty account claim set returns a valid empty-state Composition.
+36. Missing account id is rejected.
+37. Unauthorized scope is rejected by the actual SurfaceClient bridge before ability internals run.
+38. Trust band absent fixture degrades visibly and deterministically.
+39. Pure builder fixture produces deterministic proposal output without commit.
+40. Committed-output fixture uses cloned or rolled-back fixture DB state.
+41. Committed-output fixture passes identical `expected_composition_version` and expects identical assigned versions from identical starting state.
+42. Fixture controls clock, composition id, block ids, and invocation ids.
+43. Fixture uses generic account/customer data only.
+44. W4-A0 consumes W4-B `commit_composition` after W4-B merges.
+45. W4-A0 never assigns final `composition_version` locally.
+46. Bootstrap passes `expected_composition_version: 0`.
+47. Proposal input uses `Composition.metadata.composition_version: 0` placeholder.
+48. W4-A0 surfaces W4-B `StaleComposition` without changing the error contract.
+49. W4-A0 surfaces W4-B composition overflow without changing the error contract.
+50. W4-A renderer can invoke W4-A0 through SurfaceClientBridge and receive committed `AbilityOutput<Composition>`.
+51. Bridge contract test covers `Actor::SurfaceClient` with the right scope.
+52. Bridge contract test covers `Actor::SurfaceClient` without the right scope.
+53. Bridge test covers the `resolve_pre_dispatch` required-scope gap through the canonical SurfaceClient route.
+54. Every successful Invocable SurfaceClient invocation emits `emit_surface_audit` with `event_kind = ability_invoked`.
+55. **Audit detail carries `wp_user_id` from `actor.session.wp_user_id` (sourced from the W2-C-bound SurfaceClient session, NOT from any request body), plus `actor_instance` (SurfaceClient id), `account_id`, `composition_id`, `composition_version`, and `claim_ref_count`.** This satisfies `emit_surface_audit`'s mandatory `AuditFields.wp_user_id = Some(_)` requirement for `Actor::SurfaceClient` per `audit_log.rs:96` — without it the helper returns `SurfaceClientMissingWpUserId` and no audit row writes. The successful-call CI assertion (per ac §41) MUST assert `emit_surface_audit` returns `Ok(_)`, not just that it was called.
+56. Registry declaration test pins policy fields.
+57. Inventory test pins MCP exposure and SurfaceClient actor projection.
+58. Output schema is closed and generated from the typed output.
+59. Input schema is closed and rejects reserved actor/bridge fields.
+60. W4-A0 declares DOS-589 invalidation triggers for claim, account-subject, lifecycle, dismissal, source freshness, and revocation events.
+61. Cache-bust marks cached projection stale before renderer reuse.
+62. Recomposition publishes a new composition version through `commit_composition`.
+63. W4-A0 does not compose `get_entity_context` in v1.
+64. `cargo clippy -- -D warnings` passes.
+65. `cargo test` passes.
+66. `pnpm tsc --noEmit` passes if TypeScript surface typing is touched by contract fixtures.
+
+## Negative fixtures
+
+1. **`dos568_fixture_missing_account_id.rs`**
+2. Input omits or blanks `account_id`.
+3. Actor otherwise valid; scope grant includes `read.account_overview`.
+4. Expected: rejected before claim read, no `commit_composition`, no account existence leakage.
+
+5. **`dos568_fixture_unauthorized_scope.rs`**
+6. Actor is `SurfaceClient`; scope grant lacks `read.account_overview`.
+7. Ability name is known.
+8. Expected: bridge rejects before ability internals and before claim reader spy is called.
+9. Expected: no Composition, no provenance, no audit success row, no composition version event.
+
+10. **`dos568_fixture_surface_scoped_claim_reader.rs`**
+11. Actor is `SurfaceClient` with only `read.account_overview`.
+12. Fixture includes one visible account claim and one tighter-scope account claim.
+13. Expected: service call uses surface projection with actor scopes, not a raw/non-surface loader.
+14. Expected: only the visible claim reaches composition assembly.
+
+15. **`dos568_fixture_sensitivity_excluded.rs`**
+16. Account has a claim whose sensitivity requires a scope tighter than `read.account_overview`.
+17. Expected: excluded entirely with no block, no `ClaimRef`, no `field_bindings`, no provenance field attribution, no count.
+18. Expected: output still succeeds if other visible claims exist.
+
+19. **`dos568_fixture_empty_account_claim_set.rs`**
+20. Account exists and is visible; claim reader returns no active surfaced claims.
+21. Expected: successful `AbilityOutput<Composition>` with explicit empty-state section/block.
+22. Expected: empty-state block uses DisplayOnly binding and no feedback target.
+23. Expected: no raw internal diagnostic copy in user-visible attributes.
+
+24. **`dos568_fixture_trust_band_absent.rs`**
+25. Account has at least one visible claim with `trust_score: None`.
+26. Expected: claim appears only with degraded or unscored-safe treatment.
+27. Expected: block trust is not stronger than the missing claim's trust.
+28. Expected: renderer-facing attributes do not imply `likely_current`.
+29. Expected: provenance field attribution records the absent/unknown trust condition.
+
+30. **`dos568_fixture_unknown_or_stale_source_asof.rs`**
+31. Fixture includes one visible claim with unknown `source_asof` and one stale claim by freshness class.
+32. Expected: provenance warning for unknown `source_asof`.
+33. Expected: both claims cap to caution/needs-verification according to freshness class.
+34. Expected: block trust is the most cautious contributing band.
+
+35. **`dos568_fixture_field_bindings_required.rs`**
+36. Fixture renders risk, win, value, and commitment claims.
+37. Expected: Source and FeedbackTarget refs use `ClaimRef::with_field`.
+38. Expected: `claim_ref.field_path = None` is rejected for Source and FeedbackTarget roles.
+39. Expected: summaries use ComputedFrom and empty/decorative fields use DisplayOnly.
+
+40. **`dos568_fixture_surface_bridge_receives_composition.rs`**
+41. SurfaceClient actor has valid instance id and `read.account_overview`.
+42. Bridge invokes `dailyos/account-overview` through `bridges/surface_client.rs`.
+43. Expected: response is committed `AbilityOutput<Composition>`.
+44. Expected: Composition has server-assigned version after W4-B finalization.
+45. Expected: claim refs, field bindings, provenance refs, and audit success row are present.
+
+46. **`dos568_fixture_builder_determinism.rs`**
+47. Same seeded claims, clock, input, composition id, block id strategy, and invocation id.
+48. Does not call `commit_composition`.
+49. Expected: normalized proposal output and provenance match exactly.
+50. Expected: no customer-specific fixture strings.
+
+51. **`dos568_fixture_committed_output_determinism.rs`**
+52. Run committed-output comparison against cloned or rolled-back fixture DB state.
+53. Both runs pass identical `expected_composition_version` and injected ids.
+54. Expected: committed outputs match, including assigned `composition_version` from identical starting state.
+55. Expected: test does not assert byte stability after two accepted commits to the same live DB.
+
+56. **`dos568_fixture_invalidation_recomposes.rs`**
+57. Seed cached projection from visible claims.
+58. Emit included claim version, source freshness, dismissal, and tombstone events through DOS-589-style fixtures.
+59. Expected: cache marks stale, W4-A0 re-runs, `commit_composition` publishes a new composition version.
+
+## CI invariants
+
+1. **Ability registry declaration check**
+2. Walk the live registry/inventory.
+3. Assert `dailyos/account-overview` exists.
+4. Assert category is `Read`.
+5. Assert `allowed_actors` projects to `User` and `SurfaceClient`.
+6. Assert `required_scopes` exactly `["read.account_overview"]`.
+7. Assert `mcp_exposure` exactly `Invocable`.
+8. Assert `client_side_executable` exactly `false`.
+9. Assert `mutates` is empty.
+10. Assert `composes` is empty for v1.
+
+11. **Scope-gate test**
+12. Build SurfaceClient actor with only an unrelated read scope.
+13. Invoke through `src-tauri/src/bridges/surface_client.rs`.
+14. Assert ability internals are not called.
+15. Assert claim-reader seam is not called.
+16. Assert no ability metadata leaks beyond existing bridge policy.
+17. Assert same rejection class as unknown/unauthorized where bridge policy requires byte equality.
+
+18. **Surface claim-loader grep gate**
+19. Scan `account_overview.rs` and its tests for non-surface claim loader calls in the SurfaceClient path.
+20. Allow only the service/context reader seam that projects with `Actor::SurfaceClient { scopes }`.
+21. Fail on raw DB reads or `load_claims_active` variants that bypass surface projection.
+
+22. **Field-binding lint**
+23. Build representative output containing risk, win, value, and commitment blocks.
+24. Assert every block has non-empty `field_bindings` except explicit DisplayOnly-only empty state.
+25. Assert Source and FeedbackTarget refs have `field_path: Some(_)`.
+26. Assert ComputedFrom summaries list every contributing field-aware ref.
+27. Assert DisplayOnly fields cannot be routed as feedback targets.
+
+28. **Fixture-determinism tests**
+29. Pure builder fixture freezes clock and ids, skips commit, and compares normalized proposal output.
+30. Committed-output fixture runs against cloned or rolled-back DB state.
+31. Both committed runs pass identical `expected_composition_version`.
+32. Fail on non-deterministic block ordering, section ordering, trust-band drift, or unstable invocation ids.
+33. Do not compare two accepted commits to the same live DB as byte-identical.
+
+34. **SurfaceClientBridge contract test**
+35. Invoke as SurfaceClient with `read.account_overview`.
+36. Assert bridge response envelope contains ability name, version, schema version, domain data, and provenance.
+37. Assert domain data deserializes to `Composition`.
+38. Assert `composition_id`, committed `composition_version`, `claim_refs`, `field_bindings`, and `ProvenanceRef` are present.
+39. Assert W4-B stale/overflow errors are preserved when forced through a test double.
+
+40. **Audit event test**
+41. Successful Invocable invocation emits `emit_surface_audit` with `event_kind = ability_invoked`.
+42. Assert detail carries actor, account_id, composition_id, composition_version, and claim_ref_count.
+43. Assert unauthorized scope does not emit the success event.
+
+44. **Sensitivity exclusion test**
+45. Seed a tighter-than-`read.account_overview` claim.
+46. Assert no block, no `ClaimRef`, no count, and no provenance field attribution references it.
+47. Assert visible sibling claims still render.
+
+48. **Composition authorship lint**
+49. Existing `scripts/check_composition_authorship.sh` remains green.
+50. W4-A0 construction is allowed only because it lives in `abilities-runtime`.
+51. No surface, command handler, or WP code constructs `Composition`.
+
+52. **Invalidation contract test**
+53. Simulate included claim version, account-subject claim, lifecycle, dismissal, freshness, and revocation events.
+54. Assert cached projection is marked stale.
+55. Assert recomposition calls W4-A0 and publishes a new version through `commit_composition`.
+56. Assert DOS-589 delivery is mocked or faked, not reimplemented in W4-A0.
+
+57. **No PII fixture lint**
+58. Use generic names such as `Fixture Account`, `subsidiary.com`, and `user@example.com`.
+59. No real customer domains, names, emails, or account details.
+
+60. **Standard test gate**
+61. `cargo clippy -- -D warnings`
+62. `cargo test`
+63. `pnpm tsc --noEmit`
+
+## Interlocks
+
+| Producer / consumer | What W4-A0 needs | What W4-A0 provides |
+|---|---|---|
+| **W4-B (DOS-567)** | `commit_composition`, `CompositionProposal`, `CommittedComposition`, `StaleComposition`, `version_events`, `ClaimRef::with_field`, `field_bindings`, `bridges/surface_client.rs`, `validate_session_bound_wp_user_id` | First real producer proving committed account Composition output with field-aware bindings |
+| **W4-A renderer (DOS-572)** | Ability invocation path and stable Composition shape; W4-D `project_composition_for_surface(composition, ctx)` for renderer projection | Real `dailyos/account-overview` Composition for Gutenberg renderer |
+| **W4-C tamper detection** | Nothing for ability authoring | Claim/composition ids and versions for signing cached projections |
+| **W4-D fallback projection** | No dependency for W4-A0 authoring; renderer consumes W4-D's composition-level `project_composition_for_surface` | Known block payloads and preserved refs so fallback can degrade unknowns later |
+| **W4-E presence nonce** | No direct dependency | Stable claim refs/field refs for later feedback nonce routing |
+| **DOS-589 signal dispatcher** | W4-B outbox row schema and replay; dispatcher emits invalidation triggers named in §10 | Correct dependency graph so cache-bust re-runs W4-A0 and commits a new version |
+| **W5-A feedback router** | Nothing at W4-A0 time | `(claim_id, claim_version, field_path)` triples and BindingRole semantics needed to route corrections/dismissals |
+| **Claims substrate** | Active surfaced account claims, provenance JSON, trust score, lifecycle/sensitivity state | No new claim shape; only read consumption through surface projection |
+| **ADR-0105 trust/provenance** | Field attribution, source attribution, freshness classes, trust bands | Composition envelope and refs that preserve lives-once provenance |
+| **ADR-0130 composition** | Typed Composition substrate | First account overview producer using the contract |
+
+## Open questions
+
+1. **Exact ability external name shape.**
+   Spec and task say `dailyos/account-overview`; existing ability examples use names like `get_entity_context`. Confirm macro/registry permits slash names or define canonical mapping.
+
+2. **`ClaimRef::with_field` availability.**
+   W4-B packet says W4-A0 needs it, but current W4-A0 branch lacks it. W4-A0 implementation starts only after W4-B merge or rebases onto the W4-B API branch.
+
+3. **Empty account semantics.**
+   Confirm whether an account with no visible claims should show a generic empty Composition or a more specific "not enough intelligence yet" block. Product copy must follow ADR-0083 vocabulary.
+
+4. **Trust-band absent default.**
+   V2 pins no `likely_current`; implementation still needs the exact fallback split between `use_with_caution` and `needs_verification` by freshness class.
+
+### Closed in V2
+
+- **Concrete SurfaceClientBridge path:** closed by W4-B V8 §37; use `src-tauri/src/bridges/surface_client.rs`.
+- **Read category plus `commit_composition`:** closed; W4-A0 remains `Read`, and `commit_composition` is substrate finalization.
+- **`client_side_executable` value:** closed; set `false` because Gutenberg invokes server-side through PHP runtime SurfaceClient.
+- **Composition persistence ownership:** closed; W4-A0 calls W4-B finalizer directly and returns committed output.
+- **`get_entity_context` composition:** closed for v1; direct claim-reader is required until SurfaceClient TODOs close.
+
+## Linear dependency edges
+
+- **DOS-567 (W4-B) blocks DOS-568 (W4-A0).**
+- Reason: W4-A0 needs `commit_composition`, composition version assignment, outbox schema, `ClaimRef::with_field`, and `field_bindings`.
+- This edge is already named in W4-B packet Linear dependency edges.
+- **DOS-568 (W4-A0) blocks DOS-572 (W4-A renderer).**
+- Reason: the W4-A renderer needs a real Composition-producing ability to invoke.
+- **DOS-568 (W4-A0) is parallel with DOS-569 (W4-C), DOS-570 (W4-D), and DOS-571 (W4-E) after W4-B merges.**
+- Reason: W4 wave plan lines 383-395 define W4-A0/W4-C/W4-D/W4-E as stage-2 parallel work.
+- **DOS-568 indirectly feeds DOS-573 (W5-A feedback router).**
+- Reason: feedback routing needs claim refs and field refs preserved by the first Composition producer and renderer.
+- **DOS-589 depends on W4-B for substrate rows and interlocks with W4-A0 for invalidation semantics.**
+- Reason: dispatcher consumes `version_events`; W4-A0 declares which account-overview dependencies make a cached projection stale and re-commits through W4-B finalization.
+
+## L0 reviewer panel runners
+
+- `/plan-eng-review` — required.
+- `/plan-devex-review` — required because W4-A0 exposes an ability contract to SurfaceClient/WP/MCP consumers.
+- `/plan-design-review` — required because Composition shape controls the account-overview reading order and trust-band surface.
+- `/codex challenge` — required.
+- `/codex consult` — required.
+- `/cso` — required if the implementation touches trust boundary, scope filtering, provenance masking, SurfaceClient invocation, or commit_composition error handling.
+- Security reviewer focus:
+- Scope leakage on unauthorized SurfaceClient invocation.
+- Ability metadata leakage through MCP exposure.
+- Raw source/provenance leakage in block attributes.
+- Trust-band absent default.
+- Read ability classification with composition finalization.
+- Design reviewer focus:
+- Composition is magazine/editorial, not dashboard-shaped.
+- Empty-state copy is product vocabulary, not pipeline vocabulary.
+- Trust affordances are preserved as first-class meaning.
+- Devex reviewer focus:
+- Registry declaration discoverability.
+- Fixture ergonomics.
+- Bridge contract test path.
+- Error precedence inherited cleanly from W4-B.
+
+## Acceptance for L0 closure
+
+1. All reviewer panel runners complete with approve or explicitly folded conditional findings.
+2. W4-B dependency edge remains explicit and blocks implementation start until W4-B API is available.
+3. Concrete `SurfaceClientBridge` path is closed to `src-tauri/src/bridges/surface_client.rs`.
+4. Read category plus `commit_composition` is closed: W4-A0 is Read; finalization is substrate-owned.
+5. Ability policy fields are accepted: `allowed_actors`, `required_scopes`, `mcp_exposure`, and `client_side_executable = false`.
+6. Fixture plan is accepted with generic data, deterministic clock/id strategy, and split builder/committed determinism.
+7. Negative fixtures are accepted as sufficient for first producer risk.
+8. CI invariants are accepted as merge-gating, not optional review notes.
+9. Field-binding and field-path enforcement is accepted as a hard contract.
+10. Surface-scoped claim loading and sensitivity exclusion are accepted as hard contracts.
+11. Audit emission for successful Invocable calls is accepted as a hard contract.
+12. DOS-589 invalidation triggers are accepted as the cache-bust contract.
+13. W4-A renderer interlock is recorded: renderer waits for W4-A0 producer plus W4-C/W4-D/W3-B per wave plan.
+14. W4-D interlock is recorded: renderer consumes `project_composition_for_surface`, not W4-A0.
+15. Packet is posted to Linear DOS-568 as the L0 plan packet or linked from the issue.
+16. No implementation commit is made from this L0 Prep branch.
+17. This file exists at `.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md`.

--- a/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md
@@ -1,0 +1,674 @@
+# W4-B L0 packet — concurrency contract: server-assigned versions + stale-write rejection
+
+Date: 2026-05-13 (V9)
+Project: v1.4.2 — Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 4 stage-1 (gates W4-A0 / W4-C / W4-D / W4-E and the W4-A renderer)
+Issue: DOS-567 (W4-B: three-view consistency concurrency contract)
+Sibling: DOS-589 (signal subscriber + scope-filter dispatch — split per Cycle 2 partial-convergence rule)
+
+This packet captures the W4-B contract decisions resolved at L0. The Linear issue description remains the canonical execution contract; this packet supersedes it only where it makes explicit a decision the issue leaves open.
+
+## Changelog
+
+- **V9 (2026-05-13):** §6.5 precedence table amendment per W4-C Cycle 2 eng P1-N1 coordination gap. W4-C requires two new `BridgeSurfaceError` variants — `ProjectionTampered` and `ProjectionVersionRollback` — at higher precedence than the stale-watermark family. Both fire on signature/ledger verification failures before the bridge evaluates expected-version logic, so tampered or replay-rolled-back projections never receive a `correction.claim` payload (per §6 signature-check-before-409 ordering). New ac §45 fixtures pin pairwise precedence (tamper-and-stale → tamper wins; rollback-and-stale → rollback wins). No structural changes to W4-B's own substrate contract; amendment is contract-coordination with W4-C only.
+- **V8 (2026-05-13):** Class-pattern lifts from stage-2 packet Cycle 1 reviews — three recurring shapes promoted out of per-packet patching into upstream W4-B contract: (a) **NEW §17 wp_user_id session binding** — class-level rule lifted as inherited acceptance to DOS-568/569/570/571/572/573 + DOS-589. Every endpoint receiving a wp_user_id in the request body MUST verify it against the SurfaceClient session's bound wp_user_id (established at W2-C pairing). Body-asserted mismatch → 403 wrong_user before any further validation. Closes /cso Cycle 1 W4-E CRITICAL C1; preempts same-shape findings on W5-A, W4-A. (b) **§37 promoted from path-α to canonical** — pin `src-tauri/src/bridges/surface_client.rs` as the SurfaceClient route module owner. All `/v1/surface/*` endpoints (W4-C keyring + event-log fetch, W4-E nonce issue/verify, W5-A feedback router, DOS-589 dispatcher routes) land here. Closes devex Cycle 1 W4-A0/C/E packet-owner ambiguity in one pin. (c) **§Interlocks W4-D row updated** — substrate publishes `project_composition_for_surface(composition, ctx) → ProjectedComposition` as the canonical public API. Block-level helpers are internal. Composition-level cap (unknown-block count per composition) enforced inside this API; W4-A renderer consumes only the composition-level surface. Closes codex Cycle 1 W4-D HIGH-1. No structural changes to W4-B's own contract; eng + cso + devex + codex APPROVE from V6 carries forward.
+- **V7 (2026-05-13):** Migration slot correction per user — v1.4.1 (in-flight, finishing up) is using v169. W4-B's slot shifts from v169 → **v170**. Recommended block reservation updates: W4-C = v171–v174, W4-E = v175 (if persisted). Single-field rename across operative §§ (Pre-work, "What W4-B authors net-new" table, §7 schema, §8, §11, §13 backfill audit `migration_version`, Open Q1, L0 closure conditions). Historical V3/V4 changelog entries describing the v168→v169 correction are left as-is for audit trail. No structural changes; no re-review needed.
+- **V6 (2026-05-13):** Cycle 5 codex CONDITIONAL closure — codex flagged 2 residual stale `signal_events` references at lines 56 (Pre-work bullet) and 207 (§5 opening paragraph) that V5 missed. Both replaced with `version_events`. No other changes. Codex Cycle 5 explicitly: "Replace those two with `version_events`, and I would approve." V6 is text-only; no Cycle-6 re-review needed beyond codex-only confirmation of the two-line patch.
+- **V5 (2026-05-13):** Cycle 4 codex CONDITIONAL fold — 0 CRITICAL, 0 HIGH, 2 MEDIUM, 2 LOW. eng + cso + devex APPROVE confirmed at Cycle 4 (V4). All four codex Cycle 4 findings are bounded local schema/wording tweaks — material changes: (a) **§15 schema rewrite** — `version_events` gains `event_seq INTEGER PRIMARY KEY AUTOINCREMENT` for replay ordering; `cursor TEXT NOT NULL UNIQUE` is UUIDv4 (unguessable opaque ID); DOS-589 replay clause: `WHERE event_seq > ? ORDER BY event_seq` (codex MEDIUM C4-1). (b) **§13 Insert dedup concurrency rule pinned** — `ClaimMutationTarget::Insert` MUST flow through canonical commit/dedup-lock; duplicate detection inside same `BEGIN IMMEDIATE` Tx; dedup-key collisions redirect to `Reinforced` per existing `claims.rs:5286-5314` (verified by /cso Cycle 4 probe 3c). New fixture for two concurrent Inserts with same dedup_key (codex MEDIUM C4-2). (c) **§15 XOR CHECK** — `CHECK ((claim_id IS NOT NULL) != (composition_id IS NOT NULL))` replaces OR (codex LOW C4-3). (d) **§3 + Interlocks stale `signal_events` references substituted with `version_events`** (codex LOW C4-4). No structural changes; eng + cso + devex don't need Cycle-5 re-confirmation per W3 L0 precedent. Cycle-5 codex-only confirmation is the L0-closure gate.
+- **V4 (2026-05-13):** Cycle 3 reviewer fold (eng + cso + devex APPROVE; codex BLOCK with 2 HIGH + 1 MEDIUM + 1 LOW). All four codex findings are valid substrate-side bugs the other reviewers missed; V4 closes them. Material changes: (a) **§7 + §15 cursor durability rewrite** — V3 claimed cursor allocation "inside mutation transaction" makes it durable, but transaction rollback erases the row. V4 introduces a `mutation_attempts` reservation table: cursor is committed BEFORE the mutation transaction in a separate pre-mutation Tx; the mutation Tx attaches its event to the reserved cursor; on rollback/panic, a post-rollback Tx emits a terminal `mutation_aborted` event at the same cursor. 423 responses now reference a cursor that always resolves (codex HIGH C3-1). (b) **§13 `ClaimMutationTarget` enum rewrite** — V3 trait `MutatingProposal` required `expected_claim_version()` + `claim_id()`, but `ClaimProposal` (claims.rs:68) has `id: Option<String>` and fresh-insert call sites construct claims with `id: None`. V4 introduces `ClaimMutationTarget::{ Insert | Mutate }` enum; `MutatingProposal::target()` returns the enum variant; `commit_claim` dispatches per variant — fresh inserts skip version CAS by design, existing-claim mutations require both fields populated (codex HIGH C3-2). (c) **NEW `version_events` side table (v169)** — V3 §5/§15 relied on the generic `signal_events` table for outbox rows without DB-level constraints; V4 ships a dedicated `version_events` table with CHECK constraints on substrate-owned discriminants (`event_kind` enum, `cursor` format, `scope_redacted` bool) and TEXT NULL columns for caller-controlled fields, closing codex MEDIUM C3-3 + folding cso Cycle 3 path-α guard. (d) **syn dev-dependency** — added to `src-tauri/Cargo.toml` `[dev-dependencies]` per ac §34 (codex LOW C3-4). (e) §13 NOTE — `commit_claim` documented as the only path to claim_version assignment; `MutatingProposal::target()` is the contract, not the version itself (per cso Cycle 3 LOW observation). Acceptance criteria expanded from 38 to 42. ac numbering normalized.
+
+- **V3 (2026-05-13):** Cycle 2 reviewer fold (eng + cso + devex CONDITIONAL APPROVE; codex BLOCK with 1 CRITICAL + 2 HIGH still open). Material changes: (a) **CRITICAL outbox pattern** — §3 + new §15 require signal event + cursor inserted in the SAME DB transaction as the version mutation (closes codex CRITICAL C2-1, cso N4, MidFlightMutation cursor durability codex C2-5); (b) §13 rewrite — `MutatingProposal` trait at `commit_claim` boundary (compile-time hard fail) replaces `#[ability]` macro fiction (closes codex HIGH C2-3 + devex D-N1); (c) §29 rewrite — `tests/version_assignment_gate.rs` integration test using already-transitive `syn` dep, NOT a "v1.4.0 precedent" claim (closes devex D-N3); (d) NEW acceptance criterion §33 — CorrectionRef event-log fetch is scope-filtered identically to inline 409 (closes codex HIGH C2-2 + cso N2); (e) NEW §15 — SQLite domain `1..=i64::MAX` for persisted version columns; overflow at `i64::MAX` not `u64::MAX` (closes codex MEDIUM C2-4); (f) NEW §6.5 — `BridgeSurfaceError` precedence table (closes devex D-N2); (g) ac §30 enum extended with `inflated_version_rejected` (closes eng P2-NEW-2); (h) §7 rewrite — `MutationLock` is defense-in-depth, CAS is correctness; multi-process is phase-deferred to v1.4.3+, NOT W4-C tamper territory (closes eng P2-NEW-1 + cso N3); (i) §8 ac BEGIN IMMEDIATE transaction isolation (closes cso N5); (j) §1 pins `Block.field_bindings: Vec::new()` default for back-compat (closes devex side-note); (k) §5 rewrite — references DOS-589 for delivery; W4-B owns substrate-side emission + event-log schema only; (l) **Migration slot corrected: v168 was wrong (already merged on dev DOS-546 W0); W4-B = v169** (closes eng P1-NEW-1 factual). (m) New §16 — class-level scope-filter rule lifted as comment on DOS-569 + DOS-573 (closes cso scope-leak class recurrence). Acceptance criteria expanded from 30 to 36. **All Cycle 2 codex findings substrate-side fixed.**
+- **V2 (2026-05-13):** Cycle 1 fold — `commit_composition` chokepoint (closed C2), scope-filtered correction (closed C1), `field_bindings` (closed H5), signal payload schema (closed C1 partial), out-of-band ordering (closed H6), MidFlightMutation promoted, naming collision resolved.
+- **V1 (2026-05-13):** Initial draft.
+
+## Status snapshot
+
+- W2 closed clean 2026-05-12.
+- W3 L0 packet closed Cycle 3 (eng + devex + cso APPROVE); V4 Cycle-4 codex approval is the W3-A/B/C unblock gate. W3-0 (DOS-563) running in parallel session.
+- W1-A (`Actor::SurfaceClient`) + W1-E (`Composition`, `Block`, `ClaimRef`, `ProvenanceRef`) merged. Both named DOS-567 blockers — both clear.
+- W4-B is the first stage-1 substrate work and gates four parallel stage-2 lanes.
+- **Cycle 1 panel (2026-05-13):** eng CONDITIONAL, /cso CONDITIONAL, /plan-devex-review CONDITIONAL APPROVE, /codex challenge BLOCK. V2 folded all findings bounded by DOS-567 acceptance.
+- **Cycle 2 panel (2026-05-13):** eng CONDITIONAL (9/10 ADDRESSED; factual slot error), /cso CONDITIONAL APPROVE (all ADDRESSED, H2 PARTIALLY), /plan-devex-review CONDITIONAL APPROVE (all ADDRESSED), /codex challenge **BLOCK** (1 CRITICAL + 2 HIGH + 2 MEDIUM + 1 LOW). V3 folded all Cycle 2 substrate-side findings. DOS-589 sibling ticket filed for signal-bus dispatcher rewrite (partial-convergence). Class-level scope-filter rule lifted to DOS-569 + DOS-573 via Linear comments.
+- **Cycle 3 panel (2026-05-13):** eng **APPROVE**, /cso **APPROVE** (1 path-α maintenance), /plan-devex-review **APPROVE**, /codex challenge **BLOCK** (2 HIGH + 1 MEDIUM + 1 LOW). 3-of-4 APPROVE. Codex's 2 HIGH findings are real bugs the other three missed — cursor durability inside mutation transaction and `MutatingProposal` non-trivial for `ClaimProposal`. V4 closes all four codex findings. Convergence trajectory: codex BLOCK severity Cycle 1 (3C+3H) → Cycle 2 (1C+2H) → Cycle 3 (0C+2H). No class-pattern recurrence (eng/cso/devex all verified). Cycle 4 panel queued.
+
+## Pre-work confirmed (substrate reuse audit)
+
+**Headline finding:** most of the watermark surface DOS-567 asks for already exists in code. W4-B is enforcement + one migration + one bridge chokepoint + one outbox pattern + additive type changes + trait-based input enforcement — not a new contract.
+
+### Already in `src-tauri/abilities-runtime/src/abilities/composition.rs` (W1-E)
+
+- **`CompositionMetadata.composition_version: CompositionVersion`** (u64 wrapper) — line 374. Baked into wire shape.
+- **`ClaimRef { claim_id: String, claim_version: Option<u64> }`** — line 135. V3 makes population mandatory at the substrate boundary (bridge rejects `None` per §10).
+- **`ClaimRef::with_version(claim_id, version)`** — line 149. V3 adds `with_field(claim_id, version, field_path)` constructor.
+- **`ProvenanceRef { invocation_id: InvocationId, field_path: FieldPath }`** — line 263. Pre-existing per-Block. Anchors block-origin pointer per ADR-0105.
+- **`CompositionVersion::bump()`** — line 122. Currently uses `saturating_add(1)`. V3 replaces with `checked_add → Option<Self>`.
+- **`Composition::new` is `pub(crate)`** per ADR-0130 §1 substrate-owned authorship — `commit_composition` lives inside `abilities-runtime` crate.
+- **`Block::new` at line 458** — V3 adds `field_bindings: Vec<FieldBinding>` field; existing call sites get `Vec::new()` default for back-compat per §1.
+
+### Already in `src-tauri/src/services/claims.rs`
+
+- **`commit_claim(ctx, db, proposal)`** — line 4974. Single-writer for every authoritative claim mutation; gated on `ctx.check_mutation_allowed()`. V3 makes `proposal: impl MutatingProposal` (trait-bound) per §13. **Claim_version assignment site.**
+- **`CLAIM_UPDATE_ALLOWED_COLUMNS`** — line 234. `claim_version` is assigned exclusively inside `commit_claim`.
+- **No `claim_version` column on `intelligence_claims` yet.** Migration adds `claim_version INTEGER NOT NULL DEFAULT 0 CHECK (claim_version BETWEEN 0 AND 9223372036854775807)`. **Migration slot v170** (v168 merged on dev as `migrate_v168_reconcile_missing_claim_shadow_trust_columns` at 75eda588; v169 reserved by v1.4.1 in-flight work).
+- **Existing `current_claim_version_for_subject` (6 call sites at claims.rs:6272/6676/7523, db/invalidation_jobs.rs:352/730, services/invalidation_jobs.rs:88)** — per-subject version. V3 renames to `current_subject_claim_version` per §9.
+- **`db.with_transaction` pattern (claims.rs:3396)** — V3 `commit_composition` opens with `BEGIN IMMEDIATE` per §8 to prevent TOCTOU on CAS read.
+
+### Already in `src-tauri/src/signals/bus.rs` (ADR-0080)
+
+- **`emit_signal_event(...)` → `SignalEmitOutcome { id, coalesced }`** — line 73. **Confirmed today: a SQLite event-log emitter, NOT a pub/sub bus.** No subscriber registry, no dispatch loop, no `scope_permits_claim_read` predicate.
+- §5: W4-B emits structured `ClaimVersionEvent` / `CompositionVersionEvent` rows into the dedicated `version_events` table (per §15) **inside the same transaction as the version mutation** (outbox pattern). Delivery + scope-filter dispatch is **DOS-589's responsibility**, not W4-B's. W4-B owns the row schema + outbox guarantee; DOS-589 owns delivery.
+
+### Already in `src-tauri/src/audit_log.rs` (W1-A0)
+
+- **`emit_surface_audit(logger, event_kind, actor, fields) → Result<(), AuditError>`** — line 203. Enforces `wp_user_id` presence for `Actor::SurfaceClient`. V3 pins the `detail` shape per acceptance §30.
+
+### Already in `src-tauri/src/bridges/types.rs` (W2)
+
+- **`BridgeSurfaceError { AbilityUnavailable, Validation(String), Ownership(OwnershipError) }`** — line 249. V3 adds 5 new variants with precedence table per §6.5: `StaleVersion`, `StaleComposition`, `MidFlightMutation`, `ClaimVersionOverflow`, `MissingExpectedClaimVersion`.
+- **`InvocationContext`** — line 133. V3 does NOT add version fields here; `expected_claim_version` carrier lands in the ability's typed input via `MutatingProposal` trait per §13.
+
+### What W4-B authors net-new (V3)
+
+| Surface | Status | Authoring scope |
+|---|---|---|
+| `claim_version INTEGER NOT NULL DEFAULT 0 CHECK (claim_version BETWEEN 0 AND i64::MAX)` column on `intelligence_claims` (v170) | Missing | Migration; backfill per §11 |
+| `claim_version` assignment in `commit_claim` | Missing | Per accepted mutation: `max(prior) + 1` |
+| `composition_versions` table (v170) with same CHECK constraint | Missing | Per §8 |
+| `commit_composition(ctx, db, proposal: CompositionProposal) → Result<CommittedComposition, CompositionError>` | Missing | Bridge chokepoint; CAS + BEGIN IMMEDIATE |
+| `MutatingProposal` trait (per §13) | Missing | New trait at `commit_claim` boundary; compile-time enforcement |
+| `ClaimRef.field_path: Option<FieldPath>` field | Missing | New optional field |
+| `Block.field_bindings: Vec<FieldBinding>` field with `Vec::new()` default constructor | Missing | New field; back-compat via default |
+| `FieldBinding { field_path, role, claim_refs }` + `BindingRole` enum | Missing | Per §1 |
+| 5 new `BridgeSurfaceError` variants with HTTP mapping + precedence per §6.5 | Missing | Per §2, §3, §4, §7, §10 |
+| Scope-filtered `CorrectionPayload` projection | Missing | Per §2 |
+| Scope-filtered `CorrectionRef` event-log lookup endpoint | Missing | Per §16 + ac §33 |
+| Outbox-pattern signal emission in same DB transaction as version mutation | Missing | Per §15 |
+| In-memory mutation lock as defense-in-depth (NOT correctness boundary) | Missing | Per §7 |
+| `mutation_attempts` table (v170) | Missing | Per §7 three-Tx cursor protocol |
+| `version_events` dedicated table (v170) with typed CHECKs | Missing | Per §15 outbox shape |
+| `ClaimMutationTarget` enum + `MutatingProposal::target() -> &ClaimMutationTarget` | Missing | Per §13 V4 rewrite |
+| `MutationGuard` Rust type with `Drop` impl for finalize-aborted | Missing | Per §7 |
+| Startup recovery scan for stuck `mutation_attempts.status = 'in_flight'` > 30s old | Missing | Per §7 |
+| `tests/version_assignment_gate.rs` integration test using `syn` crate | Missing | Per §29 (no fictional precedent claim) |
+| `syn = { version = "2", features = ["full", "visit"] }` in `src-tauri/Cargo.toml` `[dev-dependencies]` | Missing | Per codex C3-4 |
+| `dailyos doctor` claim/composition watermark consistency check | Missing | Per ac §32 (new CLI subcommand) |
+
+## Directional decisions resolved at L0 (V3)
+
+### §1. `field_path` on `ClaimRef` + `field_bindings: Vec<FieldBinding>` on `Block`
+
+V3 pins both surfaces. They answer different questions:
+
+- **`ClaimRef.field_path: Option<FieldPath>`** — "which field of which claim does this specific ClaimRef contribute to this block?" Required for 1:1 claim→field blocks.
+- **`Block.field_bindings: Vec<FieldBinding>`** — "what is this block's full field topology, including derived/computed fields with multiple or no source claims?" Required for synthesized fields.
+
+```rust
+pub struct FieldBinding {
+    pub field_path: FieldPath,
+    pub role: BindingRole,
+    pub claim_refs: Vec<ClaimRefIndex>,
+}
+
+pub enum BindingRole {
+    Source,
+    ComputedFrom,
+    DisplayOnly,
+    FeedbackTarget,
+}
+```
+
+**Back-compat rule (devex side-note):** `Block::new()` adds `field_bindings: Vec::new()` as default value; existing W1-E call sites compile clean. The compile-time check that feedback-eligible blocks populate `field_bindings` lives in the W4-B-authored lint test (acceptance §15), not in the constructor.
+
+`ClaimRef::with_field(claim_id, version, field_path)` is the new ergonomic constructor.
+
+### §2. `409 stale_watermark` envelope — scope-filtered correction
+
+```jsonc
+// HTTP 409 Conflict (scope permits)
+{
+  "ok": false,
+  "error": "stale_watermark",
+  "claim_id": "<string>",
+  "expected": { "claim_version": <u64> },
+  "current":  { "claim_version": <u64> },
+  "correction": {
+    "claim": { /* IntelligenceClaim re-projected through Actor::SurfaceClient { scopes } */ },
+    "scope_redacted": false,
+    "retry_after_ms": <u32 | null>,
+    "cursor": "<event-cursor-string>"
+  }
+}
+
+// HTTP 409 Conflict (scope does not permit)
+{
+  "ok": false,
+  "error": "stale_watermark",
+  "claim_id": "<string>",
+  "expected": { "claim_version": <u64> },
+  "current":  { "claim_version": <u64> },
+  "correction": {
+    "claim": null,
+    "scope_redacted": true,
+    "reason": "out_of_scope",
+    "retry_after_ms": <u32 | null>,
+    "cursor": "<event-cursor-string>"
+  }
+}
+```
+
+Composition-level stale: `error: "stale_composition_watermark"`, no `correction.claim`. Inflated-version case (`expected > current`): identical envelope to stale, no correction payload, `event_kind: "inflated_version_rejected"` audit (per §6).
+
+### §3. `composition_version` is bridge-assigned via `commit_composition()` chokepoint
+
+DOS-567 acceptance: "Versions are never generated or trusted ... agent-side." V3 enforces:
+
+```rust
+pub fn commit_composition(
+    ctx: &ServiceContext,
+    db: &ActionDb,
+    proposal: CompositionProposal,
+) -> Result<CommittedComposition, CompositionError>;
+
+pub struct CompositionProposal {
+    pub composition_id: CompositionDocId,
+    pub expected_composition_version: u64,    // CAS guard; 0 for first-ever under this ID
+    pub composition: Composition,             // metadata.composition_version IGNORED on input
+}
+
+pub enum CompositionError {
+    StaleVersion { expected: u64, current: u64 },
+    Overflow { composition_id: CompositionDocId },
+    AbilityFault(String),
+}
+
+pub struct CommittedComposition {
+    pub composition_id: CompositionDocId,
+    pub composition_version: u64,             // assigned by commit_composition; overwrites ability-supplied
+    pub composition: Composition,
+}
+```
+
+**Authority rule:** `composition_version` assigned by `commit_composition` using `checked_add(1)` against the `composition_versions` row under transactional CAS. Ability's supplied value is overwritten on output; non-zero supplied values logged at warning level.
+
+**Idempotency rule:** `composition_version` advances on every accepted `commit_composition` call regardless of payload equality.
+
+**Outbox rule:** `commit_composition` inserts the structured `CompositionVersionEvent` row into the dedicated `version_events` table (per §15) within the **same DB transaction** as the `composition_versions` UPDATE/INSERT. Either both persist or neither. Delivery to subscribers is DOS-589's responsibility. This closes codex Cycle 2 CRITICAL C2-1 (post-commit signal window).
+
+**Concurrent producer rule:** two abilities concurrently calling `commit_composition` for same `composition_id` race through CAS under `BEGIN IMMEDIATE` (per §8); exactly one succeeds, other receives `StaleVersion`.
+
+### §4. Overflow defense — typed variant + checked_add + i64::MAX domain + rollback
+
+V3 fixes:
+- `CompositionVersion::bump()` at composition.rs:122 changes from `saturating_add` to `checked_add` returning `Option<Self>`.
+- `commit_claim` and `commit_composition` use `checked_add`; `None` returns typed `BridgeSurfaceError::ClaimVersionOverflow { claim_id }` (HTTP 500) or `CompositionError::Overflow { composition_id }`.
+- **Persisted domain: `1..=i64::MAX` (V3 NEW per codex C2-4).** SQLite INTEGER is signed 64-bit; persisting `u64` values above `i64::MAX` fails at storage codec. V3 pins the domain at `i64::MAX = 9223372036854775807`. Overflow fixture (`dos567_fixture_overflow.rs`) tests `claim_version = i64::MAX` not `u64::MAX`. CHECK constraint on both `intelligence_claims.claim_version` and `composition_versions.composition_version`: `CHECK (claim_version BETWEEN 0 AND 9223372036854775807)`.
+- **Transaction rollback:** overflow detection happens before DB write. No in-memory state mutates; rejection propagates without poisoning. Audit `event_kind: "claim_version_overflow"` / `composition_version_overflow`.
+- Practical reachability: `i64::MAX` mutations per claim is ~9.2 × 10^18 — unreachable. Defense is correctness, not capacity.
+
+### §5. Signal-event payload schema (W4-B substrate-side; DOS-589 delivery)
+
+W4-B's scope: substrate emits structured `ClaimVersionEvent` / `CompositionVersionEvent` rows into the dedicated `version_events` table (per §15) inside the version-mutation transaction (outbox pattern). **Delivery, subscriber registry, scope-filter dispatch, `subscription.backpressure`, replay-from-cursor are all DOS-589's responsibility.**
+
+```rust
+pub struct ClaimVersionEvent {
+    pub event_kind: ClaimEventKind,
+    pub claim_id: String,
+    pub previous_version: Option<u64>,
+    pub current_version: u64,
+    pub cursor: SignalCursor,
+    pub reason: Option<String>,
+    pub correction_ref: Option<CorrectionRef>,
+}
+
+pub enum ClaimEventKind {
+    Updated, Corrected, Superseded, Tombstoned, WriteRejected, ConflictDetected,
+}
+
+pub struct CompositionVersionEvent {
+    pub event_kind: CompositionEventKind,
+    pub composition_id: CompositionDocId,
+    pub previous_version: Option<u64>,
+    pub current_version: u64,
+    pub cursor: SignalCursor,
+    pub reason: Option<String>,
+}
+
+pub struct CorrectionRef {
+    pub event_log_id: String,
+    pub claim_id: String,
+    // Body fetch via GET /v1/surface/event-log/{event_log_id} — scope-filtered identically to §2 (per §16 + ac §33)
+}
+```
+
+**409 envelope vs signal-bus channel disambiguation (devex D-N4):**
+- 409 envelope (synchronous, 5xx-recovery path): consumed by the SurfaceClient that issued the stale write. Carries inline `correction.claim` body (scope-filtered).
+- `claim.write_rejected` signal (asynchronous, push-via-DOS-589): consumed by other subscribers observing the rejection event. Carries `correction_ref` only; full body fetch is separate.
+- **The two channels serve different consumers.** A single SurfaceClient does NOT consume both for the same rejection; the 409 is its synchronous response, and signal-bus subscribers are observers, not the writer.
+
+### §6. Out-of-band edits — ordering with W4-C + `expected == substrate_current` rule
+
+1. **W4-C signature check runs before W4-B 409 path** in the loopback endpoint. Tamper error does NOT emit `correction.claim`.
+2. **Mutation input MUST present `expected == substrate_current`.** Greater-than rejected as `StaleVersion`, audit `event_kind: "inflated_version_rejected"`.
+
+**Linear interlock edge:** DOS-569 (W4-C) inherits the signature-check-before-409 ordering as acceptance criterion.
+
+### §6.5. `BridgeSurfaceError` variant precedence table (V3 NEW per devex D-N2)
+
+When multiple rejection conditions could fire on a single request, the bridge evaluates in this order and returns the first matching variant:
+
+| Precedence | Variant | HTTP | Trigger | Owned by |
+|---|---|---|---|---|
+| 0 | `ProjectionTampered` | 422 | W4-C signature verification fails on input projection envelope (Ed25519 mismatch, malformed sentinel, missing signature). Fires BEFORE expected-version logic; tamper error does NOT emit `correction.claim` payload. | W4-C (DOS-569) |
+| 1 | `ProjectionVersionRollback` | 422 | W4-C currentness check: signature verifies but `signed_payload.composition_version < ledger.composition_version` (replayed older projection) OR `signed_payload.claim_version < ledger.claim_version`. Quarantine; no correction payload. | W4-C (DOS-569) |
+| 2 | `MissingExpectedClaimVersion` | 400 | Input lacks `expected_claim_version` (via `MutatingProposal::expected_claim_version()` returning `None` or call site bypassing trait) | W4-B (this packet) |
+| 3 | `MidFlightMutation` | 423 | `MutationLock` held on `claim_id`; rejection has lock-holder's mutation_id + cursor | W4-B |
+| 4 | `ClaimVersionOverflow` / composition overflow | 500 | `checked_add(1)` returns `None`; or persistence would exceed `i64::MAX` | W4-B |
+| 5 | `StaleVersion` (claim) | 409 | `expected != substrate_current_claim_version` (includes inflated case) | W4-B |
+| 6 | `StaleComposition` | 409 | `expected != substrate_current_composition_version` | W4-B |
+
+Read top-down; first match returns. AST CI gate (per §29) asserts the precedence is enforced at the bridge entry point via exhaustive match arms.
+
+**V9 NEW (precedence 0 + 1 added):** `ProjectionTampered` and `ProjectionVersionRollback` are W4-C-owned variants but their precedence belongs in this table because they fire at the same bridge entry-point as the W4-B family. The runtime evaluates them FIRST so that a tampered or replay-rolled-back projection never reaches stale-watermark CAS evaluation (which would leak `correction.claim` body). W4-C's L0 packet implements the variant + ledger schema; this table coordinates the ordering.
+
+### §7. `MidFlightMutation` is W4-B contract surface — lock is defense-in-depth, CAS is correctness, cursor reservation is committed BEFORE mutation transaction
+
+V4 rewrites the cursor-durability mechanism per codex Cycle 3 HIGH C3-1. V3's "cursor inside mutation transaction" was internally contradictory — a transaction rollback erases the cursor row, leaving the 423 loser polling for an event that never appears.
+
+- **Variant:** `BridgeSurfaceError::MidFlightMutation { claim_id, mutation_id, retry_after_event: SignalCursor }` → HTTP 423 Locked.
+- **Locking primitive:** in-memory `HashMap<ClaimId, MutationLock>` keyed on `claim_id`, guarded by `tokio::sync::Mutex`.
+- **Correctness vs defense-in-depth:** `claim_version` CAS in `commit_claim` is the correctness boundary; the in-memory lock is defense-in-depth. **On crash + retry, the worst-case observable is a `StaleVersion` rejection** (CAS catches the duplicate), not "duplicate accepted mutation."
+- **No durable lock state.** Startup does NOT restore lock state. Correctness is in the CAS.
+- **Multi-process safety: phase-deferred to v1.4.3+** when multi-process runtime lands. v1.4.2 single-process is canonical. Multi-process is NOT W4-C tamper territory; it's a concurrent-process correctness concern with documented 423→409 fallback (a second process bypasses the in-memory lock, hits the row CAS, receives 409 — same correctness, different code).
+
+#### Cursor durability — three-transaction protocol (V4 NEW per codex C3-1)
+
+The `retry_after_event` cursor is durable across all mutation outcomes (commit, rollback, panic) via a three-Tx protocol:
+
+1. **Pre-mutation Tx (`reserve_mutation_attempt`)** — commits FIRST, before the lock is exposed via 423:
+   - INSERT into `mutation_attempts (mutation_id, claim_id, cursor, started_at, status)` with `status = 'in_flight'`.
+   - Cursor allocated here is **durable from the moment the Tx commits.**
+   - 423 response carries `retry_after_event = cursor` from this committed row.
+
+2. **Mutation Tx (`commit_claim` / `commit_composition`)** — does the actual version mutation:
+   - Reads current version under `BEGIN IMMEDIATE`.
+   - CAS-checks `expected_version`.
+   - Writes `intelligence_claims.claim_version = N+1` (or `composition_versions.composition_version = N+1`).
+   - INSERTs into `version_events` (per §15) referencing the **same cursor** from `mutation_attempts`.
+   - UPDATEs `mutation_attempts.status = 'committed'`.
+   - COMMITs.
+
+3. **Post-rollback Tx (`finalize_mutation_attempt_aborted`)** — runs IF Tx 2 rolls back or panics:
+   - Triggered by `Drop` impl on a `MutationGuard` value OR by startup recovery scan of `mutation_attempts WHERE status = 'in_flight' AND started_at < now() - 30s`.
+   - UPDATEs `mutation_attempts.status = 'aborted'`.
+   - INSERTs a terminal `mutation_aborted` event into `version_events` at the reserved cursor.
+   - COMMITs.
+
+**Loser polling guarantee:** the 423 loser sees the cursor in `mutation_attempts` immediately (Tx 1 already committed). When the winner finishes (commits OR aborts), Tx 2 or Tx 3 writes the terminal event at that cursor. Loser receives `claim.updated` (winner committed) OR `mutation_aborted` (winner failed) — never a missing event.
+
+**`mutation_attempts` schema (v170):**
+
+```sql
+CREATE TABLE mutation_attempts (
+    mutation_id TEXT PRIMARY KEY,
+    claim_id TEXT NOT NULL,
+    cursor TEXT NOT NULL UNIQUE,
+    started_at TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('in_flight', 'committed', 'aborted')),
+    finalized_at TEXT,
+    CHECK ((status = 'in_flight' AND finalized_at IS NULL) OR (status != 'in_flight' AND finalized_at IS NOT NULL))
+);
+CREATE INDEX idx_mutation_attempts_in_flight ON mutation_attempts (started_at) WHERE status = 'in_flight';
+```
+
+**`MutationGuard` Rust type:** wraps the lock + reservation; `Drop` impl runs `finalize_mutation_attempt_aborted` on panic-unwind paths. Startup recovery scans for stuck `in_flight` attempts > 30 seconds old and marks them `aborted` (covers panic-abort and process-kill paths where Drop didn't run).
+
+- **Audit:** `event_kind: "mid_flight_rejected"` (loser-side) + `event_kind: "mutation_aborted"` (winner-side post-rollback) with `AuditFields.detail` shape per ac §34.
+- **W5-A consumer:** retry-after via cursor event (push from DOS-589); NOT a tight loop.
+
+### §8. `composition_versions` table + BEGIN IMMEDIATE
+
+Required by §3's bridge-assigned watermark contract.
+
+```sql
+CREATE TABLE composition_versions (
+    composition_id TEXT PRIMARY KEY,
+    composition_version INTEGER NOT NULL,
+    generated_at TEXT NOT NULL,
+    generated_by_invocation_id TEXT NOT NULL,
+    generated_by_actor_kind TEXT NOT NULL,
+    CHECK (composition_version BETWEEN 1 AND 9223372036854775807)
+);
+```
+
+- **Durable**, slot v170.
+- **Bootstrap on first encounter:** `commit_composition` INSERTs with `composition_version = 1` on first call for a new `composition_id`; subsequent calls UPDATE under CAS. Audit `event_kind: "composition_version_bootstrap"`.
+- **Transaction isolation (V3 NEW per cso N5):** `commit_composition` opens transaction with **`BEGIN IMMEDIATE`** (writer lock at BEGIN), not deferred. Prevents TOCTOU on read-modify-write CAS sequence.
+
+### §9. Naming collision — rename `current_claim_version_for_subject` → `current_subject_claim_version`
+
+Existing 6 call sites (claims.rs:6272, 6676, 7523; db/invalidation_jobs.rs:352, 730; services/invalidation_jobs.rs:88) renamed. Mechanical sweep; W4-B's first commit.
+
+### §10. `ClaimRef.claim_version: None` is bridge-rejected
+
+- Mutation input with `claim_version: None` returns `BridgeSurfaceError::MissingExpectedClaimVersion { claim_id }` (HTTP 400) before reaching `commit_claim`.
+- Producer-output serializer guard rejects `None` on `Source`/`FeedbackTarget` bindings.
+- Fixture `dos567_fixture_missing_version.rs` exercises both.
+
+### §11. Migration slot + backfill semantics
+
+- **Slot reservation:** W4-B claims **v170** (v168 merged on dev as `migrate_v168_reconcile_missing_claim_shadow_trust_columns`, commit 75eda588; v169 reserved by v1.4.1 in-flight work). Recommended block: W4-B = v170; W4-C = v171–v174 (Ed25519 keys, projection ledger, quarantine); W4-E = v175 (nonce persistence) if persisted, otherwise no slot.
+- **`intelligence_claims.claim_version` backfill:** existing rows initialize to `claim_version = 1`. Next `commit_claim` advances to 2.
+- **Migration-origin audit event:** v170 emits one-shot audit `event_kind: "claim_version_backfill"`, `detail: { row_count, migration_version: 170 }`, `actor_kind: "system"`. Anchors audit hash chain.
+- **Off-by-one fixture:** `dos567_fixture_backfill_off_by_one.rs` asserts fresh insert via `commit_claim` post-migration produces `claim_version = 1`; re-mutation → 2.
+
+### §12. Signal event types — emit both `claim.write_rejected` AND `claim.conflict_detected`
+
+V1/V2 unchanged in V3. Loser gets `claim.write_rejected`; concurrent-write winner gets BOTH `claim.updated` AND `claim.conflict_detected`. DOS-589 routes both with scope-filtered dispatch.
+
+### §13. `MutatingProposal` trait with `ClaimMutationTarget` enum (V4 REWRITE per codex C3-2)
+
+V3's trait shape required `expected_claim_version()` + `claim_id()`, which doesn't work for fresh inserts (current `ClaimProposal` has `id: Option<String>`; many call sites construct claims with `id: None`, e.g. `services/intelligence.rs:160`). V4 splits the cases via an enum:
+
+```rust
+pub enum ClaimMutationTarget {
+    /// Fresh insert; no prior version to compare. claim_version assigned at 1 on commit.
+    Insert {
+        subject_ref: SubjectRef,
+        claim_type: ClaimType,
+        dedup_key: Option<String>,
+    },
+    /// Existing-claim mutation; CAS guard required.
+    Mutate {
+        claim_id: String,
+        expected_claim_version: u64,
+    },
+}
+
+pub trait MutatingProposal {
+    fn target(&self) -> &ClaimMutationTarget;
+}
+
+// commit_claim signature changes:
+pub fn commit_claim<P: MutatingProposal>(
+    ctx: &ServiceContext,
+    db: &ActionDb,
+    proposal: P,
+) -> Result<CommittedClaim, ClaimError>;
+```
+
+**Dispatch in `commit_claim`:**
+- `Insert` variant: skip version CAS by design; INSERT new row with `claim_version = 1`. No `MissingExpectedClaimVersion` possible because there is no version to compare. **Concurrent Insert defense (V5 NEW per codex C4-2):** `Insert` MUST flow through the existing canonical commit/dedup-lock path at `services/claims.rs:5286-5314`. Duplicate detection (by `dedup_key` + subject + claim_type) runs inside the same `BEGIN IMMEDIATE` transaction as the row insert; collisions redirect to `CommittedClaim::Reinforced` (corroboration) rather than producing a duplicate `Inserted`. Two concurrent fresh-insert proposals with the same dedup identity produce exactly one `Inserted` + one `Reinforced` — never two duplicate rows. The existing substrate already enforces this; V4's `Insert` variant inherits the rule (does NOT introduce a parallel insert path that bypasses dedup).
+- `Mutate` variant: run version CAS against `claim_id`'s current row. If `expected_claim_version != current.claim_version`, return `StaleVersion`. If row missing, return `Validation("claim_not_found")`.
+- Bridge entry: if the caller's payload deserialization produces `ClaimMutationTarget::Mutate { expected_claim_version: 0, .. }`, that's a wire-shape violation (0 is reserved for pre-migration backfill rows, never a legitimate CAS value) — return `MissingExpectedClaimVersion`.
+
+**Compile-time enforcement:** trait bound on `commit_claim<P: MutatingProposal>` is the gate. Mutating ability whose proposal type doesn't `impl MutatingProposal` fails the type check. `commit_claim` cannot be called without going through the trait.
+
+**Migration of existing call sites (devex Cycle 3 verified ~20 sites):** `ClaimProposal` (claims.rs:68) gets `expected_claim_version: Option<u64>` field. `impl MutatingProposal for ClaimProposal` returns `ClaimMutationTarget::Mutate` when `id: Some(_)` AND `expected_claim_version: Some(_)`, else `ClaimMutationTarget::Insert`. All ~20 call sites (intel_queue.rs:4611/4784/4813/4863, bridges/mcp.rs:890, services/intelligence.rs:157, plus test sites) are updated as part of W4-B's first commit. Compile errors surface every site that needs `expected_claim_version` threaded through.
+
+**Per cso Cycle 3 LOW (commit_claim visibility):** `MutatingProposal::target()` MUST return a value sourced from a substrate read-after-write boundary, not synthesized client-side. The bridge layer captures `substrate_current_claim_version` from the most recent successful read on that `claim_id` and re-emits it on the next mutation; client-side construction with `expected_claim_version: 0` is a contract violation per the rule above. Documented as a comment-doc rule on `MutatingProposal::target()`.
+
+**Replaces V2's `#[ability]` macro fiction and V3's optional-version foot-gun.** The trait + enum IS the boundary.
+
+### §14. Rate-limit retry policy in 409 envelope
+
+`correction.retry_after_ms` populated when W2-D rate-limit budget below threshold (e.g. < 20% remaining). W5-A waits on cursor event from DOS-589 dispatcher; `retry_after_ms` is fallback upper bound. Prevents tight conflict-loop hitting W2-D 429s.
+
+### §15. Outbox pattern + dedicated `version_events` table (V4 REWRITE per codex C3-3)
+
+V3's outbox used the generic `signal_events` table (created in migration 018) directly. Codex Cycle 3 MEDIUM C3-3 + cso Cycle 3 path-α: the generic schema is TEXT-typed with no CHECK constraints on cursor format, event_kind enum, or scope_redacted bool. Substrate-correctness assumption needs DB-level enforcement on substrate-owned discriminants WITHOUT introducing caller-controlled-CHECK availability surfaces.
+
+V4 introduces a **dedicated `version_events` table** for W4-B outbox rows; V5 adds `event_seq` AUTOINCREMENT (for deterministic replay ordering) and pins `cursor` as UUIDv4 (unguessable opaque ID):
+
+```sql
+CREATE TABLE version_events (
+    event_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    cursor TEXT NOT NULL UNIQUE CHECK (length(cursor) = 36 AND cursor GLOB '*-*-*-*-*'),
+    event_kind TEXT NOT NULL CHECK (event_kind IN (
+        'claim.updated', 'claim.corrected', 'claim.superseded', 'claim.tombstoned',
+        'claim.write_rejected', 'claim.conflict_detected',
+        'composition.updated', 'composition.write_rejected',
+        'mutation_aborted'
+    )),
+    claim_id TEXT,                   -- NULL for composition events; TEXT NULL, no CHECK (caller-controlled)
+    composition_id TEXT,             -- NULL for claim events; TEXT NULL, no CHECK (caller-controlled)
+    previous_version INTEGER,        -- NULL for inserts and rejections
+    current_version INTEGER NOT NULL,
+    reason TEXT,                     -- caller-controlled; TEXT NULL, no CHECK (per cso path-α)
+    scope_redacted INTEGER NOT NULL CHECK (scope_redacted IN (0, 1)),
+    correction_event_log_id TEXT,    -- nullable pointer to durable correction body
+    mutation_id TEXT,                -- nullable; populated for events tied to mutation_attempts row
+    created_at TEXT NOT NULL,
+    actor_kind TEXT NOT NULL CHECK (actor_kind IN ('user', 'agent', 'admin', 'system', 'surface_client')),
+    CHECK ((claim_id IS NOT NULL) != (composition_id IS NOT NULL))   -- XOR: exactly one of the two
+);
+CREATE INDEX idx_version_events_claim ON version_events (claim_id, current_version);
+CREATE INDEX idx_version_events_composition ON version_events (composition_id, current_version);
+```
+
+**Cursor generation rule:** every `cursor` is a fresh UUIDv4 (16 bytes random, 122 bits entropy) generated at `mutation_attempts` row reservation time (per §7 pre-mutation Tx). The format CHECK on `version_events.cursor` (length 36 + GLOB pattern matching `8-4-4-4-12` hex blocks) catches mistyped insertions; unguessability is enforced by construction, not by CHECK.
+
+**Replay ordering (DOS-589):** consumers replay with `SELECT * FROM version_events WHERE event_seq > ? ORDER BY event_seq LIMIT N`. `event_seq` is monotonic per SQLite AUTOINCREMENT semantics; subscribers store last-seen `event_seq` (not last-seen `cursor`). Cursors are still useful for direct addressing (e.g., the 423 envelope's `retry_after_event` carries the cursor; the subscriber resolves cursor → event_seq via `SELECT event_seq FROM version_events WHERE cursor = ?`). This separation gives DOS-589 a stable replay order independent of cursor predictability.
+
+**Outbox rule:** every `commit_claim` and `commit_composition` mutation runs as one transaction that writes both the version row AND the `version_events` row. Combined with the §7 three-Tx cursor protocol:
+
+1. Pre-mutation Tx (committed first): INSERTs `mutation_attempts` row, allocates `cursor`.
+2. Mutation Tx: reads current version (`BEGIN IMMEDIATE`), CAS, writes version row, INSERTs `version_events` row referencing the same `cursor`, UPDATEs `mutation_attempts.status = 'committed'`. COMMITs.
+3. Post-rollback Tx (only if Tx 2 failed): UPDATEs `mutation_attempts.status = 'aborted'`, INSERTs `mutation_aborted` row into `version_events` at the same `cursor`.
+
+**Schema-level constraint scope (per cso Cycle 3 path-α):**
+- **Substrate-owned discriminants get CHECK:** `event_kind`, `scope_redacted`, `actor_kind`, claim/composition mutual-exclusion.
+- **Caller-controlled fields stay TEXT NULL without CHECK:** `reason` (free-form), `claim_id`/`composition_id` (opaque identifiers). Caller payload cannot trigger a CHECK violation that aborts the mutation transaction.
+- Substrate-owned values (event_kind, actor_kind) use Rust enum → canonical string mapping via Serde; the strings inserted into the DB are always one of the enumerated values by construction.
+
+**Delivery (DOS-589):** dispatcher polls (or trigger-subscribes to) `version_events` after each Tx commit; W4-B's responsibility ends at the row insert.
+
+**Why a dedicated table, not extending `signal_events`:**
+- `signal_events` (018) is a generic event log used by many subsystems (ADR-0080 propagation). Adding CHECK constraints there could regress unrelated callers.
+- `version_events` has watermark-specific shape (`previous_version`/`current_version`/`mutation_id`) and is read by DOS-589's W4-B-specific dispatcher path. Cleaner separation.
+- The DOS-589 sibling-ticket dispatcher can union over both tables if cross-subsystem replay is later needed; for v1.4.2 the dispatcher only reads `version_events`.
+
+**No "post-commit emit" race possible.** Replaces V2's "emit AFTER row persisted" and V3's "cursor inside mutation transaction" with the durable-cursor protocol from §7 + this dedicated table.
+
+### §17. Class-level `wp_user_id` session binding — lifted to all SurfaceClient consumers (V8 NEW)
+
+Per stage-2 Cycle 1 /cso review of W4-E (CRITICAL C1): every endpoint that receives a `wp_user_id` in the request body trusts that field directly, but a compromised WP admin role or buggy WP plugin can craft a signed request asserting any wp_user_id. HMAC + pairing scope check pass; the audit row then attests to a falsified human. Class shape — applies to all current and future SurfaceClient write paths.
+
+**Class-level rule (inherited by DOS-568/569/570/571/572/573 + DOS-589):**
+
+> Every endpoint that accepts a `wp_user_id` value (either in the request body, query string, header, or any other request channel) MUST verify it equals the wp_user_id bound to the SurfaceClient session at W2-C pairing time. Body-asserted values are NEVER trusted on their own. If a request's body wp_user_id does not match the session-bound value, the endpoint rejects with HTTP 403 `wrong_user` BEFORE running any further validation (signature check, scope check, nonce verify, claim read, etc.). The reject path emits an audit event with `event_kind: "wrong_user_rejected"` carrying the session-bound wp_user_id (the truthful value), the asserted wp_user_id, and the SurfaceClient instance.
+
+**Implementation in W4-B (single point of enforcement):**
+
+The `SurfaceClientBridge` (W2-D's bridge surface) gains a precondition check at request entry: when an authenticated SurfaceClient request payload contains a `wp_user_id` field at any depth, the bridge runs `validate_session_bound_wp_user_id(actor, payload)` BEFORE dispatching to the ability or service layer. The helper traverses the payload (serde-driven), collects every `wp_user_id` occurrence, and compares each to `actor.session.wp_user_id`. Any mismatch → 403 + audit, no further dispatch.
+
+This makes the rule structurally enforced rather than per-endpoint asserted. Consumers (W4-E, W5-A, etc.) do not need to re-implement the check; the bridge fail-closes for them.
+
+**Linear comments posted to DOS-568/569/570/571/572/573/589** lift this rule as inherited acceptance.
+
+### §16. Class-level scope-filter rule — lifted to DOS-569 and DOS-573 (V3 NEW)
+
+Per Cycle 2 /cso class-pattern observation (scope-leak fired V1 C1 + V2 N1 + V2 N2 = three times), V3 lifts a class-level acceptance into DOS-569 (W4-C) and DOS-573 (W5-A) via separate Linear comments:
+
+> **Class-level acceptance criterion (W4-C, W5-A, and any future claim-bound consumer):** every read endpoint that returns claim-bound content must route through the same `Actor::SurfaceClient { scopes }` projection pipeline. Direct-key fetches by `event_log_id`, `mutation_id`, `correction_id`, `projection_id`, `composition_id`, `claim_id`, or any other bearer pointer are equally scope-gated. Out-of-scope requesters receive a redacted envelope or 404; never a leaked claim body.
+
+This is structural rather than a per-finding patch. Future direct-key fetch endpoints introduced in v1.4.3+ inherit the rule.
+
+## Acceptance criteria lifted into DOS-567 (V4)
+
+### Implementation (substrate-side)
+
+1. **Migration v170** is a single migration that creates three new schema surfaces:
+   (a) adds `claim_version INTEGER NOT NULL DEFAULT 0 CHECK (claim_version BETWEEN 0 AND 9223372036854775807)` to `intelligence_claims`; existing rows initialized to `claim_version = 1`. One-shot audit `claim_version_backfill` per §11.
+   (b) creates `composition_versions` table per §8 with matching CHECK constraint.
+   (c) creates `mutation_attempts` table per §7 (`mutation_id PK, claim_id, cursor UNIQUE, started_at, status CHECK IN ('in_flight','committed','aborted'), finalized_at` + status/finalized_at consistency CHECK + partial index on in-flight attempts).
+   (d) creates `version_events` table per §15 with typed columns + CHECK constraints on substrate-owned discriminants (`event_kind`, `scope_redacted`, `actor_kind`); TEXT NULL for caller-controlled fields (`reason`, `claim_id`, `composition_id`).
+2. **`claim_version` assigned exclusively inside `commit_claim`.** `tests/version_assignment_gate.rs` integration test (using `syn` per ac §42) enforces.
+3. **`composition_version` assigned exclusively inside `commit_composition`.** Ability-supplied value overwritten on output.
+4. **`commit_composition` operates under `BEGIN IMMEDIATE` transactional CAS** against `composition_versions` row. Two concurrent abilities for same `composition_id` → one success, one `StaleVersion`. Bootstrap inserts `composition_version = 1`.
+5. **`ClaimRef.field_path: Option<FieldPath>` field added; `Block.field_bindings: Vec<FieldBinding>` field added with `Vec::new()` default; `FieldBinding`/`BindingRole` types added.** W1-E serialization round-trip preserved.
+6. **`BridgeSurfaceError` extended** with 5 new variants per §6.5 precedence table. HTTP mappings: 409, 409, 423, 500, 400.
+7. **`CorrectionPayload` is scope-filtered** through `Actor::SurfaceClient { scopes }`. Out-of-scope returns `scope_redacted: true` with no claim body.
+8. **W4-C signature check runs before W4-B 409 path** in loopback endpoint. Tamper error does NOT emit `correction.claim`.
+9. **Mutation input requires `expected_claim_version == substrate_current`.** Greater-than rejected as `StaleVersion` with no correction payload (inflated-version defense).
+10. **`MutatingProposal` trait + `ClaimMutationTarget` enum** per §13. `commit_claim<P: MutatingProposal>` accepts both `Insert` (fresh; skip version CAS; assign `claim_version = 1`) and `Mutate { claim_id, expected_claim_version }` (CAS required) variants. Compile-time enforcement via trait bound; no mutating ability can call `commit_claim` without going through the trait.
+11. **`ClaimRef.claim_version: None` in mutation proposal** triggers `MissingExpectedClaimVersion` (only when the proposal's `target()` is `Mutate { .. }` per §13 — `Insert` variant skips this check by design). Producer-output serializer guard rejects on `Source`/`FeedbackTarget` bindings regardless of variant.
+12. **In-memory mutation lock** (`HashMap<ClaimId, tokio::sync::Mutex>`) as defense-in-depth, NOT correctness boundary (§7). CAS is correctness. No durable lock state.
+13. **`commit_claim` + `commit_composition` follow three-Tx outbox protocol (§7 + §15):** (1) pre-mutation Tx commits `mutation_attempts` row with cursor; (2) mutation Tx writes version row + `version_events` row + UPDATEs `mutation_attempts.status='committed'`, all atomic; (3) on rollback/panic, post-rollback Tx writes `mutation_aborted` event + UPDATEs `status='aborted'`. Cursor is durable from end of Tx 1; 423 responses always reference a cursor that resolves.
+14. **Bridge emits `claim.write_rejected` + audit on rejected stale write.** Detail shape per ac §34.
+15. **Bridge emits `claim.conflict_detected`** to winner's audit channel on concurrent-write race.
+16. **Rename `current_claim_version_for_subject` → `current_subject_claim_version`** across all 6 call sites.
+17. **`ClaimRef::with_field(claim_id, version, field_path)` constructor added** alongside `with_version`. Lint test (per ac §33 part b) asserts every Block with feedback-eligible BlockType has every `Source`/`FeedbackTarget` binding's `ClaimRef.field_path = Some(_)`.
+18. **`CompositionVersion::bump()` rewritten** from `saturating_add` to `checked_add → Option<Self>`. Persisted domain `1..=i64::MAX` per §4.
+19. **`MutationGuard` Rust type with `Drop` impl** (per §7): wraps the in-memory `MutationLock` + `mutation_attempts` reservation; on panic-unwind, `Drop` runs `finalize_mutation_attempt_aborted` Tx 3. Startup recovery scans `mutation_attempts WHERE status='in_flight' AND started_at < now() - 30s` and marks them aborted (covers process-kill paths where `Drop` didn't run).
+
+### Negative fixtures (`src-tauri/tests/dos567_fixture_<N>_<name>.rs`)
+
+20. **`dos567_fixture_1_concurrent_writes.rs`** — two SurfaceClients writing same claim at v=5; one succeeds with v=6; loser receives 409 + scope-filtered correction; audit emits `claim.write_rejected` for loser + `claim.conflict_detected` for winner.
+21. **`dos567_fixture_2_reconnect_replay.rs`** — simulated reconnect via DOS-589 dispatcher (mock or fake); cursor replay `a→b→a` in order.
+22. **`dos567_fixture_3_stale_mcp_write.rs`** — MCP at v=8 against current v=10; rejected; scope-filtered correction.
+23. **`dos567_fixture_4_runtime_correction_during_editor_draft.rs`** — runtime v=6 arrives while editor holds v=5 draft; save rejected; draft preservation is W5-A scope.
+24. **`dos567_fixture_5_mid_flight_mutation.rs`** — concurrent invoke while lock held; HTTP 423 `MidFlightMutation`; `retry_after_event` cursor durably committed to `mutation_attempts` BEFORE 423 is emitted; loser observes either `claim.updated` (winner committed) or `mutation_aborted` (winner failed) at the cursor — never a missing event.
+25. **`dos567_fixture_overflow.rs`** — simulate `claim_version = i64::MAX`; attempt commit; `ClaimVersionOverflow { claim_id }`; audit `claim_version_overflow`; no state poisoning.
+26. **`dos567_fixture_missing_version.rs`** — `ClaimRef { claim_version: None }` on `Source` binding; mutation input rejected with `MissingExpectedClaimVersion`; producer output rejected at serialization.
+27. **`dos567_fixture_scope_leak.rs`** — SurfaceClient with `read.account_overview` submits stale write against tighter-scope claim; 409 `scope_redacted: true`, no claim body leaks.
+28. **`dos567_fixture_inflated_version.rs`** — SurfaceClient presents `expected > current`; rejected `StaleVersion`, no correction; audit `inflated_version_rejected`.
+29. **`dos567_fixture_backfill_off_by_one.rs`** — fresh post-migration insert produces `claim_version = 1`; re-mutation advances to 2.
+30. **`dos567_fixture_lock_state.rs`** — `commit_claim` panics mid-flight via injected fault; lock released on rollback; no permanent deadlock.
+31. **`dos567_fixture_outbox_atomicity.rs`** — version row write succeeds but `version_events` insert fails via injected fault → mutation Tx rolls back; no version advancement observed; cursor in `mutation_attempts` is then resolved by post-rollback Tx 3 emitting `mutation_aborted` event.
+32. **`dos567_fixture_correction_ref_scope_leak.rs`** (V3 NEW per §16 + ac §37) — out-of-scope fetch by `event_log_id` returns redacted envelope; no claim body leaks. Asserts the substrate-side endpoint, not the DOS-589 dispatcher (which DOS-589 owns).
+32a. **`dos567_fixture_cursor_durability_panic.rs`** (V4 NEW per codex C3-1) — winner acquires lock, commits pre-mutation Tx 1 (cursor reserved), then mutation Tx 2 panics via injected fault. Assertions: (i) `mutation_attempts.status = 'aborted'` after Drop/recovery; (ii) `version_events` row at the reserved cursor has `event_kind = 'mutation_aborted'`; (iii) a loser that received 423 with that cursor can deterministically observe the terminal event. Covers Drop path AND startup-recovery path (process-kill simulation).
+32b. **`dos567_fixture_fresh_insert_via_target.rs`** (V4 NEW per codex C3-2) — proposal with `ClaimMutationTarget::Insert { .. }` flows through `commit_claim` without version CAS; produces row with `claim_version = 1`; emits `claim.updated` with `previous_version: None`. Negative companion: proposal with `Mutate { expected_claim_version: 0, .. }` is rejected as `MissingExpectedClaimVersion` (0 is reserved for backfill, never legitimate CAS).
+32c. **`dos567_fixture_insert_dedup_race.rs`** (V5 NEW per codex C4-2) — two `tokio::test` spawned tasks submit `ClaimMutationTarget::Insert` proposals with the same `(subject_ref, claim_type, dedup_key)` triple concurrently. Assertions: (i) exactly one produces `CommittedClaim::Inserted`; (ii) exactly one produces `CommittedClaim::Reinforced` (corroboration on dedup-key collision); (iii) zero duplicate rows in `intelligence_claims`; (iv) both emit `version_events` rows with distinct `event_seq` and `cursor` values. Exercises the canonical commit/dedup-lock path at `claims.rs:5286-5314` under V5 §13's Insert variant.
+
+### CI invariants
+
+33. **`tests/version_assignment_gate.rs`** (V3 — replaces `src-tauri/scripts/check_version_assignments.rs` fiction): integration test using `syn` crate (already a transitive dep via `serde_derive`). Walks every `.rs` file under `src-tauri/src/` and `src-tauri/abilities-runtime/src/`; fails the build if any assignment expression to a field named `claim_version` or `composition_version` exists outside the allowlist (`services/claims.rs` for `claim_version`; `commit_composition` module for `composition_version`). Lives in `tests/` not `scripts/`. **No fictional "v1.4.0 precedent" claim — this is the first AST-based CI gate in the substrate.**
+34. **`AuditFields.detail` schema pin** — every W4-B audit record carries:
+
+```jsonc
+{
+  "claim_id": "<string | null>",
+  "composition_id": "<string | null>",
+  "expected_version": <u64 | null>,
+  "current_version": <u64 | null>,
+  "rejection_reason": "stale_watermark" | "stale_composition_watermark" | "mid_flight_mutation" | "missing_expected_claim_version" | "inflated_version_rejected" | "claim_version_overflow" | "composition_version_overflow" | "claim_version_backfill" | "composition_version_bootstrap",
+  "ability_ref": "<string | null>",
+  "invocation_id": "<uuid | null>",
+  "scope_redacted": <bool>
+}
+```
+`wp_user_id` + `actor_scopes` via `emit_surface_audit`. No PII in `detail`.
+
+35. `cargo clippy -D warnings && cargo test && pnpm tsc --noEmit` green.
+
+36. **`dailyos doctor` claim/composition watermark consistency** — new diagnostic subcommand:
+    - Walks `intelligence_claims`, asserts every `claim_version >= 1`.
+    - Walks `composition_versions`, asserts every `composition_version >= 1`.
+    - Walks `mutation_attempts WHERE status = 'in_flight'`, flags entries older than 60s as zombie attempts (startup recovery should have aborted them).
+    - Verifies outbox integrity: every `intelligence_claims.claim_version` change has a corresponding `version_events` row with matching `cursor` and an entry in `mutation_attempts` with `status IN ('committed', 'aborted')`.
+
+### V3 NEW acceptance items
+
+37. **`CorrectionRef` event-log fetch endpoint** at `GET /v1/surface/event-log/{event_log_id}` is scope-filtered identically to §2's inline 409 projection. Substrate-side endpoint owned by W4-B; DOS-589's dispatcher routes via this endpoint. Out-of-scope requesters get redacted envelope or 404. Fixture §32 asserts. **Endpoint owner module (V8 promoted from path-α):** `src-tauri/src/bridges/surface_client.rs` is the canonical SurfaceClient route module. All `/v1/surface/*` endpoints (this one, W4-C keyring at `/v1/surface/keyring`, W4-E nonce at `/v1/surface/nonce/{issue,verify}`, W5-A feedback at `/v1/surface/feedback`, DOS-589 dispatcher routes) land in this module. W4-B's first commit creates the module skeleton + the `validate_session_bound_wp_user_id` precondition helper (per §17); downstream waves register their routes inside it.
+
+38. **`BridgeSurfaceError` variant precedence table (§6.5)** enforced at bridge entry point via top-down evaluation (NOT a single `match` on a discriminant — the variants represent independent conditions that may all be true; evaluation walks them in precedence order and returns the first match). Integration test (`tests/dos567_fixture_variant_precedence.rs`) exercises each pairwise precedence case (e.g., `expected: None` + mid-flight → 400, not 423).
+
+### V4 NEW acceptance items
+
+39. **`mutation_attempts` table + three-Tx cursor protocol per §7.** Pre-mutation Tx commits cursor reservation BEFORE lock exposure. Mutation Tx attaches event to reserved cursor. Post-rollback Tx 3 (driven by `Drop` impl OR startup recovery scan for stuck `in_flight` > 30s) emits `mutation_aborted` at the reserved cursor. Cursor durability is independent of mutation outcome.
+
+40. **`ClaimMutationTarget::{Insert, Mutate}` enum** is the contract surface of `MutatingProposal::target()`. `Insert` variant: skip version CAS, INSERT new row with `claim_version = 1`. `Mutate` variant: run CAS against `claim_id` row; `expected_claim_version = 0` is reserved for backfill and rejected as `MissingExpectedClaimVersion` if presented by a caller.
+
+41. **`version_events` dedicated outbox table per §15** with typed CHECK constraints ONLY on substrate-owned discriminants (`event_kind`, `scope_redacted`, `actor_kind`) and TEXT NULL for caller-controlled fields (`reason`, `claim_id`, `composition_id`). Substrate-owned values are inserted via Rust enum → canonical string mapping (Serde); caller-controlled values cannot trigger a CHECK violation that aborts the mutation transaction (closes cso Cycle 3 path-α guard).
+
+42. **`syn` dev-dependency** added to `src-tauri/Cargo.toml` `[dev-dependencies]`:
+```toml
+syn = { version = "2", features = ["full", "visit"] }
+```
+Required for ac §33's `tests/version_assignment_gate.rs` integration test to import `syn` directly (transitive dep via `serde_derive` is not callable from `tests/`).
+
+### V8 NEW acceptance items
+
+43. **`bridges/surface_client.rs` module + `validate_session_bound_wp_user_id` precondition (§17)** — W4-B's first commit creates `src-tauri/src/bridges/surface_client.rs` with the wp_user_id session-binding precondition helper. Helper traverses any request payload (serde-driven), collects all `wp_user_id` occurrences at any depth, compares each to `Actor::SurfaceClient.session.wp_user_id`. Mismatch → 403 `wrong_user` rejection + audit emission with `event_kind: "wrong_user_rejected"` before any further dispatch. CI invariant: grep gate fails any `/v1/surface/*` route handler that does not run through `validate_session_bound_wp_user_id` at entry.
+
+44. **Fixture `dos567_fixture_wrong_user_rejected.rs`** — paired SurfaceClient session bound to `wp_user_id = 100`. Submit signed request with body asserting `wp_user_id = 200`. Assertions: (i) endpoint returns HTTP 403 `wrong_user`; (ii) no claim read, no nonce issue, no scope check runs; (iii) audit row carries session-bound `wp_user_id = 100`, asserted `wp_user_id = 200`, surface_client_id; (iv) no audit row carries `wp_user_id = 200` (the forged value never enters the audit chain).
+
+### V9 NEW acceptance items
+
+45. **Fixture `dos567_fixture_precedence_tamper_over_stale.rs`** (V9 per W4-C coordination) — request carries tampered projection envelope (Ed25519 mismatch) AND stale `expected_claim_version`. Assertion: bridge returns `ProjectionTampered` (422), NOT `StaleVersion` (409). Audit emits `projection.tamper_detected`; no `claim.write_rejected`; no `correction.claim` in response body.
+
+46. **Fixture `dos567_fixture_precedence_rollback_over_stale.rs`** (V9 per W4-C coordination) — request carries valid signature but `signed_payload.composition_version = 5` while `ledger.composition_version = 12` (replayed older projection). Assertion: bridge returns `ProjectionVersionRollback` (422), NOT `StaleComposition` (409). Audit emits `projection.version_rollback_detected`; no `correction.claim`.
+
+## Interlocks with W4 stage-2 + downstream
+
+| Consumer | What it needs from W4-B (V3 contract) | Status after W4-B merge |
+|---|---|---|
+| **DOS-589 (signal dispatcher sibling)** | `version_events` rows (with `event_seq` AUTOINCREMENT + UUIDv4 `cursor`) written via outbox pattern; `ClaimVersionEvent` / `CompositionVersionEvent` payload schemas defined; replay clause `WHERE event_seq > ? ORDER BY event_seq`; cursor→event_seq lookup; `CorrectionRef` event-log endpoint live | All surfaces ready; DOS-589 implements pub/sub on top |
+| **W4-A0 (DOS-568, producer)** | `ClaimRef::with_field()`; `commit_composition()` API; ability proposal carries `expected_composition_version`; `MutatingProposal` trait for mutating producers | All surfaces stable |
+| **W4-C (DOS-569, tamper)** | `(claim_id, claim_version, composition_id, composition_version)` quadruple; outbox events as cache-bust triggers; **signature-check-before-409 ordering acceptance**; **class-level scope-filter rule per §16** | W4-C signs against watermark; ordering + class-rule lifted into DOS-569 acceptance |
+| **W4-D (DOS-570, fallback)** | `Block.field_bindings` for derived/computed; `ClaimRef.field_path`; `BindingRole` drives admitted-field rules; **V8: canonical public API is `project_composition_for_surface(composition, ctx) → ProjectedComposition`** (composition-level, enforces unknown-block cap). Block-level helpers are internal. W4-A consumes only the composition-level surface. | Surfaces landed |
+| **W4-E (DOS-571, nonce)** | `composition_version` in nonce tuple; composition refresh invalidates nonces | Tuple ready; rule explicit |
+| **W4-A (DOS-572, renderer)** | Trust-band rendering on stale projection; 409 handling with scope-redacted fallback; `field_bindings` for layout | Renderer reads W4-C ledger; envelope locked |
+| **W5-A (DOS-573, feedback)** | `(claim_id, claim_version, field_path)` triple; refuse-to-route on `ComputedFrom`/`DisplayOnly`; 409 sync + DOS-589 push channel disambiguation; presence-nonce from W4-E; **class-level scope-filter rule per §16** | All surfaces ready |
+
+## What W4-B explicitly does NOT own (V3)
+
+- **Signal subscriber + scope-filter dispatcher + replay-from-cursor + backpressure** — DOS-589 sibling.
+- **Projection signing / Ed25519 / key lifecycle** — W4-C (DOS-569).
+- **Fallback projection rules for unknown blocks** — W4-D (DOS-570).
+- **User-presence nonce issue/verify** — W4-E (DOS-571).
+- **Gutenberg block rendering or save handler** — W4-A (DOS-572).
+- **WP-side feedback router** — W5-A (DOS-573).
+- **Out-of-band edit detection or quarantine** — W4-C.
+- **Multi-process runtime safety** — phase-deferred to v1.4.3+ when multi-process runtime lands (§7). Not W4-C tamper territory.
+- **Tight retry loops on 409/423** — W5-A consumes cursor + retry-after surfaces from DOS-589.
+- **WebSocket vs SSE transport for event push** — DOS-589 + deferred per artifact 02.
+- **Composition snapshot materialization in post meta** — deferred per artifact 02.
+- **Conflict panel rendering** — deferred per artifact 02.
+
+## Open questions
+
+All closed in V2/V3:
+
+| ID | Resolution |
+|---|---|
+| Q1 (migration slot) | v170 (V7 corrected from V6 v169 — v1.4.1 in-flight is using v169; v168 already merged on dev) |
+| Q2 (mid_flight_mutation scope) | W4-B owns variant + 423 + lock + cursor pre-allocation per §7 |
+| Q3 (conflict_detected vs write_rejected) | Emit both per §12 |
+| Q4 (backfill claim_version=1 vs 0) | 1 with one-shot audit per §11 |
+| Q5 (composition_versions table) | Required per §3+§8; durable; BEGIN IMMEDIATE |
+
+## Linear dependency edges
+
+- DOS-567 (W4-B) blocked by DOS-551 (W1-A) ✓ done.
+- DOS-567 (W4-B) blocked by DOS-556 (W1-E) ✓ done.
+- DOS-567 (W4-B) blocks DOS-568 (W4-A0).
+- DOS-567 (W4-B) blocks DOS-569 (W4-C). **Signature-check-before-409 ordering + class-level scope-filter rule per §16 inherited as acceptance.**
+- DOS-567 (W4-B) blocks DOS-570 (W4-D).
+- DOS-567 (W4-B) blocks DOS-571 (W4-E).
+- DOS-567 (W4-B) blocks DOS-572 (W4-A) — transitively.
+- DOS-567 (W4-B) blocks DOS-573 (W5-A). **Class-level scope-filter rule per §16 inherited.**
+- **DOS-567 (W4-B) blocks DOS-589** (signal dispatcher sibling — substrate row schema + outbox pattern must land first).
+- **DOS-589 blocks DOS-569 + DOS-572 + DOS-573** (delivery for signal consumers).
+
+## Path-α maintenance filings
+
+- **Multi-process framing (§7).** Filed to maintenance project (id `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`) per eng P2-NEW-1: rewrite §7 framing of multi-process safety from "W4-C tamper" to "phase-deferred concurrency to v1.4.3+ multi-process runtime work."
+
+## L0 reviewer panel — required runners
+
+- `/plan-eng-review`, `/cso`, `/codex challenge`, `/plan-devex-review`. Unanimous APPROVE for L0 closure.
+
+## Acceptance for L0 closure
+
+This packet is L0-approved when:
+
+1. eng + cso + devex + codex unanimous APPROVE on V4 (or successor cycle). Cycle 3 panel: eng + cso + devex APPROVE; codex BLOCK with 4 findings all V4-folded.
+2. DOS-567 issue description updated to reference this packet by URL for lifted criteria.
+3. Linear dependency edges added (especially DOS-569 + DOS-573 inheriting §16; DOS-589 substrate dependency).
+4. Class-level scope-filter rule comments posted on DOS-569 + DOS-573.
+5. Migration slot v170 confirmed.
+6. Reviewer findings folded into successive packet versions and dated.
+
+W4-B implementation may start as soon as L0 closes. Stage-2 fan-out (W4-A0 / W4-C / W4-D / W4-E) starts the moment W4-B merges. DOS-589 implementation may start as soon as W4-B substrate schema lands (row format + outbox guarantee).

--- a/.docs/plans/dos-546/v1.4.2-project/W4-C-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-C-L0-packet.md
@@ -1,0 +1,1058 @@
+# W4-C L0 packet - projection signing + offline tamper verification
+
+Date: 2026-05-13 (V3)
+Project: v1.4.2 - Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 4 stage-1 (gates W4-A renderer trust and W5 markdown projection)
+Issue: DOS-569 (W4-C: projection signing + offline tamper verification)
+Canonical Linear: https://linear.app/a8c/issue/DOS-569
+
+This packet captures the W4-C contract decisions resolved at L0.
+The Linear issue description remains the canonical execution contract.
+This packet supersedes it only where it makes explicit a decision the issue leaves open.
+
+## Changelog
+
+- **V3 (2026-05-13):** Cycle 2 reviewer fold. `/cso`, `/devex`, and Codex approved; eng conditional approval is closed by the W4-B V9 coordination amendment in commit `e8570cc4`.
+  - **Eng P1-N1 closed in §6, §18, §22:** W4-B V9 §6.5 has added precedence 0 `ProjectionTampered` and precedence 1 `ProjectionVersionRollback` ahead of the stale-watermark family; W4-B V9 ac §45/§46 add pairwise precedence fixtures for tamper-over-stale and rollback-over-stale.
+  - **Variant substrate contract pinned in §6 and §18:** W4-C implements `BridgeSurfaceError::ProjectionTampered` and `BridgeSurfaceError::ProjectionVersionRollback` with concrete field shapes, HTTP 422 mapping, quarantine linkage, and no `correction.claim`.
+  - **CSO path-alpha folded in §16:** W4-B owns the class-level scope-filter helper name; W4-C uses the published helper, with proposed symbol `bridge_scope_filter::filter_claim_bound_envelope`.
+  - **Eng P2/P3 cleanup folded in §8, §9, §12, §14, §21:** queued re-sign is committed v1.4.2 behavior, operator escalation is audit/CLI only with no UI, markdown sentinel parsing handles one UTF-8 BOM explicitly, and `keyring_version` bumps sweep verification-cache entries instead of waiting for lazy misses.
+  - **Devex P3 cleanup folded in §8, §10:** the signed payload hash includes the surface domain separator, and audit envelope raw `composition_id` exposure is an admin/debug branch only.
+- **V2 (2026-05-13):** Cycle 1 reviewer fold. Material changes:
+  - **Codex CRITICAL-1 folded in §3, §13, §14, §15, §18:** `SignedProjectionPayload` now excludes the detached signature envelope entirely. `key_id`, `signature_id`, `signed_at`, `alg`, `canonicalization`, and `signature_b64` live only in the envelope or ledger metadata. Replacement-key re-sign can keep canonical payload bytes unchanged because key/signature metadata is not signed.
+  - **Codex CRITICAL-2 folded in §4, §13, §14, §15, §18:** single-row `projection_ledger` signature columns replaced by stable projection ledger rows plus `projection_signatures` rows keyed by `signature_id`; `current_signature_id`, `signature_status`, `superseded_by_signature_id`, and one-active-signature uniqueness are now explicit.
+  - **CSO CRITICAL shadow-render folded in §2, §5, §18, §20:** Phase 1 shadow signing no longer allows trusted affordances. W4-A must visibly downgrade unless `projection_signature_enforcement = enforce`; mode changes emit `projection.enforcement_mode_changed`.
+  - **CSO CRITICAL quarantine DoS folded in §4, §9, §14, §17, §18, §19:** quarantine event writes coalesce per `projection_id` for 60 seconds, re-sign retries cap at 5 attempts, and workers stop looping when a projection is re-tampered within 120 seconds of the last re-sign.
+  - **Codex HIGH-3 folded in §4, §16, §18, §19:** multi-claim blocks now use `projection_ledger_block_refs` with per-ref scope metadata; mixed-scope multi-claim fixtures are required.
+  - **Codex HIGH-4 and CSO HIGH H2 folded in §5, §6, §12, §17, §18, §19:** valid old signed bytes are not trusted unless the ledger currentness check passes: live projection id, current signature id, non-tombstoned locator, and expected composition/claim watermark. Rollbacks raise `ProjectionVersionRollback` and quarantine.
+  - **Codex MEDIUM-5 folded in §8, §18, §19, §20:** verification hot path has bounded payload/block bytes, cache key `(canonical_signed_payload_sha256, signature_id, keyring_version)`, batch verification, and a worst-case render perf fixture.
+  - **CSO HIGH H1 folded in §2, §7, §18, §19:** private-key custody now requires macOS Keychain ACL scoped to the runtime binary, zeroize on secret-key paths where supported, rotation crash recovery, and atomic commit semantics across DB key status and Keychain writes.
+  - **CSO HIGH H3 folded in §10, §16, §18:** audit detail redacts or hashes claim/composition identifiers for non-admin or out-of-scope consumers and defines `scope_redacted`.
+  - **Eng P1-1 folded in §6, §18:** W4-C names `BridgeSurfaceError::ProjectionTampered` and places it in W4-B §6.5 precedence before stale-watermark correction.
+  - **Eng P1-2 folded in §1, §3, §18:** domain separators are surface-suffixed: `dailyos.wp_studio.projection.v1` and `dailyos.markdown.projection.v1`.
+  - **Devex P1-1 folded in §12, §18:** markdown projections use a file-head HTML sentinel comment carrying a base64url detached envelope.
+  - **W4-B V8 inheritance folded in §5, §11, §16, §18, §22:** all W4-C `/v1/surface/*` endpoints land in `src-tauri/src/bridges/surface_client.rs`, inherit `wp_user_id` session binding, and retain the W4-B class-level scope-filter rule.
+- **V1 (2026-05-13):** Initial W4-C L0 packet. Mirrors W4-B V7 section order and lifts W4-B load-bearing interlocks: signature verification precedes W4-B stale-write handling, direct-key reads remain scope-gated through `Actor::SurfaceClient`, and the watermark quadruple anchors the signed projection.
+
+## Status snapshot
+
+- W3 L0 packet closed the host-boundary posture for Studio and W3-A pinned the projection envelope.
+- W4-B V9 reserves the concurrency watermark contract, promotes `src-tauri/src/bridges/surface_client.rs` as the canonical `/v1/surface/*` route owner, lifts `wp_user_id` session binding into all SurfaceClient consumers, and amends §6.5 precedence for W4-C tamper/rollback before stale-watermark handling.
+- DOS-569 is blocked by W1-E, W2-C runtime anchor/pairing, and W4-B versions.
+- W4-A cannot render cached projections as trusted until W4-C lands offline verification.
+- W4-C is detection and quarantine, not bidirectional edit ingestion.
+- Markdown-as-input reconciliation remains v1.4.6 scope.
+
+## Pre-work confirmed
+
+**Headline finding:** W4-C adds new cryptographic signing substrate. The repository has keychain, audit, composition, provenance, SurfaceClient scope, and projection-status primitives, but no Ed25519 projection-signing implementation.
+
+| Surface | Confirmed substrate | W4-C decision |
+|---|---|---|
+| Crypto crate | `src-tauri/Cargo.toml` has `sha2`, `base64`, `rand`, `zeroize`, no `ed25519-dalek`, no `ring` | Add `ed25519-dalek` for Ed25519 sign/verify, `signature` traits as needed; no `ring` |
+| Existing signing | HMAC/provenance token patterns exist; updater uses Minisign externally; claims has semantic-signature naming only | Do not reuse HMAC or semantic signatures for projection authenticity |
+| Key storage | `LocalKeychain` uses macOS `security` CLI under service `com.dailyos.desktop.db`; connector token stores use same pattern | Store Ed25519 private keys in a new projection-signing keychain service/account namespace |
+| Audit | `emit_surface_audit` writes actor-kind, actor-instance, `wp_user_id`, and actor scopes for `Actor::SurfaceClient` | Tamper events route through this helper with a distinct event kind, not correction paths |
+| Composition | `CompositionMetadata.composition_version`, `ClaimRef.claim_version`, `ProvenanceRef`, `Block` exist | W4-C signs composition, block, claim refs, provenance ref, ordering, and W3-A envelope |
+| Projection status | `claim_projection_status` tracks derived projection failures, not authenticity | W4-C creates a dedicated projection ledger and quarantine state |
+| W3-A envelope | W3-A pins `dailyos_canonical_id`, `dailyos_signature`, `dailyos_source_runtime`, `dailyos_projection_version` | W4-C signs the payload fields derived from this envelope and stores signature metadata in the detached `dailyos_signature` envelope |
+| W4-A render path | W4-A consumes W4-C verification state before rendering cached bytes as trusted | W4-A renders degraded state on tamper/quarantine; it does not verify by network round trip |
+| W4-B mutation gate | W4-B owns versions and 409 stale-watermark path | W4-C verification runs before W4-B 409 handling |
+| Surface bridge owner | W4-B V8 promotes `src-tauri/src/bridges/surface_client.rs` | W4-C keyring, projection, ledger, and quarantine endpoints register in that module and inherit bridge preconditions |
+
+## Directional decisions resolved at L0
+
+### §1. Scope and outcome
+
+W4-C lands projection authenticity for WordPress DB projections and markdown filesystem projections.
+The runtime remains authoritative for claims, provenance, projection manifests, signatures, and reconciliation state.
+The runtime mutation path is the only path allowed to create a trusted projection signature.
+Out-of-band edits are detected, downgraded, quarantined, and audited.
+
+In scope:
+
+- Ed25519 signatures on every projection write.
+- RFC 8785 canonical JSON serialization of `SignedProjectionPayload`.
+- Surface-suffixed domain separators: `dailyos.wp_studio.projection.v1` and `dailyos.markdown.projection.v1`.
+- Runtime projection ledger with stable projection rows, detached signature rows, canonical signed bytes, and signature metadata.
+- Offline verification on projection read using local public keys.
+- Ledger currentness verification after cryptographic verification, so old valid signed bytes cannot be replayed as trusted.
+- Unknown-key refresh with exactly one keyring retry.
+- Key lifecycle: generation, rotation, retirement, revocation, replacement-key provisioning, queued re-sign, retired-key historical verification.
+- Quarantine state that preserves the observed tampered row or file bytes.
+- Quarantine coalescing and retry caps that keep byte-flip attacks from generating unbounded audit or queue volume.
+- Tamper-event audit emission distinct from correction events.
+- `GET /v1/surface/keyring` public-key distribution, scope-gated through `Actor::SurfaceClient`.
+
+Out of scope:
+
+- Gutenberg renderer implementation; W4-A consumes the verification result.
+- Automated repair UI; W4-C writes ledger/quarantine state and exposes audit/read endpoints.
+- Bidirectional markdown edit ingestion; v1.4.6 owns markdown-as-input.
+- New mutation authorization semantics; ADR-0102 trust rules still apply.
+- Treating a valid projection signature as permission to mutate canonical claims.
+
+Outcome:
+
+- A projection can be read without network access and classified as verified, pending, stale, tampered, unknown-key, revoked-key, or quarantined.
+- No tampered projection is silently promoted to substrate truth.
+- W4-A can render cached projection bytes only after W4-C verification succeeds or can render them visibly degraded when verification fails.
+
+### §2. Substrate reuse audit - Ed25519 crate selection, existing infra, keyring, envelope, renderer, gate
+
+**Crypto crate selection:** choose `ed25519-dalek`, not `ring`.
+
+| Candidate | Decision | Reason |
+|---|---|---|
+| `ed25519-dalek` | Selected | Direct Ed25519 API, RustCrypto `signature` traits, mature verification path, no algorithm negotiation pressure |
+| `ring` | Rejected for W4-C | Broader crypto surface than needed; less ergonomic key lifecycle and signature trait integration for this narrow contract |
+| HMAC | Rejected | W2 HMAC authenticates transport requests, not public offline projection verification |
+| RSA/ECDSA | Rejected | Linear DOS-569 and artifact 03 explicitly ban RSA, ECDSA, and algorithm negotiation |
+
+`ed25519-dalek` must be added to `src-tauri/Cargo.toml` when implementation starts.
+The current checkout does not include an Ed25519 crate.
+The implementation uses `zeroize` for in-memory private-key handling where supported and follows ADR-0092 operational hardening for key material custody.
+
+Existing signature-like code is not reusable as projection authenticity:
+
+- HMAC/provenance confirmation tokens prove a paired request, not a projection artifact.
+- Updater Minisign verification is a distribution concern, not runtime projection signing.
+- `compute_semantic_signature` in `services/claims.rs` is a dedup/canonicalization helper, not cryptography.
+- `sha2` remains useful for ledger hashes and observed/canonical excerpt hashes, not as a signature substitute.
+
+Keyring storage:
+
+- Private signing keys live only in the runtime keychain under a projection-specific service/account namespace.
+- The keychain item ACL is pinned to the signed DailyOS runtime binary, not a broad login-keychain read grant.
+- Rotation commits are atomic across `projection_signing_keys.key_status` and keychain writes: if either side fails, the transaction rolls back and startup recovery marks the key transition incomplete.
+- Secret-key material is zeroized on the Ed25519 secret-key path where the crate and platform APIs support it; public keys and signature bytes are not treated as secret.
+- The W4-C tables store `key_id`, public keys, statuses, validity windows, and audit metadata.
+- Public verification keys are not secret and may be distributed to WordPress and markdown projections.
+- `key_id` is runtime-generated opaque identity, not a filesystem path and not a Keychain label.
+
+W3-A envelope:
+
+- Every W3-A-authored storage row destined for W4-C signature carries `dailyos_canonical_id`, `dailyos_signature`, `dailyos_source_runtime`, and `dailyos_projection_version`.
+- `dailyos_signature` stores the detached signature envelope.
+- `dailyos_source_runtime` binds to the W2-C runtime anchor / runtime instance identity.
+- `dailyos_projection_version` is the projection-envelope version, distinct from W4-B `composition_version`.
+
+W4-A render path:
+
+- W4-A reads W4-C verification state and `projection_signature_enforcement` before rendering cached projection bytes as trusted.
+- W4-A may paint pixels optimistically, but it cannot show a trusted provenance affordance until verification succeeds and enforcement mode is `enforce`.
+- In `shadow` or `disabled`, verified bytes may be shown as content, but the trust affordance is visibly downgraded because the runtime is not enforcing signatures.
+- If verification fails, W4-A renders degraded trust-band state and points to the W4-C ledger/quarantine record.
+
+W4-B mutation gate:
+
+- W4-B owns claim/composition version assignment and stale-write rejection.
+- W4-C consumes the W4-B watermarks and runs before W4-B stale-write envelopes.
+- Tamper errors never become W4-B correction payloads.
+
+ADR anchors:
+
+- ADR-0083 governs user-facing tamper copy vocabulary.
+- ADR-0074 and ADR-0078 are substrate-reuse reminders: composition salience consumes existing retrieval, not a W4-C concern.
+- ADR-0092 governs local key custody posture.
+- ADR-0094 governs append-only audit hygiene.
+- ADR-0102 governs ability trust and SurfaceClient policy.
+- ADR-0105 and ADR-0108 govern provenance references and rendering caps.
+- ADR-0111 governs `Actor::SurfaceClient` scopes and audit identity.
+- ADR-0129 and ADR-0130 govern WordPress-as-surface and substrate-owned composition.
+
+### §3. Watermark contract anchoring
+
+W4-C signs the W4-B watermark quadruple:
+
+| Field | Source | Required in signed payload |
+|---|---|---|
+| `claim_id` | `ClaimRef.claim_id` / `intelligence_claims.id` | Yes |
+| `claim_version` | W4-B assigned claim version | Yes |
+| `composition_id` | `CompositionDocId` / projection metadata | Yes |
+| `composition_version` | W4-B assigned composition version | Yes |
+
+The quadruple anchors the signature to a specific claim snapshot inside a specific composition snapshot.
+Changing any one of the four values invalidates the signature.
+This includes ref/version swaps where visible text is unchanged.
+
+The W3-A envelope is split into signed projection payload and detached signature envelope:
+
+| Field family | Signing rule |
+|---|---|
+| `dailyos_canonical_id` | Included in `SignedProjectionPayload` as projection canonical identity |
+| `dailyos_source_runtime` | Included in `SignedProjectionPayload` as runtime anchor / source runtime binding |
+| `dailyos_projection_version` | Included in `SignedProjectionPayload` as projection envelope schema version |
+| `dailyos_signature` | Excluded from `SignedProjectionPayload` entirely; stored as detached envelope and ledger metadata |
+
+Payload-excludes-envelope rule:
+
+- `SignedProjectionPayload` contains the projection identity, runtime anchor, projection envelope version, surface target, composition watermark, block ordering, block payloads, claim refs, claim versions, field paths, and provenance refs.
+- `SignedProjectionPayload` does **not** contain `key_id`, `signature_id`, `signed_at`, `alg`, `canonicalization`, `signature_b64`, `keyring_version`, or any other detached signature envelope field.
+- `alg = Ed25519` and `canonicalization = RFC8785-JSON` are verified from the detached envelope and ledger metadata before running Ed25519 verification; they are not themselves part of the bytes signed by the key.
+- Replacement-key re-signing therefore produces a new `signature_id` and signature envelope over the same canonical payload bytes when canonical claim/projection state has not changed.
+- Envelope mutation outside `signature_b64` is rejected by envelope/ledger currentness checks, not by pretending those envelope bytes are inside `SignedProjectionPayload`.
+
+Linear DOS-569 adds the payload shape constraint:
+
+- Use `blocks[]` entries, not loose parallel arrays.
+- Each block entry includes `block_id`, `block_type`, `claim_refs[]`, `claim_versions[]`, `field_paths[]`, `provenance_ref`, canonical block payload, and order index.
+- The top-level payload includes composition id/version, projection target, runtime anchor, projection canonical identity, projection envelope version, surface-specific domain separator, and ordering.
+- Signature verification fails if block id, block type, claim ref, claim version, field path, provenance ref, composition version, projection target, runtime anchor, or ordering changes.
+
+Domain separator decision:
+
+- WordPress DB projections use `domain: "dailyos.wp_studio.projection.v1"`.
+- Markdown filesystem projections use `domain: "dailyos.markdown.projection.v1"`.
+- The domain separator is inside `SignedProjectionPayload` and is covered by Ed25519.
+- Surface-agnostic `dailyos.projection.v1` is rejected for v1.4.2 because a valid signed payload must not be copyable between WordPress block storage and markdown sentinel storage.
+
+Canonicalization:
+
+- Signed bytes are RFC 8785 canonical JSON serialization of `SignedProjectionPayload`.
+- JSON object key order is canonicalized; array order remains semantically meaningful and signed.
+- Timestamps, if present inside the projection payload, are serialized as RFC3339 UTC strings.
+- Binary fields inside the payload are base64url without padding.
+- The detached signature envelope is canonicalized separately for storage/transport stability, but those envelope bytes are not Ed25519-signed.
+
+### §4. Migration slot reservations
+
+W4-C has exactly four migration slots: v171 through v174.
+W4-B V8 carries the V7 slot correction: W4-B at v170 and W4-C at v171-v174.
+W4-C does not claim v175.
+
+| Slot | Migration name | Concrete schema |
+|---|---|---|
+| v171 | `171_w4c_projection_signing_keys.sql` | `projection_signing_keys`, `projection_key_status_events` |
+| v172 | `172_w4c_projection_ledger_signature.sql` | `projection_ledger`, `projection_signatures`, `projection_ledger_blocks`, `projection_ledger_block_refs` |
+| v173 | `173_w4c_projection_quarantine_state.sql` | `projection_quarantine`, `projection_ledger.quarantine_state`, quarantine indexes |
+| v174 | `174_w4c_replacement_key_provisioning.sql` | `projection_replacement_keys`, `projection_resign_queue`, retired/revoked key linkage |
+
+Concrete table and column allocation:
+
+| Slot | Table / alteration | Required columns |
+|---|---|---|
+| v171 | `projection_signing_keys` | `key_id` PK, `public_key_b64`, `key_status` (`active`/`rotating`/`retired`/`revoked`), `created_at`, `valid_from`, `valid_until`, `retired_at`, `revoked_at`, `replacement_key_id`, `keychain_service`, `keychain_account_ref` |
+| v171 | `projection_key_status_events` | `event_id` PK, `key_id`, `previous_status`, `next_status`, `reason`, `created_at`, `actor_kind` |
+| v172 | `projection_ledger` | `projection_id` PK, `surface`, `surface_locator`, `surface_locator_hash`, `locator_status` (`live`/`tombstoned`), `dailyos_canonical_id`, `dailyos_source_runtime`, `dailyos_projection_version`, `composition_id`, `composition_version`, `current_signature_id`, `canonical_signed_payload_sha256`, `claim_watermark_sha256`, `last_verified_at`, `verification_status` |
+| v172 | `projection_signatures` | `signature_id` PK, `projection_id` FK, `key_id` FK, `signature_status` (`active`/`superseded`/`revoked`/`retired`), `alg`, `canonicalization`, `canonical_signed_payload_bytes`, `canonical_signed_payload_sha256`, `signature_bytes`, `signature_envelope_b64url`, `issued_at`, `superseded_by_signature_id`, `revoked_at`, `retired_at` |
+| v172 | `projection_ledger_blocks` | `projection_id`, `block_id`, `block_order`, `block_type`, `block_payload_sha256` |
+| v172 | `projection_ledger_block_refs` | `projection_id`, `block_id`, `claim_ref_index`, `claim_id`, `claim_version`, `field_path`, `provenance_invocation_id`, `provenance_field_path`, `scope_grant_hash` |
+| v173 | `projection_ledger` alteration | `quarantine_state` with values `none`, `suspected`, `quarantined`, `resolved`; `last_quarantine_event_at`; `quarantine_event_count` |
+| v173 | `projection_quarantine` | `quarantine_id` PK, `projection_id`, `surface`, `surface_locator_hash`, `observed_payload_hash`, `observed_signature_b64`, `expected_signature_id`, `verification_error`, `field_pointer`, `byte_range_start`, `byte_range_end`, `sanitized_observed_excerpt_hash`, `detected_by`, `detected_at`, `last_seen_at`, `seen_count`, `coalesced_until`, `status` |
+| v174 | `projection_replacement_keys` | `replacement_id` PK, `old_key_id`, `new_key_id`, `reason`, `provisioned_at`, `activated_at`, `completed_at`, `recovery_status` |
+| v174 | `projection_resign_queue` | `queue_id` PK, `projection_id`, `old_signature_id`, `old_key_id`, `new_key_id`, `status`, `attempts`, `max_attempts`, `last_error`, `last_resign_at`, `last_retampered_at`, `operator_escalated_at`, `queued_at`, `updated_at` |
+
+Required constraints:
+
+- `projection_signatures.alg = 'Ed25519'`.
+- `projection_signatures.canonicalization = 'RFC8785-JSON'`.
+- `projection_ledger.surface IN ('wordpress_db', 'markdown_file')`.
+- `projection_ledger.locator_status IN ('live', 'tombstoned')`.
+- `projection_signing_keys.key_status IN ('active', 'rotating', 'retired', 'revoked')`.
+- `projection_signatures.signature_status IN ('active', 'superseded', 'revoked', 'retired')`.
+- `projection_resign_queue.status IN ('queued', 'in_progress', 'succeeded', 'failed', 'operator_escalation')`.
+- `projection_quarantine.status IN ('open', 'reprojected', 'dismissed', 'resolved')`.
+- `projection_resign_queue.max_attempts DEFAULT 5 CHECK (max_attempts BETWEEN 1 AND 10)`.
+- Partial unique index: exactly one `projection_signatures` row with `signature_status = 'active'` per live `projection_id`.
+- `projection_ledger.current_signature_id` must reference the active row for that `projection_id`.
+- `projection_signatures.superseded_by_signature_id` references a newer signature row when status is `superseded`.
+- `projection_ledger_block_refs` primary key is `(projection_id, block_id, claim_ref_index)` so multi-claim blocks are scope-filtered by every referenced claim, not by a scalar shortcut.
+
+### §5. Data flow
+
+Write path:
+
+1. Composition-producing ability returns `AbilityOutput<Composition>` per ADR-0102 and ADR-0130.
+2. W4-B assigns `claim_version` and `composition_version`.
+3. Projection writer builds the W3-A envelope.
+4. Projection writer constructs `SignedProjectionPayload`.
+5. Canonicalizer produces RFC 8785 JSON bytes.
+6. Runtime loads the active Ed25519 private key from keychain.
+7. Runtime signs canonical bytes and writes signature envelope.
+8. Runtime writes projection bytes, the stable `projection_ledger` row, the active `projection_signatures` row, and block/ref rows in the same projection transaction.
+9. Runtime emits audit `projection.signature_issued`.
+
+Surface route ownership and preconditions:
+
+- All W4-C `/v1/surface/*` endpoints land in `src-tauri/src/bridges/surface_client.rs`, the canonical module promoted by W4-B V8.
+- The bridge runs W4-B V8 `validate_session_bound_wp_user_id(actor, payload)` before keyring, projection, ledger, or quarantine logic.
+- Body/query/header supplied `wp_user_id` values are never trusted independently of the paired SurfaceClient session binding.
+- The route module then applies W4-B's class-level scope-filter helper before returning any claim-bound ledger, quarantine, or projection metadata.
+
+Read path:
+
+1. SurfaceClient parses the projection and extracts the detached `dailyos_signature` envelope.
+2. SurfaceClient reconstructs `SignedProjectionPayload` from block bytes and signed envelope-adjacent fields, excluding the detached signature envelope entirely.
+3. SurfaceClient locates `key_id` from the envelope in its cached keyring.
+4. SurfaceClient verifies envelope metadata (`alg`, `canonicalization`, runtime anchor, projection id) and then verifies Ed25519 signature against canonical payload bytes.
+5. SurfaceClient or runtime reconciliation checks ledger currentness before trusted render.
+6. Trusted rendering requires cryptographic verification success, currentness success, and `projection_signature_enforcement = enforce`.
+7. Verification or currentness failure marks it degraded, emits tamper audit, and writes/coalesces quarantine state.
+8. Runtime reconciliation compares observed bytes to `projection_ledger` and `projection_signatures`.
+
+Offline verification rule:
+
+- The normal verify path makes no network call.
+- The public key needed for verification must already be in the embedded/cached keyring.
+- Unknown-key refresh is the only allowed runtime fetch during verification and retries once.
+- If the refresh cannot run, the projection remains unverified, not trusted.
+
+Unknown-key path:
+
+1. Verifier sees unknown `key_id`.
+2. Verifier renders pending/unverified state.
+3. Verifier calls `GET /v1/surface/keyring` once through the paired SurfaceClient route.
+4. Verifier refreshes cache and retries verification once.
+5. If still unknown, it records `UnknownKeyAfterRefresh` and enqueues reconciliation.
+
+Currentness path:
+
+1. After Ed25519 succeeds, runtime compares the detached envelope's `signature_id` to `projection_ledger.current_signature_id`.
+2. Runtime verifies the `projection_id` exists, `locator_status = 'live'`, and the locator hash matches the current surface locator.
+3. Runtime compares `composition_id`, `composition_version`, and `claim_watermark_sha256` against the ledger's expected live watermark.
+4. Any mismatch is `ProjectionVersionRollback` if the bytes are validly signed but stale, replayed, restored from backup, imported by SQL, or resurrected after tombstone.
+5. `ProjectionVersionRollback` creates quarantine and cannot render trusted, even though Ed25519 verification succeeded.
+
+Quarantine path:
+
+1. Verification fails with mismatch, missing signature, revoked key, wrong runtime anchor, unsupported algorithm, unsupported canonicalization, unknown key after refresh, or currentness rollback.
+2. Runtime records or coalesces `projection_quarantine` preserving observed state hashes and locator hash.
+3. Runtime updates `projection_ledger.quarantine_state = 'quarantined'`.
+4. Runtime emits tamper audit, subject to the 60-second coalescing window.
+5. W4-A renders degraded state from ledger/quarantine.
+
+### §6. Out-of-band edits ordering - sig check BEFORE W4-B 409
+
+This is the load-bearing W4-C acceptance criterion.
+
+1. **W4-C signature check runs before W4-B 409 path** in the loopback endpoint.
+2. **Tamper error does NOT emit `correction.claim`.**
+3. A tampered projection is not a stale writer.
+4. A stale writer may be corrected only after the projection being used as the write basis verifies.
+5. Signature failure returns a tamper/degraded response and emits a tamper event, not `claim.write_rejected`.
+
+Ordering table, aligned with W4-B V9 §6.5 in commit `e8570cc4`. W2-C pairing, HMAC, and actor validity remain pre-dispatch bridge preconditions; the W4-B/W4-C variant precedence starts only after those checks pass.
+
+| Precedence | Check | Failure result | Emits `correction.claim` |
+|---|---|---|---|
+| Pre-dispatch | W2-C pairing / HMAC / actor validity | Auth/surface error | No |
+| 0 | W4-C projection signature verification fails | `BridgeSurfaceError::ProjectionTampered` / 422 / quarantine | No |
+| 1 | W4-C signed payload verifies but ledger currentness rolls back | `BridgeSurfaceError::ProjectionVersionRollback` / 422 / quarantine | No |
+| 2 | W4-B missing expected version | 400 | No |
+| 3 | W4-B mid-flight mutation | 423 | No |
+| 4 | W4-B overflow | 500 | No |
+| 5/6 | W4-B stale watermark | 409 stale envelope | Scope-filtered if permitted |
+
+Out-of-band edits include:
+
+- direct markdown edits inside DailyOS sentinels
+- direct WordPress DB row edits
+- WordPress admin UI edits of DailyOS-owned block attributes
+- plugin transforms that strip or modify signed fields
+- DB restore or SQL import
+- Studio `wp_cli` passthrough mutations
+- copied signatures between blocks
+
+The W4-B 409 path remains available for legitimate stale writes after authenticity and currentness are established.
+If authenticity is not established, there is no trustworthy basis for `correction.claim`.
+W4-B V9 §6.5 has added `BridgeSurfaceError::ProjectionTampered` and `BridgeSurfaceError::ProjectionVersionRollback` ahead of stale-watermark variants in commit `e8570cc4`; W4-B V9 ac §45 and §46 own pairwise precedence fixtures for tamper-over-stale and rollback-over-stale.
+
+W4-C-owned `BridgeSurfaceError` variants, substrate shape:
+
+```rust
+BridgeSurfaceError::ProjectionTampered {
+    projection_id: ProjectionId,
+    signature_id: SignatureId,
+    key_id: KeyId,
+    observed_signature_status: SignatureStatus,
+    quarantine_id: QuarantineId,
+}
+
+BridgeSurfaceError::ProjectionVersionRollback {
+    projection_id: ProjectionId,
+    signed_composition_version: u64,
+    ledger_composition_version: u64,
+    signed_claim_version: Option<u64>,
+    ledger_claim_version: Option<u64>,
+}
+```
+
+Variant rules:
+
+- Both variants are added to `src-tauri/src/bridges/types.rs` and map to HTTP 422 at the bridge boundary.
+- `ProjectionTampered` fires for signature verification failure, malformed or missing signature carrier, unsupported envelope/canonicalization, wrong runtime anchor, copied signature, or revoked-key verification failure.
+- `ProjectionVersionRollback` fires only after Ed25519 succeeds and the ledger currentness comparison proves the signed composition or claim watermark is older than live ledger state.
+- `signed_claim_version` and `ledger_claim_version` serialize as `u64` or `null`; `null` is allowed for composition-wide payloads without a scalar claim version.
+- Both variants must carry enough typed data to link the response, quarantine row, and audit event without stringly typed ids or raw claim bodies.
+- Neither variant emits `correction.claim`, `claim.write_rejected`, or W5 feedback/correction payloads.
+
+### §7. Key lifecycle state machine
+
+Key states:
+
+| State | Signs new projections | Verifies historical projections | Distributed in keyring | Notes |
+|---|---|---|---|---|
+| `active` | Yes | Yes | Yes | Exactly one active key signs normal writes |
+| `rotating` | Yes, bounded transition | Yes | Yes | Replacement has been provisioned; re-sign queue active |
+| `retired` | No | Yes | Yes | Historical verification only |
+| `revoked` | No | No trusted verification | Yes, status included | Key compromise or invalid custody |
+
+Valid transitions:
+
+| From | To | Trigger |
+|---|---|---|
+| none | `active` | First key generation |
+| `active` | `rotating` | Planned rotation begins |
+| `rotating` | `retired` | Re-sign queue completes |
+| `active` | `revoked` | Compromise, custody failure, or admin revocation |
+| `rotating` | `revoked` | Compromise during rotation |
+| `retired` | `revoked` | Historical key later declared compromised |
+| `revoked` | none | No transition out; revocation is terminal |
+
+Generation:
+
+- Runtime generates Ed25519 keypair using OS CSPRNG.
+- Private key is stored in runtime keychain with an ACL scoped to the signed DailyOS runtime binary.
+- Public key row is inserted into `projection_signing_keys`.
+- `key_id` is opaque and runtime-generated.
+- Secret-key buffers are zeroized on drop where supported by the selected Ed25519 crate and platform wrapper.
+- Audit emits `projection.key_generated`.
+
+Rotation:
+
+- Runtime provisions a replacement key.
+- Old active key becomes `rotating`.
+- New key becomes `active`.
+- Re-sign queue is populated for live projections.
+- Old key becomes `retired` after queued re-sign completes.
+- The status transaction and keychain write are crash-safe: startup recovery reconciles DB rows whose keychain item is missing, and keychain items whose DB transaction did not commit.
+- A failed or partial rotation leaves no trusted key in a split-brain state; verification downgrades until recovery resolves it.
+
+Revocation:
+
+- Runtime marks key `revoked`.
+- Any signature under that key fails trusted verification with `KeyRevoked`.
+- Replacement key is provisioned.
+- Live projections signed by the revoked key are queued for re-sign but render degraded until refreshed.
+
+Retirement:
+
+- Retired keys stay in the public keyring for historical verification.
+- Retired keys never sign new projections.
+- Removing retired keys from keyring is not allowed in v1.4.2.
+
+### §8. Unknown-key refresh
+
+Unknown key is not immediately tamper.
+It is an unverified state with a bounded refresh path.
+
+Algorithm:
+
+```rust
+fn verify_with_unknown_key_refresh(projection, keyring_cache) -> VerificationResult {
+    match verify_projection(projection, keyring_cache) {
+        Err(UnknownKey(key_id)) => {
+            refresh_keyring_once();
+            verify_projection(projection, keyring_cache)
+                .map_err(|err| err.with_refresh_attempted(true))
+        }
+        other => other,
+    }
+}
+```
+
+Rules:
+
+- Refresh happens at most once per projection verification attempt.
+- Retry happens immediately after successful keyring response.
+- If refresh fails, verifier returns `UnknownKeyRefreshFailed`.
+- If refresh succeeds but key remains absent, verifier returns `UnknownKeyAfterRefresh`.
+- Both outcomes render unverified and enqueue reconciliation.
+- Neither outcome emits `correction.claim`.
+
+Cache TTL:
+
+- WP plugin caches keyring for the paired session.
+- Runtime response carries `max_age_seconds`.
+- Default TTL is 300 seconds.
+- Unknown-key failure bypasses TTL and forces the single refresh.
+- Revocation status in a refreshed keyring overrides any cached active/retired state immediately.
+
+Backoff:
+
+- Unknown-key refresh uses the W2-D SurfaceClient read budget.
+- Repeated unknown-key failures for the same `key_id` are coalesced for 60 seconds per SurfaceClient instance.
+- Coalescing suppresses duplicate fetches, not verification failures.
+
+Read-path performance budget:
+
+- Canonical payload bytes are capped per projection and per block before verification; oversize projections return degraded `PayloadTooLarge` state and enqueue reconciliation.
+- Verification cache key is `(canonical_signed_payload_sha256, signature_id, keyring_version)`.
+- The surface `domain_separator` is inside `SignedProjectionPayload` and therefore inside `canonical_signed_payload_sha256`; the cache key does not need a separate domain-separator field.
+- Cache hits still run the ledger currentness check; cryptographic verification may be reused only for the exact payload hash, signature id, and keyring version.
+- When refreshed keyring state advances `keyring_version`, the verifier sweeps all cached cryptographic verification entries for older keyring versions. Lazy-on-miss eviction is rejected because revoked-key status must affect already warm render reads immediately after the keyring bump.
+- Batch verification groups projections by `key_id` and `keyring_version` for W4-A render sweeps.
+- Worst-case render acceptance must cover the largest allowed block count, maximum allowed canonical bytes, mixed scope refs, and a cold keyring cache.
+
+### §9. Quarantine semantics
+
+Quarantine preserves tampered state.
+It does not delete or overwrite the bad row or file.
+
+Quarantine writes:
+
+- `projection_ledger.quarantine_state = 'quarantined'`.
+- `projection_quarantine` row stores the locator, observed payload hash, observed signature, expected signature id, verification error, and safe diff pointers.
+- The WP row or markdown file remains in place until repair/reprojection.
+- If an auto-reproject follow-up later writes canonical bytes, it writes a new signature and leaves the quarantine record queryable.
+
+Do-not-overwrite and coalescing rule:
+
+- W4-C detection never overwrites the observed tampered bytes as part of the detection transaction.
+- Reprojection is a separate action with a separate audit event.
+- If the same tampered bytes are observed repeatedly, increment `seen_count` and update `last_seen_at`.
+- If observed bytes change within 60 seconds for the same `projection_id`, coalesce into the open quarantine row, increment `seen_count`, update `last_seen_at`, and append only hashed/sanitized diff pointers.
+- If observed bytes change after the 60-second coalescing window, create a new divergence revision under the same projection thread.
+- The audit writer emits at most one `projection.quarantined` event per `projection_id` per coalescing window and increments counters for suppressed duplicates.
+- This is the byte-flip DoS defense: an attacker cannot create unbounded quarantine revisions, audit rows, or re-sign queue entries by changing one byte repeatedly.
+
+Surface behavior:
+
+- W4-A reads W4-C ledger/quarantine state and degrades the trust band.
+- High-sensitivity blocks may collapse body content per ADR-0108 rendering policy.
+- Banner copy must follow ADR-0083 product vocabulary.
+- Internal key ids, raw signatures, and raw tampered sensitive text are not shown to unauthorized actors.
+
+Quarantine status values:
+
+| Status | Meaning |
+|---|---|
+| `open` | Tamper is active and unrepaired |
+| `reprojected` | Runtime wrote a fresh signed projection |
+| `dismissed` | Operator acknowledged without repair |
+| `resolved` | Subsequent verification succeeded and audit remains |
+
+Re-sign loop guard:
+
+- Re-sign queue rows default to `max_attempts = 5`.
+- After `max_attempts`, the queue row transitions to `operator_escalation`, quarantine remains `open`, and W4-A keeps degraded rendering.
+- Re-sign worker refuses to process a projection re-tampered within 120 seconds of `last_resign_at`.
+- A re-tampered projection updates `last_retampered_at` and waits for the cooldown instead of looping write/sign/write/sign.
+- Operator escalation is audited once per queue row, not once per retry.
+- Operator escalation is visible through audit/CLI inspection in v1.4.2; W4-C does not add a new UI surface for escalation state.
+
+### §10. Tamper-event audit envelope
+
+Tamper events are integrity events.
+They are distinct from correction events and do not flow through the W4-B 409 path.
+
+Event kinds:
+
+| Event kind | When |
+|---|---|
+| `projection.signature_issued` | Runtime signs a projection |
+| `projection.verify_succeeded` | Read verification succeeds |
+| `projection.tamper_detected` | Signature/canonicalization/runtime-anchor mismatch |
+| `projection.unknown_key_refresh` | Verifier refreshes keyring for unknown key |
+| `projection.key_revoked_detected` | Projection uses revoked key |
+| `projection.quarantined` | Quarantine row is created |
+| `projection.resign_queued` | Replacement-key flow queues projection |
+| `projection.resigned` | Re-sign writes a new signature |
+
+Audit detail shape:
+
+```jsonc
+{
+  "projection_id": "<string>",
+  "surface": "wordpress_db | markdown_file",
+  "surface_locator_hash": "<sha256>",
+  "dailyos_canonical_id": "<string>",
+  "composition_id_hash": "<sha256>",
+  "composition_id": "<admin-only raw id, omitted by default>",
+  "composition_version": 12,
+  "claim_id_hashes": ["<sha256 | admin-only raw ids>"],
+  "claim_versions": [7],
+  "signature_id": "<string | null>",
+  "key_id": "<string | null>",
+  "verification_error": "SignatureMismatch | MissingSignature | UnknownKeyAfterRefresh | KeyRevoked | WrongRuntimeAnchor | UnsupportedAlgorithm | UnsupportedCanonicalization | ProjectionIdentityMismatch",
+  "quarantine_id": "<string | null>",
+  "refresh_attempted": false,
+  "scope_redacted": false
+}
+```
+
+Audit hygiene:
+
+- Use `emit_surface_audit` for SurfaceClient-originated reads.
+- `wp_user_id` is required for `Actor::SurfaceClient`.
+- `actor_instance` and `actor_scopes` are derived from the actor variant.
+- Detail payload stores hashes and identifiers, not raw sensitive content.
+- Non-admin or out-of-scope consumers receive hashed `claim_id`, hashed `composition_id`, hashed locator, and `scope_redacted = true`.
+- `composition_id_hash` is the default audit field; admin/debug raw-id access is a separate scope-gated branch that may return `composition_id` to authorized operators only. Do not place raw composition ids under a `*_hash` key in default streams.
+- Admin/debug consumers may resolve raw ids through a separate scope-gated inspection path, not through default audit streams.
+- `scope_redacted = true` means at least one claim-bound field, locator, or excerpt was withheld because the actor lacked scope.
+- Audit category is `security` or `anomaly`; never `correction`.
+
+### §11. Keyring distribution endpoint
+
+Endpoint:
+
+`GET /v1/surface/keyring`
+
+Owner module:
+
+`src-tauri/src/bridges/surface_client.rs` owns this route per W4-B V8 §37. The same module owns W4-C projection, ledger, and quarantine read endpoints.
+
+Purpose:
+
+- Distribute public Ed25519 verification keys to paired SurfaceClients.
+- Support offline verification for normal reads.
+- Publish retired keys for historical verification.
+- Publish revoked key status so clients fail closed.
+
+Request:
+
+- Requires W2-C pairing and HMAC request authentication.
+- Requires `Actor::SurfaceClient { instance, scopes }`.
+- Runs W4-B V8 `wp_user_id` session binding before any keyring lookup when the request carries a user id.
+- Requires a read scope that permits projection verification for the requested surface.
+- Does not accept a bearer key id as authorization.
+
+Response:
+
+```jsonc
+{
+  "ok": true,
+  "runtime_anchor_id": "<runtime-anchor>",
+  "keyring_version": 14,
+  "max_age_seconds": 300,
+  "keys": [
+    {
+      "key_id": "dailyos-runtime-ed25519-2026-05",
+      "alg": "Ed25519",
+      "public_key_b64": "<base64url>",
+      "status": "active | rotating | retired | revoked",
+      "valid_from": "2026-05-13T00:00:00Z",
+      "valid_until": null,
+      "revoked_at": null,
+      "replacement_key_id": null
+    }
+  ]
+}
+```
+
+Scope gating:
+
+- The endpoint returns only keys reachable for the SurfaceClient's granted projection surfaces.
+- A WP SurfaceClient without markdown scope does not receive markdown-only runtime anchors if those become distinct.
+- If the request is out of scope, return a redacted envelope or 404; never leak claim-bound ledger content.
+- Key material is public, but endpoint existence, runtime anchors, and ledger associations still follow SurfaceClient scope rules.
+
+### §12. Studio wp_cli out-of-band surface
+
+W3 L0 V4 resolved the host-boundary posture:
+
+- Studio MCP and DailyOS plugin MCP are at different layers, not competing.
+- Studio's `wp_cli` and `site_import/export` tools can mutate the WP DB independently of DailyOS scope enforcement.
+- DailyOS treats those mutations as out-of-band edits.
+- They hit the W4-B watermark contract plus W4-C tamper detection.
+- They surface in trust-band rendering as degraded verification state.
+- They are never silently promoted to canonical substrate.
+
+W4-C handling:
+
+- A `studio mcp wp_cli` edit to a DailyOS-owned block invalidates the signature if signed fields change.
+- W4-C records the divergence in `projection_quarantine`.
+- W4-C emits `projection.tamper_detected` and `projection.quarantined`.
+- W4-A reads ledger/quarantine state and renders degraded trust.
+- W3-C audit can carry the host-side divergence signal, but W3-C does not own UI degradation.
+
+Developer experience:
+
+- Developers exercising Studio host-layer commands may see degraded verification states.
+- This is intentional detection behavior, not a W3-C bug.
+- A future surface affordance can support "this was my edit" attribution; v1.4.2 detects, records, and refuses silent promotion.
+
+Markdown signature carrier:
+
+- Markdown projections carry the detached signature envelope in a file-head HTML-style sentinel comment.
+- Format: `<!-- dailyos-signature: <base64url-no-padding-envelope-json> -->` as the first non-BOM bytes of the file.
+- Sentinel parsing strips exactly one UTF-8 BOM before checking the file-head signature comment; any other leading bytes, comments, whitespace, or duplicated sentinels degrade to malformed/missing signature and quarantine.
+- The base64url payload decodes to the detached envelope containing `signature_id`, `key_id`, `alg`, `canonicalization`, `signed_at`, `signature_b64`, `keyring_version`, `dailyos_source_runtime`, and `dailyos_projection_version`.
+- The sentinel is not part of `SignedProjectionPayload`; the payload is reconstructed from the markdown projection body plus signed metadata fields.
+- If the sentinel is missing, duplicated, not at file head, malformed, or claims an unsupported envelope version, verification returns degraded state and quarantine.
+- W5 markdown projection inherits this carrier; sidecar files are rejected for v1.4.2 because filesystem moves can separate content from signature metadata.
+
+Replay surfaces:
+
+- DB restore, SQL import, and markdown file restore can replay old bytes with a still-valid Ed25519 signature.
+- Those cases are caught by ledger currentness, not cryptography alone.
+- Fixtures must cover signed rollback, signed replay under a live locator, and tombstoned projection resurrection.
+
+### §13. Fixture C wiring
+
+Artifact 03 Fixture C is the W4-C key-compromise golden fixture.
+
+Setup:
+
+- Runtime has active key `dailyos-runtime-ed25519-2026-05`.
+- Runtime signs a WP projection and a markdown projection.
+- Ledger records stable projection rows and active `projection_signatures` rows for both projections.
+- Test marks the active key compromised in `projection_signing_keys`.
+
+Expected:
+
+- SurfaceClient treats signatures from the revoked key as verification failures with `KeyRevoked`.
+- Runtime revokes the entire pairing for that key id.
+- Runtime provisions a replacement Ed25519 key in the runtime keychain.
+- Runtime re-signs all live projections reachable from the projection ledger.
+- Re-signed projections keep the same canonical signed payload bytes unless canonical claim state has changed, because detached envelope fields are not signed payload fields.
+- Ledger records old signature ids as `revoked` or `superseded` and new signature ids as `active`; the stable `projection_ledger.current_signature_id` points at the new active row.
+- No projection signed by the revoked key renders as trusted after revocation.
+
+W4-C fixture implementation names:
+
+| Fixture | Assertion |
+|---|---|
+| `dos569_fixture_c_key_compromise.rs` | Full Fixture C flow |
+| `dos569_fixture_key_revoked_render.rs` | Revoked key fails read verification |
+| `dos569_fixture_replacement_resign_queue.rs` | Live projections are queued and re-signed |
+| `dos569_fixture_retired_key_history.rs` | Retired keys verify old bytes but cannot sign |
+
+Fixture C is the acceptance fixture for key revocation, replacement-key provisioning, queued re-sign, and revoked-key rendering.
+
+### §14. Replacement-key provisioning
+
+Replacement-key provisioning is queued, not synchronous.
+Artifact 03 leaves synchronous visible re-sign as an open question; DOS-569 commits v1.4.2 to queued re-sign with degraded render until refreshed.
+
+Flow:
+
+1. Active key is marked `revoked` or `rotating`.
+2. Runtime generates a replacement Ed25519 keypair.
+3. New key is written to keychain and `projection_signing_keys`.
+4. `projection_replacement_keys` records old/new relationship.
+5. Runtime walks `projection_ledger` joined to `projection_signatures` for live projections signed by old key.
+6. Runtime inserts `projection_resign_queue` rows with `max_attempts = 5`.
+7. Worker reuses canonical signed payload bytes from the active or last-valid signature row.
+8. Worker signs with new key and writes only the detached signature envelope to the WP block attribute or markdown sentinel unless canonical state changed.
+9. Worker inserts a new `projection_signatures` row, marks the old row `superseded` or `revoked`, updates `projection_ledger.current_signature_id`, and marks queue row `succeeded`.
+
+Rules:
+
+- Canonical payload bytes remain unchanged unless canonical claim state has changed.
+- Re-sign does not "fix" tampered observed bytes; it signs canonical runtime-authored bytes.
+- If projection storage write fails, queue row stays `failed` with `last_error`.
+- Failed re-sign does not remove quarantine or degraded rendering.
+- Replacement key activation is audited.
+- A projection re-tampered within 120 seconds of the last re-sign is not re-signed again until cooldown expires.
+- After `max_attempts`, the queue row transitions to `operator_escalation`; it does not loop indefinitely.
+
+Queue idempotency:
+
+- Unique key: `projection_id + old_signature_id + new_key_id`.
+- Retrying a failed row reuses the same queue row and increments `attempts`.
+- A projection that has already been re-signed with the new key is skipped.
+
+### §15. Retired-key historical verification
+
+Retired keys are verify-only.
+
+Historical verification rule:
+
+- `retired` keys remain published in `GET /v1/surface/keyring`.
+- A projection signed while the key was active verifies successfully if the key is now retired.
+- A retired key cannot sign new projections.
+- A retired key can later become revoked if compromise is discovered.
+- If a retired key becomes revoked, historical projections under that key become untrusted and render degraded.
+
+Ledger rule:
+
+- `projection_ledger.projection_id` remains stable for the live projection identity.
+- Historical signature rows live in `projection_signatures`; `signature_id` is the primary key for each signature instance.
+- Re-sign creates a new signature id, links it through `superseded_by_signature_id`, and updates `projection_ledger.current_signature_id`; it does not erase the old signature row.
+- Audit replay can verify historical bytes with retired public keys by loading the historical `projection_signatures` row.
+
+Validity windows:
+
+- `valid_from` and `valid_until` are used for audit and clock-skew diagnostics.
+- Verification does not trust the WP host clock.
+- Runtime compares `issued_at` against key validity using runtime clock.
+- Clock skew warnings do not convert a valid retired-key signature into tamper unless the issued timestamp is outside a credible runtime-issued window.
+
+### §16. Class-level scope-filter conformance
+
+W4-C conforms to the W4-B class-level scope-filter rule.
+This section is conformance, not a reference.
+
+Inherited rule:
+
+> Class-level acceptance criterion (W4-C, W5-A, and any future claim-bound consumer): every read endpoint that returns claim-bound content must route through the same `Actor::SurfaceClient { scopes }` projection pipeline. Direct-key fetches by `event_log_id`, `mutation_id`, `correction_id`, `projection_id`, `composition_id`, `claim_id`, or any other bearer pointer are equally scope-gated. Out-of-scope requesters receive a redacted envelope or 404; never a leaked claim body.
+
+W4-C endpoints and conformance:
+
+Path-alpha helper contract:
+
+- W4-B owns the published helper symbol for class-level scope filtering.
+- W4-C uses whatever helper W4-B publishes; it does not fork a W4-C-local filter.
+- Proposed W4-B-owned symbol name: `bridge_scope_filter::filter_claim_bound_envelope`.
+- W4-C direct-key, ledger, quarantine, and projection-state reads call that helper after resolving claim refs and before returning any claim-bound envelope.
+
+
+| Endpoint/read | Claim-bound? | Required conformance |
+|---|---|---|
+| `GET /v1/surface/keyring` | Indirectly, via runtime anchor and key status | Route through SurfaceClient; return scoped key set and no ledger bodies |
+| `GET /v1/surface/projections/{projection_id}` | Yes | Verify actor scopes against all claim refs before returning projection metadata |
+| `GET /v1/surface/projections/{projection_id}/ledger` | Yes | Return redacted ledger if scope misses any claim ref |
+| `GET /v1/surface/quarantine/{quarantine_id}` | Yes | Never return observed excerpts unless claim scope permits |
+| `GET /v1/surface/compositions/{composition_id}/verification` | Yes | Scope-gate by composition and contained claim refs |
+| `GET /v1/surface/claims/{claim_id}/projection-state` | Yes | Scope-gate by claim id and surface grants |
+
+Direct-key handling:
+
+- `projection_id` is not authorization.
+- `composition_id` is not authorization.
+- `claim_id` is not authorization.
+- `signature_id` is not authorization.
+- `quarantine_id` is not authorization.
+- `key_id` is not authorization.
+
+Projection read implementation rule:
+
+1. Parse actor as `Actor::SurfaceClient { instance, scopes }`.
+2. Resolve requested object to its claim refs without returning body.
+3. Evaluate scope permits for every claim-bound ref.
+4. If permitted, return full scoped projection/ledger/quarantine envelope.
+5. If not permitted, return redacted envelope or 404.
+6. Emit audit with `scope_redacted = true` when redacted.
+
+Keyring endpoint nuance:
+
+- Public keys are public cryptographic material, but the endpoint still exposes runtime anchor state, key lifecycle, and surface pairing posture.
+- It therefore uses SurfaceClient scope gating and audit.
+- It never returns private key material or keychain labels.
+
+Multi-claim block scope rule:
+
+- A block can cite multiple claims. `projection_ledger_blocks.claim_id` is therefore forbidden as a scalar authorization shortcut.
+- `projection_ledger_block_refs` is the only scope source for block-level claim refs.
+- A read is fully scoped only when the actor has scope for every ref row attached to every returned block.
+- If the actor has partial scope, return a redacted block envelope with `scope_redacted = true`; do not leak the unscoped claim body, field path, or raw provenance pointer.
+- Mixed-scope fixtures must include a single block with two claim refs where only one is in scope.
+
+W4-B V8 session-binding inheritance:
+
+- W4-C endpoints inherit the W4-B V8 class-level `wp_user_id` session-binding precondition.
+- If a W4-C request carries any asserted `wp_user_id`, the bridge compares it to the paired session's bound user before signature, currentness, scope, or keyring checks.
+- Mismatch returns 403 `wrong_user`, emits `wrong_user_rejected`, and does not look up ledger rows.
+
+### §17. Risks and edge cases
+
+| Risk | Decision / mitigation |
+|---|---|
+| Clock skew on key validity | Runtime clock is authoritative; WP clock is ignored for verification |
+| Concurrent rotation | `projection_signing_keys` transition transaction serializes active/rotating state |
+| Partial re-sign failure | Queue row remains `failed`; old projection remains degraded if revoked-key signed |
+| Envelope evolution | `dailyos_projection_version` is signed; version parser is explicit |
+| Empty projection | Sign canonical empty `blocks[]` payload |
+| Masked provenance | Masking renders as masked, not signature failure, per ADR-0108 |
+| Copied signature | Fails because `projection_id`, block id, claim refs, and ordering are signed |
+| Plugin JSON reorder | No failure if canonical DailyOS payload reconstructs identically |
+| Plugin strips signature | `MissingSignature`, quarantine, audit |
+| Unknown key while offline | Unverified state; no trusted render; refresh waits until available |
+| Revoked retired key | Historical verification fails after revocation |
+| Same bytes observed repeatedly | Increment `seen_count`; no duplicate quarantine spam |
+| Byte-flip quarantine DoS | Coalesce per `projection_id` for 60 seconds and cap re-sign retries |
+| DB restore signed rollback | Ed25519 may pass; ledger currentness returns `ProjectionVersionRollback` |
+| SQL import signed replay | Current signature id and claim watermark must match live ledger before trusted render |
+| Tombstoned projection resurrection | `locator_status = tombstoned` blocks trusted render and quarantines |
+| Keychain/DB split-brain | Startup recovery reconciles keychain item and `projection_signing_keys` status |
+| High-sensitivity tamper | W4-A may collapse body and show only degraded state |
+| Runtime anchor mismatch | Quarantine; do not trust WP-provided anchor |
+| Canonicalization bug | Property tests and golden vectors lock RFC 8785 output |
+
+### §18. Acceptance criteria
+
+1. **Every projection write is signed with Ed25519.** Fixture: `dos569_fixture_nominal_wp_projection.rs`.
+2. **No HMAC/RSA/ECDSA/algorithm negotiation is accepted for projection authenticity.** Fixture: `dos569_fixture_unsupported_alg.rs`.
+3. **Signed bytes use RFC 8785 canonical JSON and surface-suffixed domain separators.** WordPress uses `dailyos.wp_studio.projection.v1`; markdown uses `dailyos.markdown.projection.v1`. Fixture: `dos569_fixture_domain_separator.rs`.
+4. **`SignedProjectionPayload` excludes the detached signature envelope entirely.** `key_id`, `signature_id`, `signed_at`, `alg`, `canonicalization`, `signature_b64`, and `keyring_version` are envelope/ledger metadata only. Fixture: `dos569_fixture_payload_excludes_envelope.rs`.
+5. **Replacement-key re-sign over unchanged canonical state keeps `canonical_signed_payload_sha256` unchanged while producing a new `signature_id`.** Fixture: `dos569_fixture_resign_same_payload_new_signature.rs`.
+6. **The signed payload uses structured `blocks[]`, not loose parallel arrays.** Fixture: `dos569_fixture_block_ordering_mutation.rs`.
+7. **The W4-B quadruple `claim_id`, `claim_version`, `composition_id`, `composition_version` is signed.** Fixture: `dos569_fixture_ref_version_swap.rs`.
+8. **W3-A envelope fields `dailyos_canonical_id`, `dailyos_signature`, `dailyos_source_runtime`, `dailyos_projection_version` are honored with payload/envelope split semantics.** Fixture: `dos569_fixture_w3a_envelope.rs`.
+9. **Ledger schema preserves old and new signatures.** `projection_ledger` is stable by `projection_id`; `projection_signatures` is keyed by `signature_id`; only one active signature exists per live projection. Fixture: `dos569_fixture_signature_history_schema.rs`.
+10. **Currentness check gates trusted render after Ed25519 succeeds.** Fixture: `dos569_fixture_current_signature_required.rs`.
+11. **DB restore signed rollback returns `ProjectionVersionRollback` and quarantines.** Fixture: `dos569_fixture_db_restore_signed_rollback.rs`.
+12. **SQL import signed replay returns `ProjectionVersionRollback` and quarantines.** Fixture: `dos569_fixture_sql_import_signed_replay.rs`.
+13. **Tombstoned projection resurrection cannot render trusted.** Fixture: `dos569_fixture_tombstoned_projection_resurrection.rs`.
+14. **Offline verification succeeds with cached public key and no network call.** Fixture: `dos569_fixture_offline_verify_no_runtime.rs`.
+15. **Unknown key refresh calls keyring once and retries once.** Fixture: `dos569_fixture_unknown_key_refresh_once.rs`.
+16. **Unknown key after refresh renders unverified and enqueues reconciliation.** Fixture: `dos569_fixture_unknown_key_after_refresh.rs`.
+17. **Revoked key fails verification with `KeyRevoked`.** Fixture: `dos569_fixture_key_revoked_render.rs`.
+18. **Retired key verifies historical bytes but cannot sign new projections.** Fixture: `dos569_fixture_retired_key_history.rs`.
+19. **Private key storage is hardened.** Keychain ACL is scoped to runtime binary, secret-key path zeroizes where supported, and rotation crash recovery resolves DB/keychain split-brain. Fixtures: `dos569_fixture_keychain_acl.rs`, `dos569_fixture_rotation_crash_recovery.rs`.
+20. **Replacement-key provisioning queues all live projections signed by old key and caps retries.** Fixture: `dos569_fixture_replacement_resign_queue.rs`.
+21. **Fixture C key compromise flow passes end to end.** Fixture: `dos569_fixture_c_key_compromise.rs`.
+22. **Re-sign worker does not loop on re-tampered projections.** Fixture: `dos569_fixture_resign_retamper_cooldown.rs`.
+23. **Quarantine preserves tampered WP row or markdown bytes.** Fixture: `dos569_fixture_quarantine_preserves_observed.rs`.
+24. **Quarantine events coalesce per `projection_id` for 60 seconds.** Fixture: `dos569_fixture_quarantine_coalescing.rs`.
+25. **Tamper event audit is distinct from correction events.** Fixture: `dos569_fixture_tamper_not_correction.rs`.
+26. **Audit fields are hashed/redacted for out-of-scope consumers with `scope_redacted = true`.** Fixture: `dos569_fixture_audit_scope_redaction.rs`.
+27. **Signature and currentness checks run before W4-B 409 path.** Fixture: `dos569_fixture_tamper_before_409.rs`.
+28. **Tamper errors map to `BridgeSurfaceError::ProjectionTampered` and do not emit `correction.claim`.** Fixture: `dos569_fixture_no_correction_payload_on_tamper.rs`.
+29. **`GET /v1/surface/keyring` is SurfaceClient scope-gated and owned by `src-tauri/src/bridges/surface_client.rs`.** Fixture: `dos569_fixture_keyring_scope_gate.rs`.
+30. **W4-C routes inherit W4-B V8 `wp_user_id` session binding.** Fixture: `dos569_fixture_wrong_user_rejected.rs`.
+31. **Direct-key ledger/quarantine reads by `projection_id`, `composition_id`, `claim_id`, `signature_id`, or `quarantine_id` are scope-gated.** Fixture: `dos569_fixture_direct_key_scope_gate.rs`.
+32. **Multi-claim blocks scope-filter through `projection_ledger_block_refs`, including mixed-scope refs in the same block.** Fixture: `dos569_fixture_mixed_scope_multi_claim_block.rs`.
+33. **Studio `wp_cli` out-of-band edit lands in tamper ledger.** Fixture: `dos569_fixture_studio_wp_cli_tamper.rs`.
+34. **Markdown signature carrier is a file-head HTML sentinel comment with base64url detached envelope.** Fixture: `dos569_fixture_markdown_signature_sentinel.rs`.
+35. **Masked provenance remains a rendering mask, not a signature failure.** Fixture: `dos569_fixture_masked_provenance.rs`.
+36. **Canonicalization property tests reject unstable map ordering and preserve block array ordering.** Fixture: `dos569_property_canonicalization.rs`.
+37. **Verification hot path is bounded and cached by `(canonical_signed_payload_sha256, signature_id, keyring_version)`.** Fixture: `dos569_fixture_verification_perf_budget.rs`.
+38. **W4-A trusted affordance is gated on `projection_signature_enforcement = enforce`; shadow mode renders visibly unverified/degraded.** Fixture: `dos569_fixture_shadow_mode_downgrades_trust.rs`.
+39. **Enforcement mode changes emit `projection.enforcement_mode_changed`.** Fixture: `dos569_fixture_enforcement_mode_audit.rs`.
+40. **W4-C implements `BridgeSurfaceError::ProjectionTampered` substrate-side** with `projection_id`, `signature_id`, `key_id`, `observed_signature_status`, and `quarantine_id`; the variant maps to 422 and never carries `correction.claim`. Fixture: `dos569_fixture_projection_tampered_variant_shape.rs`.
+41. **W4-C implements `BridgeSurfaceError::ProjectionVersionRollback` substrate-side** with `projection_id`, `signed_composition_version`, `ledger_composition_version`, `signed_claim_version`, and `ledger_claim_version`; claim versions serialize as `u64` or `null`. Fixture: `dos569_fixture_projection_version_rollback_variant_shape.rs`.
+42. **W4-C defers pairwise stale precedence fixtures to W4-B V9 ac §45/§46** while still returning the typed W4-C variants that those fixtures assert. W4-C substrate fixtures cover variant construction, quarantine linkage, and audit payloads.
+
+### §19. Test plan
+
+Unit tests:
+
+- `projection_signing::signs_ed25519_and_verifies`.
+- `projection_signing::rejects_non_ed25519_alg`.
+- `projection_keyring::state_machine_valid_transitions`.
+- `projection_keyring::state_machine_rejects_revoked_to_active`.
+- `projection_canonical::rfc8785_golden_vectors`.
+- `projection_canonical::payload_excludes_detached_signature_envelope`.
+- `projection_quarantine::idempotency_key_coalesces_same_observed_hash`.
+- `projection_quarantine::coalesces_changed_bytes_within_window`.
+- `projection_currentness::rejects_current_signature_mismatch`.
+- `projection_currentness::returns_projection_version_rollback_variant_shape`.
+- `projection_currentness::rejects_tombstoned_locator`.
+- `projection_scope::direct_key_fetch_requires_surface_scope`.
+
+Integration tests:
+
+- WP projection write signs and inserts ledger plus signature rows.
+- Markdown projection write signs and inserts ledger plus signature rows.
+- Markdown projection writes file-head sentinel comment and no sidecar.
+- Read verification succeeds offline with cached keyring.
+- Unknown key triggers one refresh and one retry.
+- Tamper before stale write returns tamper, not W4-B 409.
+- W4-B V9 ac §45/§46 pairwise precedence fixtures pass against W4-C's typed tamper and rollback variants.
+- Revoked key triggers replacement-key provisioning and queued re-sign.
+- Re-sign retry cap transitions to operator escalation.
+- DB restore, SQL import, and tombstone resurrection fixtures all return `ProjectionVersionRollback`.
+- Studio `wp_cli` mutation is detected as out-of-band tamper.
+- Keyring endpoint is HMAC-gated, session-bound, and scope-gated.
+
+Fixture tests:
+
+- Artifact 03 Fixture A hostile markdown edit.
+- Artifact 03 Fixture B hostile WP DB row mutation.
+- Artifact 03 Fixture C signature key compromise simulation.
+- Artifact 03 Fixture D benign plugin row mutation.
+- Artifact 03 Fixture E signature copy between blocks.
+- DOS-569 nominal verification.
+- DOS-569 ordering mutation.
+- DOS-569 runtime anchor mismatch.
+- DOS-569 mixed-scope multi-claim block.
+- DOS-569 shadow-mode degraded render.
+- DOS-569 keychain ACL and rotation crash recovery.
+
+Property-based tests:
+
+- JSON object key ordering does not change canonical bytes.
+- Array ordering does change canonical bytes.
+- Equivalent numeric JSON forms canonicalize identically under RFC 8785 rules.
+- Random block permutations fail verification unless order is restored.
+- Detached signature envelope mutation outside `signature_b64` fails envelope/ledger currentness checks even when payload hash is unchanged.
+- Claim ref/version pair swaps fail verification even if visible text is unchanged.
+
+CI gates:
+
+- Grep gate forbids projection authenticity code from using HMAC signing helpers.
+- Grep gate forbids private key serialization into WP options/postmeta/block JSON.
+- AST or grep gate requires all projection ledger direct-key endpoints call W4-B's published scope-filter helper, proposed as `bridge_scope_filter::filter_claim_bound_envelope`.
+- AST or grep gate requires all W4-C `/v1/surface/*` routes live under `src-tauri/src/bridges/surface_client.rs` and run the W4-B V8 session-binding precondition.
+- Perf gate verifies worst-case render stays under the accepted verification budget with cold cache and then with cache hits.
+- Golden fixture files pin canonical bytes and signatures.
+
+### §20. Rollout
+
+Phase 1 - shadow signing:
+
+- Sign every projection write.
+- Store ledger and signature rows.
+- Run verification and currentness checks on read.
+- Do not block content render yet, but trusted provenance affordances are not allowed in shadow mode.
+- W4-A must mark shadow-mode projections visibly unverified/degraded even if Ed25519 succeeds.
+- Collect audit counts for missing signature, unknown key, canonicalization error, mismatch, and currentness rollback.
+- Emit `projection.enforcement_mode_changed` when entering or leaving shadow mode.
+
+Phase 2 - degraded rendering enforcement:
+
+- W4-A consumes verification result.
+- Verified and current projections render trusted provenance affordance only when enforcement mode is `enforce`.
+- Failed, stale, replayed, rollback, or shadow-mode projections render degraded trust-band state.
+- Quarantine rows are created for failures.
+- Tamper events are visible in audit.
+
+Phase 3 - replacement-key enforcement:
+
+- Enable revocation path.
+- Enable replacement-key provisioning.
+- Enable queued re-sign.
+- Keep retired-key historical verification enabled.
+
+Kill-switch:
+
+- Runtime flag: `projection_signature_enforcement = shadow | enforce | disabled`.
+- `shadow` means "measure and visibly downgrade," not "render trusted while measuring".
+- `disabled` is emergency only and still logs unsigned-projection reads.
+- Kill-switch does not allow tampered bytes to mutate canonical claims.
+- Kill-switch state is audited as `projection.enforcement_mode_changed`.
+
+Rollback:
+
+- Schema migrations are additive.
+- Existing projections can render degraded if signatures are absent.
+- No canonical claim rows depend on W4-C tables for correctness.
+- Re-enabling enforcement reuses ledger rows where present and backfills signatures on next projection write.
+
+### §21. Open questions for L0 reviewers
+
+| ID | Question | Proposed L0 answer |
+|---|---|---|
+| Q1 | Is `ed25519-dalek` acceptable vs `ring`? | Yes; narrower Ed25519 API and better signature-trait fit |
+| Q2 | Should visible projections re-sign synchronously after revocation? | No. v1.4.2 commits queued re-sign with degraded render until refreshed; synchronous visible re-sign is out of scope |
+| Q3 | Should keyring route be public unauthenticated because keys are public? | No; key material is public, endpoint metadata is scope-gated |
+| Q4 | Should quarantine store raw observed text? | No by default; store hashes/sanitized excerpt hashes unless sensitivity policy permits |
+| Q5 | Should a retired key ever be removed from keyring? | No in v1.4.2; historical verification requires it |
+| Q6 | Should tamper emit correction events for feedback loops? | No; tamper is integrity, not correction |
+| Q7 | Should `dailyos_projection_version` equal `composition_version`? | No; projection envelope schema and composition watermark are distinct |
+| Q8 | Should offline verification require embedded public key per block? | No; cache/keyring supplies public key; signature envelope carries `key_id` |
+| Q9 | Should signature envelope metadata be included in signed bytes? | No; payload-excludes-envelope is the Phase 0 contract |
+| Q10 | Should markdown use sidecar signatures? | No; v1.4.2 uses a file-head HTML sentinel comment |
+
+### §22. Cross-wave dependencies
+
+| Consumer | W4-C provides | Dependency |
+|---|---|---|
+| W3-A plugin skeleton | Signed W3-A envelope semantics | W3-A pins envelope fields |
+| W3-C MCP server | Host-layer out-of-band mutations route to tamper ledger | Studio `wp_cli` is out-of-band |
+| W4-A0 producer | Projection writer signs substrate-authored compositions | W4-B watermarks must exist first |
+| W4-A renderer | Offline verification result, ledger currentness, quarantine state, and enforcement mode | W4-C must merge before trusted cached render; shadow mode downgrades trust |
+| W4-B concurrency | Signature check before 409, signed watermark quadruple, `BridgeSurfaceError::ProjectionTampered`, `BridgeSurfaceError::ProjectionVersionRollback`, route owner, scope-filter, and `wp_user_id` session binding | W4-B V9 §6.5 amendment in commit `e8570cc4` inherited; W4-B V9 ac §45/§46 test pairwise precedence |
+| DOS-589 signal dispatcher | Tamper/re-sign events may become subscriber inputs later | W4-C emits audit/ledger now; dispatcher integration can follow |
+| W4-D fallback | Unknown block fallback remains signed if payload is signed | W4-D must not render unsigned raw payload as trusted |
+| W4-E nonce | Feedback writes still require user-presence nonce | W4-C does not authorize mutations |
+| W5-A feedback | Tamper is not feedback/correction | Distinct event channel prevents correction pollution |
+| W5 markdown projection | Markdown signatures and comments use same ledger/keyring | Bidirectional markdown ingestion remains v1.4.6 |
+
+W4-C implementation may start when L0 closes and W4-B substrate watermarks are available.
+Stage-2 rendering cannot claim trusted cached projection support until W4-C verification is merged.

--- a/.docs/plans/dos-546/v1.4.2-project/W4-D-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-D-L0-packet.md
@@ -1,0 +1,918 @@
+# W4-D L0 packet — substrate fallback projection + edit-routing rules
+
+Date: 2026-05-13 (V3)
+Project: v1.4.2 — Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 4 stage-2 (gates W4-A renderer and W5-A feedback routing)
+Issue: DOS-570 (W4-D: substrate-side fallback projection + edit-routing rules)
+Depends on: DOS-556 (W1-E Composition types) + DOS-567 (W4-B V8 BindingRole contract)
+
+This packet captures the W4-D contract decisions resolved at L0. The Linear
+issue description remains the canonical execution contract; this packet
+supersedes it only where it makes explicit a decision the issue leaves open.
+
+## Changelog
+
+- **V3 (2026-05-13):** Cycle 2 conditional reviewer fold. Resolves codex
+  N1 by keeping the projector pure inside `abilities-runtime`: the public API
+  returns `(ProjectedComposition, Vec<AuditIntent>)`, and the app/service caller
+  drains those intents through `emit_surface_audit(...)`. Resolves codex N2 by
+  pinning `ProjectionDiagnostic` to the §9 field list, including
+  `composition_id`, `composition_version`, `original_type_id`, and `reason`.
+  Folds eng P3-new-1/P3-new-2 by closing `ProducerOutputInvalidReason` and
+  `EditRouteRefusalReason` as enums. Folds devex P3-DX-1 by expanding the
+  public re-export list, and removes the audit error variant because audit
+  failure is caller-owned after N1.
+- **V2 (2026-05-13):** Cycle 1 reviewer fold. Promotes
+  `project_composition_for_surface(...) -> ProjectedComposition` as the public
+  API, with block helpers internal and cap enforcement inside the composition
+  projector per W4-B V8. Adds DTO/module/registry pins, fail-closed
+  `unknown_role`, schema-field classification with `fallback_policy_version`,
+  exact audit detail schemas, SurfaceClient scope projection, hardened enum
+  widening, ComputedFrom/DisplayOnly scope gates, FeedbackTarget with 0 claim
+  refs behavior, and acceptance section 53 plus section 54 for sequencing and
+  asymmetric forward-compat. Notes W4-B §17/§37 endpoint inheritances have no
+  direct W4-D endpoint work.
+- **V1 (2026-05-13):** Initial L0 packet. Folds Linear DOS-570, W4-B V7
+  surfaces (`Block.field_bindings`, `BindingRole`, `ClaimRef.field_path`),
+  ADR-0130 §3 as amended by phase-0 artifact 07, and artifact 11 edit-routing
+  semantics. Resolves banner-copy precedence in favor of Linear's newer
+  product-facing copy: "Rendered as nearest known type — payload may be
+  incomplete." Selected type id remains available only in diagnostics/audit.
+
+## Status snapshot
+
+- W1-E landed the base `Composition`, `Block`, `ClaimRef`, `ProvenanceRef`, and
+  block fallback skeleton. W4-D consumes that shape; it does not re-author it.
+- W4-B V8 is the hard dependency. W4-D implementation starts after W4-B merges
+  or the branch is rebased onto W4-B's `FieldBinding` / `BindingRole` surfaces.
+- W4-D is pure substrate policy. It requires **no migration** and claims no
+  migration slot.
+- W4-A renderer may not infer fallback policy locally. It consumes W4-D's
+  substrate-published `ProjectedComposition` and edit-routing metadata.
+- W5-A feedback router may not guess from Gutenberg diffs. It consumes W4-D's
+  role-dispatched edit routes and refuses fields with no explicit receiver.
+- Linear DOS-570 acceptance is newer than ADR-0130's exact banner example. This
+  packet treats Linear's copy as canonical for v1.4.2.
+- W4-B V8 inherited interlock: composition-level projection is the only public
+  surface; block-level fallback helpers are private implementation details.
+- W4-B §17 `wp_user_id` session binding and §37 `surface_client.rs` endpoint
+  ownership are acknowledged inherited constraints. W4-D has no endpoints, so
+  it has no direct bridge route or session-binding implementation obligation.
+
+## Pre-work confirmed (substrate reuse audit)
+
+**Headline finding:** W4-D is not a greenfield renderer feature. The repository
+already contains a partial fallback projector in the composition substrate, but
+it lacks the W4-B role topology, sensitivity-aware admitted-field registry,
+audit/cap contract, and W5-A edit-routing metadata that DOS-570 requires.
+
+### Already in `src-tauri/abilities-runtime/src/abilities/composition.rs`
+
+- **`BlockType` taxonomy** exists with canonical variants:
+  `AccountOverview`, `ClaimSummary`, `EvidenceList`, `HealthSnapshot`,
+  `RelationshipMap`, `RiskCallout`, `ActionList`, `MarkdownDocument`, and
+  `Custom { type_id }`.
+- **`ClaimRef { claim_id, claim_version }`** exists and is preserved by the
+  fallback skeleton. W4-B adds `field_path`; W4-D must consume that field for
+  pointer-level attribution and edit routing.
+- **`ProvenanceRef { invocation_id, field_path }`** exists and validates
+  against the canonical provenance envelope. W4-D preserves it exactly; it does
+  not dereference it to reconstruct dropped fields.
+- **`Block { attributes, claim_refs, provenance }`** exists. W4-B adds
+  `field_bindings: Vec<FieldBinding>`; W4-D treats those bindings as the
+  routing authority.
+- **`project_to_nearest_known(...)`** exists with deterministic nearest-type
+  scoring and pointer reconstruction. W4-D must harden it into a published
+  policy surface: declared schemas only, sensitivity-aware admitted fields,
+  raw-payload exclusion across DOM/JS/logs, audit-intent generation, caller
+  emission, and cap handling.
+- **Current gap:** existing fallback banner includes the selected type id
+  (`Rendered as {selected_type_id} — payload may be incomplete`). DOS-570 pins
+  generic user-visible copy. W4-D must update the product-facing banner while
+  keeping selected type id in diagnostics.
+
+### Already in `src-tauri/abilities-runtime/src/sensitivity.rs`
+
+- **Render policy by sensitivity and surface** exists for `Public`, `Internal`,
+  `Confidential`, and `UserOnly`.
+- W4-D should reuse this policy path when deciding whether an admitted field is
+  renderable, redacted, or dropped for a `SurfaceClient`.
+- W4-D must not introduce a parallel sensitivity check or stringly typed copy of
+  the sensitivity ladder.
+
+### Already in W4-B V8 contract
+
+- **`Block.field_bindings: Vec<FieldBinding>`** is the substrate-published field
+  topology for a block.
+- **`BindingRole` enum** is:
+  `Source`, `ComputedFrom`, `DisplayOnly`, `FeedbackTarget`.
+- **`ClaimRef.field_path`** is optional on the claim ref but mandatory for
+  `Source` and `FeedbackTarget` bindings that address claim fields.
+- **`project_composition_for_surface(...)` interlock** is inherited from W4-B
+  V8: W4-D publishes a composition-level surface, enforces the unknown-block cap
+  inside that surface, and keeps block helpers internal.
+- **Class-level scope-filter rule from W4-B §16** applies to W4-D projection:
+  rendered content for `Actor::SurfaceClient` must be filtered through the same
+  requester scopes before it reaches W4-A, MCP, CLI, or Tauri surfaces.
+- W4-D is the primary first consumer of this V8 surface. If W4-B changes the
+  role enum or field names, W4-D packet V3 or its successor must fold that
+  before implementation.
+
+### Already in `src-tauri/src/audit_log.rs`
+
+- **`emit_surface_audit(...)`** exists and enforces `SurfaceClient` audit shape.
+- W4-D audit writes must go through service-layer code that calls the existing
+  audit helper. No command handler writes audit rows directly.
+
+## Directional decisions resolved at L0
+
+### §1. W4-D publishes policy; renderers consume projections
+
+W4-D's output is a substrate policy surface, not a WordPress-only helper.
+
+The implementation exposes one public Rust API that all surfaces call:
+
+```rust
+pub fn project_composition_for_surface(
+    composition: &Composition,
+    ctx: &FallbackProjectionContext,
+) -> Result<(ProjectedComposition, Vec<AuditIntent>), ProjectionError>;
+```
+
+The exact module name is implementation-owned, but the boundary is not:
+
+- input is a substrate `Composition` plus actor/surface context;
+- output is a projected composition DTO safe for a surface to render;
+- output carries per-block banner, trust-band cap, diagnostics, and edit routes;
+- output carries composition-level cap diagnostics and audit intents;
+- output never carries dropped raw values;
+- audit emission itself is not in `abilities-runtime`; callers in the app crate
+  emit returned intents through existing audit helpers.
+
+Block-level helpers such as `project_block_for_surface_internal(...)` may exist,
+but they are `pub(crate)` or private implementation details. They may not be the
+normative API, because the unknown-block cap is composition-level state. W4-A may
+adapt `ProjectedComposition` into Gutenberg render props. It may not call block
+helpers directly, recompute nearest type, count unknown blocks, enforce the cap,
+re-run sensitivity admissibility, or rebuild edit routing.
+
+### §1.1. DTO and module shape pinned for implementation
+
+W4-D lands in
+`src-tauri/abilities-runtime/src/abilities/fallback_projection.rs` unless the
+implementation proves a smaller diff by extending
+`src-tauri/abilities-runtime/src/abilities/composition.rs`. Either placement must
+re-export the public API through the existing abilities module path so consumers
+can import:
+
+```rust
+pub use abilities_runtime::abilities::{
+    project_composition_for_surface,
+    AuditIntent,
+    EditRoute,
+    FallbackProjectionContext,
+    ProjectionDiagnostic,
+    ProjectionError,
+    ProjectedComposition,
+};
+```
+
+The DTO shape is pinned at L0 so W4-A/W5-A do not invent parallel wire shapes:
+
+```rust
+pub struct ProjectedComposition {
+    pub composition_id: CompositionDocId,
+    pub composition_version: Option<u64>,
+    pub fallback_policy_version: u32,
+    pub blocks: Vec<ProjectedBlock>,
+    pub diagnostics: Vec<ProjectionDiagnostic>,
+    pub unknown_block_count: u32,
+    pub unknown_block_cap: u32,
+    pub dropped_unknown_block_count: u32,
+}
+
+pub struct ProjectedBlock {
+    pub block_id: BlockId,
+    pub block_index: u32,
+    pub original_type_id: String,
+    pub selected_known_type_id: String,
+    pub payload: serde_json::Value,
+    pub banner: Option<String>,
+    pub trust_band: TrustBand,
+    pub claim_refs: Vec<ClaimRef>,
+    pub provenance: Vec<ProvenanceRef>,
+    pub edit_routes: Vec<EditRoute>,
+    pub diagnostics: Vec<ProjectionDiagnostic>,
+}
+
+pub struct EditRoute {
+    pub field_path: FieldPath,
+    pub role: BindingRole,
+    pub claim_refs: Vec<ClaimRef>,
+    pub feedback_allowed: bool,
+    pub refusal_reason: Option<EditRouteRefusalReason>,
+}
+
+pub struct ProjectionDiagnostic {
+    pub diagnostic_kind: DiagnosticKind,
+    pub composition_id: CompositionId,
+    pub composition_version: u64,
+    pub original_type_id: Option<String>,
+    pub selected_known_type_id: Option<String>,
+    pub block_id: Option<BlockId>,
+    pub reason: DiagnosticReason,
+    pub dropped_pointer_count: u32,
+}
+
+pub struct AuditIntent {
+    pub event_kind: &'static str,
+    pub category: AuditCategory,
+    pub detail: serde_json::Value,
+}
+
+#[serde(rename_all = "snake_case")]
+pub enum AuditCategory {
+    Security,
+    DataAccess,
+    Ai,
+    Anomaly,
+    Config,
+    System,
+}
+
+pub struct FallbackProjectionContext {
+    pub actor: Actor,
+    pub surface: SurfaceKind,
+    pub fallback_policy_version: u32,
+    pub unknown_block_cap: u32,
+    pub include_non_sensitive_pointer_names: bool,
+}
+
+pub enum ProjectionError {
+    MissingRule { block_type: BlockType },
+    InvalidProducerOutput { reason: ProducerOutputInvalidReason },
+}
+
+#[serde(rename_all = "snake_case")]
+pub enum ProducerOutputInvalidReason {
+    SourceBindingMissingFieldPath,
+    FeedbackTargetMissingFieldPath,
+    BindingTargetsUnknownField,
+    UnknownRole,
+    AmbiguousReceiver,
+    ConflictingDuplicateBinding,
+    MissingDeclaredSchema,
+    InvalidFieldPath,
+    NonClaimFeedbackReceiverUnsupported,
+}
+
+#[serde(rename_all = "snake_case")]
+pub enum EditRouteRefusalReason {
+    Computed,
+    DisplayOnly,
+    SourceWithoutTarget,
+    MissingClaimRef,
+    AmbiguousReceiver,
+    SensitivityBlocked,
+    UnknownRole,
+    OutOfScope,
+    FallbackDegradedWithoutReceiver,
+}
+```
+
+`fallback_policy_version` is a `u32`. It changes when admitted fields, denied
+fields, widening rules, fallback banner policy, trust-cap behavior, or
+edit-route refusal semantics change. It does not change for runtime payload
+content.
+
+`ProjectionError` intentionally has no audit-wrapping variant. Audit
+errors are produced by the app/service caller while draining `AuditIntent`
+values, not by the pure projector in `abilities-runtime`. The runtime-owned
+`AuditCategory` maps one-to-one to the strings accepted by `AuditFields::new`
+(`security`, `data_access`, `ai`, `anomaly`, `config`, `system`).
+
+### §2. Migration footprint is none
+
+W4-D requires no table, column, trigger, or migration slot.
+
+All net-new durable behavior is expressed through:
+
+- Rust policy/registry code;
+- serialized projection DTOs returned to surfaces;
+- audit intents returned by the projector and emitted by callers through the existing audit log;
+- tests/fixtures that pin the projection contract.
+
+If implementation discovers a need for persisted registry rows, that is not
+DOS-570 as scoped. It requires a successor L0 packet because it would change the migration
+footprint and wave slot plan.
+
+### §3. Projection rule registry per known BlockType
+
+Every non-`Custom` `BlockType` must have one substrate `BlockProjectionRule`.
+The registry is closed over the enum; a CI/unit test fails when a new known
+variant lacks a rule.
+
+Each rule publishes the same information regardless of concrete struct shape:
+known field pointers, required/optional pointer sets, sensitivity tier, allowed
+surfaces, render annotations, default trust band, and `BindingRole`.
+
+Initial rule coverage required before W4-D can merge:
+
+| BlockType | Admitted field set requirement |
+|---|---|
+| `AccountOverview` | Account display fields, summary fields, health/risk/action list fields, relationship labels; no raw account JSON catch-all |
+| `ClaimSummary` | Claim title/body/status/as-of fields and field-level source/trust metadata |
+| `EvidenceList` | Evidence labels/source labels/source-as-of fields; source excerpts only if admitted and sensitivity-gated |
+| `HealthSnapshot` | Health band/score/rationale/trend fields |
+| `RelationshipMap` | Node labels/roles and edge labels; no hidden identifiers as display fields |
+| `RiskCallout` | Title/body/severity/recommended action fields |
+| `ActionList` | Item title/status/due-at/owner-label fields |
+| `MarkdownDocument` | Title/body/section heading/section body fields; no arbitrary JSON stringify fallback |
+| `dailyos/text` generic fallback | Empty payload only for unknown fallback; preserved refs/banner/trust cap |
+
+No rule may contain a wildcard that admits a whole object (`/*`) or an arbitrary
+unknown value. Array wildcards are allowed only for declared item schemas such as
+`/items/*/title`.
+
+The `BlockProjectionRule` registry lives beside the projector in
+`fallback_projection.rs`, or in `composition.rs` only if the implementation keeps
+the projector there. The implementation must choose one forward-compatible shape:
+
+- an exhaustive `match BlockType` returning static `BlockProjectionRule` const
+  data; or
+- a `OnceLock<HashMap<BlockType, BlockProjectionRule>>` with a startup-time
+  exhaustiveness assertion over every non-`Custom` variant.
+
+Schema-field classification is mandatory. Every known schema leaf is classified
+as `admitted` or `denied`; new leaves on an existing known schema default to
+`denied` until explicitly classified. Any admitted-field change bumps
+`fallback_policy_version`. Producer payload fields not in the admitted set for
+the running substrate version are dropped, audited as `unknown_admitted_field`,
+and never raw-rendered.
+
+### §4. BindingRole dispatch matrix
+
+W4-D dispatches on W4-B's V8 `BindingRole`. These roles are additive rows over
+field paths; a single field path may have more than one binding row when it both
+renders a source and exposes an explicit feedback receiver.
+
+| Role | Meaning | Render behavior | W5-A edit-route behavior |
+|---|---|---|---|
+| `Source` | 1:1 claim-to-field attribution | Render with provenance and trust band per ADR-0105/0108; preserve `claim_ref`, `claim_version`, and `field_path` | Not sufficient by itself for feedback. If no `FeedbackTarget` row also exists, W5-A refuses correction routing. |
+| `ComputedFrom` | N:M derived field computed from one or more claims | Render as computed/derived. Surface may show provenance summary, but the field is not a direct claim value. | W5-A MUST refuse feedback routing. User corrections need an explicit designed flow, not a guessed write to sources. |
+| `DisplayOnly` | Surface-local or layout/display field | Read-only render. No provenance/trust requirement unless separately present on a `Source` row. | No feedback target and no edit affordance. Edits stay local or are ignored by substrate routing. |
+| `FeedbackTarget` | Explicit feedback receiver for the field | Render may expose correction/dismiss affordance when nonce and surface rules allow. `claim_refs` length may be 0..N, but claim correction requires at least one receiver. | Only role W5-A can route as claim feedback. 0 refs means W5-A refuses claim correction unless a later explicit non-claim receiver exists. |
+
+**No role inference:** W5-A must not infer feedback eligibility from field names,
+Gutenberg attributes, or whether a value visually looks like a claim.
+
+**Unknown role fail-closed:** producer-output validation fails when a block
+contains an unknown or future `BindingRole`. If projection encounters one anyway
+from stale data or deserialization drift, the affected route is refused with
+`unknown_role`, a diagnostic is emitted, and `feedback_allowed` is never true.
+
+**Cross-claim scope gate:** `ComputedFrom` render requires requester scope to
+permit read access on every claim in `claim_refs`. If any source claim is
+out-of-scope, the field is dropped, not blanked and not redacted. `DisplayOnly`
+with non-empty `claim_refs` follows the same every-claim gate because its
+rendered value can still leak an aggregate signal.
+
+**FeedbackTarget with 0 claim_refs:** the field may render only as read-only
+content after normal scope/sensitivity gates. It publishes no claim correction
+route, sets `feedback_allowed = false`, uses refusal reason
+`missing_claim_ref`, emits a diagnostic, and exposes no nonce-consuming
+affordance unless a future explicit non-claim receiver type is added by a later
+packet.
+
+### §5. Unknown block fallback algorithm
+
+Unknown `BlockType::Custom { type_id }` degrades by deterministic, schema-bounded
+projection onto a known type.
+
+Inputs:
+
+- unknown block value;
+- declared schema for the unknown type, sourced from composition manifest,
+  block registry, or versioned schema bundle;
+- known-type projection registry;
+- actor/surface context.
+
+Hard rules:
+
+1. The selector uses declared schemas and metadata only.
+2. Runtime payload values are never used for type selection.
+3. Missing unknown schema is treated as empty schema.
+4. Empty schema or no eligible intersection renders generic `dailyos/text`.
+5. Projection happens at JSON Pointer granularity.
+6. Container objects are reconstructed only to hold admitted leaves.
+7. Sibling objects are never copied wholesale.
+8. Array projection rebuilds each item with only intersected item pointers.
+9. Scalar widening is allowed only for declared safe cases: integer to number,
+   and enum member to display string only when the value space is declared in
+   the known rule schema and that known rule marks it display text. Unknown
+   schemas cannot define an admissible enum member set.
+10. Object-to-string, array-to-string, arbitrary-JSON-to-string, and
+    number-to-date-string widening are forbidden.
+
+Nearest-type scoring follows artifact 07:
+
+| Score component | Weight |
+|---|---:|
+| `composition_kind` match | 100 |
+| compatible required pointer overlap | 10 per pointer |
+| compatible optional pointer overlap | 2 per pointer |
+| render annotation similarity | 0-20 |
+| namespace-prefix similarity | 0-5 |
+
+Tie-break order is total score, kind match, required overlap, optional overlap,
+annotation similarity, then lexicographically smaller type id.
+
+### §6. Raw-payload exclusion contract
+
+Dropped payload values must never appear in:
+
+- visible text;
+- `data-*` attributes;
+- hidden inputs;
+- tooltips;
+- Gutenberg block attributes;
+- HTML comments;
+- hydration state;
+- REST preload state;
+- serialized JS props;
+- inspector/debug panels;
+- console logs;
+- audit detail;
+- diagnostics;
+- snapshots written to post meta.
+
+The implementation should include a negative fixture with sentinel values in
+dropped fields and assert that the serialized projected result contains none of
+those sentinel strings.
+
+### §7. Banner contract
+
+Every fallback render carries a non-dismissible banner:
+
+```text
+Rendered as nearest known type — payload may be incomplete.
+```
+
+This is the DOS-570 product-facing copy. It intentionally does not expose:
+
+- original unknown type id;
+- selected known type id;
+- dropped pointer names;
+- sensitivity labels;
+- pipeline words such as enrichment, schema projection, substrate, or LLM.
+
+Selected known type remains in diagnostics and audit for support/QA. Any
+user-visible copy change requires product/design review before implementation.
+
+### §8. Trust/provenance behavior for fallback
+
+Fallback is a presentation degradation, not a claim rewrite.
+
+- `claim_refs` are preserved exactly.
+- `ProvenanceRef` is preserved exactly.
+- W4-D must not dereference either to reconstruct dropped payload fields.
+- The visible fallback block's trust band is capped at `needs_verification`.
+- Source-role fields that survive projection render with ADR-0105 source
+  attribution and ADR-0108 actor-filtered provenance treatment.
+- For `Actor::SurfaceClient`, `ProjectedBlock` content routes through W4-B §16
+  requester-scope projection before render. Out-of-scope fields are dropped by
+  the same path as sensitivity-blocked fields, with no placeholder text.
+- `ComputedFrom` and `DisplayOnly` fields with claim refs render only when the
+  requester can read every referenced claim. Partial visibility drops the field.
+- If provenance resolution fails, the block degrades visibly; it never renders
+  as fully trusted.
+- The preserved claim refs may still resolve to their real claim-level trust in
+  an "about this" affordance. The block itself remains visibly degraded.
+
+### §9. Diagnostics and audit intents
+
+Diagnostics default to counts, not names.
+
+`ProjectionDiagnostic` must include this field list verbatim:
+
+```rust
+pub struct ProjectionDiagnostic {
+    pub diagnostic_kind: DiagnosticKind,
+    pub composition_id: CompositionId,
+    pub composition_version: u64,
+    pub original_type_id: Option<String>,
+    pub selected_known_type_id: Option<String>,
+    pub block_id: Option<BlockId>,
+    pub reason: DiagnosticReason,
+    pub dropped_pointer_count: u32,
+}
+```
+
+`DiagnosticReason` is a closed enum, not a free-form string. It must cover the
+reasons emitted by this packet: `unknown_block_type`,
+`unknown_block_cap_exceeded`, `unknown_admitted_field`, `sensitivity_blocked`,
+`out_of_scope`, `unknown_role`, `missing_claim_ref`, `ambiguous_receiver`, and
+`fallback_degraded_without_receiver`.
+
+Diagnostics never include dropped pointer names or dropped values. Audit detail
+may record whether a policy would allow pointer names, but the V3 detail schemas
+below carry counts and a boolean only; adding actual names requires a later
+schema version and product/security review. Dropped values never appear.
+
+The projector returns `Vec<AuditIntent>` and does not call
+`emit_surface_audit(...)`. This keeps `abilities-runtime` independent from the
+app crate, where `src-tauri/src/audit_log.rs` lives. The caller, typically a
+service-layer composition/surface path or `src-tauri/src/bridges/surface_client.rs`,
+drains intents in stable order and calls `emit_surface_audit` once per intent.
+The actor variant passed to that helper must match the calling surface.
+SurfaceClient requires `wp_user_id`; audit emission fails if the actor lacks it.
+That failure is returned by the caller's operation, not by `ProjectionError`.
+
+Detail payloads exclude claim text, pointer values, source excerpts, customer
+names, emails, and all PII. The caller maps `AuditIntent.category` into
+`AuditFields::new(category, detail)` and attaches `wp_user_id` only for
+`Actor::SurfaceClient`. Command handlers do not write audit rows directly.
+
+`custom_block_fallback_applied` returns one `AuditIntent` per fallback block
+with this exact JSON detail schema. The old ambiguous `cap_applied` boolean is
+not emitted:
+
+```jsonc
+{
+  "schema_version": 1,
+  "composition_id": "string",
+  "composition_version": "u64|null",
+  "block_id": "string",
+  "block_index": "u32",
+  "original_type_id": "string",
+  "selected_known_type_id": "string",
+  "projected_pointer_count": "u32",
+  "dropped_pointer_count": "u32",
+  "pointer_names_included": "boolean",
+  "composition_cap_state": "within_cap|cap_exceeded",
+  "block_cap_action": "projected",
+  "fallback_policy_version": "u32"
+}
+```
+
+`custom_block_fallback_cap_exceeded` returns one `AuditIntent` per composition
+when the composition exceeded the cap. A block affected by that excess is
+represented by `block_cap_action`, not by overloading composition state:
+
+```jsonc
+{
+  "schema_version": 1,
+  "composition_id": "string",
+  "composition_version": "u64|null",
+  "unknown_block_count": "u32",
+  "unknown_block_cap": "u32",
+  "dropped_unknown_block_count": "u32",
+  "dropped_block_ids": ["string"],
+  "fallback_policy_version": "u32",
+  "reason": "unknown_block_cap_exceeded"
+}
+```
+
+### §10. Unknown-block cap
+
+Default cap: **5 unknown blocks per composition render**.
+
+The cap is enforced inside `project_composition_for_surface`. It is configurable
+through substrate configuration, not per surface. A composition dominated by
+unknown blocks is treated as a producer bug.
+
+Behavior:
+
+1. Walk blocks in stable composition order.
+2. Apply fallback to the first `N` unknown custom blocks.
+3. Drop excess unknown blocks from the rendered projection.
+4. Preserve no raw payload from dropped excess blocks.
+5. Return a `custom_block_fallback_cap_exceeded` `AuditIntent`.
+6. Surface diagnostic count to W4-A.
+
+W4-A may show a composition-level degraded-state notice using product-approved
+copy, but it may not reveal dropped block payload.
+
+### §11. Edit-routing metadata
+
+Every projected block carries edit routes derived from `field_bindings`: field
+path, role, claim refs, `feedback_allowed`, and a refusal reason when false.
+`feedback_allowed` is true only for `FeedbackTarget` rows with enough receiver
+information for W5-A's action. Refusal reasons use the closed
+`EditRouteRefusalReason` enum from §1.1: computed, display-only,
+source-without-target, missing claim ref, ambiguous receiver, sensitivity-blocked,
+unknown_role, out-of-scope, and fallback-degraded-without-receiver. Unknown or
+future roles are never converted into routable feedback.
+
+W4-D publishes these routes; W5-A enforces nonce, concurrency, save-time diff,
+and actual feedback application.
+
+## Acceptance criteria lifted into DOS-570 (V3)
+
+### Implementation
+
+1. **No migration.** W4-D ships pure substrate logic and tests; no schema
+   migration or slot reservation.
+2. **Every known `BlockType` has a `BlockProjectionRule`.** CI/unit test fails
+   for missing non-`Custom` variants.
+3. **Rules publish admitted JSON-pointer fields** with sensitivity tier and
+   allowed-surface metadata.
+4. **Rules publish edit-routing metadata** derived from W4-B `BindingRole`.
+5. **Unknown `BlockType::Custom` resolves by declared schema overlap and
+   nearest-known-type intersection.**
+6. **Selection uses declared schemas only, never runtime payload values.**
+7. **Projection copies only admitted intersected pointers.** No object/array
+   sibling copy-through.
+8. **Missing unknown schema renders generic `dailyos/text` with empty payload.**
+9. **No schema intersection renders generic `dailyos/text` with empty payload.**
+10. **Unknown-block payload fields are never rendered raw** in DOM, JS,
+    Gutenberg attributes, REST preload, tooltips, logs, diagnostics, or audit.
+11. **`claim_refs` are preserved exactly** for applied fallback blocks.
+12. **`ProvenanceRef` is preserved exactly** for applied fallback blocks.
+13. **Fallback MUST NOT dereference `claim_refs` or `ProvenanceRef`** to
+    reconstruct dropped payload fields.
+14. **Fallback banner renders with exact DOS-570 copy:** "Rendered as nearest
+    known type — payload may be incomplete."
+15. **Banner is non-dismissible** for v1.4.2.
+16. **Fallback trust band is capped at `needs_verification`.**
+17. **Source-role fields render with provenance and trust band** per
+    ADR-0105/0108 after sensitivity gating.
+18. **ComputedFrom fields render only after every-claim scope checks** and are
+    not feedback-routable.
+19. **DisplayOnly fields render read-only, expose no edit affordance, and with
+    non-empty claim refs pass the same every-claim scope gate as ComputedFrom.**
+20. **FeedbackTarget fields publish explicit feedback receivers** for W5-A only
+    when receiver metadata is present.
+21. **W5-A refuses feedback routing** for ComputedFrom, DisplayOnly, Source-only,
+    unknown_role, missing receiver, zero-ref receiver, or ambiguous receiver
+    routes.
+22. **Unknown-block count cap defaults to 5** and is enforced inside
+    `project_composition_for_surface`, not by W4-A orchestration.
+23. **Excess unknown blocks are dropped by the composition API** from rendered
+    projection after cap.
+24. **Projector returns `custom_block_fallback_applied` AuditIntent** once per
+    fallback block using the exact §9 detail schema; the caller emits it through
+    `emit_surface_audit(...)`.
+25. **Projector returns `custom_block_fallback_cap_exceeded` AuditIntent** once
+    per composition using the exact §9 detail schema when the composition
+    exceeds the cap; the caller emits it through `emit_surface_audit(...)`.
+26. **Diagnostics include counts by default.**
+27. **Dropped pointer names do not appear in V3 diagnostics**; future schemas
+    that add names require non-sensitive policy plus product/security review.
+28. **Dropped payload values never appear in diagnostics or audit.**
+29. **Projection result includes `fallback_policy_version: u32`** so render caches
+    can invalidate when fallback rules change.
+30. **W4-A renderer consumes `ProjectedComposition`** and has no independent
+    nearest-known, admitted-field, cap, or edit-route logic.
+31. **Future MCP/CLI/Tauri surfaces can call the same composition API.**
+32. **All audit writes flow through services/existing audit helpers**, not
+    command-handler DB writes; `abilities-runtime` only returns `AuditIntent`
+    values and contains no dependency on `src-tauri/src/audit_log.rs`.
+33. **No product-copy drift:** banner copy changes require product/design review.
+
+### Negative fixtures
+
+34. **`dos570_fixture_1_unknown_sensitive_payload_dropped.rs`** — unknown block
+    contains sentinel sensitive fields; rendered result, diagnostics, audit, and
+    serialized props contain none of the dropped values.
+35. **`dos570_fixture_2_refs_preserved.rs`** — fallback preserves `claim_refs`
+    and `ProvenanceRef` exactly while dropping non-admitted payload.
+36. **`dos570_fixture_3_no_schema_generic.rs`** — no unknown schema produces
+    generic `dailyos/text`, empty payload, banner, preserved refs.
+37. **`dos570_fixture_4_no_intersection_generic.rs`** — declared schema exists
+    but has zero eligible intersection; no invented text.
+38. **`dos570_fixture_5_array_projection.rs`** — `/items/*/title` projects but
+    `/items/*/private_note` does not.
+39. **`dos570_fixture_6_unsafe_widening_rejected.rs`** — object/array/arbitrary
+    JSON values never stringify into rendered text.
+40. **`dos570_fixture_7_cap_exceeded.rs`** — calling
+    `project_composition_for_surface` on 9 unknown blocks with cap 5 returns 5
+    fallback blocks, drops 4, and returns the cap `AuditIntent`; a caller-path
+    companion drains that intent through `emit_surface_audit` and verifies the
+    written audit record.
+41. **`dos570_fixture_8_diagnostics_redaction.rs`** — sensitive dropped pointer
+    names are omitted; counts remain; Actor SurfaceClient scopes drop
+    out-of-scope fields exactly like sensitivity-blocked fields.
+42. **`dos570_fixture_9_binding_role_matrix.rs`** — Source, ComputedFrom,
+    DisplayOnly, FeedbackTarget, and unknown/future-role fail-closed handling
+    dispatch exactly per §4.
+43. **`dos570_fixture_10_source_without_feedback_target_refused.rs`** — source
+    renders provenance/trust, but edit route refuses feedback.
+44. **`dos570_fixture_11_computed_from_refused.rs`** — N:M derived field renders
+    only when all source claims are in scope; W5-A fake router refuses correction.
+45. **`dos570_fixture_12_display_only_no_affordance.rs`** — display/layout field
+    with claim refs uses the same scope gate, renders read-only, and emits no
+    feedback route.
+46. **`dos570_fixture_13_feedback_target_routes.rs`** — explicit receiver
+    produces a routable edit route with claim id, claim version, and field path;
+    FeedbackTarget with 0 claim_refs is refused and exposes no nonce affordance.
+47. **`dos570_fixture_14_policy_version_cache_key.rs`** — changing rule version
+    changes projected cache key/signature input without changing claim state.
+
+### CI invariants
+
+48. **Known BlockType coverage gate:** every non-`Custom` enum variant has one
+    `BlockProjectionRule`.
+49. **No catch-all admitted field gate:** tests fail if a rule admits arbitrary
+    object payload or raw JSON stringify fallback.
+50. **Dropped-value absence gate:** sentinel fixture asserts projected DTO JSON
+    and `AuditIntent.detail` / emitted audit detail exclude dropped values.
+51. **Role-routing gate:** `ComputedFrom`, `DisplayOnly`, unknown_role, and
+    FeedbackTarget with 0 claim_refs cannot produce `feedback_allowed = true`.
+52. **L1 commands green:** `cargo clippy -- -D warnings && cargo test && pnpm
+    tsc --noEmit`.
+53. **W4-B sequencing gate:** section 53 requires the W4-D implementation branch
+    to declare a compile-time assertion that `BindingRole::FeedbackTarget` and
+    `Block.field_bindings` resolve before any W4-D projector file builds.
+54. **Asymmetric schema-evolution gate:** section 54 requires producer payload
+    fields not in the registered admitted set for the running substrate version
+    to be dropped, audited as `unknown_admitted_field`, and never raw-rendered.
+    Forward-compat is asymmetric: unknown input fields are safe to ignore, but
+    new admitted fields require classification and a `fallback_policy_version`
+    bump.
+55. **Surface scope projection gate:** ProjectedBlock content for
+    `Actor::SurfaceClient` routes through W4-B §16 scopes; out-of-scope fields
+    are dropped exactly as sensitivity-blocked fields.
+56. **Public re-export gate:** consumers can import `EditRoute`,
+    `ProjectionError`, `ProjectionDiagnostic`, and `AuditIntent` from the
+    existing abilities module path without reaching into private modules.
+57. **Invalid producer output gate:** `ProjectionError::InvalidProducerOutput`
+    carries only the closed `ProducerOutputInvalidReason` enum from §1.1; no
+    arbitrary string reasons or catch-all variants.
+58. **Audit boundary gate:** projection tests assert the projector returns
+    `AuditIntent` values, and caller-path tests assert services or
+    `surface_client.rs` are responsible for `emit_surface_audit(...)` failures.
+
+## Intelligence Loop fit
+
+### 1. Claim model
+
+W4-D does not introduce new claim tables or claim types. It consumes existing
+claim refs and W4-B field bindings. Source-role and FeedbackTarget fields are
+claim-bound with explicit `claim_id`, `claim_version`, and `field_path`; they are
+not ad-hoc display-only data.
+
+### 2. Provenance + trust
+
+Source fields render through ADR-0105/0108 provenance and trust-band rules.
+Fallback preserves `ProvenanceRef` and caps visible block trust at
+`needs_verification`. Sensitivity metadata on admitted fields participates in
+render/drop decisions.
+
+### 3. Signals + invalidation
+
+Fallback is read-side derived state and emits no claim-mutation signal. Render
+caches must key on `composition_version`, `block_registry_version`, and
+`fallback_policy_version`. Rule changes invalidate derived projections and W4-C
+signature inputs, but do not mutate underlying claims.
+
+### 4. Runtime + surfaces
+
+`project_composition_for_surface` is callable from W4-A WordPress, future
+MCP/CLI renderers, and Tauri surfaces. Surface behavior differs only in native
+paint; the `ProjectedComposition`, raw-payload exclusion, trust cap, scope
+projection, and edit routes are the same.
+
+### 5. Feedback loop
+
+User corrections, dismissals, corroborations, and contradictions flow only when
+W5-A receives an explicit `FeedbackTarget` route and a valid W4-E nonce. Feedback
+then mutates claim state through existing services. Fallback audit/cap intents
+are observability, not claim feedback.
+
+## Edge cases
+
+- Empty payload, missing schema, or no schema intersection: banner plus empty
+  generic payload; preserved refs; no invented text.
+- Schema has only sensitive fields: fields are dropped and diagnostics stay count-only.
+- Array field with mixed item shapes: rebuild only declared compatible item pointers.
+- Duplicate role rows are additive; duplicate FeedbackTarget rows are ambiguous
+  unless the normalized receiver set is identical.
+- FeedbackTarget with zero claim refs is not claim-correctable in v1 and exposes no nonce-consuming affordance.
+- Source binding without `ClaimRef.field_path` fails producer-output validation.
+- Provenance ref cannot resolve: show provenance-unavailable treatment; do not
+  synthesize provenance from payload.
+- Registry changes mid-render use one atomic snapshot for the full composition.
+- Custom type becoming known after upgrade uses the known rule on next render.
+- Cap excess blocks are dropped with an audit intent; no hidden payload placeholders.
+- Surface override of banner copy/admitted fields is a contract violation.
+
+## Rollout risks
+
+1. **Renderer-local drift.** W4-A may reimplement fallback in PHP. Mitigation:
+   renderer consumes `ProjectedComposition` and tests assert no raw-payload
+   branch.
+2. **Banner-copy split.** ADR example includes type id; Linear pins generic copy.
+   Mitigation: visible copy follows Linear; type id stays diagnostic-only.
+3. **Source vs feedback confusion.** Source is claim-bound but not necessarily
+   editable. Mitigation: only FeedbackTarget enables feedback route.
+4. **Sensitive diagnostics.** Pointer names can leak. Mitigation: counts by
+   default; names require explicit non-sensitive policy.
+5. **Permissive existing skeleton.** Mitigation: harden registry, sensitivity,
+   audit-intent, cap, and sentinel absence tests before merge.
+6. **Cache staleness.** Mitigation: include `fallback_policy_version` in cache
+   and signature inputs.
+
+## Interlocks with W4 stage-2 + downstream
+
+| Consumer | What it needs from W4-D | Status after W4-D merge |
+|---|---|---|
+| **W4-A renderer (DOS-572)** | Safe `ProjectedComposition`, exact banner, trust cap, no raw payload, edit routes for saved block attrs | Renderer can render unknown blocks without local policy |
+| **W5-A feedback (DOS-573)** | Role-dispatched edit routes, FeedbackTarget receiver metadata, refusal reasons | Save handler can route without guessing from Gutenberg diffs |
+| **W4-C tamper (DOS-569)** | Stable projected bytes and policy version for signature/cache inputs | Signature covers post-policy projection, not raw unknown payload |
+| **W4-E nonce (DOS-571)** | Field path and feedback action only for FeedbackTarget routes | Nonce binding stays claim-field precise |
+| **Future MCP/CLI/Tauri surfaces** | Same substrate projector and diagnostics | No surface-local privacy policy fork |
+
+## What W4-D explicitly does NOT own
+
+- **W4-B field topology.** `FieldBinding`, `BindingRole`, `ClaimRef.field_path`,
+  and version watermarks are W4-B. W4-D inherits the surfaces and compile-time
+  checks for their presence; it does not define them.
+- **W4-A rendering code.** Gutenberg PHP/JS consumes W4-D output.
+- **W5-A feedback application.** W4-D publishes routes; W5-A applies feedback.
+- **W4-C signatures/quarantine.** W4-D supplies projected bytes and policy
+  version; W4-C signs/verifies.
+- **W4-E nonce lifecycle.** W4-D marks eligible fields; W4-E binds user
+  presence to action/field/version.
+- **New persistent registry store.** Out of scope unless a successor L0 packet
+  approves a migration.
+- **Product redesign of fallback UX.** Exact copy is pinned; visual treatment is
+  W4-A/design unless copy changes.
+- **Surface endpoints.** W4-B §17 `wp_user_id` body/session binding and W4-B §37
+  `surface_client.rs` route placement apply to endpoint-owning work. W4-D owns no
+  `/v1/surface/*` endpoint and has no direct bridge obligation.
+
+## Open questions
+
+All resolved in V3 unless reviewers reopen:
+
+| ID | Resolution |
+|---|---|
+| Q1 (migration slot) | No migration; pure substrate logic |
+| Q2 (banner copy) | Linear DOS-570 generic product copy wins over ADR example with type id |
+| Q3 (unknown-block cap) | Default 5 per composition render; configurable substrate-side |
+| Q4 (pointer names in diagnostics) | V3 diagnostics are count-only; names require a later schema and review |
+| Q5 (Source editability) | Source renders provenance/trust; only FeedbackTarget routes feedback |
+| Q6 (0-ref FeedbackTarget) | Not claim-correctable in v1; W5-A refuses claim feedback |
+
+## Linear dependency edges
+
+- DOS-570 is blocked by DOS-556 (W1-E Composition types) — clear once W1-E is
+  merged in the implementation branch.
+- DOS-570 is blocked by DOS-567 (W4-B V8 field topology).
+- DOS-570 blocks DOS-572 (W4-A renderer).
+- DOS-570 blocks DOS-573 (W5-A feedback router).
+- DOS-570 is related to DOS-546 parent spike.
+- W0-A ADR-0130 amendment is a documentation dependency; implementation follows
+  the landed ADR/amendment plus this packet's Linear-copy resolution.
+
+## L0 reviewer panel — required runners
+
+- `/plan-eng-review` for architecture, rule registry, cache invalidation, and
+  W4-B/W4-A/W5-A interlocks.
+- `/cso` because this is a privacy/trust-boundary feature preventing raw payload
+  disclosure.
+- `/codex challenge` for adversarial review of projection leaks and role-routing
+  ambiguity.
+- `/plan-devex-review` because W4-D publishes a cross-surface API consumed by WP
+  and future MCP/CLI/Tauri surfaces.
+- `/plan-design-review` is conditional: required only if banner copy, visible
+  fallback treatment, or user-facing terminology changes from Linear DOS-570.
+
+Unanimous APPROVE from the required panel closes L0.
+
+## V2 to V3 reviewer fold record
+
+Cycle 2 status: eng, cso, and devex approved V2; codex returned conditional
+findings N1/N2 plus minor folds. V3 resolves those conditions in-place:
+
+- **Codex N1 HIGH:** The audit emission contract no longer requires
+  `abilities-runtime` to call `emit_surface_audit`. The projector returns
+  `Vec<AuditIntent>`; app/service callers emit through the existing helper.
+- **Codex N2 MEDIUM:** `ProjectionDiagnostic` now carries the composition and
+  original-type fields required by §9, with a closed `DiagnosticReason`.
+- **Eng P3-new-1:** `ProjectionError::InvalidProducerOutput` now carries a
+  closed `ProducerOutputInvalidReason` enum.
+- **Eng P3-new-2:** `EditRouteRefusalReason` is pinned in the DTO sketch.
+- **Devex P3-DX-1:** `EditRoute`, `ProjectionError`, `ProjectionDiagnostic`,
+  and `AuditIntent` are listed in the public re-export contract.
+- **Devex P3-DX-2:** The old audit error variant is removed; audit emission
+  failures belong to the caller path that drains intents.
+
+## Acceptance for L0 closure
+
+This packet is L0-approved when:
+
+1. eng + cso + devex APPROVE and codex conditional findings are folded into
+   V3 or a successor cycle.
+2. DOS-570 issue description links this packet as the lifted contract.
+3. Reviewers agree W4-D has no migration footprint.
+4. Reviewers agree banner visible copy follows Linear's generic sentence.
+5. Reviewers agree BindingRole dispatch matrix in §4 is the W5-A routing source.
+6. Reviewers agree unknown-block cap default is 5 and substrate-side.
+7. Reviewer findings are folded into successive packet versions and dated.
+
+W4-D implementation may start as soon as L0 closes and W4-B's V8 surfaces are
+available on the implementation branch. W4-A renderer starts only after W4-D
+merges, because W4-A acceptance consumes this substrate policy directly.

--- a/.docs/plans/dos-546/v1.4.2-project/W4-E-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W4-E-L0-packet.md
@@ -1,0 +1,991 @@
+# W4-E L0 packet - user-presence nonce lifecycle for feedback writes
+Date: 2026-05-13 (V2)
+Project: v1.4.2 - Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 4 stage-2 (after W4-B; before W5-A feedback routing)
+Issue: DOS-571 (W4-E: user-presence nonce lifecycle for feedback writes)
+Linear: https://linear.app/a8c/issue/DOS-571
+Working branch: dos-546-w4-e-l0-prep
+This packet captures the W4-E contract decisions resolved at L0. Linear remains the canonical execution contract. This packet supersedes it only where it makes an implicit decision explicit, or where it reconciles Linear, Phase 0 artifact 10, and W4-B V8.
+
+## Changelog
+
+- **V2 (2026-05-13):** Cycle 1 reviewer fold. eng CONDITIONAL APPROVE, /cso CONDITIONAL, /plan-devex-review CONDITIONAL, and /codex challenge CONDITIONAL findings are folded into the contract. Material changes: inherit W4-B V8 §17 `wp_user_id` session binding and §37 `src-tauri/src/bridges/surface_client.rs` route ownership; make `claim_version` mandatory in the nonce binding; pin immutable `PresenceNonceBinding` lifecycle transitions; pin HMAC-SHA256 digest derivation from service-local W2-B secret material; pin W2-D rate-limit keys and per-session outstanding nonce ceiling; require store-pressure LRU invalidation; serialize freshness checks with consume; require W5-A to carry nonce-bound expected versions into W4-B CAS; pin `tokio::sync::Mutex<HashMap<NonceDigest, PresenceNonceBinding>>` plus composition invalidation index; make lazy invalidation on verify the correctness boundary; require `Actor::SurfaceClient` for `/nonce/*`; add authenticated rejection audit shape; add v175 persistence restart-drain rule; add fixtures for immutability, malformed `claim_version`, rate exhaustion, store pressure, cross-actor calls, stale claim version, freshness/consume race, and restart replay.
+- **V1 (2026-05-13):** Initial L0 packet draft for DOS-571.
+## Status snapshot
+- Linear DOS-571 is Todo, High priority.
+- Linear scope: nonce issue/verify endpoints and WP-mediated nonce request path.
+- Linear dependency: blocked by DOS-567, DOS-557, DOS-558, DOS-559.
+- Linear downstream: blocks DOS-573.
+- W4-B V8 is the upstream composition/version and SurfaceClient bridge contract.
+- W4-B V8 reserves W4-E migration slot v175 only if persisted.
+- Local branch migration tail currently reaches v167.
+- W4-B V8 says dev has v168, v1.4.1 owns v169, W4-B owns v170.
+- W4-C owns v171-v174 by W4-B V8 recommendation.
+- W4-E must not use v168-v174 even if this temp branch does not show them.
+- Trust-boundary work: `/cso` is required at L0 and L2.
+- Cycle 1 panel: eng CONDITIONAL APPROVE; /cso CONDITIONAL with 3 CRITICAL, 3 HIGH, 3 MEDIUM, 3 LOW; /plan-devex-review CONDITIONAL; /codex challenge CONDITIONAL with 1 HIGH, 2 MEDIUM, 1 LOW.
+- V2 folds all named Cycle 1 findings into the packet and requires a Cycle 2 panel before L0 closure.
+- This packet does not implement code.
+- This packet does not commit.
+## Scope from DOS-571
+W4-E proves fresh human presence for feedback writes.
+W4-E ships:
+1. `POST /v1/surface/nonce/issue`.
+2. `POST /v1/surface/nonce/verify`.
+3. Single-use server-bound nonces.
+4. Binding to `session_id`.
+5. Binding to `wp_user_id`.
+6. Binding to `claim_id`.
+7. Binding to `field_path`.
+8. Binding to `action`.
+9. Binding to `composition_version`.
+10. Binding to `claim_version` when W4-B claim versions are available.
+11. Expiry at or below 60 seconds.
+12. Atomic consume.
+13. Audit emission on issue, verify, reject, invalidation.
+14. WP block-editor nonce request through WP REST and PHP.
+W4-E does not ship:
+1. Full W5-A feedback router.
+2. `/v1/surface/feedback` write semantics.
+3. Gutenberg re-render UI.
+4. W5-A version-changed re-confirm UX.
+5. W4-B `commit_composition`.
+6. W4-C projection signing.
+7. DOS-589 dispatcher.
+8. New claim feedback substrate.
+## Acceptance reconciliation
+There is a real contract conflict.
+Phase 0 artifact 10 says:
+- replay is `409`;
+- expiry is `410`;
+- wrong field/action are `409`;
+- wrong version is `409`.
+The v1.4.2 project issue slice says:
+- mismatched action is `403`;
+- wrong field is `403`;
+- expired is `403`;
+- already consumed is `403`.
+Linear DOS-571 says:
+- wrong version is `409`;
+- not generic authorization failure;
+- only when actor/session are otherwise valid.
+L0 decision:
+- Presence-token failures return `403`.
+- Stale claim or composition versions return `409`.
+- Malformed requests return `400`.
+- Auth failures return `401` or `403` before nonce lookup.
+- Rate limits return `429`.
+- Reason codes stay specific for W5-A UI.
+This preserves Linear's stale-version rule and the task's `403` nonce-failure rule.
+## Pre-work confirmed
+**Headline finding:** W4-E is a gate, not a new feedback path.
+It composes with:
+- W2-A loopback HTTP endpoint.
+- W2-B HMAC signing.
+- W2-C pairing/session.
+- W2-D rate-limit matrix.
+- W4-B composition and claim watermarks.
+- W5-A feedback router.
+- Existing claim feedback services.
+- Existing SurfaceClient audit helper.
+### Already in W4-B V8
+- **W4-B §1:** `ClaimRef.field_path` gives W4-E a canonical field target.
+- **W4-B §3:** `composition_version` is assigned by `commit_composition`.
+- **W4-B §3:** every accepted composition commit advances the version.
+- **W4-B §8:** `composition_versions` is durable.
+- **W4-B §8:** `commit_composition` uses `BEGIN IMMEDIATE`.
+- **W4-B §15:** `version_events` is the version-change outbox.
+- **W4-B §15:** replay ordering uses `event_seq`.
+- **W4-B §15:** cursor is UUIDv4.
+- **W4-B §17:** `validate_session_bound_wp_user_id(actor, payload)` is the inherited SurfaceClient bridge precondition for every request carrying `wp_user_id`.
+- **W4-B §17:** body/query/header asserted `wp_user_id` never becomes the trusted actor identity; mismatch returns `403 wrong_user` before downstream nonce code.
+- **W4-B §37:** `src-tauri/src/bridges/surface_client.rs` is the canonical owner for all `/v1/surface/*` endpoints.
+- **W4-B §37:** W4-E registers `/v1/surface/nonce/{issue,verify}` in that module and does not create a second SurfaceClient route owner.
+- **W4-B interlock row:** W4-E nonce tuple includes `composition_version`.
+- **W4-B §13 task note plus interlock row:** composition refresh invalidates nonces.
+- **W4-B interlock row:** W5-A consumes presence nonce.
+### Already in audit infrastructure
+- `AuditFields::new(category, detail)` exists.
+- `AuditFields::with_wp_user_id(wp_user_id)` exists.
+- `emit_surface_audit(logger, event_kind, actor, fields)` exists at line 203.
+- `Actor::SurfaceClient` audit requires `wp_user_id`.
+- `actor_instance` comes from the actor, not caller-controlled detail.
+- `actor_scopes` comes from the actor, not caller-controlled detail.
+- Tests already cover SurfaceClient audit write and missing `wp_user_id`.
+- W4-E nonce event is named in audit helper docs.
+### Already in feedback substrate
+- `FeedbackAction` is a closed typed enum.
+- `record_claim_feedback` is the service-layer feedback write entry.
+- `record_claim_feedback` persists `claim_feedback`.
+- `record_claim_feedback` applies lifecycle effects.
+- `record_claim_feedback` emits feedback signals.
+- W5-A calls this service after nonce verification.
+- W4-E does not call it during issue or verify.
+### Already in WP planning
+- `DailyOS_Runtime_Client` is the PHP runtime client surface.
+- WP executor verifies capability and pairing.
+- JS never receives bearer material.
+- JS never receives HMAC key material.
+- JS calls WP REST.
+- PHP calls Rust runtime.
+- Direct browser-to-runtime calls are out of scope.
+### Already in rate-limit planning
+- Artifact 09 places nonce validation inside `SurfaceClientBridge`.
+- Feedback writes consume SurfaceClient budget.
+- Feedback writes consume WP user budget.
+- Feedback writes consume WP site budget.
+- Feedback writes consume ability budget.
+- Feedback writes consume scope budget.
+- Nonce failures also count against nonce-failure budget.
+### Migration slot audit
+- Local branch: migration list reaches v167.
+- W4-B V8: v168 already merged on dev.
+- W4-B V8: v169 is v1.4.1 in-flight.
+- W4-B V8: W4-B owns v170.
+- W4-B V8: W4-C owns v171-v174.
+- W4-B V8: W4-E owns v175 if persisted.
+- Default W4-E storage is in-memory, so no migration.
+- Persistence requires v175 and packet revision.
+## What W4-E authors net-new
+| Surface | Status | Scope |
+|---|---|---|
+| `SurfaceNonceService` | Missing | issue, verify, consume, expire, invalidate |
+| In-memory nonce store | Missing | digest-keyed binding map |
+| Optional persisted nonce store | Conditional | v175 only |
+| `/v1/surface/nonce/issue` | Missing | runtime endpoint |
+| `/v1/surface/nonce/verify` | Missing | runtime endpoint |
+| `src-tauri/src/bridges/surface_client.rs` route registration | Inherited from W4-B §37 | register nonce endpoints in canonical SurfaceClient module |
+| `validate_session_bound_wp_user_id` precondition use | Inherited from W4-B §17 | bridge runs before nonce service dispatch |
+| `PresenceNonceBinding` | Missing | tuple plus timestamps |
+| `PresenceNonceAction` | Missing | four feedback verbs |
+| Atomic consume primitive | Missing | single winner |
+| Invalidation observer | Missing | W4-B composition events |
+| Lazy invalidation on verify | Missing | correctness boundary for stale compositions |
+| W2-D nonce budget integration | Missing | issue/verify/failure charging by pinned axes |
+| Outstanding nonce ceiling | Missing | per-session cap and 429 response |
+| Store-pressure eviction | Missing | LRU invalidation and audit |
+| Audit detail builder | Missing | shared nonce audit shape |
+| WP nonce request JS | Missing | block editor gesture path |
+| Negative fixtures | Missing | all rejection paths |
+## Directional decisions resolved at L0
+### §1. Upstream contracts consumed from W4-B
+W4-E consumes W4-B rather than redefining watermarks.
+Contracts:
+- Field identity comes from W4-B §1.
+- Composition freshness comes from W4-B §3 and §8.
+- Version-change delivery comes from W4-B §15.
+- Session-bound `wp_user_id` validation comes from W4-B §17.
+- SurfaceClient endpoint ownership comes from W4-B §37.
+- Composition refresh invalidation is the W4-B interlock row for W4-E.
+- Stale composition handling aligns with W4-B stale composition `409`.
+Refresh rule:
+```text
+commit_composition(composition_id) advances N -> N+1
+  -> outstanding nonces for composition_id and version <= N become invalid.
+```
+The user must see the refreshed block and click again.
+
+V8 inheritance rule:
+- `src-tauri/src/bridges/surface_client.rs` owns both nonce endpoints.
+- The bridge entry point calls `validate_session_bound_wp_user_id(actor, payload)` before `services::surface_nonce::*` is reached.
+- W4-E must not add an independent body-level `wp_user_id` trust path.
+- W4-E may compare tuple `wp_user_id` values only after the bridge has established the truthful session-bound user.
+- Body mismatch returns `403 wrong_user` and never reaches nonce lookup, claim lookup, rate-limited issue, or consume code.
+- The W4-E acceptance suite includes an ordering fixture proving the bridge precondition runs before nonce code.
+### §2. Nonce tuple definition
+Minimum tuple required by this task:
+```text
+(session_id, wp_user_id, claim_id, field_path, action, claim_version, composition_version)
+```
+Implementation tuple:
+```text
+(
+  surface_client_id,
+  session_id,
+  wp_user_id,
+  claim_id,
+  field_path,
+  action,
+  claim_version,
+  composition_id,
+  composition_version
+)
+```
+Why include the extra fields:
+- Linear DOS-571 explicitly includes `claim_version`.
+- W4-B W5-A interlock names `(claim_id, claim_version, field_path)`.
+- `surface_client_id` is needed for audit correlation.
+- `composition_id` is needed for refresh invalidation.
+Rules:
+- `session_id` binds one paired session.
+- `wp_user_id` binds one WP editor user.
+- `claim_id` binds one substrate-authored claim.
+- `field_path` binds one W4-B field path.
+- `action` binds one feedback verb.
+- `claim_version` binds the observed claim version and is mandatory, not `Option`.
+- `composition_id` binds invalidation scope.
+- `composition_version` binds the rendered composition version.
+
+Required-field rule:
+- `claim_version` is a wire-required `u64` on both issue and verify.
+- Missing, null, empty string, float, negative, object, array, or stringly typed `claim_version` rejects with `400 malformed_claim_version`.
+- W4-E does not infer `claim_version` from `claim_id` during issue to paper over a malformed request.
+- W4-E does query the claim store for the current version to decide freshness; that query is validation, not inference of the request tuple.
+### §3. Action vocabulary
+W4-E wire actions:
+```text
+correct | dismiss | corroborate | contradict
+```
+W5-A maps those to typed claim feedback.
+Recommended mapping:
+| W4-E action | W5-A meaning | Candidate substrate action |
+|---|---|---|
+| `correct` | corrected value | `NeedsNuance` |
+| `dismiss` | hide/reject on surface | context-dependent |
+| `corroborate` | confirm current | `ConfirmCurrent` |
+| `contradict` | mark wrong | `MarkFalse` |
+W4-E validates action identity only.
+W5-A owns semantic mapping.
+### §4. Storage model
+Default storage is in-memory primary.
+Rationale:
+- TTL is at most 60 seconds.
+- Runtime restart should force re-click.
+- Nonce is not an authorization token.
+- Durable audit already exists.
+- The task explicitly requests in-memory primary.
+Binding shape:
+```rust
+pub struct PresenceNonceBinding {
+    nonce_digest: NonceDigest,
+    fields: PresenceNonceBindingFields,
+    lifecycle: PresenceNonceLifecycle,
+    _sealed: private::Sealed,
+}
+
+pub struct PresenceNonceBindingFields {
+    surface_client_id: SurfaceClientId,
+    session_id: SessionId,
+    wp_user_id: u64,
+    claim_id: ClaimId,
+    field_path: FieldPath,
+    action: PresenceNonceAction,
+    claim_version: u64,
+    composition_id: CompositionId,
+    composition_version: u64,
+    generated_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+pub struct PresenceNonceLifecycle {
+    consumed_at: Option<DateTime<Utc>>,
+    invalidated_at: Option<DateTime<Utc>>,
+}
+```
+Immutability rule:
+- `PresenceNonceBinding` is immutable after insertion.
+- Tuple fields are constructor-only.
+- The struct is sealed; external modules cannot construct partial bindings or mutate fields.
+- There are no public setters for tuple fields.
+- The only permitted lifecycle mutations are atomic compare-and-set transitions from `None` to `Some(now)` for `consumed_at` or `invalidated_at`.
+- Lifecycle methods return `AlreadyConsumed`, `AlreadyInvalidated`, or `LostRace` instead of overwriting prior timestamps.
+- `consumed_at` and `invalidated_at` are mutually exclusive terminal states.
+- Tests must fail if a future patch exposes a mutable tuple-field setter or writes tuple fields after insertion.
+
+Type-system enforcement:
+```rust
+mod private {
+    pub struct Sealed;
+}
+
+impl PresenceNonceBinding {
+    pub fn new(fields: PresenceNonceBindingFields, digest: NonceDigest) -> Self;
+    pub fn try_mark_consumed(&mut self, now: DateTime<Utc>) -> Result<(), ConsumeRace>;
+    pub fn try_mark_invalidated(&mut self, now: DateTime<Utc>, reason: InvalidationReason) -> Result<(), InvalidateRace>;
+}
+```
+Persistence variant:
+- Claim v175.
+- Store keyed digest, not raw token.
+- Add SQL consume guard.
+- Add sweep and retention rules.
+- Drain the in-memory store before enabling persisted rows on restart or migration.
+- Refuse startup if both in-memory and persisted nonce stores contain live entries for the same runtime instance.
+- Add migration tests.
+- Update this packet before coding.
+### §5. Token generation
+Generation follows artifact 10:
+- 32 bytes from OS cryptographic RNG.
+- base64url without padding.
+- opaque token returned to browser.
+- keyed digest stored server-side.
+- digest is `HMAC-SHA256(service_local_nonce_key, raw_nonce_bytes)`.
+- `service_local_nonce_key` is derived once at startup from W2-B HMAC secret material with a nonce-specific context label.
+- the derived key is pinned for the runtime lifetime and never rotated while live nonces exist.
+- startup key derivation failure fail-closes endpoint registration.
+- no binding record in DOM.
+- no binding record in block attributes.
+- no binding record in post content.
+- no raw token in audit.
+- no raw token in logs.
+
+Digest rules:
+- Raw nonce bytes are never stored.
+- Digest comparison uses constant-time equality.
+- Digest prefixes in audit are truncated and non-reversible.
+- Key rotation across restart is allowed because in-memory nonces intentionally die on restart.
+- The v175 persisted variant cannot rotate the digest key until all persisted unexpired rows are drained or invalidated.
+### §6. Issue endpoint
+Runtime endpoint:
+```http
+POST /v1/surface/nonce/issue
+```
+Request:
+```json
+{
+  "session_id": "surface-session-1",
+  "wp_user_id": 42,
+  "claim_id": "claim-uuid",
+  "field_path": "claims[0].summary",
+  "action": "correct",
+  "claim_version": 7,
+  "composition_id": "composition-uuid",
+  "composition_version": 17,
+  "request_id": "request-uuid"
+}
+```
+Response:
+```json
+{
+  "ok": true,
+  "presence_nonce": "base64url-32-byte-token",
+  "expires_at": "2026-05-13T15:01:00Z",
+  "ttl_seconds": 60,
+  "request_id": "request-uuid"
+}
+```
+Validation order:
+1. Bridge authenticates the SurfaceClient actor enough to load the W2-C session binding.
+2. Bridge rejects any non-`Actor::SurfaceClient` caller with `403 wrong_actor`.
+3. Bridge runs W4-B §17 `validate_session_bound_wp_user_id(actor, payload)`.
+4. Body/session mismatch returns `403 wrong_user` before nonce service dispatch.
+5. Verify request shape, including mandatory `claim_version: u64`.
+6. Verify bearer.
+7. Verify HMAC.
+8. Verify active session.
+9. Verify SurfaceClient scope.
+10. Charge W2-D issue budgets.
+11. Verify claim exists.
+12. Verify claim is substrate-authored.
+13. Verify canonical field path.
+14. Verify action allowed for field.
+15. Query claim store for current `claim_version` via `services::claims::current_claim_version_for_claim(claim_id)`.
+16. Verify current composition version.
+17. Verify current claim version.
+18. Enforce per-session outstanding nonce ceiling.
+19. Generate nonce.
+20. Store binding.
+21. Emit `presence_nonce_issued`.
+Clients may propose context.
+The runtime creates the binding.
+
+W2-D issue budget keys:
+```text
+surface_client_id
+wp_user_id
+claim_id
+field_path
+action
+```
+Rules:
+- Every issue request consumes the SurfaceClient issue budget after actor/session binding succeeds.
+- The budget key is exactly the five axes above; do not add request_id, nonce digest, composition version, or arbitrary WP metadata.
+- HMAC failure after actor/session association charges the nonce-failure budget before returning.
+- Per-session outstanding nonce ceiling applies before RNG generation.
+- A session with too many live nonces receives `429 rate_limited`.
+- Acceptance fixture issues 1000 sequential nonces for one session without verification and observes the first configured ceiling breach as `429`.
+- The configured ceiling may be lower than 1000, but the fixture must drive 1000 attempts and assert that exhaustion occurs before all succeed.
+
+Store-size cap:
+- The service has a global in-memory live-binding cap.
+- When the cap is exceeded, evict least-recently-issued unconsumed bindings.
+- Eviction marks bindings invalidated with `reason = "store_pressure"`.
+- Eviction emits `presence_nonce_invalidated` aggregate audit with safe count and reason.
+- Store pressure never silently drops a nonce without changing lifecycle state.
+### §7. Verify endpoint
+Runtime endpoint:
+```http
+POST /v1/surface/nonce/verify
+```
+Request:
+```json
+{
+  "presence_nonce": "base64url-32-byte-token",
+  "session_id": "surface-session-1",
+  "wp_user_id": 42,
+  "claim_id": "claim-uuid",
+  "field_path": "claims[0].summary",
+  "action": "correct",
+  "claim_version": 7,
+  "composition_id": "composition-uuid",
+  "composition_version": 17,
+  "feedback_request_id": "request-uuid"
+}
+```
+Success:
+```json
+{
+  "ok": true,
+  "verified": true,
+  "consumed_at": "2026-05-13T15:00:21Z",
+  "request_id": "request-uuid"
+}
+```
+Reject:
+```json
+{
+  "ok": false,
+  "error": "presence_nonce_rejected",
+  "reason": "mismatched_action",
+  "message": "Refresh this block and try again.",
+  "request_id": "request-uuid"
+}
+```
+Validation order:
+1. Bridge authenticates the SurfaceClient actor enough to load the W2-C session binding.
+2. Bridge rejects any non-`Actor::SurfaceClient` caller with `403 wrong_actor`.
+3. Bridge runs W4-B §17 `validate_session_bound_wp_user_id(actor, payload)`.
+4. Body/session mismatch returns `403 wrong_user` before nonce service dispatch.
+5. Verify request shape, including mandatory `claim_version: u64`.
+6. Verify bearer and HMAC.
+7. Verify session and scope.
+8. Charge W2-D verify/failure budgets.
+9. Lookup nonce digest.
+10. Compare tuple.
+11. Check expiry.
+12. Query claim store for current `claim_version`.
+13. Check current composition version.
+14. Consume atomically in the same serialized decision as steps 10-13.
+15. Emit `presence_nonce_verified`.
+16. Return success to W5-A with nonce-bound expected versions.
+Verify does not apply feedback.
+
+Freshness and consume race rule:
+- The version checks and lifecycle transition are one serialized service decision.
+- The service must not check current versions, release the mutex, then later consume the nonce.
+- If composition advances between a speculative verify check and consume, the real consume decision returns `409 composition_version_stale`.
+- If claim version advances between a speculative verify check and consume, the real consume decision returns `409 claim_version_stale`.
+- W5-A receives the nonce-bound `claim_version` and `composition_version` on success and carries those expected versions into W4-B CAS when applying feedback.
+- This second CAS is required because a version may advance after W4-E verify succeeds but before W5-A applies feedback.
+
+Pinned claim-version query path:
+```rust
+services::claims::current_claim_version_for_claim_id(ctx, db, claim_id) -> Result<u64, ClaimLookupError>
+```
+Rules:
+- W4-E queries this service during issue and verify.
+- Direct SQL from the bridge or handler is forbidden.
+- A missing claim returns `403 wrong_claim` only after the nonce tuple can be trusted.
+- A current-version mismatch returns `409 claim_version_stale`.
+- The response includes no claim body; W5-A owns correction and re-confirm UX.
+
+Nonce failure budgets:
+- Tuple mismatch, expiry, replay, invalidation, and unknown nonce charge the W2-D nonce-failure bucket.
+- HMAC failure charges the nonce-failure bucket when a SurfaceClient actor/session can be identified safely.
+- The budget axes for nonce failures are `surface_client_id`, `wp_user_id`, `claim_id`, `field_path`, and `action` when those fields are available after request-shape validation.
+- If request shape is malformed before those fields parse, charge the narrowest authenticated actor/session bucket available.
+### §8. Lifecycle
+```text
+feedback gesture
+  -> WP JS requests nonce from WP REST
+  -> PHP calls /v1/surface/nonce/issue
+  -> runtime stores binding
+  -> JS receives opaque token
+  -> W5-A sends token for verification
+  -> PHP calls /v1/surface/nonce/verify
+  -> runtime consumes token
+  -> W5-A applies feedback
+```
+States:
+```text
+issued
+  -> consumed
+  -> expired
+  -> invalidated_by_composition_refresh
+  -> rejected
+```
+Rules:
+- `issued` can become `consumed` once.
+- `issued` can become `expired`.
+- `issued` can become `invalidated_by_composition_refresh`.
+- `issued` can become `invalidated_by_store_pressure`.
+- `expired` cannot become `consumed`.
+- `invalidated` cannot become `consumed`.
+- `consumed` is terminal.
+- terminal timestamps are first-writer-wins.
+- no lifecycle transition mutates tuple fields.
+### §9. Atomic consume
+Atomic consume is mandatory.
+In-memory default:
+- Store bindings behind a service-owned `tokio::sync::Mutex`.
+- Primary map is `HashMap<NonceDigest, PresenceNonceBinding>`.
+- Secondary invalidation index is `HashMap<CompositionId, HashSet<NonceDigest>>`.
+- Check tuple, expiry, invalidation, and consumed state together.
+- Check current claim and composition versions inside the same critical section.
+- Transition under the same critical section.
+- Exactly one verifier wins.
+- Later verifiers get `replayed`.
+- Do not hold a `std::sync::Mutex` across await points.
+- Do not expose a lock guard outside `services::surface_nonce`.
+- Do not use a read-only preflight verify API.
+- The only success path consumes.
+
+Async lock discipline:
+```rust
+pub struct SurfaceNonceStore {
+    inner: tokio::sync::Mutex<SurfaceNonceStoreInner>,
+}
+
+struct SurfaceNonceStoreInner {
+    by_digest: HashMap<NonceDigest, PresenceNonceBinding>,
+    by_composition: HashMap<CompositionId, HashSet<NonceDigest>>,
+    lru: VecDeque<NonceDigest>,
+}
+```
+The store may call claim/composition query services before acquiring the mutex only as advisory preflight. The authoritative decision re-checks freshness under the mutex immediately before lifecycle transition. If a service call must await while the mutex is held, the implementation must restructure around a serialized command queue instead of switching to `std::sync::Mutex`.
+Persistence variant:
+```sql
+UPDATE presence_nonces
+SET consumed_at = :now,
+    consume_request_id = :request_id
+WHERE nonce_digest = :digest
+  AND consumed_at IS NULL
+  AND invalidated_at IS NULL
+  AND expires_at >= :now;
+```
+Affected rows must equal one.
+### §10. Expiry
+TTL is 60 seconds maximum.
+Rules:
+- Default TTL is 60 seconds.
+- Shorter TTL is allowed for high-risk actions.
+- Longer TTL is forbidden in v1.4.2.
+- Verify checks expiry synchronously.
+- Sweep is cleanup only.
+- Expired token use emits reject audit.
+- Passive expiry does not emit one audit row per token in in-memory V1.
+### §11. Composition refresh invalidation
+W4-B makes the version available.
+W4-E owns invalidation.
+Default rule:
+- Index outstanding nonces by `composition_id`.
+- Observe W4-B `composition.updated` from `version_events`.
+- When current version becomes `N+1`, invalidate version `<= N`.
+- Verify returns `409 composition_version_stale` when actor/session are valid.
+- Emit `presence_nonce_invalidated` audit with count.
+Correctness boundary:
+- Lazy invalidation during verify is mandatory and sufficient for correctness.
+- The `version_events` subscriber is an optimization that reduces stale nonce lifetime.
+- Missed, delayed, duplicated, or reordered subscriber delivery must not allow a stale nonce to verify.
+- Every verify re-reads or otherwise confirms the current composition version before consume.
+- If the binding's `composition_version` is lower than current, verify marks the binding invalidated and returns `409 composition_version_stale`.
+- The invalidation index accelerates batch invalidation; it is not the only stale-detection mechanism.
+Outbox rule:
+- W4-B §15 remains the version outbox.
+- W4-E consumes W4-B composition events as invalidation triggers.
+- W4-E does not create a second outbox.
+- W4-E does not silently add a new `version_events.event_kind`.
+- A distinct durable `nonce.invalidated` event requires v175 and packet revision.
+### §12. Audit emission
+Every SurfaceClient nonce event uses:
+```rust
+emit_surface_audit(
+    logger,
+    event_kind,
+    &actor,
+    AuditFields::new("security", detail).with_wp_user_id(wp_user_id),
+)
+```
+Event kinds:
+- `presence_nonce_issued`.
+- `presence_nonce_verified`.
+- `presence_nonce_rejected`.
+- `presence_nonce_invalidated`.
+Detail fields:
+- `request_id`.
+- `surface_client_id`.
+- `session_id_hash`.
+- `nonce_digest_prefix`.
+- `claim_id`.
+- `field_path`.
+- `claim_version`.
+- `composition_id`.
+- `composition_version`.
+- `action`.
+- `result`.
+- `reason`.
+Reject audit rule:
+- Every authenticated rejection emits `presence_nonce_rejected`.
+- "Authenticated" means the bridge has enough actor/session context to safely attribute to `Actor::SurfaceClient`.
+- Unauthenticated transport failures may emit metrics, but do not forge actor audit rows.
+- The reject detail shape is class-safe and contains no raw nonce, no proposed correction text, and no claim body.
+- Rejection details use bounded enums, not caller-provided strings.
+
+Safe reject detail shape:
+```json
+{
+  "request_id": "<uuid | null>",
+  "surface_client_id": "<opaque id>",
+  "session_id_hash": "<hash>",
+  "wp_user_id": 42,
+  "claim_id": "<string | null>",
+  "field_path": "<string | null>",
+  "claim_version": 7,
+  "composition_id": "<string | null>",
+  "composition_version": 17,
+  "action": "correct",
+  "reason": "wrong_user",
+  "rejection_class": "actor" 
+}
+```
+Audit prohibitions:
+- no raw nonce;
+- no corrected value;
+- no raw IP unless existing policy permits hashing;
+- no raw user-agent unless existing policy permits hashing;
+- no customer names;
+- no customer domains;
+- no emails.
+### §13. Rejection taxonomy
+| HTTP | Reason | Meaning |
+|---:|---|---|
+| 400 | `malformed_request` | invalid shape |
+| 400 | `missing_nonce` | token absent |
+| 400 | `malformed_claim_version` | missing/null/empty/wrong-type claim version |
+| 401 | `unauthenticated_surface` | bearer/HMAC missing or invalid |
+| 403 | `wrong_actor` | caller is not `Actor::SurfaceClient` |
+| 403 | `scope_denied` | missing feedback scope |
+| 403 | `wrong_session` | session mismatch |
+| 403 | `wrong_user` | WP user mismatch |
+| 403 | `wrong_claim` | claim mismatch |
+| 403 | `wrong_field` | field mismatch |
+| 403 | `mismatched_action` | action mismatch |
+| 403 | `expired` | TTL exceeded |
+| 403 | `replayed` | already consumed |
+| 403 | `invalidated` | invalidated without version lookup |
+| 409 | `claim_version_stale` | claim watermark stale |
+| 409 | `composition_version_stale` | composition watermark stale |
+| 429 | `rate_limited` | budget exhausted |
+Precedence:
+1. Minimal actor/session binding needed for W4-B §17.
+2. `wrong_actor`.
+3. W4-B §17 `wrong_user` precondition.
+4. Transport auth.
+5. Pairing/session/scope.
+6. Request shape, including `claim_version`.
+7. Rate limit.
+8. Nonce lookup.
+9. Binding mismatch.
+10. Expiry.
+11. Version stale.
+12. Atomic consume.
+
+Reason-class mapping:
+- `actor`: `wrong_actor`, `wrong_user`, `wrong_session`.
+- `auth`: `unauthenticated_surface`, HMAC failure.
+- `shape`: `malformed_request`, `missing_nonce`, `malformed_claim_version`.
+- `binding`: `wrong_claim`, `wrong_field`, `mismatched_action`.
+- `lifecycle`: `expired`, `replayed`, `invalidated`.
+- `freshness`: `claim_version_stale`, `composition_version_stale`.
+- `budget`: `rate_limited`.
+### §14. WP-side JS contract
+Browser JS never calls Rust directly.
+Flow:
+```text
+Gutenberg affordance click
+  -> JS POST /wp-json/dailyos/v1/nonce
+  -> PHP checks WP capability and current user
+  -> PHP loads pairing/session
+  -> PHP calls DailyOS_Runtime_Client::issue_nonce()
+  -> PHP returns opaque nonce and expires_at
+```
+JS request to WP REST:
+```json
+{
+  "block_client_id": "editor-block-id",
+  "claim_id": "claim-uuid",
+  "field_path": "claims[0].summary",
+  "action": "correct",
+  "claim_version": 7,
+  "composition_id": "composition-uuid",
+  "composition_version": 17
+}
+```
+JS rules:
+- request nonce on feedback gesture;
+- do not request at page load;
+- do not request only at save time;
+- send `claim_version` as a JSON number, not a string;
+- fail closed if the rendered block lacks `claim_version`;
+- do not store nonce in post content;
+- do not store nonce in block attributes;
+- strip nonce attributes before serialization;
+- never receive bearer or HMAC key.
+### §15. Service boundary
+All mutations go through `services/`.
+Shape:
+```text
+src-tauri/src/bridges/surface_client.rs
+  -> auth/context
+  -> validate_session_bound_wp_user_id()
+  -> services::surface_nonce::issue_nonce()
+  -> services::surface_nonce::verify_nonce()
+```
+Rules:
+- Handlers do not write DB tables directly.
+- Handlers do not mutate nonce maps directly.
+- Route handlers live in `bridges/surface_client.rs`, not a new nonce-specific bridge module.
+- The bridge precondition runs before nonce service code for both issue and verify.
+- Service owns issue, verify, sweep, invalidation, and audit.
+- Service accepts frozen clock in tests.
+- Service accepts deterministic RNG in tests.
+- Service exposes no non-consuming verify.
+- Service owns the in-memory mutex and composition index.
+- Service owns all W2-D budget charging calls for nonce issue, verify, and nonce-failure buckets.
+### §16. Interlocks
+W4-B must land first.
+W4-E needs:
+- canonical `field_path`;
+- current `claim_version`;
+- current `composition_version`;
+- `composition_id`;
+- W4-B stale composition semantics;
+- W4-B `version_events`.
+- W4-B §17 session-bound `wp_user_id` bridge precondition.
+- W4-B §37 canonical SurfaceClient route module.
+W2-D supplies:
+- SurfaceClient rate-limit budget primitives.
+- budget buckets for issue, verify, and nonce failure.
+- HMAC failure accounting once actor/session context is known.
+W5-A consumes W4-E.
+W5-A needs:
+- opaque nonce token;
+- verify success/failure;
+- stable reason codes;
+- 409 stale-version responses;
+- request-id audit correlation.
+- nonce-bound expected `claim_version` and `composition_version` on verify success.
+W5-A owns:
+- feedback payload;
+- action semantic mapping;
+- calling `record_claim_feedback`;
+- carrying nonce-bound expected versions into W4-B CAS;
+- block re-render;
+- version-changed re-confirm UX.
+### §17. Intelligence Loop fit
+Claim model:
+- Nonce is not a claim.
+- Feedback gated by nonce can mutate claim lifecycle and trust inputs.
+- W4-E must not create display-only intelligence data.
+Provenance and trust:
+- Audit binds actor, WP user, claim, field, action, claim version, composition version.
+- W5-A records provenance reference during feedback application.
+- W4-E does not adjust trust scores.
+- Stale-version rejects preserve trust by forcing feedback to re-anchor on current claim state.
+Signals and invalidation:
+- W4-E invalidation is driven by W4-B composition events.
+- W4-E lazy-invalidates on verify when event delivery lags.
+- W5-A feedback emits feedback signals through existing services.
+- W4-E emits audit, not trust signals.
+Runtime and surfaces:
+- Tauri runtime owns issue and verify.
+- WordPress mediates browser calls through PHP.
+- MCP is not in scope unless a future SurfaceClient feedback path uses it.
+Feedback loop:
+- corrections, dismissals, corroborations, contradictions reach feedback services only after verify;
+- rejects do not create feedback facts;
+- repeated rejects can feed abuse telemetry, rate limits, or pairing health without changing claim state.
+## Acceptance criteria lifted into DOS-571
+
+### Implementation criteria
+1. `POST /v1/surface/nonce/issue` and `POST /v1/surface/nonce/verify` are registered in `src-tauri/src/bridges/surface_client.rs` per W4-B V8 §37.
+2. Both endpoints run through W4-B V8 §17 `validate_session_bound_wp_user_id` before any W4-E nonce service code.
+3. Body/session `wp_user_id` mismatch returns `403 wrong_user` before nonce lookup, claim lookup, rate-limited issue, RNG generation, or consume.
+4. Only `Actor::SurfaceClient` can call `/v1/surface/nonce/*`; all other actors return `403 wrong_actor`.
+5. `claim_version` is a required `u64` in issue and verify requests and in `PresenceNonceBinding`.
+6. `PresenceNonceBinding` tuple fields are immutable after insertion.
+7. Lifecycle mutation is limited to first-writer-wins `consumed_at` or `invalidated_at` transitions.
+8. Nonce digest uses HMAC-SHA256 with a service-local key derived at startup from W2-B HMAC secret material.
+9. The nonce digest key is pinned for the runtime lifetime and is not rotated while live nonces exist.
+10. In-memory store uses `tokio::sync::Mutex<HashMap<NonceDigest, PresenceNonceBinding>>`.
+11. Invalidation index uses `HashMap<CompositionId, HashSet<NonceDigest>>`.
+12. No `std::sync::Mutex` is held across await points.
+13. Issue budgets use W2-D axes `surface_client_id`, `wp_user_id`, `claim_id`, `field_path`, and `action`.
+14. Verify/failure budgets use the same axes when parseable and the narrowest authenticated actor/session bucket otherwise.
+15. Per-session outstanding nonce ceiling is enforced before RNG generation.
+16. Global store-size cap evicts by LRU and emits `presence_nonce_invalidated reason=store_pressure`.
+17. Verify re-checks current claim version with `services::claims::current_claim_version_for_claim_id(ctx, db, claim_id)`.
+18. Verify re-checks current composition version before consume.
+19. Freshness checks and consume are one serialized service decision.
+20. W5-A receives nonce-bound expected versions on verify success and passes them into W4-B CAS during feedback write.
+21. Lazy invalidation during verify is the correctness boundary; the `version_events` subscriber is an optimization.
+22. Every authenticated rejection emits `presence_nonce_rejected` with the safe reject detail shape from §12.
+23. v175 persistence variant drains or invalidates the in-memory store before accepting persisted live nonces after restart.
+
+### Negative fixtures
+24. Expired nonce rejects with `403 expired`.
+25. Replayed nonce rejects with `403 replayed`.
+26. Cross-user nonce rejects with `403 wrong_user`.
+27. Cross-session nonce rejects with `403 wrong_session`.
+28. Wrong action rejects with `403 mismatched_action`.
+29. Wrong field rejects with `403 wrong_field`.
+30. Wrong claim rejects with `403 wrong_claim`.
+31. Missing nonce rejects before lookup.
+32. Missing composition version rejects before issue.
+33. Stale claim version returns `409 claim_version_stale`.
+34. Stale composition version returns `409 composition_version_stale`.
+35. Composition refresh invalidates prior outstanding nonce.
+36. Atomic race yields one success and one replay.
+37. Unknown nonce rejects without feedback write.
+38. Missing `wp_user_id` audit emission fails.
+39. WP block serialization strips nonce.
+40. Direct browser-to-runtime attempt is rejected.
+41. `dos571_fixture_bridge_precondition_order.rs` proves `validate_session_bound_wp_user_id` runs before nonce code by asserting no RNG call, no claim query, no rate-limit issue charge, and no nonce lookup on body mismatch.
+42. `dos571_fixture_wrong_actor.rs` calls nonce issue/verify as any actor other than `Actor::SurfaceClient` and receives `403 wrong_actor`.
+43. `dos571_fixture_binding_immutable.rs` attempts to mutate tuple fields after insertion and fails at compile time or through a dedicated mutation-gate test.
+44. `dos571_fixture_lifecycle_cas.rs` races consume vs invalidation and observes exactly one terminal timestamp.
+45. `dos571_fixture_claim_version_missing.rs` omits `claim_version` and receives `400 malformed_claim_version`.
+46. `dos571_fixture_claim_version_empty.rs` sends empty/null `claim_version` and receives `400 malformed_claim_version`.
+47. `dos571_fixture_claim_version_wrong_type.rs` sends string/object/float/negative `claim_version` and receives `400 malformed_claim_version`.
+48. `dos571_fixture_issue_rate_exhaustion.rs` performs 1000 sequential issue attempts for one session and observes `429 rate_limited` before all succeed.
+49. `dos571_fixture_store_pressure_lru.rs` exceeds global store cap and asserts oldest live nonce is invalidated with `reason=store_pressure`.
+50. `dos571_fixture_hmac_failure_budget.rs` sends signed-context HMAC failures and asserts nonce-failure budget charging without unsafe audit attribution.
+51. `dos571_fixture_claim_version_drift.rs` issues at claim version 7, advances the claim to 8, then verify returns `409 claim_version_stale`.
+52. `dos571_fixture_freshness_consume_race.rs` advances composition between an advisory verify check and consume; real consume returns `409 composition_version_stale`.
+53. `dos571_fixture_lazy_invalidation.rs` drops or delays the `version_events` subscriber and still rejects stale composition during verify.
+54. `dos571_fixture_reject_audit_shape.rs` covers every authenticated rejection class and asserts `presence_nonce_rejected` detail contains only safe bounded fields.
+55. `dos571_fixture_persistence_restart_drain.rs` covers v175 mode: restart drains in-memory live entries before persisted nonce replay is accepted.
+## Test plan
+### Code path diagram
+```text
+ISSUE
+WP JS -> WP REST -> PHP client -> runtime issue
+  -> SurfaceClientBridge
+  -> W4-B §17 wp_user_id precondition
+  -> auth/session/scope
+  -> rate limits
+  -> claim/field/action validation
+  -> W4-B version check
+  -> RNG + digest
+  -> store binding
+  -> audit issued
+VERIFY
+W5-A/PHP -> runtime verify
+  -> SurfaceClientBridge
+  -> W4-B §17 wp_user_id precondition
+  -> auth/session/scope
+  -> rate limits
+  -> digest lookup
+  -> tuple compare
+  -> expiry/current-version check inside serialized decision
+  -> atomic consume with nonce-bound expected versions
+  -> audit verified
+  -> W5-A applies feedback
+INVALIDATE
+W4-B commit_composition
+  -> version_events composition.updated
+  -> W4-E subscriber invalidates lower-version nonces when delivered
+  -> W4-E verify lazily invalidates lower-version nonces when subscriber lags
+  -> audit invalidated
+```
+### Integration tests
+- Valid HTTP issue returns nonce and expiry.
+- Valid HTTP verify consumes nonce.
+- Concurrent duplicate verify returns one success.
+- Verify success returns nonce-bound expected versions for W5-A CAS.
+- WP REST handler calls PHP runtime client.
+- Serialized Gutenberg block contains no nonce.
+- W5-A mock refuses to write when verify fails.
+- W5-A mock passes nonce-bound expected versions into W4-B CAS after verify.
+- SurfaceClient route registration is in `bridges/surface_client.rs`.
+### Security tests
+- Cross-user replay rejects.
+- Cross-session replay rejects.
+- Cross-actor issue and verify reject.
+- Changed field rejects.
+- Changed action rejects.
+- Stale tab after composition refresh returns `409`.
+- Stale claim after issue returns `409`.
+- Composition update racing consume returns `409`.
+- Rate-limit exhaustion returns `429`.
+- HMAC failures charge nonce-failure budget.
+- Every authenticated rejection emits safe reject audit.
+- Store pressure invalidates by LRU and emits aggregate invalidation audit.
+### Persistence tests if v175 is chosen
+- v175 migration applies idempotently.
+- raw nonce absent from persisted rows.
+- SQL consume updates exactly one row.
+- restart drains in-memory store before persisted live rows can be replayed.
+- digest-key rotation fails closed unless live persisted rows are drained.
+- sweep preserves required audit evidence.
+## Migration, rollout, and observability
+Default rollout:
+- no migration;
+- in-memory store;
+- durable audit log;
+- endpoint registration after W4-B.
+Persistence rollout:
+- claim v175;
+- add migration file;
+- register migration;
+- on startup, drain or invalidate the in-memory store before opening persisted nonce verification;
+- reject mixed in-memory/persisted live stores for the same runtime instance;
+- add migration tests;
+- add retention and sweep policy;
+- update this packet before code.
+Metrics:
+- issue count;
+- verify success count;
+- reject count by reason;
+- invalidation count;
+- replay count;
+- wrong_actor count;
+- wrong_user precondition count;
+- malformed_claim_version count;
+- store_pressure invalidation count;
+- outstanding nonce gauge by session;
+- average nonce age at verify;
+- p95 issue-to-verify latency;
+- missing `wp_user_id` audit failures.
+Logs:
+- WARN for current-version lookup failure.
+- WARN for audit emission failure.
+- WARN for persistence restart drain failure.
+- INFO for invalidation batch count.
+- INFO for store-pressure eviction batch count.
+- DEBUG for normal issue/verify without raw token.
+## NOT in scope
+- Full W5-A feedback router.
+- User-facing re-confirm UX.
+- Persistent nonce table by default.
+- Bloom filter replay cache by default.
+- New trust scoring logic.
+- New feedback actions.
+- New signal dispatcher.
+- Browser-direct runtime calls.
+- Saving nonce to post content.
+- Multi-process runtime redesign.
+## Open questions
+| ID | Question | Recommendation |
+|---|---|---|
+| Q1 | Add distinct `nonce.invalidated` outbox rows? | No for V1; use W4-B `composition.updated`. |
+| Q2 | Consume mismatch attempts defensively? | No; consume only on full valid match. |
+| Q3 | Is `claim_version` mandatory? | Yes when W4-B exposes it. |
+| Q4 | How does `dismiss` map to feedback? | W5-A owns by UI context. |
+| Q5 | Shorter TTL for `contradict`? | Optional later; max stays 60s. |
+| Q6 | Which WP capability gates nonce request? | W5-A/WP plugin decides; DailyOS scope still required. |
+| Q7 | Passive expiry audit rows? | No for in-memory V1; aggregate metrics only. |
+| Q8 | Who owns `/v1/surface/nonce/*` route registration? | Closed by W4-B V8 §37: `src-tauri/src/bridges/surface_client.rs`. |
+| Q9 | Does W4-E locally validate `wp_user_id`? | No; it inherits W4-B V8 §17 bridge precondition, then compares tuple values only after truthful actor binding. |
+| Q10 | Can verify check freshness before consuming? | Only as advisory preflight; authoritative freshness and consume are one serialized decision. |

--- a/.docs/plans/dos-546/v1.4.2-project/W5-A-L0-packet.md
+++ b/.docs/plans/dos-546/v1.4.2-project/W5-A-L0-packet.md
@@ -1,0 +1,1073 @@
+# W5-A L0 packet - click-bound WordPress feedback router
+
+Date: 2026-05-13 (V2)
+Project: v1.4.2 - Personal Intelligence Engine: WordPress Foundation
+Parent: DOS-546
+Wave: 5 - Feedback + theme + negative fixtures
+Issue: DOS-573 (W5-A: WordPress-side feedback router)
+Linear: https://linear.app/a8c/issue/DOS-573
+Working branch: dos-546-w5-a-l0-prep
+Worktree: /private/tmp/dailyos-w5-a-l0-prep
+
+This packet captures the W5-A plan contract for L0 review.
+Linear remains the canonical execution surface.
+This packet supersedes the issue text only where it makes an implicit decision explicit.
+
+W5-A is the WordPress-side feedback router.
+It is the client-side and PHP-side path that turns a deliberate block affordance click into a typed runtime feedback write.
+It does not infer corrections from Gutenberg save diffs.
+It does not write substrate state directly.
+It does not invent a second feedback substrate.
+
+The load-bearing user outcome is:
+
+```text
+user click
+  -> WP JS validates W4-D edit-route affordance metadata
+  -> WP PHP verifies WordPress REST nonce and edit_post(post_id)
+  -> WP PHP confirms the post/block signed projection envelope is current
+  -> WP PHP submits typed feedback through DailyOS_Runtime_Client
+  -> runtime issues, atomically verifies, and consumes the W4-E nonce inside the feedback path
+  -> runtime applies feedback through existing claim services and W4-B commit path
+  -> runtime returns the post-commit composition_version
+  -> WP re-invokes W4-A0/W4-A and swaps the rendered block with current scoped HTML
+```
+
+## Status snapshot
+
+- W5-A is Wave 5, not Wave 4.
+- A V1 L0 packet can be authored now because the upstream contracts are stable enough:
+  W4-B V9 owns watermark, bridge errors, route module ownership, and session-bound user checks.
+- W4-D V3 owns edit-route projection semantics and refusal reasons.
+- W4-E V2 owns presence nonce issue/verify and click-bound nonce lifecycle.
+- W3-B owns the PHP runtime client and HMAC-signed transport once implemented.
+- DOS-589 owns dispatcher delivery for retry-after cursors and scope-filtered replay.
+- W4-A renderer work is upstream of W5-A for visible affordances and block re-rendering.
+- The current prep worktree contains the project docs but not W4 stage packet files; the upstream packets were read from the main worktree and the W4-B model packet from `/private/tmp/dailyos-w4-l0-prep`.
+- This packet is documentation only.
+- This packet does not implement code.
+- This packet does not commit.
+- This packet does not create a PR.
+
+## Pre-work
+
+### Upstream packets read
+
+- W4-B V9 model packet:
+  `/private/tmp/dailyos-w4-l0-prep/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md`.
+- W4-B V9 upstream packet:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md`.
+- W4-A0 packet:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md`.
+- W4-D V3 packet:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/W4-D-L0-packet.md`.
+- W4-E V2 packet:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/W4-E-L0-packet.md`.
+- W3 packet:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/W3-L0-packet.md`.
+- DOS-573 issue slice:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/02-issues.md`.
+- Wave plan:
+  `/Users/jamesgiroux/Documents/dailyos-repo/.docs/plans/dos-546/v1.4.2-project/03-wave-plan.md`.
+
+### W4-B V9 contracts inherited
+
+- W4-B section 1 gives W5-A `ClaimRef.field_path` and `Block.field_bindings`.
+- W4-B section 2 gives W5-A the `409 stale_watermark` envelope and scope-filtered correction behavior.
+- W4-B section 3 makes `composition_version` bridge-assigned through `commit_composition`.
+- W4-B section 5 defines version event rows and assigns delivery to DOS-589.
+- W4-B section 6 requires W4-C signature check before W4-B 409 handling.
+- W4-B section 6.5 defines `BridgeSurfaceError` precedence.
+- W4-B section 7 defines `MidFlightMutation` and durable `retry_after_event` cursor behavior.
+- W4-B section 13 defines the claim mutation target model and `commit_claim` boundary.
+- W4-B section 14 gives retry-after guidance for 409 envelopes.
+- W4-B section 15 defines the `version_events` outbox used by DOS-589.
+- W4-B section 16 gives the class-level scope-filter rule inherited by DOS-573.
+- W4-B section 17 gives `wp_user_id` session binding inherited by DOS-573.
+- W4-B acceptance 37 pins `src-tauri/src/bridges/surface_client.rs` as the owner for `/v1/surface/*` routes, including `/v1/surface/feedback`.
+
+### W4-D V3 contracts inherited
+
+- W4-D section 1 publishes `project_composition_for_surface(composition, ctx)`.
+- W4-D section 1.1 pins `ProjectedComposition`, `ProjectedBlock`, and `EditRoute`.
+- W4-D section 4 pins `BindingRole` dispatch.
+- `BindingRole::Source` preserves claim attribution and visible provenance.
+- `BindingRole::Source` alone is not enough for correction routing.
+- `BindingRole::ComputedFrom` must refuse feedback.
+- `BindingRole::DisplayOnly` must expose no feedback UI.
+- `BindingRole::FeedbackTarget` is the explicit feedback receiver.
+- `FeedbackTarget` with zero claim refs is not claim-correctable in v1.4.2.
+- W4-D section 11 publishes `edit_routes` with `feedback_allowed` and refusal reasons.
+- W4-D acceptance 21 requires W5-A to refuse ComputedFrom, DisplayOnly, Source-only, unknown role, missing receiver, zero-ref receiver, and ambiguous receiver routes.
+
+### W4-E V2 contracts inherited
+
+- W4-E section 2 defines the nonce tuple:
+  `(surface_client_id, session_id, wp_user_id, claim_id, field_path, action, claim_version, composition_id, composition_version)`.
+- W4-E section 3 defines the click action vocabulary:
+  `correct`, `dismiss`, `corroborate`, `contradict`.
+- W4-E section 6 registers `POST /v1/surface/nonce/issue`.
+- W4-E section 7 registers `POST /v1/surface/nonce/verify`.
+- W4-E section 7 returns nonce-bound expected versions on verify success.
+- W4-E section 8 makes nonce issue click-bound, not page-load-bound or save-bound.
+- W4-E section 9 requires atomic consume.
+- W4-E section 11 makes lazy invalidation during verify the correctness boundary.
+- W4-E section 12 pins safe audit emission.
+- W4-E section 13 pins rejection taxonomy.
+- W4-E section 14 pins browser-to-WP-to-PHP-to-runtime nonce request flow.
+- W4-E section 15 requires all mutations to go through services.
+
+### W3 and transport contracts inherited
+
+- W3 section W3-B owns `DailyOS_Runtime_Client` and HMAC signing.
+- W3 section 72 defaults PHP runtime transport to WordPress HTTP API wrapped in `DailyOS_Runtime_Client`.
+- W3 section W3-B requires exact-byte canonicalization to match W2 HMAC.
+- W3 section W3-B forbids exposing bearer or HMAC key material to JS.
+- W3 section W3-B requires key material redaction in debug paths.
+- W2 transport and HMAC remain the runtime trust boundary for `/v1/surface/*`.
+- W5-A therefore adds methods to the runtime client, not browser calls to Rust.
+
+### DOS-589 contracts inherited
+
+- DOS-589 consumes W4-B `version_events` with `event_seq` replay ordering.
+- DOS-589 resolves `retry_after_event` cursors for 423 `MidFlightMutation`.
+- DOS-589 routes `claim.write_rejected` and related events scope-filtered.
+- W5-A consumes DOS-589 events for retry/re-render behavior.
+- W5-A does not implement the dispatcher.
+- W5-A must not poll in a tight loop on 409 or 423.
+
+### Substrate reuse audit
+
+- Rust has an existing signed-route candidate for `POST /v1/surface/feedback` in `src-tauri/src/surface_runtime/mod.rs`.
+- Rust has existing SurfaceClient rate-limit classes including `FeedbackWrite` in `src-tauri/src/bridges/surface_client.rs`.
+- Rust has existing `submit.feedback` scope in SurfaceClient pairing defaults.
+- Rust has existing typed feedback substrate:
+  `src-tauri/abilities-runtime/src/abilities/feedback.rs`.
+- Rust has existing service write entry:
+  `src-tauri/src/services/claims.rs::record_claim_feedback`.
+- Rust feedback actions include `ConfirmCurrent`, `MarkOutdated`, `MarkFalse`, `WrongSubject`, `WrongSource`, `CannotVerify`, `NeedsNuance`, `SurfaceInappropriate`, and `NotRelevantHere`.
+- Rust `ClaimFeedbackInput` carries `claim_id`, `action`, `actor`, `actor_id`, and `payload_json`.
+- Rust tests already cover feedback persistence, lifecycle changes, repair enqueueing, idempotent replay behavior, unknown claim rejection, and simulate-mode rejection.
+- No WP plugin `register_rest_route` precedent was found in this worktree or the main worktree.
+- No PHP `DailyOS_Runtime_Client::submit_feedback` method was found in this worktree or the main worktree.
+- No W4-E nonce request integration exists yet in PHP source in this worktree.
+- Therefore W5-A authors the WP REST route, PHP feedback router, runtime-client feedback method, and JS click integration as net-new WordPress surfaces.
+
+## What W5-A authors net-new
+
+| Surface | Status | W5-A scope |
+|---|---|---|
+| `wp/dailyos/includes/class-dailyos-feedback-router.php` | Missing | WP REST endpoint, WP REST nonce gate, `edit_post(post_id)` gate, post/block projection membership check, nonce request, feedback submission |
+| `/wp-json/dailyos/v1/feedback` | Missing | Browser JS calls this WP endpoint, never Rust directly |
+| `wp/dailyos/blocks/account-overview/feedback.js` | Missing | Enqueued front-end click handler with delegated listeners for W4-A `data-dailyos-feedback-action` affordances |
+| Client-side route lookup | Missing | Resolve clicked field against W4-D `edit_routes`; fail closed if absent/refused; server still replays route authorization |
+| W4-A affordance data attrs | W4-A-owned output consumed by W5-A | Require `data-dailyos-feedback-action`, `data-dailyos-field-path`, `data-dailyos-claim-id`, `data-dailyos-claim-version`, `data-dailyos-composition-id`, `data-dailyos-composition-version`, and `data-dailyos-block-id` |
+| `DailyOS_Runtime_Client::issue_nonce` | W3-B obligation, consumed by W5-A | Accept array context and return runtime response array with the same HMAC signing/canonicalization as `submit_feedback` |
+| `DailyOS_Runtime_Client::submit_feedback` | Missing | HMAC-signed POST to `/v1/surface/feedback` |
+| Runtime `/v1/surface/feedback` handler registration | Partially represented as signed route candidate | Implement in `src-tauri/src/bridges/surface_client.rs` per W4-B section 37 |
+| Runtime feedback request DTO | Missing | Typed payload with nonce-bound versions and feedback action |
+| Feedback action mapper | Missing | Map W4-E wire verbs to substrate `FeedbackAction` variants |
+| W4-E nonce verify inside feedback handler | Missing | `/v1/surface/feedback` delegates atomic verify-and-consume to W4-E; PHP never calls `/v1/surface/nonce/verify` directly |
+| W4-B CAS handoff | Missing | Pass nonce-bound expected claim/composition versions into commit path |
+| W4-B error envelope mapper | Missing | Preserve 422/409/423 precedence and reason codes back to WP |
+| WP-side 409 refresh path | Missing | Reinvoke W4-A0 producer path and scope-filter correction |
+| WP-side 423 wait path | Missing | Subscribe/wait via DOS-589 cursor, no tight retry loop |
+| WP-side 422 tamper path | Missing | Show tamper banner, do not retry until W4-C clears |
+| Feedback audit details | Missing | Submit/reject audit through `emit_surface_audit` |
+| Negative fixtures | Missing | `dos573_fixture_*` suite |
+| CI lint gates | Missing | No save-diff inference, no direct claim writes, no browser-to-runtime feedback |
+
+## Directional decisions
+
+### 1. Feedback is click-bound, not save-diff inferred
+
+Decision:
+W5-A routes feedback only from an explicit feedback affordance click.
+
+Accepted gestures:
+- `correct`
+- `dismiss`
+- `corroborate`
+- `contradict`
+
+Rejected sources:
+- Gutenberg save diff.
+- Attribute autosave.
+- Paste/nesting/reorder diff.
+- Visual text changes without a feedback affordance event.
+- Inferred field changes from block JSON.
+- Server-side comparison between old and new post content.
+
+Rationale:
+- DOS-573 issue text says the L0 cycle-3 reconciliation made feedback click-bound.
+- W4-E section 8 says each discrete feedback gesture issues and immediately consumes a nonce.
+- W4-D separates substrate-bound feedback from surface-local display/layout attrs.
+- Save-diff inference would create nonces too early, after expiry, or without proof of deliberate user intent.
+- Save-diff inference would also tempt WP to infer binding roles from field names, violating W4-D section 4.
+
+Implementation rule:
+- The JS event object must carry a click-generated `feedback_request_id`.
+- `feedback_request_id` is client-correlation only; runtime replay protection is the W4-E nonce, not this browser-provided id.
+- The router must reject requests that lack a recognized affordance action.
+- The router must not inspect arbitrary changed attributes to synthesize feedback.
+- A display/layout save may persist WP-local state, but it emits no substrate feedback event.
+
+### 2. WP REST endpoint shape
+
+Decision:
+W5-A registers:
+
+```http
+POST /wp-json/dailyos/v1/feedback
+```
+
+The browser request body is:
+
+```json
+{
+  "post_id": 123,
+  "block_client_id": "editor-block-id",
+  "composition_id": "composition-uuid",
+  "composition_version": 17,
+  "block_id": "block-uuid",
+  "field_path": "claims[0].summary",
+  "claim_id": "claim-uuid",
+  "claim_version": 7,
+  "action": "correct",
+  "value": "Corrected value when action requires it",
+  "feedback_request_id": "request-uuid"
+}
+```
+
+`register_rest_route` args:
+
+| Arg | Type | Required | `validate_callback` rule |
+|---|---|---:|---|
+| `post_id` | integer | yes | positive integer; permission callback later requires `current_user_can('edit_post', post_id)` |
+| `block_client_id` | string | yes | non-empty string matching the rendered wrapper id/client id format |
+| `composition_id` | string | yes | UUID string |
+| `composition_version` | integer | yes | positive integer |
+| `block_id` | string | yes | UUID string from the signed projected block |
+| `field_path` | string | yes | non-empty projected field path; no arbitrary JSONPath execution |
+| `claim_id` | string | yes | UUID string |
+| `claim_version` | integer | yes | positive integer |
+| `action` | string enum | yes | one of `correct`, `dismiss`, `corroborate`, `contradict` |
+| `value` | string or object | conditional | required for `correct`; rejected for `corroborate`; optional structured reason for `contradict`; absent for `dismiss` |
+| `feedback_request_id` | string | yes | UUID string; client-correlation only |
+
+Validation rules:
+- Field validation lives in `args` callbacks, not in `handle_feedback`.
+- `permission_callback` verifies the caller is logged in.
+- `permission_callback` verifies `X-WP-Nonce` with `wp_verify_nonce($nonce, 'wp_rest')` before any runtime call.
+- `permission_callback` requires `current_user_can('edit_post', post_id)`, not only `edit_posts`.
+- A user who can `edit_posts` globally but cannot edit the requested `post_id` receives WP 403 before nonce issue.
+- PHP verifies `block_id`, `composition_id`, `composition_version`, and the referenced `edit_routes` belong to the current signed projection envelope for that `post_id` and block before requesting a nonce.
+- PHP derives `wp_user_id` from `get_current_user_id()`.
+- Browser-provided `wp_user_id` is ignored or rejected.
+- JS may pass `block_client_id` for editor correlation only.
+- JS must not pass bearer token or HMAC material.
+- JS must not pass, receive, or store the presence nonce in block attributes, post content, local storage, or JS globals.
+- The REST `OPTIONS` schema exposes only the typed request shape above; it must not disclose internal field names, claim inventories, scope tokens, or concrete claim ids beyond the schema type.
+
+PHP class shape:
+
+```php
+final class DailyOS_Feedback_Router {
+    public function __construct( DailyOS_Runtime_Client $runtime_client ) {}
+    public function register_routes(): void {}
+    public function permission_callback( WP_REST_Request $request ): bool {}
+    public function handle_feedback( WP_REST_Request $request ): WP_REST_Response {}
+    private function build_runtime_event( WP_REST_Request $request, string $nonce ): array {}
+    private function map_bridge_error_to_wp_response( array $runtime_response ): WP_REST_Response {}
+}
+```
+
+### 3. Runtime feedback endpoint shape
+
+Decision:
+W5-A submits to:
+
+```http
+POST /v1/surface/feedback
+```
+
+The runtime request body is:
+
+```json
+{
+  "session_id": "surface-session-1",
+  "wp_user_id": 42,
+  "post_id": 123,
+  "block_id": "block-uuid",
+  "claim_id": "claim-uuid",
+  "field_path": "claims[0].summary",
+  "action": "correct",
+  "claim_version": 7,
+  "composition_id": "composition-uuid",
+  "composition_version": 17,
+  "presence_nonce": "opaque-token",
+  "value": "Corrected value when action requires it",
+  "feedback_request_id": "request-uuid"
+}
+```
+
+Rules:
+- The request is HMAC-signed through `DailyOS_Runtime_Client::submit_feedback`.
+- `feedback_request_id` is passed through for log and browser correlation only; runtime does not trust it for replay protection.
+- The route lands in `src-tauri/src/bridges/surface_client.rs` per W4-B V9 acceptance 37.
+- Handler registration for `/v1/surface/feedback` is explicit W5-A scope; it is not deferred for discovery in a later packet.
+- The bridge runs W4-B section 17 `wp_user_id` session binding before nonce verify or claim lookup.
+- The bridge resolves `composition_id`, `composition_version`, `block_id`, and `field_path` to the signed `ProjectedComposition.edit_routes` and refuses non-`FeedbackTarget` routes server-side.
+- Runtime-side route refusal is authoritative even if JS and PHP both supplied matching route metadata.
+- The feedback handler delegates to the W4-E nonce authority for atomic verify-and-consume.
+- PHP never calls `/v1/surface/nonce/verify` directly.
+- Verify success returns nonce-bound expected versions.
+- The handler passes those expected versions into W4-B CAS while applying feedback.
+- The handler calls `record_claim_feedback` or its W4-B-updated service wrapper.
+- No command handler or bridge handler writes DB rows directly.
+
+### 4. Nonce lifecycle
+
+Decision:
+Nonce acquisition happens inside the PHP feedback submit path, not in JS and not at affordance render time:
+
+```text
+click
+  -> JS POST /wp-json/dailyos/v1/feedback with typed request body and X-WP-Nonce
+  -> PHP validates WP REST nonce, edit_post(post_id), and current post/block projection membership
+  -> PHP calls /v1/surface/nonce/issue through DailyOS_Runtime_Client::issue_nonce
+  -> PHP receives opaque nonce
+  -> PHP immediately POSTs /v1/surface/feedback with nonce
+  -> runtime feedback handler delegates atomic verify-and-consume to W4-E nonce store
+  -> runtime commits feedback through services in the same protected path
+```
+
+Canonical flow pins:
+- Affordances are W4-D edit-route-gated, not nonce-gated.
+- W4-A may render affordance DOM only when `edit_routes` allow feedback, but that render does not issue or embed a nonce.
+- JS never receives a W4-E presence nonce.
+- JS never calls `/v1/surface/nonce/issue`, `/v1/surface/nonce/verify`, or `/v1/surface/feedback`.
+- PHP requests a nonce only after WP REST nonce, post capability, and post/block projection membership pass.
+- PHP never calls `/v1/surface/nonce/verify` directly.
+- The W4-E WP-visible `/wp-json/dailyos/v1/nonce` endpoint is reserved for future surfaces that decouple nonce acquisition; DOS-573 click-then-submit does not call it.
+
+Rules:
+- W5-A does not request nonces at page load.
+- W5-A does not request nonces on save.
+- W5-A does not cache nonces in post content, block attributes, local storage, or transient PHP state.
+- If nonce issue fails, W5-A does not submit feedback.
+- If nonce verify fails inside `/v1/surface/feedback`, runtime does not apply feedback.
+- On W4-E `409 claim_version_stale` or `409 composition_version_stale`, W5-A refreshes rather than asking the user to reuse the old gesture.
+- On expired, replayed, mismatched field, mismatched action, wrong claim, or wrong user, W5-A shows the appropriate failure state and requires a new click.
+
+#### 4.5 Loading state
+
+- The clicked affordance sets `aria-busy="true"`, becomes disabled, and replaces the button glyph with an inline spinner while the request is pending.
+- Loading state lasts no more than 2 seconds for ordinary request latency.
+- If the runtime returns or implies a longer wait, W5-A switches to the 423 wait pattern instead of leaving the button in indefinite busy state.
+- Loading state is cleared only after success re-render, refresh replacement, terminal rejection, or undo-state transition completes.
+
+### 5. Edit-route consumption from W4-D
+
+Decision:
+W5-A treats `ProjectedComposition.blocks[].edit_routes` as the only route source.
+
+Allowed route:
+- `role = FeedbackTarget`
+- `feedback_allowed = true`
+- `claim_refs.length >= 1`
+- requested `claim_id`, `claim_version`, and `field_path` match one receiver
+- requester has the SurfaceClient scope needed to submit feedback
+
+Refused route:
+- `ComputedFrom`
+- `DisplayOnly`
+- `Source` without an adjacent explicit `FeedbackTarget`
+- `FeedbackTarget` with zero claim refs
+- missing route
+- unknown role
+- ambiguous receiver
+- sensitivity blocked
+- out of scope
+- fallback degraded without receiver
+
+Render-time rule:
+- W4-A render output must not emit affordance DOM for `ComputedFrom`, `DisplayOnly`, `Source`-only, zero-ref `FeedbackTarget`, missing, unknown, ambiguous, sensitivity-blocked, or out-of-scope routes.
+- This is a rendered HTML invariant, not only a submit-time refusal.
+- Valid account-overview affordances render inline and expose `data-ds-name="IntelligenceCorrection"`.
+
+W4-A data attrs consumed by W5-A:
+- `data-dailyos-feedback-action`
+- `data-dailyos-field-path`
+- `data-dailyos-claim-id`
+- `data-dailyos-claim-version`
+- `data-dailyos-composition-id`
+- `data-dailyos-composition-version`
+- `data-dailyos-block-id`
+
+W5-A JS integration:
+- W5-A authors `wp/dailyos/blocks/account-overview/feedback.js`.
+- The script is enqueued on rendered front-end pages that include `dailyos/account-overview`.
+- The script uses delegated click listeners on `data-dailyos-feedback-action` attributes emitted by W4-A `render.php`.
+- The script reads the data attrs, builds the typed WP REST request, and never reads arbitrary visible text as route authority.
+
+Server-authoritative rule:
+- JS route validation is an early UX fail-closed check only.
+- PHP validates that the request belongs to the current signed post/block projection before nonce issue.
+- Runtime resolves `composition_id`, `composition_version`, `block_id`, and `field_path` to `edit_routes` again and refuses non-`FeedbackTarget` routes before mutation.
+- W5-A must not infer feedback eligibility from Gutenberg attribute names, visible labels, DOM text, CSS classes, block type alone, or claim refs without a `FeedbackTarget`.
+
+### 6. Feedback action mapping
+
+Decision:
+W5-A maps the four WP affordance verbs to typed substrate feedback.
+
+Initial mapping:
+
+| WP action | Runtime action | Substrate action |
+|---|---|---|
+| `corroborate` | `corroborate` | `ConfirmCurrent` |
+| `contradict` | `contradict` | `MarkFalse` |
+| `correct` | `correct` | `NeedsNuance` |
+| `dismiss` | `dismiss` | `SurfaceInappropriate` |
+
+Rules:
+- `correct` requires `value` or a typed correction payload.
+- `corroborate` must not carry a corrected value.
+- `contradict` may carry optional reason text but must not be required to.
+- `dismiss` is surface dismissal because DOS-573 is a rendered-block feedback router, not a global claim-deletion surface.
+- A future global tombstone affordance requires distinct UX and a packet amendment.
+- The mapper must be a closed enum mapping, not caller-provided substrate action strings.
+
+##### 6.1 SurfaceInappropriate surface metadata (V3 per codex C2 HIGH)
+
+`SurfaceInappropriate` is the only feedback variant whose persisted payload requires a non-empty `surface` field — substrate validator at `claims.rs:5586` rejects a `SurfaceInappropriate` event with empty or null surface. W5-A's wire schema (§2 WP REST) does NOT accept a `surface` field from the browser (caller cannot assert which surface they are on; the substrate would have to trust client-provided context).
+
+Rule:
+- The runtime endpoint `/v1/surface/feedback` constructs the `surface` metadata server-side from the validated `composition_id` + the block type extracted from the W4-D projection envelope (every W4-A0 producer is keyed `BlockType → surface_kind` per W4-A0 V5 §6.3). For the v1.4.2 v1 block this resolves to `"account_overview"`.
+- The mapping table `block_type → surface_kind` is closed enum and lives in the runtime; JS/PHP never supplies a surface string.
+- The constructed `surface` metadata also feeds the SurfaceInappropriate event's audit emission (so dismiss audits carry which surface was dismissed from, not just the claim id).
+- If the block type is unknown (e.g., projection envelope corrupt or an experimental block), the runtime rejects the dismiss with `422 InvalidBlockSurface`; no SurfaceInappropriate event is persisted with empty surface.
+
+#### 6.3 Undo window (V3 contract per codex C2 MEDIUM)
+
+Undo is a server-authoritative inverse-mutation path. The browser cannot supply substrate action strings, cannot extend the window, and cannot replay the undo.
+
+Authoritative state:
+- Each successful feedback submit returns an opaque `undo_token` in the response body — an HMAC over `(feedback_event_id || actor_session_id || expires_at)` signed with the runtime's W4-E HMAC key.
+- The 30-second window is enforced server-side via `expires_at` carried in the HMAC payload. UI-visible expiry is advisory only.
+- The `undo_token` is single-use: the runtime maintains a server-side consumed-tokens table (TTL 60s, double the window for replay margin) and rejects any second use with `409 UndoAlreadyApplied`.
+
+Wire flow:
+- Browser POST to WP REST `/dailyos/v1/feedback/undo` with `{ undo_token }` + WP REST nonce; no other fields.
+- WP REST passes through to runtime `/v1/surface/feedback/undo`, which:
+  1. Verifies HMAC + `expires_at` not elapsed + token not already consumed.
+  2. Loads the original `feedback_event_id`; the substrate computes the inverse action server-side via a closed mapping (`ConfirmCurrent → revoke`, `MarkFalse → revoke`, `NeedsNuance → revoke-with-tombstone`, `SurfaceInappropriate → revoke-dismiss`). Browser supplies no action.
+  3. Re-runs the W4-B precedence/concurrency checks for the inverse mutation (it is a real mutation, not a logical erasure).
+  4. Marks token consumed.
+
+Rules:
+- Undo follows the same WP REST nonce, `edit_post(post_id)`, post/block projection membership, route, scope, and service-boundary checks as the original feedback.
+- Undo does NOT consume a fresh W4-E presence nonce — the `undo_token` is the W4-E authority token for the inverse mutation, scoped tighter (single feedback event, single use, 30s).
+- Undo emits an `audit_event` distinct from the original feedback (`feedback_undone`), carrying the original `feedback_event_id`, the inverse action applied, the actor, and the surface kind.
+- Undo expiry is UI-visible but does not store nonce/HMAC material in JS state beyond `undo_token` itself; a click after expiry returns `410 UndoExpired` and the inline row clears the undo control on response.
+- Browser cannot construct, derive, or interpret the `undo_token` — it is treated as opaque bytes.
+
+#### 6.5 Affordance labels and placement
+
+| Action | User-visible label |
+|---|---|
+| `corroborate` | `Looks right` |
+| `contradict` | `Mark wrong` |
+| `correct` | `Fix this` |
+| `dismiss` | `Hide` |
+
+Rules:
+- Primary feedback-action DOM exposes only these four labels for the four W4-E actions.
+- Raw verbs such as `corroborate`, `contradict`, `correct`, and `dismiss` must not leak as visible button text.
+- The transient Undo control is a post-submit state control, not a `data-dailyos-feedback-action` primary affordance.
+- Affordances render inline in the block body with `data-ds-name="IntelligenceCorrection"`.
+- Affordances must not render in the Gutenberg sidebar, a modal, or a top-bar control.
+- The inline correct editor expands in place and matches the shipped `IntelligenceCorrection` variant `correct`.
+
+### 7. Error handling preserves W4-B precedence
+
+Decision:
+Runtime evaluates and returns the W4-B V9 precedence order:
+
+| Precedence | Variant | HTTP | W5-A handling |
+|---:|---|---:|---|
+| 0 | `ProjectionTampered` | 422 | show tamper banner; do not retry until W4-C clears |
+| 1 | `ProjectionVersionRollback` | 422 | show rollback/tamper banner; do not retry until refreshed projection clears |
+| 2 | `MissingExpectedClaimVersion` | 400 | fail closed; W5-A bug or stale render; refresh block |
+| 3 | `MidFlightMutation` | 423 | subscribe/wait using DOS-589 cursor and `retry_after_event` |
+| 4 | `ClaimVersionOverflow` | 500 | fail loud; no retry loop |
+| 5 | `StaleVersion` | 409 | refresh through W4-A0/W4-A with scope-filtered correction |
+| 6 | `StaleComposition` | 409 | refresh composition; require a new click |
+
+Canonical call graph:
+- PHP calls `/v1/surface/nonce/issue` and then `/v1/surface/feedback`.
+- PHP never calls `/v1/surface/nonce/verify` directly.
+- `/v1/surface/feedback` atomically verifies-and-consumes the nonce through W4-E and commits feedback through W4-B/services.
+- W4-E remains the nonce authority; W5-A delegates verification to runtime.
+
+Rules:
+- 422 wins over 409 when both tamper and stale are true.
+- 423 wins over stale when the mutation lock is held.
+- Missing expected version is a 400 bug path, not a feedback user error.
+- W5-A must not collapse all runtime failures into `403`.
+- W5-A must pass through safe machine-readable reason codes to JS.
+
+#### 7.5 Error-state surface map
+
+| Runtime result | Pattern | Severity/state | User-visible copy |
+|---|---|---|---|
+| 422 `ProjectionTampered` | TamperBanner / `ConsistencyFindingBanner` | high | `This block cannot be edited until verified.` |
+| 422 `ProjectionVersionRollback` | `ConsistencyFindingBanner` | medium | `This block is on older version. Refreshing…` |
+| 423 `MidFlightMutation` | inline spinner on affordance row | busy | `Saving someone else edit…` |
+| 409 `StaleVersion` or `StaleComposition` | silent refresh plus toast | status, 2s auto-dismiss | `Updated to latest.` |
+| 400 `MissingExpectedClaimVersion` | DevTools console only | n/a | no in-block user copy |
+| 500 `ClaimVersionOverflow` | `ConsistencyFindingBanner` | high | `This claim has reached its edit limit.` |
+| 429 rate-limited | inline below affordance row | warning | `Too many edits — try again in N seconds.` |
+| sensitivity or scope-filtered refusal | inline unavailable state | neutral | `This content is no longer available here.` |
+
+Rules:
+- Sensitivity refusals never say `you do not have permission` in user-facing copy.
+- The wire response for sensitivity refusals carries no claim metadata; audit detail may record reason `scope_filtered` server-side.
+- 409 toast auto-dismisses after 2 seconds.
+
+### 8. 409 stale-watermark handling
+
+Decision:
+W5-A refreshes rendered block HTML through W4-A0/W4-A after success and after stale-watermark responses.
+
+Success flow:
+
+```text
+runtime 200 applied
+  -> runtime returns post-commit composition_version
+  -> WP re-invokes W4-A0 producer/read path with the same SurfaceClient scope set used for the original render
+  -> W4-A renderer produces current scoped block HTML
+  -> WP REST response returns rendered_html and composition_version
+  -> JS replaces the block outer wrapper DOM
+  -> clicked affordance loading state clears only after replacement completes
+```
+
+Success response body:
+
+```json
+{
+  "outcome": "applied",
+  "composition_id": "composition-uuid",
+  "composition_version": 18,
+  "rendered_html": "<div data-dailyos-block-id=\"block-uuid\">...</div>",
+  "feedback_request_id": "request-uuid",
+  "undo_token": "opaque-base64-bytes",
+  "undo_expires_at": "2026-05-13T15:30:30Z"
+}
+```
+
+`undo_token` is an opaque base64 string produced by the runtime per §6.3 V3; it carries the HMAC-bound `(feedback_event_id || actor_session_id || expires_at)` payload. The browser MUST treat it as opaque bytes; the substrate is the sole authority on validity, expiry, and inverse-action derivation. `undo_expires_at` is advisory UI-only; the substrate enforces expiry from the HMAC payload.
+
+409 flow:
+
+```text
+runtime 409 stale_watermark or stale_composition_watermark
+  -> WP receives scope-filtered correction envelope or correction_ref
+  -> WP re-invokes W4-A0 producer/read path for the block scope
+  -> W4-A renderer returns refreshed scoped HTML
+  -> WP REST response returns outcome refresh_required and corrected_html
+  -> JS replaces the block outer wrapper DOM
+  -> prior click is spent; a new click is required for another feedback write
+```
+
+409 response body:
+
+```json
+{
+  "outcome": "refresh_required",
+  "composition_id": "composition-uuid",
+  "composition_version": 18,
+  "corrected_html": "<div data-dailyos-block-id=\"block-uuid\">...</div>",
+  "toast": "Updated to latest."
+}
+```
+
+Rules:
+- `corrected_html` is re-rendered block HTML, not raw claim JSON.
+- Inline `correction.claim` is already scope-filtered by W4-B section 2.
+- If `scope_redacted = true`, WP must not attempt a direct claim fetch by id.
+- Refresh must use the same SurfaceClient scopes as the original render; no elevated scope, `Actor::System`, or admin bypass is allowed.
+- If a `correction_ref` arrives via DOS-589, the event-log lookup is scope-filtered through `Actor::SurfaceClient` with the original scope set.
+- WP may use `correction.retry_after_ms` as a fallback wait ceiling.
+- WP must prefer DOS-589 event/cursor behavior where supplied.
+- WP must not tight-loop feedback submission after 409.
+
+### 9. 423 mid-flight handling
+
+Decision:
+On 423 `MidFlightMutation`, W5-A waits for the W4-B/DOS-589 cursor.
+
+Rules:
+- Runtime response includes `retry_after_event`.
+- W5-A subscribes or waits through DOS-589.
+- W5-A never polls `/v1/surface/feedback` in a tight loop.
+- Cursor resolution can produce committed update or mutation-aborted terminal event.
+- On committed update, W5-A refreshes the block and requires a new click if the user still wants to act.
+- On mutation aborted, W5-A may re-enable the affordance after refreshing current claim/composition versions.
+
+### 10. 422 tamper handling
+
+Decision:
+On 422 `ProjectionTampered` or `ProjectionVersionRollback`, W5-A refuses retry.
+
+Rules:
+- Do not request another nonce for the same stale/tampered projection.
+- Do not submit feedback again with a fresh nonce.
+- Show the W4-A/W4-C tamper banner state.
+- Tamper UI displays no `signed_payload`, `claim_id`, `composition_id`, or `field_path`.
+- Tamper UI may show only an opaque incident id and an operator reason code.
+- Wait until W4-C clears quarantine or a refreshed signed projection arrives.
+- Do not expose `correction.claim`; W4-B V9 says tamper variants return no correction payload.
+
+### 11. Capability, auth, and scope
+
+Decision:
+W5-A enforces WordPress authorization, post-bound edit authorization, and runtime SurfaceClient authorization.
+
+WP side:
+- `post_id` is required in the WP REST request body.
+- `permission_callback` requires a logged-in user.
+- `permission_callback` verifies `X-WP-Nonce` against the `wp_rest` action.
+- Missing or invalid `X-WP-Nonce` returns WP 403 before nonce issue or runtime feedback calls.
+- `permission_callback` requires `current_user_can('edit_post', post_id)`.
+- `current_user_can('edit_posts')` alone is not sufficient.
+- PHP derives `wp_user_id` from WordPress current user.
+- browser-provided `wp_user_id` is ignored or rejected.
+- PHP confirms the signed projected composition belongs to the requested `post_id` and block before nonce issue.
+
+Runtime side:
+- W4-B section 17 validates request `wp_user_id` against session-bound `wp_user_id`.
+- W2/W3 HMAC and bearer validation run before protected route dispatch.
+- SurfaceClient must have `submit.feedback`.
+- W2-D feedback budgets apply.
+- Runtime resolves route authority from the signed projected composition, not from browser trust.
+- W4-E nonce verification runs inside `/v1/surface/feedback` before feedback mutation.
+- 409 refresh and DOS-589 correction-ref lookups use the original SurfaceClient scope set with no elevation.
+
+### 12. Audit emission
+
+Decision:
+Every feedback submit and every authenticated reject emits safe audit through the runtime path when the runtime is reached.
+WP-side rejects that happen before runtime calls emit a local WP log entry that W6-A can correlate.
+
+Submit event kind:
+- `surface_feedback_submitted`
+
+Applied event kind:
+- `surface_feedback_applied`
+
+Reject event kind:
+- `surface_feedback_rejected`
+
+WP local reject scope:
+- Missing or invalid WP REST nonce returns 403 before nonce issue; if logged safely, the local WP log includes only opaque incident id, route name, and reason code.
+- `edit_post(post_id)` failure returns 403 before nonce issue; local WP log records `post_edit_denied` with `wp_user_id`, `post_id`, `feedback_request_id` when authenticated.
+- Missing route, refused route, malformed body, or projection-membership failure before nonce issue records a local WP log with safe correlation ids and no raw block payload.
+- W6-A correlates WP local logs with runtime audit by `feedback_request_id`, `wp_user_id`, route name, and incident id.
+
+Safe runtime detail shape:
+
+```json
+{
+  "feedback_request_id": "request-uuid",
+  "surface_client_id": "surface-client-id",
+  "wp_user_id": 42,
+  "claim_id": "claim-uuid",
+  "field_path": "claims[0].summary",
+  "claim_version": 7,
+  "composition_id": "composition-uuid",
+  "composition_version": 17,
+  "action": "correct",
+  "outcome": "applied",
+  "reason": null,
+  "bridge_error": null,
+  "scope_redacted": false
+}
+```
+
+Prohibitions:
+- no raw nonce;
+- no HMAC key;
+- no bearer token;
+- no corrected free-text value in audit detail unless a later privacy review explicitly allows a redacted/hash representation;
+- no customer names, domains, or emails;
+- no raw post content;
+- no raw block payload;
+- no `signed_payload` in UI, logs, or wire responses.
+
+### 13. Intelligence Loop fit
+
+1. Claim model:
+   W5-A writes feedback against existing claims by `(claim_id, claim_version, field_path)`.
+   It does not create display-only data.
+2. Provenance and trust:
+   `record_claim_feedback` preserves actor and action semantics; trust/source effects remain in the existing typed feedback substrate.
+3. Signals and invalidation:
+   feedback application emits existing claim feedback signals and W4-B version events through the service path.
+4. Runtime and surfaces:
+   WP is one SurfaceClient consumer; MCP/Tauri consumers must observe the same claim state after feedback commits.
+5. Feedback loop:
+   user corrections, dismissals, corroborations, and contradictions feed back through claim lifecycle, source reliability, trust inputs, and W4-A0 recomposition.
+
+## Acceptance criteria
+
+1. W5-A registers `POST /wp-json/dailyos/v1/feedback`.
+2. W5-A implements `DailyOS_Feedback_Router` with constructor, `register_routes`, `permission_callback`, `handle_feedback`, `build_runtime_event`, and `map_bridge_error_to_wp_response`.
+3. The REST route defines args callbacks for `post_id`, `block_client_id`, `composition_id`, `composition_version`, `block_id`, `field_path`, `claim_id`, `claim_version`, `action`, `value`, and `feedback_request_id`.
+4. Request validation runs in args callbacks, not in `handle_feedback`.
+5. The request body requires `post_id`.
+6. The route has a WordPress `permission_callback`.
+7. The permission callback requires a logged-in user.
+8. The permission callback verifies `X-WP-Nonce` with `wp_verify_nonce($nonce, 'wp_rest')` before runtime calls.
+9. Missing or invalid `X-WP-Nonce` returns WP 403 before nonce issue.
+10. The permission callback requires `current_user_can('edit_post', post_id)`, not only `edit_posts`.
+11. A logged-in user with `edit_posts` but without `edit_post` for `post_id` cannot submit and triggers no runtime call.
+12. Browser JSON cannot assert trusted `wp_user_id`.
+13. PHP derives `wp_user_id` from `get_current_user_id()`.
+14. PHP verifies `block_id`, `composition_id`, `composition_version`, and `edit_routes` belong to the current signed projection for the requested post/block before nonce issue.
+15. The REST `OPTIONS` response exposes only typed request schema and no internal field names, claim inventories, claim ids, or scope tokens.
+16. JS click handlers exist for `correct`, `dismiss`, `corroborate`, and `contradict`.
+17. W5-A authors and enqueues `wp/dailyos/blocks/account-overview/feedback.js` on rendered front-end pages.
+18. W4-A `render.php` emits `data-dailyos-feedback-action`, `data-dailyos-field-path`, `data-dailyos-claim-id`, `data-dailyos-claim-version`, `data-dailyos-composition-id`, `data-dailyos-composition-version`, and `data-dailyos-block-id` for valid affordances.
+19. Feedback is emitted only from explicit affordance clicks.
+20. Gutenberg save diffs do not emit feedback events.
+21. Surface-local display/layout autosaves do not consume nonces.
+22. Affordance DOM is not emitted for `ComputedFrom`, `DisplayOnly`, `Source`-only, or zero-ref `FeedbackTarget` routes.
+23. JS validates the clicked field against W4-D `edit_routes`.
+24. Runtime re-resolves `composition_id`, `composition_version`, `block_id`, and `field_path` to signed `edit_routes` and refuses non-`FeedbackTarget` routes server-side.
+25. Missing route fails closed before nonce issue and emits only safe WP local reject detail.
+26. `ComputedFrom` routes expose no feedback UI and cannot submit.
+27. `DisplayOnly` routes expose no feedback UI and cannot submit.
+28. `Source` without `FeedbackTarget` cannot submit.
+29. `FeedbackTarget` with zero claim refs cannot submit.
+30. Ambiguous receiver cannot submit.
+31. Unknown/future role cannot submit.
+32. Sensitivity or scope-filtered refusal surfaces `This content is no longer available here.` and no claim metadata in the wire response.
+33. `correct` carries a typed corrected value payload.
+34. `corroborate` maps to `ConfirmCurrent`.
+35. `contradict` maps to `MarkFalse`.
+36. `correct` maps to `NeedsNuance`.
+37. `dismiss` maps to `SurfaceInappropriate`.
+38. The action mapper is a closed enum and never accepts caller-provided substrate action strings.
+39. Primary affordance labels are exactly `Looks right`, `Mark wrong`, `Fix this`, and `Hide`.
+40. Raw action verbs do not leak into visible DOM as button labels.
+41. Affordances render inline with `data-ds-name="IntelligenceCorrection"`, not in Gutenberg sidebar, modal, or top-bar.
+42. Inline correct editor expands in place and matches shipped `IntelligenceCorrection` variant `correct`.
+43. Every successful feedback submit response body includes an opaque `undo_token` (HMAC over `feedback_event_id || actor_session_id || expires_at` signed by W4-E HMAC key) and an advisory `undo_expires_at` (UI display only). The 30-second window is server-enforced from the HMAC payload, not the wire-visible timestamp.
+44. Undo POST to `/dailyos/v1/feedback/undo` with `{ undo_token }` + WP REST nonce; the substrate verifies HMAC + expiry + single-use consumed-token table; on success the runtime derives the inverse action server-side from a closed mapping (browser supplies NO action string and NO fresh W4-E presence nonce — the `undo_token` IS the W4-E authority for the inverse mutation, scoped tighter to single-event/single-use/30s).
+45. Clicked affordance loading state sets `aria-busy="true"`, disables the control, and replaces the glyph with an inline spinner.
+46. Loading state lasts no more than 2 seconds before switching to the 423 wait pattern when a longer wait is needed.
+47. W5-A calls W4-E `/v1/surface/nonce/issue` through PHP runtime client after WP REST nonce, post capability, and post/block projection membership pass.
+48. Affordances are W4-D edit-route-gated, not nonce-gated.
+49. JS never receives a W4-E presence nonce.
+50. The W4-E WP-visible `/wp-json/dailyos/v1/nonce` endpoint is not called by DOS-573 click-then-submit.
+51. W5-A immediately submits `/v1/surface/feedback` with the nonce.
+52. PHP never calls `/v1/surface/nonce/verify` directly.
+53. JS never calls Rust runtime directly.
+54. JS never receives HMAC key material.
+55. JS never receives bearer token material.
+56. Nonce is not stored in block attributes, post content, local storage, logs, or audit details.
+57. `DailyOS_Runtime_Client::issue_nonce` accepts array context and signs with the same W3-B HMAC path as `submit_feedback`.
+58. `DailyOS_Runtime_Client::submit_feedback` signs the request with the W3-B HMAC path.
+59. Runtime `/v1/surface/feedback` handler registration is W5-A scope.
+60. Runtime `/v1/surface/feedback` lands in `src-tauri/src/bridges/surface_client.rs`.
+61. Runtime bridge runs W4-B section 17 `wp_user_id` session binding before nonce verify or claim lookup.
+62. Runtime authoritatively refuses non-`FeedbackTarget` route submissions before mutation.
+63. Runtime atomically verifies and consumes the nonce at the W4-E nonce store inside `/v1/surface/feedback` before feedback mutation.
+64. Runtime does not trust `feedback_request_id` for replay protection; the nonce provides replay protection.
+65. Runtime passes nonce-bound expected versions into W4-B CAS.
+66. Runtime applies feedback through `services::claims::record_claim_feedback` or the W4-B-updated service entry.
+67. No direct DB write exists in WP PHP.
+68. No direct DB write exists in runtime bridge handler.
+69. Every mutation goes through `services/`.
+70. On success, feedback row persists in the existing claim feedback substrate.
+71. On success, claim lifecycle/trust effects match the typed feedback matrix.
+72. On success, W4-B version events or feedback signals are emitted through existing substrate paths.
+73. On 200 success, WP receives post-commit `composition_version`, re-invokes W4-A0/W4-A, replaces rendered block HTML, and only then clears affordance loading state.
+74. On 409 stale claim watermark, W5-A refreshes with scope-filtered correction behavior using the same SurfaceClient scopes as original render.
+75. On 409 stale composition watermark, W5-A refreshes composition and requires a new click.
+76. On 409, WP REST response body returns `outcome: "refresh_required"` and `corrected_html`; it does not return raw claim JSON.
+77. On 409 `correction_ref` from DOS-589, event-log lookup is scope-filtered through `Actor::SurfaceClient` with no `Actor::System` or scope elevation.
+78. On 423 mid-flight mutation, W5-A waits on DOS-589 cursor and does not tight-loop.
+79. On 422 projection tamper, W5-A shows tamper banner and refuses retry until W4-C clears.
+80. Tamper UI exposes no `signed_payload`, `claim_id`, `composition_id`, or `field_path`; it shows only opaque incident id and operator reason code.
+81. On 422 projection rollback, W5-A refreshes signed projection and refuses feedback retry against old projection.
+82. On 400 missing expected version, W5-A treats it as a bug/stale render, writes DevTools console detail only, and refreshes.
+83. On 403 nonce mismatch, expired, replayed, wrong field, wrong action, wrong claim, or wrong user, no feedback write occurs.
+84. On 429 rate limit, UI surfaces `Too many edits — try again in N seconds.` without replaying automatically.
+85. Every BridgeSurfaceError maps to the section 7.5 DS pattern and copy.
+86. Every authenticated feedback submit emits `surface_feedback_submitted`.
+87. Every applied feedback emits `surface_feedback_applied`.
+88. Every authenticated runtime reject emits `surface_feedback_rejected`.
+89. WP-side rejects for capability failure, malformed body, projection membership failure, or missing route emit safe local WP logs for W6-A correlation.
+90. Audit details contain no raw nonce, no HMAC key, no bearer token, no raw corrected text, no raw post content, no raw block payload, and no customer names, domains, or emails.
+91. WP-side route tests cover WP REST nonce rejection and post-bound capability rejection.
+92. PHP unit tests cover runtime-client request body, `issue_nonce`, `submit_feedback`, and HMAC canonical path.
+93. Runtime tests cover W4-B error precedence for feedback and runtime-side route refusal.
+94. End-to-end fixture covers user click through feedback apply through block re-render.
+95. PHP fuzz fixtures cover missing WP REST nonce, minimal OPTIONS schema, and malformed body rejection.
+96. Accessibility tests cover visible-name matching accessible names, Enter/Space activation, focus preservation through state changes, `role="status"` announcements, trust-band differentiation via `data-ds-state` plus iconography, and inline editor focus trapping until submit or cancel.
+97. `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` green before L1 close.
+
+## Negative fixtures
+
+All W5-A fixtures use the per-DOS prefix `dos573_fixture_`.
+
+1. **`dos573_fixture_1_click_bound_correct.rs`**
+   User clicks `correct` on a FeedbackTarget route; nonce issued; feedback submitted; runtime maps to `NeedsNuance`; block refreshes.
+2. **`dos573_fixture_2_click_bound_dismiss.rs`**
+   User clicks `dismiss`; route maps to surface dismissal; claim no longer renders on the surface after refresh.
+3. **`dos573_fixture_3_click_bound_corroborate.rs`**
+   User clicks `corroborate`; maps to `ConfirmCurrent`; trust/user-confirmation state updates.
+4. **`dos573_fixture_4_click_bound_contradict.rs`**
+   User clicks `contradict`; maps to `MarkFalse`; active read surfaces stop rendering the claim.
+5. **`dos573_fixture_5_save_diff_no_feedback.rs`**
+   Gutenberg attribute diff without affordance click does not request nonce and does not submit feedback.
+6. **`dos573_fixture_6_computed_from_refused.rs`**
+   W4-D route is `ComputedFrom`; rendered HTML exposes no feedback affordance; forced POST is rejected before nonce issue.
+7. **`dos573_fixture_7_display_only_refused.rs`**
+   W4-D route is `DisplayOnly`; rendered HTML exposes no feedback affordance; forced POST is rejected before nonce issue.
+8. **`dos573_fixture_8_source_only_refused.rs`**
+   Source binding without explicit FeedbackTarget renders provenance but no feedback route.
+9. **`dos573_fixture_9_feedback_target_zero_refs.rs`**
+   FeedbackTarget with zero claim refs exposes no nonce-consuming affordance and forced POST rejects.
+10. **`dos573_fixture_10_ambiguous_receiver_refused.rs`**
+    Multiple incompatible receivers for one field reject with no nonce issue.
+11. **`dos573_fixture_11_missing_route_refused.rs`**
+    Field path absent from `edit_routes` rejects; no runtime feedback call.
+12. **`dos573_fixture_12_post_edit_capability_refused.php`**
+    Logged-in user has `edit_posts` but not `edit_post` for `post_id`; WP 403 returns before nonce issue and no runtime call occurs.
+13. **`dos573_fixture_13_browser_wp_user_ignored.rs`**
+    Browser asserts a different `wp_user_id`; PHP ignores/rejects it and uses current user only.
+14. **`dos573_fixture_14_wrong_user_bridge_precondition.rs`**
+    Signed runtime request body has `wp_user_id` mismatch; W4-B section 17 returns `403 wrong_user` before nonce verify.
+15. **`dos573_fixture_15_missing_nonce.rs`**
+    Runtime feedback POST without nonce rejects and writes no feedback row.
+16. **`dos573_fixture_16_expired_nonce.rs`**
+    W4-E returns `403 expired`; W5-A does not retry automatically.
+17. **`dos573_fixture_17_replayed_nonce.rs`**
+    Two submits with same nonce: one apply, one `403 replayed`; no duplicate feedback effect.
+18. **`dos573_fixture_18_mismatched_field_nonce.rs`**
+    Nonce bound to one field is submitted for another; `403 wrong_field`; no write.
+19. **`dos573_fixture_19_mismatched_action_nonce.rs`**
+    Nonce bound to `correct` is used for `dismiss`; `403 mismatched_action`; no write.
+20. **`dos573_fixture_20_stale_claim_409.rs`**
+    Claim advances after render; feedback returns 409 stale watermark; WP refreshes with scope-filtered correction.
+21. **`dos573_fixture_21_stale_composition_409.rs`**
+    Composition advances after render; feedback returns 409 stale composition; WP refreshes and requires new click.
+22. **`dos573_fixture_22_mid_flight_423.rs`**
+    Mutation lock held; response includes `retry_after_event`; W5-A waits through DOS-589; no tight loop.
+23. **`dos573_fixture_23_tamper_422.rs`**
+    Projection signature mismatch and stale version both true; 422 `ProjectionTampered` wins over 409; no correction payload and no sensitive ids in UI.
+24. **`dos573_fixture_24_rollback_422.rs`**
+    Signed older projection and stale composition both true; 422 rollback wins over 409.
+25. **`dos573_fixture_25_missing_expected_version_400.rs`**
+    Missing `claim_version` in rendered route or request rejects before feedback write.
+26. **`dos573_fixture_26_rate_limited_429.rs`**
+    Feedback write budget exhausted; UI surfaces retry state; no automatic replay.
+27. **`dos573_fixture_27_scope_redacted_409.rs`**
+    Stale correction is out of SurfaceClient scope; response has `scope_redacted: true`; WP does not direct-fetch claim body.
+28. **`dos573_fixture_28_audit_submit_apply_reject.rs`**
+    Submit, apply, runtime reject, and local WP reject paths each emit safe audit or local log details.
+29. **`dos573_fixture_29_no_raw_nonce_persisted.rs`**
+    Search serialized post content, block attributes, logs, and audit details; raw nonce absent.
+30. **`dos573_fixture_30_no_direct_claim_write_from_wp.rs`**
+    Static gate finds no SQL claim writes or direct substrate writes in WP plugin source.
+31. **`dos573_fixture_31_runtime_service_boundary.rs`**
+    Runtime handler calls service entry; bridge code does not execute feedback SQL directly.
+32. **`dos573_fixture_32_block_rerender_corrected_state.rs`**
+    Real account-overview fixture click applies feedback, receives post-commit `composition_version`, and re-renders the block with current state before loading clears.
+33. **`dos573_fixture_33_wp_rest_nonce_missing.php`**
+    Missing `X-WP-Nonce` returns WP 403 before nonce issue and before any runtime call.
+34. **`dos573_fixture_34_options_schema_minimal.php`**
+    REST `OPTIONS` response exposes only the typed request schema and no internal field names, claim ids, or scope tokens.
+35. **`dos573_fixture_35_malformed_body_rejected.php`**
+    Malformed or wrong-typed body fails args validation before `handle_feedback` and before nonce issue.
+
+## CI invariants
+
+1. **No save-diff feedback gate.**
+   Static test fails if `class-dailyos-feedback-router.php` reads arbitrary Gutenberg save diffs to synthesize feedback.
+2. **WP REST route gate.**
+   Test asserts `/wp-json/dailyos/v1/feedback` is registered with a permission callback.
+3. **WP REST nonce gate.**
+   Fixture asserts missing or invalid `X-WP-Nonce` fails with WP 403 before nonce issue or runtime call.
+4. **Post-bound capability gate.**
+   Fixture asserts `current_user_can('edit_post', post_id)` is required and `edit_posts` alone is insufficient.
+5. **WP REST args schema gate.**
+   Tests assert validation lives in args callbacks for every request field and malformed bodies never enter `handle_feedback`.
+6. **No browser-to-runtime gate.**
+   JS tests assert browser calls WP REST only.
+7. **No nonce persistence gate.**
+   Serialization tests assert no nonce in post content, block attrs, local storage, audit, or logs.
+8. **No refused affordance DOM gate.**
+   Rendered HTML tests assert no affordance DOM is emitted for ComputedFrom, DisplayOnly, Source-only, zero-ref FeedbackTarget, missing, unknown, or ambiguous routes.
+9. **Edit-route gate.**
+   Tests assert only W4-D `FeedbackTarget feedback_allowed=true` routes can submit.
+10. **Runtime route authority gate.**
+    Runtime tests assert `/v1/surface/feedback` re-resolves signed `edit_routes` and refuses non-FeedbackTarget submissions even when JS/PHP metadata claims eligibility.
+11. **Runtime-client method gate.**
+    PHP tests assert `DailyOS_Runtime_Client::submit_feedback` signs the exact JSON body sent to runtime.
+12. **Runtime-client nonce issue gate.**
+    PHP tests assert `DailyOS_Runtime_Client::issue_nonce(array $context): array` signs with the same W3-B HMAC canonicalization as `submit_feedback`.
+13. **SurfaceClient route-owner gate.**
+    Runtime route registration for `/v1/surface/feedback` lives in `src-tauri/src/bridges/surface_client.rs`.
+14. **Session-bound user gate.**
+    Runtime feedback tests assert W4-B section 17 rejects wrong `wp_user_id` before nonce verify or claim read.
+15. **Nonce topology gate.**
+    Static and runtime tests assert PHP never calls `/v1/surface/nonce/verify`; `/v1/surface/feedback` atomically verifies-and-consumes at the W4-E nonce store.
+16. **409 response shape gate.**
+    Tests assert 409 WP REST response includes `outcome: "refresh_required"` and `corrected_html`, not raw claim JSON.
+17. **No scope elevation refresh gate.**
+    Static/runtime tests assert W5-A 409 refresh and DOS-589 `correction_ref` lookup use `Actor::SurfaceClient` with original scopes, never `Actor::System` or elevated scopes.
+18. **Bridge precedence gate.**
+    Pairwise tests assert W4-B V9 precedence for tamper, rollback, missing version, mid-flight, overflow, stale claim, and stale composition.
+19. **Error-state copy gate.**
+    UI tests assert each BridgeSurfaceError maps to the section 7.5 pattern and copy, including no permission-language for sensitivity refusals.
+20. **Affordance label gate.**
+    JS/DOM tests assert primary feedback affordances expose only `Looks right`, `Mark wrong`, `Fix this`, and `Hide`; raw action verbs do not appear as visible labels.
+21. **Accessibility gate.**
+    Tests assert visible-name matching accessible names, Enter/Space activation, focus preservation through state changes, `role="status"` announcements, trust-band differentiation via `data-ds-state` plus iconography, and inline-editor focus trapping until submit or cancel.
+22. **REST enumeration gate.**
+    OPTIONS tests assert only typed request shape is exposed and no internal field names, concrete claim ids, or scope tokens are listed.
+23. **Service-boundary gate.**
+    Grep/static test fails direct DB writes from WP feedback router and runtime bridge handler.
+24. **Audit safety gate.**
+    Tests assert feedback audit and WP local reject details contain no raw nonce, raw corrected text, HMAC key, bearer token, post content, raw block payload, customer names, domains, emails, or signed payload.
+25. **DOS-589 wait gate.**
+    423 fixture asserts W5-A waits on `retry_after_event` and does not retry feedback in a tight loop.
+26. **L1 commands.**
+    `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`.
+
+## Interlocks
+
+| Upstream/downstream | W5-A dependency | W5-A obligation |
+|---|---|---|
+| W3-B runtime client | PHP HMAC transport and pairing/session material | Add `submit_feedback`; expose `issue_nonce(array $context): array` with HMAC signing identical to `submit_feedback`; surface DOS-565 Linear comment for W3-B owner ack; never expose secrets to JS |
+| W4-A renderer | Visible inline affordances, `IntelligenceCorrection` placement, and required data attrs | Consume delegated clicks from `feedback.js`; require W4-A `render.php` attrs; do not render refused-route affordance DOM |
+| W4-A0 producer | Recomposition after success, stale refresh, and rollback refresh | Reinvoke with the same SurfaceClient scopes as original render; do not synthesize block state locally |
+| W4-B | Watermarks, CAS, bridge errors, scope-filter correction, session-bound `wp_user_id`, route owner | Preserve versions and error precedence; route through services |
+| W4-C | Projection signatures, tamper and rollback detection | Treat 422 as non-retryable until projection is refreshed/cleared |
+| W4-D | `ProjectedComposition.edit_routes` and refusal reasons | Route only explicit FeedbackTarget routes; fail closed otherwise |
+| W4-E | Nonce issue, atomic verify-and-consume, expected-version return, and future WP nonce endpoint | Request nonce inside PHP submit path; never expose nonce to JS; never call verify from PHP; delegate verify to `/v1/surface/feedback` |
+| DOS-589 | Cursor replay, retry-after delivery, scope-filter dispatch | Wait on 423 cursor and refresh on delivered version events |
+| W5-C | Negative fixture catalog | Hand off all `dos573_fixture_*` fixtures for bundle consolidation |
+| W6-A | Forensic/audit trace | Emit enough safe runtime audit and WP local reject detail for originator trace by `wp_user_id`, `feedback_request_id`, incident id, and SurfaceClient instance |
+
+## What W5-A explicitly does NOT own
+
+- W4-A visual design for affordance placement beyond necessary feedback states.
+- W4-A0 producer logic or composition authoring.
+- W4-B `commit_claim`, `commit_composition`, version tables, or bridge error definitions.
+- W4-C Ed25519 signing, ledger, quarantine, or tamper clearance.
+- W4-D projection policy or edit-route generation.
+- W4-E nonce storage, verify semantics, TTL, or invalidation.
+- DOS-589 dispatcher implementation, replay ordering, or subscription transport.
+- New feedback tables.
+- New claim lifecycle semantics.
+- New trust-scoring model.
+- Multi-block feedback beyond `dailyos/account-overview`.
+- Bulk feedback operations.
+- Browser direct runtime transport.
+- Direct WP database writes to claim/substrate state.
+- Markdown-as-input reconciliation.
+- MCP-specific feedback UX.
+
+## Open questions
+
+All V2 questions are closed unless L0 reviewers reopen them.
+
+| ID | Resolution |
+|---|---|
+| Q1: click-bound vs save-diff | Click-bound only. DOS-573 and W4-E section 8 settle this. |
+| Q2: WP endpoint | `POST /wp-json/dailyos/v1/feedback`. |
+| Q3: runtime endpoint | `POST /v1/surface/feedback` in `bridges/surface_client.rs`. |
+| Q4: routability source | W4-D `edit_routes`; no WP inference. Runtime replays route authority server-side. |
+| Q5: Source role feedback | Source alone is not enough; requires explicit FeedbackTarget. |
+| Q6: zero-ref FeedbackTarget | Refused in v1.4.2 and no affordance DOM is emitted. |
+| Q7: dismiss semantics | `dismiss` maps to `SurfaceInappropriate`; global tombstone needs a future packet and distinct UX. |
+| Q8: 423 handling | DOS-589 cursor wait; no tight retry. |
+| Q9: 422 handling | Tamper/rollback banner; no retry until W4-C clears/refreshed projection arrives. |
+| Q10: audit value payload | Do not include raw corrected text in audit detail for V2. |
+| Q11: cross-packet nonce UX | W4-E section 707's WP-visible nonce endpoint is reserved for future decoupled nonce surfaces. DOS-573 does not call it; nonce issue happens inside PHP submit immediately before `/v1/surface/feedback`, and JS never receives a nonce. |
+
+## Linear dependency edges
+
+- DOS-573 is blocked by DOS-565 (W3-B runtime client + HMAC).
+- DOS-573 is blocked by DOS-567 (W4-B concurrency/bridge contract).
+- DOS-573 is blocked by DOS-568 (W4-A0 producer).
+- DOS-573 is blocked by DOS-569 (W4-C tamper/signature contract).
+- DOS-573 is blocked by DOS-570 (W4-D edit-routing projection).
+- DOS-573 is blocked by DOS-571 (W4-E nonce lifecycle).
+- DOS-573 is blocked by DOS-572 (W4-A renderer).
+- DOS-573 is blocked by DOS-589 for 423 retry-after and signal dispatch behavior.
+- DOS-573 blocks W5-C fixture consolidation for DOS-573-specific cases.
+- DOS-573 feeds W6-A audit forensic exercise.
+
+## L0 reviewer panel runners
+
+- `/plan-eng-review` for architecture, data flow, service boundaries, and interlocks.
+- `/cso` because W5-A crosses WP/browser/PHP/runtime trust boundaries and handles nonce-gated feedback writes.
+- `/plan-devex-review` because W5-A defines WP REST and PHP runtime-client behavior that future block authors must use.
+- `/plan-design-review` because the feedback affordance UX and error states are user-visible.
+- `/codex challenge` for adversarial review of nonce bypasses, route inference, stale/tamper precedence, and audit leakage.
+
+Unanimous approval is required for L0 closure.
+
+## Acceptance for L0 closure
+
+This packet is L0-approved when:
+
+1. eng, cso, devex, design, and codex all approve the V2 packet or a successor revision.
+2. DOS-573 Linear description links to this packet.
+3. DOS-573 dependency edges are updated to include W4-A, W4-B, W4-C, W4-D, W4-E, W3-B, and DOS-589.
+4. W4-D refusal matrix is copied into DOS-573 acceptance or linked as inherited acceptance.
+5. W4-E nonce tuple and click-bound lifecycle are copied into DOS-573 acceptance or linked as inherited acceptance.
+6. W4-B V9 bridge precedence is copied into DOS-573 acceptance or linked as inherited acceptance.
+7. DOS-589 cursor dependency is explicit for 423 behavior.
+8. W5-C fixture catalog receives the `dos573_fixture_*` list.
+9. Cycle-1 review findings are folded into this V2 dated packet revision and the changelog names each category.
+10. No code is started from this packet until L0 closes or the issue owner explicitly accepts a conditional start.
+
+W5-A implementation starts after L0 closure and after its blockers have landed enough for real integration.
+The implementation is done only when a real click through the account-overview block produces a nonce-bound feedback write, updates the substrate through services, emits safe audit, and re-renders the block with corrected current state.
+
+## Changelog
+
+- **V1 (2026-05-13):** Initial L0 packet for DOS-573.
+- Grounded on W4-B V9, W4-D V3, W4-E V2, W3-B/W2 transport contracts, DOS-589 dispatcher contract, and DOS-573 issue text.
+- Resolved the click-bound model as explicit affordance feedback, not save-diff inference.
+- Pinned `/wp-json/dailyos/v1/feedback` as the WP REST endpoint and `/v1/surface/feedback` as the runtime endpoint.
+- Pinned W5-A consumption of `ProjectedComposition.blocks[].edit_routes` from W4-D.
+- Pinned W4-B V9 `BridgeSurfaceError` precedence as the runtime rejection order W5-A must preserve.
+- Pinned W4-E nonce acquisition before feedback submission and runtime-side nonce verify before feedback commit.
+- Pinned 409, 423, and 422 handling as distinct UI/runtime paths.
+- Pinned `edit_posts` as the initial WordPress capability gate before V2 post-bound tightening.
+- Pinned audit emission on every submit and every authenticated reject through `emit_surface_audit`.
+- Recorded that this worktree had no existing WP `register_rest_route` or PHP `DailyOS_Runtime_Client::submit_feedback` implementation to reuse.
+- **V2 (2026-05-13):** Folded cycle-1 review findings from Codex, Eng, CSO, DevEx, and UI-Design in place.
+- Codex findings: tightened WP authz to `edit_post(post_id)`, required `post_id`, bound request fields to current signed post/block projection, pinned canonical nonce UX, prohibited PHP direct verify, and added Q11 for W4-E section 707.
+- Eng findings: added rendered-HTML no-affordance gate, post-success W4-A0 re-render before loading clear, WP local reject logs for W6-A correlation, closed dismiss mapping to `SurfaceInappropriate`, and explicit W5-A handler registration scope.
+- CSO findings: added WP REST nonce gate, runtime-side route refusal, no scope elevation on 409/DOS-589 refresh, tamper UI redaction, W4-E atomic nonce store ownership, minimal OPTIONS schema, `feedback_request_id` trust boundary, and fixtures 33-35.
+- DevEx findings: added W3-B `issue_nonce` obligation plus DOS-565 owner-ack comment, `feedback.js` integration/data attrs, `DailyOS_Feedback_Router` class skeleton, REST args schema, and 409 `corrected_html` response contract.
+- UI-Design findings: added approved affordance labels, DS error-state map, inline `IntelligenceCorrection` placement, 30 second undo, loading-state behavior, sensitivity refusal copy, and accessibility pins.
+- **V3.1 (2026-05-13):** Cycle 3 codex confirmation pass — closed two stale-contract drifts after V3 §6.3 landed:
+  - Success response body shape (§2 example) now includes `undo_token` alongside `undo_expires_at`. Documented `undo_token` as opaque base64, substrate-only interpreter, advisory expiry on the wire vs HMAC-payload-enforced expiry server-side.
+  - AC #43 + #44 rewritten to match §6.3 V3 contract: AC #43 names `undo_token` + advisory `undo_expires_at`, AC #44 names the undo POST + HMAC verify path + closed-mapping inverse derivation + explicit "no fresh W4-E presence nonce" rule (the V3 §6.3 boundary).
+
+- **V3 (2026-05-13):** Folded cycle-2 codex CONDITIONAL findings. Material changes:
+  - **HIGH fix (codex C2):** §6.1 added — `SurfaceInappropriate` requires non-empty `surface` metadata per substrate validator at `claims.rs:5586`. W5-A wire schema does NOT accept a client-supplied surface field; runtime constructs `surface` server-side from the closed `block_type → surface_kind` map sourced from W4-A0 V5 §6.3. Unknown block type fails closed with `422 InvalidBlockSurface` rather than persisting a SurfaceInappropriate event with empty surface. Audit emission for dismiss carries the constructed surface kind.
+  - **MEDIUM fix (codex C2):** §6.3 Undo window rewritten as a full server-authoritative contract — opaque `undo_token` returned in submit response (HMAC over `feedback_event_id || actor_session_id || expires_at` signed by W4-E HMAC key), single-use enforced via server-side consumed-tokens table (TTL 60s, replay margin), 30-second window enforced via `expires_at` inside HMAC payload (UI-visible expiry advisory), inverse mutation derived server-side via closed mapping (`ConfirmCurrent/MarkFalse → revoke`, `NeedsNuance → revoke-with-tombstone`, `SurfaceInappropriate → revoke-dismiss`), W4-B precedence/concurrency re-runs for the inverse mutation, distinct `feedback_undone` audit event with original feedback_event_id and inverse action.
+  - Browser cannot construct, derive, or interpret the `undo_token` — opaque bytes only.
+


### PR DESCRIPTION
## Linear ticket

DOS-546 (v1.4.2 — Personal Intelligence Engine: WordPress Foundation). Bundles L0 packets for DOS-W3, DOS-567, DOS-568, DOS-569, DOS-570, DOS-571, DOS-572, DOS-573, DOS-589.

## Summary

Bundles nine L0 plan packets reached unanimous APPROVE (codex + eng + cso + devex + ui-design, 1–5 review cycles each, bounded by acceptance criteria). Lands the W3–W5 substrate-to-surface contract docs so W4 implementation work can begin.

## What changed

- Added `.docs/plans/dos-546/v1.4.2-project/W3-L0-packet.md` (DOS-W3 — WP runtime client + HMAC signer; in-flight sister session)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-A-L0-packet.md` (DOS-572 V3.2 — renderer; runtime-side cache + opaque `cache_hint_token`)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-A0-L0-packet.md` (DOS-568 V5 — `AbilityOutput<Composition>` producer shape)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-B-L0-packet.md` (DOS-567 V9 — substrate concurrency contract, `version_events` outbox, BridgeSurfaceError precedence)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-C-L0-packet.md` (DOS-569 V3 — Ed25519 verify-on-read, quarantine, shadow-trust)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-D-L0-packet.md` (DOS-570 V3 — `project_composition_for_surface` composition-level API)
- Added `.docs/plans/dos-546/v1.4.2-project/W4-E-L0-packet.md` (DOS-571 V2 — nonce issue/verify, atomic nonce store)
- Added `.docs/plans/dos-546/v1.4.2-project/W5-A-L0-packet.md` (DOS-573 V3.1 — feedback router; `undo_token` HMAC contract)
- Added `.docs/plans/dos-546/v1.4.2-project/DOS-589-L0-packet.md` (DOS-589 V3.2 — signals dispatcher; cursor envelope, version-frozen composition gate)

No source files touched. L0 packets only.

## Test plan

- [x] `cargo clippy -- -D warnings` clean — n/a (docs-only diff; preflight 14 gates green at push)
- [x] `cargo test --lib` passes — n/a (docs-only diff)
- [x] `pnpm tsc --noEmit` clean — n/a (docs-only diff)
- [x] `pnpm test` passes — n/a (no frontend changes)
- [x] Manual verification: cross-packet substrate-reference consistency check — every W4-B `§N` resolves to V9; `cache_hint_token` round-trip language matches between W4-A §6.3.1 and W4-D consumer text; DOS-589 cursor envelope shape matches W4-B V9 §15 PK contract.

## Definition of Done

- [x] Acceptance criteria from each Linear ticket are encoded as numbered AC lists in each packet; reviewer panels validated against AC per L0 review boundary.
- [x] End-to-end flow: L0 contract documents — successor (W4 implementation) consumes these as the per-ticket execution contract.
- [x] No stubs, TODOs, or "Phase 2" deferrals — every open question is either resolved in V3.x or transferred to follow-up via path-α to the Codebase Maintenance project.
- [x] Tests — n/a (docs-only); commit-msg `L2-status: n-a-doc-only` accepted by hook.

## §4 Security

`security_auditor_invoked: false`

**Exemption ID**: `EXEMPT-DOC-ONLY`

**Exemption rationale**: Diff is exclusively additions of nine markdown planning documents under `.docs/plans/dos-546/v1.4.2-project/`. No code, no migrations, no config, no workflow, no dependency. The packets THEMSELVES describe security-relevant substrate (trust boundaries, nonce/HMAC contracts, scope filtering) — each packet had `/cso` + codex security review during its L0 cycles and reached unanimous APPROVE. The implementation PRs that consume these packets will each invoke the security auditor at L2 per the trigger matrix above.

- [ ] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

All ten triggers answered no — diff is markdown additions only.

## Follow-ups

- Linear MCP audit-trail comments (Cycle 1–5 reviewer verdicts + L0 closure announcements) — deferred until Linear MCP reconnects.
- W3 L0 is in-flight in a sister session; included here for project completeness. If the sister session lands its own commit, this PR's W3 packet will rebase cleanly (additive, same path).

## Notes for review

- L2 review of this PR is `n-a-doc-only` per the commit-msg gate; reviewers should focus on cross-packet contract consistency rather than code.
- Each packet's changelog records every cycle's findings + fixes, so the audit trail is in-document.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
