### PR TITLE
v1.4.7 L0 wave plan packet (unanimous APPROVE after 5 cycles)

### DIFF
--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -35,6 +35,24 @@ Cycle 2 changes (folded in below):
 
 Cycle 2 is heavy — 15 changes across 6 classes — but most are propagation/cleanup. The single substantive new design (Class S MCP client trust boundary) ships as a W0 deliverable. No wave shape changes; no migration slot changes (still v220–v239); no new ADRs beyond the already-planned ADR-0102 + ADR-0128 amendments (Class S folds into ADR-0102 amendment scope).
 
+## Cycle 3 amendments (2026-05-14)
+
+Cycle 2 codex verdicts: CSO **APPROVE-WITH-CONDITIONS** (5 CLOSED, 0 new); Challenge **BLOCK** (1 CLOSED, 4 OPEN — all class-A propagation gaps); Eng **BLOCK** (2 CLOSED, 4 OPEN/PARTIAL + 3 new MED); DX **REQUEST-CHANGES** (4 CLOSED, 2 PARTIAL + 3 new MED).
+
+Class A propagation hit AGAIN (third v1.4.7 cycle, sixth time across v1.4.6+v1.4.7 combined). Discipline failure on my part — when amending convention, I update the changelog/named-exceptions table but miss the lane-body text downstream.
+
+Cycle 3 changes:
+1. **Tool name propagation sweep.** All lane bodies + release gate now use canonical `dailyos.<verb>.<noun>` names: `dailyos.read.daily_briefing`, `dailyos.read.meeting_briefing`, `dailyos.read.portfolio_attention`, `dailyos.search.workspace_memory`, `dailyos.read.workspace_source_provenance`, `dailyos.write.place_document`, `dailyos.submit.note`, `dailyos.submit.action`, `dailyos.submit.action_status`. W1-B taxonomy text updated to match.
+2. **W3 wave header serial language** (was "in parallel after"). Now matches §"Named exceptions" cycle 2 staging.
+3. **W4 wave header serial language** (was "Three agents in parallel"). Now matches §"Named exceptions" cycle 2 staging.
+4. **`contracts.rs` nested types now derive `Serialize, Deserialize`** — `Side`, `ParamSpec`, `ParamSchema`, `ReturnSpec`, `ToolExample`, `Page<T>`, `OpaqueConversationHandle`, `McpActor`, `McpClientId`, `ScopedName`, `Scope`. Snippet now compile-ready end-to-end.
+5. **Scope-check field reference fixed** (Eng new MED): security gate text now reads `tool.description().scopes_required.is_subset(actor.granted_scopes)` instead of the erroneous `actor.scopes_required`.
+6. **`OpaqueConversationHandle` lifecycle contract pinned** (DX new MED): explicit mint trigger, response envelope field, echo location in request envelope, 24h expiry, first-write behavior, revocation, "no raw conversation IDs accepted" rule. Public wire shape now reviewer-quality.
+7. **Scope namespace rule disambiguated** (DX new MED): v1.4.6-reused scopes stay unprefixed verbatim; new v1.4.7 scopes use `dailyos.<verb>.<noun>` prefix; manifest validation rejects unlisted aliases.
+8. **Cross-session continuity check added to release gate** (Eng new MED): release gate now requires both same-conversation AND new-session-with-prior-handle fixtures.
+
+Cycle 3 is pure propagation discipline + contract polish; no architectural change. Class-A discipline note added: **future amendment commits MUST grep every active reference to changed contract names/values BEFORE committing.** This is the third v1.4.7 cycle hit by the same class — done with patches; the discipline IS the work.
+
 ---
 
 ## L0 prep posture (2026-05-14)
@@ -310,24 +328,33 @@ Two agents.
           pub scopes_required: Vec<Scope>,
       }
 
-      pub enum Side { Read, SubmitCorrection, Write }
+      // Cycle 3 amendment: every public type derives Serialize + Deserialize so the ToolDescription tree compiles.
+      #[derive(Serialize, Deserialize)] pub enum Side { Read, SubmitCorrection, Write }
 
-      pub struct ScopedName(pub String);       // canonical: "dailyos.<verb>.<noun>"
-      pub struct Scope(pub String);            // canonical: "<verb>.<noun>" or "dailyos.<verb>.<noun>"
+      #[derive(Serialize, Deserialize)] pub struct ScopedName(pub String);       // canonical: "dailyos.<verb>.<noun>"
+      #[derive(Serialize, Deserialize)] pub struct Scope(pub String);
+      // Scope namespace rule (cycle 3 DX disambiguation): scopes reused VERBATIM from v1.4.6 stay unprefixed
+      // (e.g., "write.workspace_place_document", "read.workspace_graph", "read.entity_names").
+      // NEW v1.4.7-introduced scopes are prefixed: "dailyos.<verb>.<noun>"
+      // (e.g., "dailyos.submit.note", "dailyos.submit.action", "dailyos.read.portfolio_attention").
+      // Manifest validation rejects any scope not on the canonical allowlist.
 
+      #[derive(Serialize, Deserialize)]
       pub struct ParamSpec {
           pub name: String,
           pub schema: ParamSchema,             // JSON-schema-shaped
           pub required: bool,
           pub description: String,
       }
-      pub struct ParamSchema(pub serde_json::Value);  // valid JSON Schema fragment
+      #[derive(Serialize, Deserialize)] pub struct ParamSchema(pub serde_json::Value);  // valid JSON Schema fragment
 
+      #[derive(Serialize, Deserialize)]
       pub struct ReturnSpec {
           pub schema: ParamSchema,             // JSON-schema-shaped response
           pub description: String,
       }
 
+      #[derive(Serialize, Deserialize)]
       pub struct ToolExample {
           pub prompt: String,                  // example user-facing prompt that should select this tool
           pub invocation: serde_json::Value,   // example { "name": "...", "arguments": {...} }
@@ -335,18 +362,15 @@ Two agents.
       }
 
       // Shared pagination envelope (cycle 2 DX MED #5). v1.4.6 WorkspaceGraphResponse v1 is a documented pass-through exception.
-      pub struct Page<T> {
-          pub items: Vec<T>,
-          pub next_cursor: Option<String>,     // opaque base64; same format convention as v1.4.6 W3-C
-          pub page_size: u32,
-      }
+      #[derive(Serialize, Deserialize)]
+      pub struct Page<T> { pub items: Vec<T>, pub next_cursor: Option<String>, pub page_size: u32 }
 
       // Server-minted opaque conversation handle (cycle 2 Class D #9 + CSO MED #3).
-      // Required on writes, recommended on reads. Server mints on first call in a conversation; host clients echo back.
-      // Replaces raw caller-provided conversation_id (which could leak PII through audit/signal payloads).
-      pub struct OpaqueConversationHandle(pub String);  // server-minted, non-PII, non-enumerable
+      // See "OpaqueConversationHandle lifecycle contract" section below for mint/echo/expiry rules.
+      #[derive(Serialize, Deserialize)] pub struct OpaqueConversationHandle(pub String);  // server-minted, non-PII, non-enumerable
 
       // Actor for MCP-originated calls (cycle 2 Class S — McpClient enum variant lives in actor.rs, shipped as part of W0 ADR-0102 PR)
+      #[derive(Serialize, Deserialize)]
       pub enum McpActor {
           Client {
               client_id: McpClientId,                    // server-issued after pairing
@@ -355,7 +379,7 @@ Two agents.
               granted_scopes: Vec<Scope>,                // loaded server-side from per-client manifest
           },
       }
-      pub struct McpClientId(pub String);    // server-issued during pairing; non-spoofable
+      #[derive(Serialize, Deserialize)] pub struct McpClientId(pub String);    // server-issued during pairing; non-spoofable
 
       // Tool handler trait — every handler implements this; W1-A defines, subsequent lanes implement
       pub trait McpToolHandler: Send + Sync {
@@ -376,6 +400,13 @@ Two agents.
       ```
     - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes (against the server-side scope manifest loaded by `auth`, NOT caller-provided `granted_scopes`), validates `OpaqueConversationHandle` presence on `Side::Write` tools (returns `ConversationRequired` if absent), invokes handler, records audit row, emits `McpToolInvoked` signal.
     - `auth.rs` (W1-A only owner; new per cycle 2 Class S) — MCP client authentication + session contract: `pair_client(handshake) -> McpClientId`; loads server-side scope manifest per `McpClientId`; revocation; transport HMAC verification helper; opaque conversation handle minting.
+  - **`OpaqueConversationHandle` lifecycle contract (cycle 3 DX MED — public wire shape):**
+    - **Mint trigger:** server mints on the first MCP call from a client that does not present an existing handle. Server mints AND returns the new handle in the response envelope's top-level `conversation_handle` field (separate from the tool's typed response payload).
+    - **Echo location:** subsequent calls from the same conversation pass the handle in the request envelope's top-level `conversation_handle` field.
+    - **Expiry:** 24 hours from last touch (refreshed on every call); server may rotate before then. After expiry, server mints a new handle on the next call (transparent to caller).
+    - **First-write behavior:** if a `Side::Write` tool is the FIRST call in a conversation (no prior handle), server mints a fresh handle, performs the write, and returns the handle. Caller MUST persist the handle for follow-up.
+    - **Revocation:** server-side admin API can revoke a handle; subsequent presentations return `Unauthorized { missing_scope: "valid_conversation" }` and the caller must restart with a new conversation.
+    - **No raw conversation IDs accepted:** any client-asserted `conversation_id` field in tool params is rejected with `BadParams { detail: "use envelope conversation_handle" }`.
     - `actor_policy.rs` (W1-A only owner) — scope/permission matrix for `Actor::McpClient` (consumed by `gateway.rs` after `auth.rs` resolves the actor).
     - `audit.rs` (W1-A only owner) — audit log writer with **keyed HMAC-SHA256 hashes** for `params_hash` and `response_hash` (cycle 2 CSO MED #2). Per-install audit key + `key_id`. Raw params/responses stay out of logs.
     - `taxonomy.rs` (DOS-478 / W1-B owner; W1-A creates empty placeholder).
@@ -385,7 +416,7 @@ Two agents.
 - **Don't touch:** `services/claims.rs`, `services/feedback.rs`, `services/actions.rs`, `services/workspace_ingestion/*` (consumer-only); existing MCP server entry points outside `services/mcp_v2/`; `actor.rs` (cycle 1 amendment for `Actor::McpClient` is already covered by the W0 ADR-0102 amendment which lands before W1-A starts).
 - **Depends on:** v1.4.6 fully merged; W0 ADR amendments merged.
 - **Security gate:** DOS-168 is security-annotated.
-  - Every MCP tool call validates `actor.scopes_required.is_subset(actor.granted_scopes)` BEFORE handler invocation.
+  - Every MCP tool call validates `tool.description().scopes_required.is_subset(actor.granted_scopes)` BEFORE handler invocation (cycle 3 fix per Eng MED — `scopes_required` lives on `ToolDescription`, not `McpActor`; `granted_scopes` is loaded server-side from the per-client manifest by `auth.rs`, NOT caller-provided).
   - Audit row written transactionally with handler invocation (handler success ⊕ rollback).
   - `McpToolInvoked` signal payload contains `tool_name`, `client_id`, `conversation_id` — NO raw parameters or response data (Suite S check).
   - Per-actor + per-tool rate limits enforced at gateway BEFORE handler invocation.
@@ -413,8 +444,9 @@ Two agents.
 - **`/plan-ceo-review` + `/plan-devex-review` gate:** taxonomy is product strategy — `/plan-ceo-review` validates the displacement use case framing ("DailyOS for the user's working professional world; NOT for broad corpus") at L0 plan. `/plan-devex-review` validates the tool-name + scope conventions at L0 plan.
 - **Tool-naming convention (proposed; finalized at L0 plan):**
   - All v1.4.7 tools live under `dailyos.*` namespace.
-  - Read tools: `dailyos.<noun>_<query_kind>` — e.g., `dailyos.account_status`, `dailyos.portfolio_attention`, `dailyos.search_workspace_memory`.
-  - Write tools: `dailyos.<verb>_<noun>` — e.g., `dailyos.create_action`, `dailyos.update_action_status`, `dailyos.add_note`, `dailyos.place_document`.
+  - All tools: `dailyos.<verb>.<noun>` (cycle 2/3 canonical convention; dot-separated, no underscores between verb and noun).
+  - Read tools: verb is `read` (default), or one of `search` / `list` / `get` / `prepare` for action-shaped reads. E.g., `dailyos.read.account_status`, `dailyos.read.portfolio_attention`, `dailyos.search.workspace_memory`, `dailyos.read.workspace_source_provenance`.
+  - Write tools: verb is `write` for system/AI-attributable creations, or `submit` for user-attributable corrections. E.g., `dailyos.submit.action`, `dailyos.submit.action_status`, `dailyos.submit.note`, `dailyos.write.place_document`.
   - Resources (read-only browsable): `dailyos://<entity_type>/<id>` URI scheme.
 - **Tool-description content discipline:**
   - `summary` is one sentence, surfaced verbatim to host models.
@@ -453,7 +485,7 @@ Three agents. DOS-175 (briefing replacement — Bug priority Urgent) merges firs
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_briefing.rs` (W1-A pre-created placeholder; W2-A fills); legacy briefing snapshot read paths to deprecate (enumerated at L0 plan via grep).
 - **Don't touch:** Gateway / contracts / actor policy (W1 owners); other handlers (other lane owners).
 - **Depends on:** W1 merged.
-- **Done when:** `dailyos.daily_briefing` and `dailyos.meeting_briefing` tools dispatch to ability-backed current-context queries; legacy snapshot read code paths removed (or wrapped with deprecation warnings); response shape includes provenance + freshness per ADR-0108; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** `dailyos.read.daily_briefing` and `dailyos.read.meeting_briefing` tools (canonical naming per cycle 2 #8) dispatch to ability-backed current-context queries; legacy snapshot read code paths removed (or wrapped with deprecation warnings); response shape includes provenance + freshness per ADR-0108; `cargo test` + `cargo clippy -D warnings` clean.
 
 ### Agent W2-B — DOS-172: Pagination + ranked discovery
 
@@ -467,11 +499,11 @@ Three agents. DOS-175 (briefing replacement — Bug priority Urgent) merges firs
 ### Agent W2-C — DOS-173: Portfolio attention tool
 
 - **Spec:** [DOS-173](https://linear.app/a8c/issue/DOS-173).
-- **Goal:** One efficient MCP tool — `dailyos.portfolio_attention` — that asks "which accounts/projects/people/open loops need attention" without chaining many low-level calls. Ability-backed, claim/source-aware, trust-rendered.
+- **Goal:** One efficient MCP tool — `dailyos.read.portfolio_attention` (canonical naming per cycle 2 #8) — that asks "which accounts/projects/people/open loops need attention" without chaining many low-level calls. Ability-backed, claim/source-aware, trust-rendered.
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_portfolio.rs` (W1-A pre-created placeholder); new ability `abilities-runtime/src/abilities/portfolio_attention.rs` if no existing ability covers it (confirm at L0 plan from grep).
 - **Don't touch:** Other handlers; v1.4.5 substrate (consume read-only).
 - **Depends on:** W1 merged; W2-A merged.
-- **Done when:** `dailyos.portfolio_attention` returns ranked attention items with claim/trust band + provenance refs + freshness; ability-backed (no direct DB queries); pagination via DOS-172's pattern; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** `dailyos.read.portfolio_attention` returns ranked attention items with claim/trust band + provenance refs + freshness; ability-backed (no direct DB queries); pagination via DOS-172's pattern; `cargo test` + `cargo clippy -D warnings` clean.
 
 ### W2 merge gate
 
@@ -485,7 +517,7 @@ L0 → L2 cleared. Required artifacts:
 
 ## Wave 3 — Workspace Memory Tools
 
-Three agents. DOS-479 (workspace memory search) merges first to establish the W3 pattern; DOS-171 (privacy-rendered resources) and DOS-480 (work-product placement) run in parallel after.
+Three agents, **fully serialized per cycle 2 amendment (DOS-171 explicitly depends on DOS-480 merged):** stage 3a = W3-A (DOS-479) only; stage 3b = W3-B (DOS-480) only; stage 3c = W3-C (DOS-171) only.
 
 ### Agent W3-A — DOS-479: Workspace memory search + graph traversal + provenance tools over MCP
 
@@ -539,12 +571,12 @@ L0 → L2 → L3 cleared. Required artifacts:
 
 ## Wave 4 — Controlled Feedback & Writes
 
-Three agents in parallel (file-disjoint).
+Three agents, **partially serialized per cycle 2 amendment:** stage 4a = W4-B (DOS-169 create_action) only; stage 4b = W4-A (DOS-167 note capture) + W4-C (DOS-170 update_action_status) in parallel after W4-B (file-disjoint; W4-A consumes workspace memory + action substrate; W4-C consumes action substrate).
 
 ### Agent W4-A — DOS-167: MCP note + observation capture
 
 - **Spec:** [DOS-167](https://linear.app/a8c/issue/DOS-167).
-- **Goal:** `dailyos.add_note(entity_id, content, sensitivity?, source_attribution?)` MCP tool that captures user observations from host conversations through `services::claims::commit_claim` (or a dedicated `services::notes` if present — confirm at L0 plan from grep). Lower default trust for AI-attributable note content.
+- **Goal:** `dailyos.submit.note(entity_id, content, sensitivity?, source_attribution?)` MCP tool (canonical naming per cycle 2 #8) that captures user observations from host conversations through `services::claims::commit_claim` (or a dedicated `services::notes` if present — confirm at L0 plan from grep). Lower default trust for AI-attributable note content.
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_note.rs` (W1-A placeholder).
 - **Depends on:** W1 + W2 + W3 merged (note capture references workspace memory for source attribution).
 - **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.note` scope.
@@ -554,7 +586,7 @@ Three agents in parallel (file-disjoint).
 ### Agent W4-B — DOS-169: MCP create_action
 
 - **Spec:** [DOS-169](https://linear.app/a8c/issue/DOS-169).
-- **Goal:** `dailyos.create_action(entity_id, title, due?, priority?, source_attribution?)` MCP tool routing through `services::actions`. Receipt-based, signal-emitting.
+- **Goal:** `dailyos.submit.action(entity_id, title, due?, priority?, source_attribution?)` MCP tool (canonical naming per cycle 2 #8) routing through `services::actions`. Receipt-based, signal-emitting.
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs` (W1-A placeholder).
 - **Depends on:** W1 merged.
 - **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.action` scope.
@@ -564,7 +596,7 @@ Three agents in parallel (file-disjoint).
 ### Agent W4-C — DOS-170: MCP update_action_status
 
 - **Spec:** [DOS-170](https://linear.app/a8c/issue/DOS-170).
-- **Goal:** `dailyos.update_action_status(action_id, new_status, note?)` MCP tool routing through `services::actions`. Preserves intent + provenance.
+- **Goal:** `dailyos.submit.action_status(action_id, new_status, note?)` MCP tool (canonical naming per cycle 2 #8) routing through `services::actions`. Preserves intent + provenance.
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs` (W1-A placeholder).
 - **Depends on:** W4-B merged (consumes the action creation pattern + audit shape).
 - **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.action_status` scope.
@@ -638,7 +670,7 @@ L0 → L2 → L3 → L4 → L5 cleared. Required artifacts:
 - [ ] CI invariant: tool-description corpus has eval coverage (DOS-481 fixture-per-tool)
 
 ### v1.4.6 contract pass-through
-- [ ] dailyos.search_workspace_memory returns WorkspaceGraphProjection v1 unchanged
+- [ ] dailyos.search.workspace_memory returns WorkspaceGraphProjection v1 unchanged
 - [ ] dailyos.place_document delegates to v1.4.6 place_document ability with full PlaceDocumentReceipt v1 fidelity
 - [ ] Sensitivity rendering matches v1.4.6 (file paths absent without read.entity_names; raw claim text absent in aggregates)
 - [ ] Pagination cursor format matches v1.4.6 W3-C convention
@@ -656,6 +688,7 @@ L0 → L2 → L3 → L4 → L5 cleared. Required artifacts:
 
 ### Cross-conversation continuity
 - [ ] Manual fixture: same conversation asks two related questions; second reflects state from first
+- [ ] Manual fixture: NEW MCP session presents a previously-issued OpaqueConversationHandle; server resolves and surfaces prior conversation state (cycle 3 amendment per Eng cycle 2 MED — closes the cross-session gap; matches W5-B test fixture (b))
 
 ### Linear hygiene
 - [ ] All 13 v1.4.7 issues closed Done

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -69,6 +69,15 @@ Class-A discipline this cycle: I grep-audited BEFORE editing this time (commands
 
 Cycle 4 is contract polish only; no architectural change. CSO not re-dispatched (cycle 2 APPROVE-WITH-CONDITIONS still holds — cycle 3+4 changes are tool-name + lifecycle-contradiction reconciliation, no new trust-boundary surface).
 
+## Cycle 5 amendments (2026-05-14)
+
+Cycle 4 codex verdicts: Eng **APPROVE** (5 CLOSED, no new); Challenge **APPROVE** (5 CLOSED, no new); DX **BLOCK** (3 CLOSED, 1 OPEN + 1 new MED — both the same finding: `McpActor::Client.conversation` field name doesn't match lifecycle envelope name `conversation_handle`).
+
+Cycle 5 fix (one):
+1. **`McpActor::Client.conversation` → `McpActor::Client.conversation_handle`** — field name now matches the cycle 3 lifecycle contract that pins `conversation_handle` as the canonical envelope name on both request and response sides.
+
+Cycle 5 is a one-line rename; no semantic change. Final L0 cycle expected.
+
 ---
 
 ## L0 prep posture (2026-05-14)
@@ -390,7 +399,7 @@ Two agents.
       pub enum McpActor {
           Client {
               client_id: McpClientId,                    // server-issued after pairing
-              conversation: Option<OpaqueConversationHandle>,
+              conversation_handle: Option<OpaqueConversationHandle>,  // cycle 5: field renamed from `conversation` to match lifecycle contract envelope name
               tool_name: ScopedName,
               granted_scopes: Vec<Scope>,                // loaded server-side from per-client manifest
           },

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -53,6 +53,22 @@ Cycle 3 changes:
 
 Cycle 3 is pure propagation discipline + contract polish; no architectural change. Class-A discipline note added: **future amendment commits MUST grep every active reference to changed contract names/values BEFORE committing.** This is the third v1.4.7 cycle hit by the same class — done with patches; the discipline IS the work.
 
+## Cycle 4 amendments (2026-05-14)
+
+Cycle 3 codex verdicts: Challenge **BLOCK** (4 CLOSED + 3 NEW from class-A miss); Eng **REQUEST CHANGES** (5 CLOSED + 3 NEW); DX **BLOCK** (5 OPEN converging on same set as Challenge/Eng); CSO held APPROVE-WITH-CONDITIONS from cycle 2. All three cycle-3 lanes converged on the same 5-finding cluster: I claimed "all lane bodies use canonical names" in cycle 3 changelog item #1 then immediately violated it for `dailyos.place_document` in three locations. Plus 3 contradictions/typos that snuck in.
+
+Cycle 4 fixes (all tight, all surgical — grep-validated this time):
+
+1. **`dailyos.place_document` → `dailyos.write.place_document` everywhere** (W0 scope mapping table line 199; W3-B done-when line 548; release gate line 674). Closes Challenge/Eng/DX shared finding.
+2. **`dailyos.read.briefing` → `dailyos.read.daily_briefing` + `dailyos.read.meeting_briefing`** in W0 scope mapping table (the actual W2-A tool surface ships TWO briefing tools, not one). Closes Eng MED.
+3. **OpaqueConversationHandle first-write contradiction resolved** (Eng/DX HIGH cycle 3). Gateway now mints a handle transparently if absent on writes — no `ConversationRequired` error path. The error variant is removed from `ToolError`. Revoked handles still return `Unauthorized { missing_scope: "valid_conversation" }`. Reconciles gateway/lifecycle/W3-B security gate to the same single behavior: writes don't fail on missing handle; first-write mints.
+4. **W3-A new scope `read.workspace_source_provenance` → `dailyos.read.workspace_source_provenance`** per cycle 2 #8 namespace rule (new v1.4.7 scopes get the `dailyos.<verb>.<noun>` prefix; only v1.4.6-reused scopes stay unprefixed). Closes Eng MED.
+5. **`conversation_id` → `conversation_handle`** in architecture invariants table line 251 + `McpToolInvoked` signal payload line 421 + Eng-flagged audit references. Aligns audit/signal language with the cycle 3 lifecycle contract that forbids raw caller-provided conversation IDs. Closes Eng MED.
+
+Class-A discipline this cycle: I grep-audited BEFORE editing this time (commands: `grep -nE 'dailyos\.[a-z_]+(?<!\.read|\.write|\.submit)\.|...'`, `grep -n 'conversation_id'`, `grep -n 'ConversationRequired'`). All five fixes anchored at known line numbers. Commit will pass cycle 4 verification or class-A is no longer survivable as a discipline failure — at that point the doc needs a structural rewrite, not patches.
+
+Cycle 4 is contract polish only; no architectural change. CSO not re-dispatched (cycle 2 APPROVE-WITH-CONDITIONS still holds — cycle 3+4 changes are tool-name + lifecycle-contradiction reconciliation, no new trust-boundary surface).
+
 ---
 
 ## L0 prep posture (2026-05-14)
@@ -196,12 +212,12 @@ Linear hygiene items to resolve before W0 closes:
 
    | v1.4.6 scope (already shipped) | v1.4.7 reuse / extension |
    |---|---|
-   | `write.workspace_place_document` | reused verbatim by `dailyos.place_document` MCP tool (W3-B) |
+   | `write.workspace_place_document` | reused verbatim by `dailyos.write.place_document` MCP tool (W3-B) |
    | `read.workspace_graph` | reused verbatim by `dailyos.search.workspace_memory` (W3-A) |
    | `read.entity_names` | reused as gating scope for entity-name disclosure across all v1.4.7 read surfaces |
    | `submit.feedback` / `submit.correction` / `submit.dismissal` | extended pattern for v1.4.7: `dailyos.submit.note` (W4-A), `dailyos.submit.action` (W4-B), `dailyos.submit.action_status` (W4-C) |
-   | (new) | `dailyos.read.account_status`, `dailyos.read.portfolio_attention`, `dailyos.read.briefing` (W2 lanes) |
-   | (new) | `dailyos.read.workspace_source_provenance` (W3-A), `dailyos.read.entity_resource` (W3-C) |
+   | (new) | `dailyos.read.account_status`, `dailyos.read.portfolio_attention`, `dailyos.read.daily_briefing`, `dailyos.read.meeting_briefing` (W2 lanes) |
+   | (new) | `dailyos.read.workspace_source_provenance` (W3-A; per cycle 3 #7 — new v1.4.7 scope so prefixed `dailyos.<verb>.<noun>`), `dailyos.read.entity_resource` (W3-C) |
 
    Verbs allowed: `read` (queries), `submit` (user-attributable corrections), `write` (system/AI-attributable creations). Read tools may optionally use `search` / `list` / `get` / `prepare` as verb-prefix when the action shape is more specific than generic `read`.
 
@@ -248,7 +264,7 @@ All v1.4.0–v1.4.6 invariants remain active. v1.4.7 adds:
 | Every MCP write tool is on the explicit MCP write allowlist with operation-specific scope | Existing CI lint script `src-tauri/scripts/check_mcp_write_allowlist.sh` (extended in v1.4.6 W4-C) covers the new v1.4.7 write tools | W4 merge |
 | Tool descriptions are typed `ToolDescription` structs (W1-A `contracts.rs`), not free-form strings | Compile-time check (struct, not `String`); CI snapshot test on the description corpus | W1 merge |
 | Source-aware tool outputs (DOS-171, DOS-479) honor v1.4.6 sensitivity rendering (file paths absent unless caller has `read.entity_names`; raw claim text NEVER returned in aggregates) | Suite S test against the W3-C `WorkspaceGraphProjection v1` redaction rules | W3 merge |
-| Actor attribution on every mutation: `Actor::McpClient { client_id, conversation_id }` recorded in audit log + signal payloads | grep CI on signal emission helpers; audit log row schema test | W4 merge |
+| Actor attribution on every mutation: `Actor::McpClient { client_id, conversation_handle }` recorded in audit log + signal payloads — server-minted opaque handle, NEVER raw caller-provided conversation IDs (cycle 4 reconciliation per Eng MED) | grep CI on signal emission helpers; audit log row schema test asserts `conversation_handle` field present and `conversation_id` absent | W4 merge |
 | Tool-description corpus has eval coverage — every tool description has at least one host-model prompt fixture asserting it gets selected for the right ask AND not for the wrong ask | DOS-481 deliverable; CI gate at W5 | W5 merge |
 
 ---
@@ -387,18 +403,17 @@ Two agents.
           fn invoke(&self, actor: &McpActor, params: serde_json::Value) -> Result<serde_json::Value, ToolError>;
       }
 
-      // Typed errors propagated to MCP wire
+      // Typed errors propagated to MCP wire (cycle 4: ConversationRequired removed; gateway mints handles transparently per cycle 3 lifecycle first-write rule)
       pub enum ToolError {
           BadParams { detail: String },
-          Unauthorized { missing_scope: Scope },
+          Unauthorized { missing_scope: Scope },     // also returned when caller presents a revoked OpaqueConversationHandle (with missing_scope: "valid_conversation")
           NotFound { resource: String },
           RateLimited { retry_after_seconds: u32 },
-          ConversationRequired,                // cycle 2: when a write tool gets no OpaqueConversationHandle
           UpstreamFailure { detail: String },
           Internal { trace_id: String },
       }
       ```
-    - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes (against the server-side scope manifest loaded by `auth`, NOT caller-provided `granted_scopes`), validates `OpaqueConversationHandle` presence on `Side::Write` tools (returns `ConversationRequired` if absent), invokes handler, records audit row, emits `McpToolInvoked` signal.
+    - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes (against the server-side scope manifest loaded by `auth`, NOT caller-provided `granted_scopes`), ensures `OpaqueConversationHandle` is set for `Side::Write` tools (server-mints via `auth::mint_handle()` if absent, per the cycle 3 lifecycle contract first-write rule — no error path on first write; the new handle is returned in the response envelope), invokes handler, records audit row, emits `McpToolInvoked` signal.
     - `auth.rs` (W1-A only owner; new per cycle 2 Class S) — MCP client authentication + session contract: `pair_client(handshake) -> McpClientId`; loads server-side scope manifest per `McpClientId`; revocation; transport HMAC verification helper; opaque conversation handle minting.
   - **`OpaqueConversationHandle` lifecycle contract (cycle 3 DX MED — public wire shape):**
     - **Mint trigger:** server mints on the first MCP call from a client that does not present an existing handle. Server mints AND returns the new handle in the response envelope's top-level `conversation_handle` field (separate from the tool's typed response payload).
@@ -418,7 +433,7 @@ Two agents.
 - **Security gate:** DOS-168 is security-annotated.
   - Every MCP tool call validates `tool.description().scopes_required.is_subset(actor.granted_scopes)` BEFORE handler invocation (cycle 3 fix per Eng MED — `scopes_required` lives on `ToolDescription`, not `McpActor`; `granted_scopes` is loaded server-side from the per-client manifest by `auth.rs`, NOT caller-provided).
   - Audit row written transactionally with handler invocation (handler success ⊕ rollback).
-  - `McpToolInvoked` signal payload contains `tool_name`, `client_id`, `conversation_id` — NO raw parameters or response data (Suite S check).
+  - `McpToolInvoked` signal payload contains `tool_name`, `client_id`, `conversation_handle` (the server-minted opaque handle per cycle 3 lifecycle contract; cycle 4 reconciliation per Eng MED — never raw caller-provided `conversation_id`) — NO raw parameters or response data (Suite S check).
   - Per-actor + per-tool rate limits enforced at gateway BEFORE handler invocation.
   - `/cso` at L0 plan AND L2 diff.
 - **`/plan-devex-review` gate:** the gateway pattern is the substrate every other v1.4.7 tool builds on. The `McpToolHandler` trait shape, error taxonomy, and tool-description type all need to be reviewer-quality DX before subsequent lanes start. `/plan-devex-review` at L0 plan.
@@ -526,7 +541,7 @@ Three agents, **fully serialized per cycle 2 amendment (DOS-171 explicitly depen
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_workspace_search.rs` (W1-A placeholder).
 - **Don't touch:** v1.4.6 `services::workspace_ingestion::*` (consumer-only); placement handler (DOS-480 owns); resource handler (DOS-171 owns).
 - **Depends on:** W1 + W2 merged; v1.4.6 W3-C (`WorkspaceGraphProjection v1`) frozen and merged.
-- **Tools shipped (cycle 2 amendment renames to canonical `<dot>.<verb>.<noun>` per Class C):** `dailyos.search.workspace_memory(entity_filter?, category_filter?, lifecycle_filter?, freshness_filter?)` returning the v1.4.6 `WorkspaceGraphProjection v1` shape unchanged (pagination cursor passes through; this is the documented v1.4.6 pass-through exception to v1.4.7's shared `Page<T>` envelope). Plus `dailyos.read.workspace_source_provenance(file_id)` returning per-file provenance + ingestion run history + claim attribution. Required scopes: `read.workspace_graph` (reused verbatim from v1.4.6 W3-C) for `dailyos.search.workspace_memory`; `read.workspace_source_provenance` (new) for the provenance tool.
+- **Tools shipped (cycle 2 amendment renames to canonical `<dot>.<verb>.<noun>` per Class C):** `dailyos.search.workspace_memory(entity_filter?, category_filter?, lifecycle_filter?, freshness_filter?)` returning the v1.4.6 `WorkspaceGraphProjection v1` shape unchanged (pagination cursor passes through; this is the documented v1.4.6 pass-through exception to v1.4.7's shared `Page<T>` envelope). Plus `dailyos.read.workspace_source_provenance(file_id)` returning per-file provenance + ingestion run history + claim attribution. Required scopes: `read.workspace_graph` (reused verbatim from v1.4.6 W3-C) for `dailyos.search.workspace_memory`; `dailyos.read.workspace_source_provenance` (new v1.4.7 scope; cycle 4 amendment per Eng MED — new scopes carry the `dailyos.<verb>.<noun>` prefix per cycle 2 #8 namespace rule) for the provenance tool.
 - **Security gate:** `/cso` at L0 plan AND L2 diff.
   - Sensitivity rendering: caller must have `read.entity_names` to see entity names in response; otherwise null per v1.4.6 redaction rule.
   - File paths NEVER returned (only `file_id`).
@@ -544,8 +559,8 @@ Three agents, **fully serialized per cycle 2 amendment (DOS-171 explicitly depen
   - Caller must have `write.workspace_place_document` scope (cycle 2: reused verbatim from v1.4.6).
   - All v1.4.6 W4-C security rules apply: server-derived `source_asof`, transactional validation+write+enqueue, per-actor rate limits, idempotency by `(entity_id, content_sha256, client_dedup_key)`.
   - The `resolved_path` field in the receipt is gated by `read.entity_names` per v1.4.6 W4-C cycle-9 amendment — MCP handler honors this without modification.
-  - `OpaqueConversationHandle` REQUIRED on this `Side::Write` tool (cycle 2 Class D #9). Gateway returns `ConversationRequired` if absent.
-- **Done when:** `dailyos.place_document` MCP tool delegates to v1.4.6's `place_document` ability; receipt serialization exact match for v1.4.6 `PlaceDocumentReceipt v1`; rate limits + idempotency tested; `/cso` L0 plan AND L2 diff approval recorded.
+  - `OpaqueConversationHandle` is the conversation context for this `Side::Write` tool (cycle 2 Class D #9). Per the cycle 3 lifecycle contract first-write rule, gateway server-mints a fresh handle if absent, performs the write, and returns the handle in the response envelope. No `ConversationRequired` error path — first-write is a valid scenario the gateway handles transparently. (Cycle 4 amendment reconciles the gateway gating contradiction Eng/DX both flagged in cycle 3.)
+- **Done when:** `dailyos.write.place_document` MCP tool (canonical naming per cycle 2 #8) delegates to v1.4.6's `place_document` ability; receipt serialization exact match for v1.4.6 `PlaceDocumentReceipt v1`; rate limits + idempotency tested; `/cso` L0 plan AND L2 diff approval recorded.
 
 ### Agent W3-C — DOS-171: Privacy-rendered MCP resources for entity + source profiles
 
@@ -671,7 +686,7 @@ L0 → L2 → L3 → L4 → L5 cleared. Required artifacts:
 
 ### v1.4.6 contract pass-through
 - [ ] dailyos.search.workspace_memory returns WorkspaceGraphProjection v1 unchanged
-- [ ] dailyos.place_document delegates to v1.4.6 place_document ability with full PlaceDocumentReceipt v1 fidelity
+- [ ] dailyos.write.place_document delegates to v1.4.6 place_document ability with full PlaceDocumentReceipt v1 fidelity
 - [ ] Sensitivity rendering matches v1.4.6 (file paths absent without read.entity_names; raw claim text absent in aggregates)
 - [ ] Pagination cursor format matches v1.4.6 W3-C convention
 

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -1,0 +1,596 @@
+# v1.4.7 — MCP Server v2 (Abilities-First) — Wave Plan
+
+## L0 prep posture (2026-05-14)
+
+Unlike v1.4.6 (which carried an approved project-level L0 verdict in the Linear description), v1.4.7's project description has no prior L0 approve. Cycle 1 of the L0 loop folds **project-scope review and wave-plan review into one pass** — codex Challenge / Eng / DX / CSO agents review both dimensions simultaneously against this packet. The packet is structured so each lane block names its project-scope rationale (mission-gate fit, scope-boundary justification) alongside its wave-scope contract (files owned, depends-on, done-when), so the same review cycle can clear both.
+
+## Lessons folded in from v1.4.6 L0 (10 cycles to converge)
+
+1. **Class-A propagation discipline.** When amending an API or relocating a contract, every active reference is updated in the same edit. v1.4.6 cycles 2/3/4/5 all hit "downstream propagation incomplete" findings; v1.4.7's draft pre-empts by grepping every named contract and its references in this initial draft.
+2. **Shared types in W1-A `contracts.rs` from day one.** Trait wave-timing inversions cost v1.4.6 cycles 3-6. v1.4.7 W1-A pre-defines every cross-lane contract in `services/mcp_v2/contracts.rs` and pre-creates the full submodule skeleton with `pub mod` declarations so subsequent lanes never edit `mod.rs`.
+3. **Frozen contract surfaces from cycle 1.** v1.4.6 spent cycles 8-10 on contract-sharpness amendments (DOS-474 idempotency key, DOS-489 query input, etc.). v1.4.7 pins typed input/output/error structs at cycle 1 to avoid the same back-and-forth.
+4. **Migration slot block reserved upfront.** v220-v239 (after v1.4.6's v200-v219 + buffer). v1.4.7 likely needs few migrations because it's a contract layer over existing substrate.
+5. **Cross-version dependency citations are explicit.** Every lane that consumes v1.4.6 substrate cites the exact frozen schema (`WorkspaceGraphProjection v1`, `PlaceDocumentInput v1`, etc.) rather than vague "uses v1.4.6 workspace memory."
+6. **Issue-body cleanup at W0.** Several v1.4.7 Linear issues still reference the pre-renumbering `v1.4.9 / v1.4.10` numbering (these are now v1.4.6 / v1.4.7 respectively). W0 close gate includes a cleanup pass.
+
+---
+
+**Date:** 2026-05-14
+**Target outcome:** Ship MCP v2 as a **co-equal head** over the same personal intelligence substrate as the Tauri app — abilities, claims, provenance, trust, lifecycle, AND the just-merged v1.4.6 workspace memory contracts. Host models (Claude Desktop, Cursor, ChatGPT) reach for DailyOS for the user's working understanding of their professional world (accounts, projects, people, meetings, sources, open loops) and explicitly NOT for broad corpus / web search jobs. Tool descriptions function as product copy.
+**Source of truth:** Linear project [v1.4.7 — MCP Server v2 (Abilities-First)](https://linear.app/a8c/project/v147-mcp-server-v2-abilities-first-6e12027c36c9) + this wave plan at `.docs/plans/v1.4.7-waves.md`.
+**Predecessor projects/docs:**
+- v1.4.6 waves: `.docs/plans/v1.4.6-waves.md` — workspace memory substrate. **v1.4.7 implementation gates on v1.4.6 merge.** Specifically v1.4.7 consumes: `WorkspaceGraphProjection v1` schema (DOS-489 / W3-C), `PlaceDocumentInput / Receipt / Error` contract (DOS-474 / W4-C), `WorkspaceCategoryRegistry` + `WorkspaceCategory` enum (W1-A `contracts.rs`), `services::workspace_ingestion` mutation surface, `link::override_link` API (DOS-465 / W1-C), `pipeline::quarantine_source` API (W2-A), `WorkspaceFile { kind: WorkspaceFileKind }` `DataSource` variant (ADR-0107 amendment).
+- v1.4.0/v1.4.1 substrate: claim service (`commit_claim`), Signal Policy Registry, Durable Invalidation Job Model, trust scoring, freshness decay, provenance rendering, `services::feedback`, `services::actions`.
+- v1.4.2 SurfaceClient foundation: `SurfaceClient` actor variant + loopback transport (which DailyOS already uses for the Tauri+WP bridge; v1.4.7 MCP head sits beside the SurfaceClient as another consumer of the same ability runtime, not on top of it).
+- ADRs: 0080 (signals), 0098 (source-aware lifecycle), 0102 (abilities runtime — likely amended by v1.4.7), 0105 (trust scoring), 0107 (source taxonomy), 0108 (provenance rendering + privacy), 0125 (claim anatomy), 0128 (headless DailyOS — likely amended by v1.4.7), 0129 (composable surfaces).
+**Success metric:** Tool-description host-selection eval (DOS-481) shows the displacement use case working — when a host model has DailyOS + broad corpus tools available, it picks DailyOS for personal-working-context questions (accounts, projects, people, meetings, sources, open loops) AND explicitly avoids picking DailyOS for broad enterprise/web corpus questions. Plus E2E validation (DOS-482) on real workspace data confirms tool outputs respect v1.4.6 source lifecycle, sensitivity rendering, provenance, and signal/invalidation.
+**Migration slots reserved:** v220–v239 (20 slots). v1.4.6 holds v200–v219; v180–v199 is v1.4.2 W5/W6 expansion buffer; v176–v179 is DOS-589; v175 is W4-E; v171–v174 is v1.4.2 W4-C.
+
+---
+
+## Release thesis
+
+DailyOS already exposes an MCP server, but most of it is legacy: stale briefing snapshots, ad-hoc reads, no ability-backed write surface, no source-aware tools, no host-selection language. v1.4.7 closes that gap as a **co-equal head**, not an export pipe. Two layers of expansion:
+
+1. **Original MCP v2 expansion** (legacy issue set DOS-167–DOS-175): replace stale reads with ability-backed current context, add portfolio attention + ranked discovery + pagination, add controlled feedback/note/action writes through `services::*` with receipts and signal emission.
+2. **v1.4.6-enabled expansion** (new issue set DOS-478–DOS-482, DOS-479, DOS-480, DOS-171): expose the v1.4.6 source registry / lifecycle / claim proposals / graph projection / placement contract through MCP tools that respect privacy rendering and sensitivity rules. AI agents can search workspace memory, place documents, inspect provenance, and correct source attribution — all through the same service boundary the Tauri app uses.
+
+The non-trivial product-design constraint: **tool descriptions are the product surface**. A vague description ("query DailyOS data") makes Claude pick generic search tools. A sharp description ("for the user's working understanding of their professional world: accounts, projects, people, meetings, open loops; NOT for broad enterprise / web corpus search") creates the right boundary. v1.4.7 treats tool-description text as version-controlled product copy with eval coverage (DOS-481).
+
+---
+
+## What v1.4.0–v1.4.6 leave behind (consumed contracts)
+
+This section lists the EXACT frozen contracts v1.4.7 consumes. Citing them precisely is how we avoid v1.4.6 cycles 2-5's "downstream propagation incomplete" failure mode.
+
+**From v1.4.0/v1.4.1:**
+- `services::claims::commit_claim` (sole writer for `intelligence_claims`); `services::feedback`; `services::actions`; Signal Policy Registry; durable invalidation queue; trust scoring; freshness decay; provenance rendering substrate (ADR-0108).
+- `CLAIM_TYPE_REGISTRY` (`abilities-runtime/src/abilities/claims.rs::ClaimType`); `ClaimSensitivity` (ADR-0125).
+
+**From v1.4.2 (relevant subset; v1.4.7 does not consume the WordPress UI bits):**
+- `Actor::SurfaceClient` actor variant (`actor.rs`) — v1.4.7 introduces a sibling `Actor::McpClient` variant for MCP-originated calls; both consume the same ability runtime.
+- ADR-0130 composition contract is NOT consumed by v1.4.7 (no Gutenberg blocks shipping in v1.4.7).
+
+**From v1.4.6 (cited explicitly per consumer):**
+- `services::workspace_ingestion::contracts::WorkspaceCategory` enum + slug serialization (cycle 9 frozen).
+- `WorkspaceCategoryRegistry` (W1-B) — per-entity category allowlist + path resolution.
+- `WorkspaceGraphProjection v1` schema + `WorkspaceGraphQueryInput v1` request shape + `WorkspaceGraphResponse v1 { Projection | NotModified }` (W3-C frozen API; v1.4.7 W3 lanes consume).
+- `WorkspaceGraphAudit v1` JSON schema (W3-C; v1.4.7 W5 evaluation lane consumes).
+- `place_document` ability + `PlaceDocumentInput v1` (`category: Option<String>`) + `PlaceDocumentReceipt v1` (`category`, `resolved_path: Option<String>` gated by `read.entity_names`) + `PlacementError` typed enum (W4-C frozen API; v1.4.7 W3 DOS-480 lane consumes).
+- `IngestPipeline::run(IngestRequest)` (W2-A; v1.4.7 doesn't call directly — goes through `place_document` ability).
+- `services::workspace_ingestion::link::override_link(emitter: &dyn SignalEmitter, ...)` (W1-C; v1.4.7 may surface relink as an MCP write).
+- `services::workspace_ingestion::pipeline::quarantine_source(file_id, reason, actor)` (W2-A; v1.4.7 may surface quarantine as an MCP write).
+- New `SignalType` variants: `WorkspaceFileIngested`, `WorkspaceFileRejected`, `WorkspaceFilePendingEntityAssignment`, `WorkspaceFileQuarantined`, `WorkspaceFileEntityLinkChanged` (W3-B; v1.4.7 W3 invalidation behavior consumes).
+- `DataSource::WorkspaceFile { kind: WorkspaceFileKind }` (ADR-0107 amendment merged in v1.4.6 W0; v1.4.7 surfaces this kind in graph projection responses).
+
+**v1.4.7 does NOT ship:**
+- New v1.4.6-style schema (workspace_ingestion is owned by v1.4.6; v1.4.7 only adds MCP-facing query / write tool layers).
+- New trust UI primitives, claim-receipt UI, lint mode (those are v1.4.4 scope).
+- Salience scoring / recommendations (v1.4.5 scope).
+- New `CLAIM_TYPE_REGISTRY` variants (consumes existing).
+- Bulk high-trust ingestion of AI-generated work product (explicit non-goal per project description).
+- External-system mutation beyond approved DailyOS abilities (explicit non-goal).
+
+---
+
+## Reading order
+
+1. This doc — wave assignments, merge gates, frozen contracts.
+2. v1.4.7 Linear project description — full scope + Definition of Done.
+3. Per-issue Linear ticket — frozen implementation contract.
+4. v1.4.6 wave plan — for the substrate v1.4.7 consumes; specifically the W3-C and W4-C lane sections that define the frozen schemas above.
+5. ADR-0128 (headless DailyOS — likely amended in W0) and ADR-0102 (abilities runtime — likely amended in W0).
+6. Shared Primitive and Service Ownership doc (Linear doc `c729429f-79c9-4131-a243-5500d6e2a605`) — applies to every issue.
+7. Prior wave proof bundles when working after Wave 0.
+
+---
+
+## Review ladder for v1.4.7
+
+The L0–L6 ladder from v1.4.0-waves.md applies. v1.4.7-specific amendments:
+
+| Level | Applies | Notes |
+|---|---|---|
+| **L0 Prep (Plan Hardening)** | Every issue + project-scope | `/plan-eng-review` default. `/plan-devex-review` mandatory for **every issue** (this is an entirely DX-facing project — every tool is consumer-facing). `/cso` mandatory for the gateway lane (DOS-168), all write-tool lanes (DOS-167, DOS-169, DOS-170), and the v1.4.6-substrate-consuming lanes that surface workspace data (DOS-171, DOS-479, DOS-480). `/plan-ceo-review` for DOS-478 (taxonomy + host-selection language is product strategy). |
+| **L0 (Plan)** | Every issue + project-scope | Codex challenge + domain reviewer + Codex consult. `/cso` required for security-annotated lanes. |
+| **L1 (Self)** | Every issue | Standard. |
+| **L2 (Diff)** | Every issue | **L2 runs locally before push.** Codex review + code-reviewer + `/plan-devex-review` (every diff is a DX surface). `/cso` re-review for security lanes. |
+| **L3 (Wave)** | W1, W3, W4 (heaviest contract or write surfaces) | Codex challenge + architect-reviewer + Suite S/P/E. |
+| **L4 (Surface)** | W5 — host-model selection eval (DOS-481) | Tool-description text reviewed as product copy by `/plan-devex-review`; eval against fixture host-model prompts. |
+| **L5 (Drift)** | W5 release close | `/plan-eng-review` + architect-reviewer against v1.4.7 DoD AND v1.4.6 substrate-consumer parity. |
+| **L6 (Human)** | If escalated | Same triggers as v1.4.x. |
+
+Security-annotated lanes (carry `/cso` at L0 plan AND L2 diff): DOS-168 (gateway + actor policy), DOS-167 (note/observation through claim/source services), DOS-169 (action creation), DOS-170 (action status update), DOS-171 (privacy-rendered resources), DOS-479 (workspace memory search — sensitivity boundary), DOS-480 (work-product placement — write boundary).
+
+DX-mandatory lanes (every lane carries `/plan-devex-review` because the entire project is a DX surface, but these have heightened DX scrutiny): DOS-478 (taxonomy + host-selection contract), DOS-481 (tool-description eval), DOS-175 (briefing replacement — change in observable MCP behavior), DOS-172 (pagination/ranking — pagination contract is a permanent shape), DOS-173 (portfolio attention — net-new tool surface).
+
+CEO-review lane: DOS-478 — the tool-taxonomy + host-selection contract IS the product-strategy artifact. `/plan-ceo-review` validates the displacement use case framing.
+
+---
+
+## Migration slot assignments
+
+Reserved block: **v220–v239** (20 slots). Allocation guidance — most v1.4.7 lanes need NO migration (they're contract / tool-handler / eval layers over existing substrate); the few that do are listed below.
+
+| Wave | Likely slots | Issues that may need migrations |
+|---|---|---|
+| W1 — Contract & Policy | v220–v224 | DOS-168 gateway tables (actor attribution audit log; tool-call ledger if needed) |
+| W2 — Ability-Backed Reads | (none expected) | DOS-172/173/175 are read-side; no schema change |
+| W3 — Workspace Memory Tools | (none expected) | All consume v1.4.6 contracts; no new schema |
+| W4 — Controlled Feedback & Writes | v225–v229 | DOS-167 note capture if a new claim-source kind is needed; DOS-169/170 if action-attribution audit needs new columns |
+| W5 — Evaluation & Release Gate | (none expected) | Eval fixtures live in tests, not migrations |
+
+If a wave needs more slots than allocated, the wave coordinator pauses and claims from the unassigned reserve (v230–v239) — never silently borrows from adjacent blocks.
+
+---
+
+## Scope cleanup before kickoff (W0)
+
+Linear hygiene items to resolve before W0 closes:
+
+1. **Issue-body renumbering cleanup.** Several v1.4.7 issues still reference the pre-renumbering `v1.4.9 / v1.4.10` taxonomy: DOS-167, DOS-168, DOS-170, DOS-171, DOS-172, DOS-173, DOS-175, DOS-479, DOS-480, DOS-481, DOS-482 all contain `v1.4.9` (now v1.4.6) and/or `v1.4.10` (now v1.4.7) references in their bodies. W0 includes a one-pass edit on each issue body to substitute current numbering. Doesn't change scope; eliminates a class of reviewer confusion.
+
+2. **Cross-version dependency confirmation — v1.4.6.** Confirm v1.4.6 has merged to `dev` with these specific contracts live and frozen: `WorkspaceGraphProjection v1` + `WorkspaceGraphQueryInput v1` + `WorkspaceGraphResponse v1` (W3-C); `PlaceDocumentInput v1` + `PlaceDocumentReceipt v1` + `PlacementError` typed enum (W4-C); `WorkspaceCategoryRegistry` + `WorkspaceCategory` enum slug serialization (W1-A `contracts.rs`); `pipeline::quarantine_source` (W2-A); `link::override_link(&dyn SignalEmitter, ...)` (W1-C); five new `WorkspaceFile*` SignalType variants + invalidation allowlist additions (W3-B); ADR-0107 `WorkspaceFile { kind: WorkspaceFileKind }` `DataSource` variant. **If any item is not yet merged, v1.4.7 implementation is blocked; document the gap on the affected v1.4.7 issue.**
+
+3. **ADR amendments needed.** Two likely:
+   - **ADR-0102 (abilities runtime)** — for any new actor variant (`Actor::McpClient`), new `mcp_exposure` modes if the existing tri-state `None | MetadataOnly | Invocable` proves insufficient, and any new scope-naming convention (see #4 below).
+   - **ADR-0128 (headless DailyOS)** — for v2 expansion principles: tool-description as product copy, host-selection language, cross-conversation continuity as a named affordance.
+   Both amendments drafted, reviewed, and merged before W1 L0 plans open. Resolves L0 questions #1 and #2.
+
+4. **Scope naming convention decision (formerly v1.4.x maintenance issue DOS-618).** v1.4.7 introduces many new MCP-invocable abilities. Either align on the existing `submit.*` convention (v1.4.0/v1.4.1 user-correction-class writes), introduce a coherent `read.*` / `write.*` / `submit.*` taxonomy (`read.*` for non-mutating, `write.*` for system/AI-attributable creations, `submit.*` for user-attributable corrections), or ship v1.4.7 with both conventions and migrate later. **Decision recorded as part of the ADR-0102 amendment.**
+
+5. **Shared Primitive and Service Ownership doc** — confirm Linear doc `c729429f-79c9-4131-a243-5500d6e2a605` (originally for v1.4.6) extends to v1.4.7 every-tool-routes-through-services discipline. Likely already does; reconcile.
+
+6. **`Actor::McpClient` introduction.** v1.4.2 introduced `Actor::SurfaceClient`. v1.4.7 needs `Actor::McpClient` for MCP-originated calls — distinct from `SurfaceClient` because the access control matrices, audit attribution, and rate-limit budgets differ. Record as part of ADR-0102 amendment.
+
+7. **Migration slot pre-announcement.** Announce v220–v239 reservation in `#dailyos` and on the v1.4.x maintenance waves doc to avoid silent collision with in-flight maintenance PRs.
+
+8. **Path-α maintenance issue protocol active.** Same as v1.4.6: theoretical hardening or scope-expansion findings during cycle 1+ codex review file as DailyOS Maintenance Linear issues (`b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`), not blocking v1.4.7.
+
+---
+
+## Wave shape
+
+| Wave | Issues | Parallel agents | Wall-clock target |
+|---|---|---|---|
+| **W0** — Plan freeze + ADR amendments + scope cleanup | (no implementation; coordination + ADRs) | 0 | 2–3 days (ADR amendments take real review time) |
+| **W1** — Contract & Policy | DOS-168, DOS-478 | 2 | 4–5 days |
+| **W2** — Ability-Backed Reads | DOS-172, DOS-173, DOS-175 | 3 | 4–5 days |
+| **W3** — Workspace Memory Tools | DOS-171, DOS-479, DOS-480 | 3 | 5–6 days |
+| **W4** — Controlled Feedback & Writes | DOS-167, DOS-169, DOS-170 | 3 | 4–5 days |
+| **W5** — Evaluation & Release Gate | DOS-481, DOS-482 | 2 | 5–6 days (host-model eval is non-trivial) |
+
+Total: 13 implementation issues + 1 coordination wave. Estimated wall-clock: ~4 weeks.
+
+**Default ordering:** each wave gates on the prior wave's merge.
+
+**Named exceptions:**
+- W2 internal staging: DOS-175 (replace stale briefing reads — Bug priority Urgent) ships first as it unblocks downstream parity. DOS-172 (pagination) and DOS-173 (portfolio attention) run in parallel after DOS-175 merges.
+- W3 internal staging: DOS-479 (workspace memory search) merges first as DOS-171 (privacy-rendered resources) and DOS-480 (work-product placement) both depend on the W3 ability-runtime patterns DOS-479 establishes.
+- W4 internal staging: DOS-167 (note capture), DOS-169 (create_action), DOS-170 (update_action_status) are file-disjoint and run in parallel after W1 gateway lands.
+- W5 internal staging: DOS-481 (tool-description eval) ships first as DOS-482 (E2E validation) consumes the eval fixtures.
+
+---
+
+## Architecture invariants
+
+All v1.4.0–v1.4.6 invariants remain active. v1.4.7 adds:
+
+| Invariant | Mechanism | Activated by |
+|---|---|---|
+| Every MCP tool routes through an ability or approved service — no direct DB reads/writes from tool handlers | CI lint script `src-tauri/scripts/check_mcp_tool_handler_allowlist.sh` modeled on `check_claim_writer_allowlist.sh`: forbids `conn.execute` / `db.upsert_*` / `db.query_*` from `services/mcp_v2/handlers/*.rs` outside the approved ability invocation pattern | W1 (DOS-168) merge |
+| Every MCP write tool is on the explicit MCP write allowlist with operation-specific scope | Existing CI lint script `src-tauri/scripts/check_mcp_write_allowlist.sh` (extended in v1.4.6 W4-C) covers the new v1.4.7 write tools | W4 merge |
+| Tool descriptions are typed `ToolDescription` structs (W1-A `contracts.rs`), not free-form strings | Compile-time check (struct, not `String`); CI snapshot test on the description corpus | W1 merge |
+| Source-aware tool outputs (DOS-171, DOS-479) honor v1.4.6 sensitivity rendering (file paths absent unless caller has `read.entity_names`; raw claim text NEVER returned in aggregates) | Suite S test against the W3-C `WorkspaceGraphProjection v1` redaction rules | W3 merge |
+| Actor attribution on every mutation: `Actor::McpClient { client_id, conversation_id }` recorded in audit log + signal payloads | grep CI on signal emission helpers; audit log row schema test | W4 merge |
+| Tool-description corpus has eval coverage — every tool description has at least one host-model prompt fixture asserting it gets selected for the right ask AND not for the wrong ask | DOS-481 deliverable; CI gate at W5 | W5 merge |
+
+---
+
+## Wave 0 — Plan freeze + ADR amendments + scope cleanup
+
+W0 is coordination + ADR work, not implementation. No migration slots consumed.
+
+**W0 open gate (before W1 L0 plans are written):**
+- [ ] v1.4.6 cross-version dependency confirmation recorded (all v1.4.6 contracts listed in §"What v1.4.0–v1.4.6 leave behind" confirmed merged on `dev`)
+- [ ] Issue-body renumbering cleanup completed for all v1.4.7 issues containing stale `v1.4.9` / `v1.4.10` references
+- [ ] ADR-0102 amendment drafted (covers `Actor::McpClient` introduction + scope naming convention decision)
+- [ ] ADR-0128 amendment drafted (covers v2 expansion principles: tool-description as product copy, host-selection language, cross-conversation continuity)
+- [ ] Shared Primitive and Service Ownership doc reviewed; v1.4.7 scope confirmed consistent
+- [ ] Migration slot reservation v220–v239 announced
+- [ ] Scope naming convention decision recorded (which of `read.*` / `write.*` / `submit.*` taxonomy v1.4.7 adopts; documented in ADR-0102 amendment)
+
+**W0 close gate:**
+- [ ] Both ADR amendments merged
+- [ ] All issue bodies renumbered
+- [ ] L0 questions table reviewed; resolutions recorded
+- [ ] W1 agent lane contracts written and in L0 review
+
+---
+
+## Wave 1 — Contract & Policy
+
+Two agents.
+
+### Agent W1-A — DOS-168: MCP v2 ability/service gateway + actor policy + skeleton
+
+- **Spec:** [DOS-168](https://linear.app/a8c/issue/DOS-168).
+- **Goal:** Build the MCP v2 gateway — the single entry point that receives MCP tool calls, validates `Actor::McpClient` policy, dispatches through the ability runtime, captures audit attribution, and emits signals. **W1-A pre-creates the entire `services/mcp_v2/` module skeleton** (per v1.4.6 lessons): `mod.rs` with all `pub mod` declarations, `contracts.rs` with shared types + traits + Null impls, empty placeholder files for every submodule that subsequent lanes fill.
+- **Files owned (exclusive):**
+  - New migration(s) in `src-tauri/src/migrations.rs` (slots v220–v222 — actor attribution audit log + tool-call ledger if needed).
+  - Full submodule skeleton under `src-tauri/src/services/mcp_v2/`:
+    - `mod.rs` (W1-A only owner; contains all `pub mod` declarations: `pub mod contracts; pub mod gateway; pub mod handlers; pub mod taxonomy; pub mod actor_policy; pub mod audit;` + per-handler submodule decls added by W1-A in advance: `pub mod tool_briefing; pub mod tool_portfolio; pub mod tool_pagination; pub mod tool_resources; pub mod tool_workspace_search; pub mod tool_placement; pub mod tool_note; pub mod tool_create_action; pub mod tool_update_action_status; pub mod tool_eval;`).
+    - `contracts.rs` (W1-A only owner) — defines:
+      ```rust
+      // Tool description as typed product copy
+      pub struct ToolDescription {
+          pub name: ScopedName,                // e.g., "dailyos.account_status"
+          pub summary: String,                 // 1-line summary surfaced to host models
+          pub when_to_call: String,            // "for the user's working understanding of..."
+          pub when_NOT_to_call: String,        // "NOT for broad enterprise/web corpus search"
+          pub parameters: Vec<ParamSpec>,
+          pub returns: ReturnSpec,
+          pub examples: Vec<ToolExample>,
+          pub scopes_required: Vec<Scope>,
+      }
+      pub struct ScopedName(pub String);       // e.g., "dailyos.search_workspace_memory"
+      pub struct Scope(pub String);            // canonical naming per W0 ADR-0102 amendment
+
+      // Actor for MCP-originated calls
+      pub enum McpActor {
+          Client { client_id: String, conversation_id: Option<String>, tool_name: ScopedName },
+      }
+
+      // Tool handler trait — every handler implements this; W1-A defines, subsequent lanes implement
+      pub trait McpToolHandler: Send + Sync {
+          fn description(&self) -> &ToolDescription;
+          fn invoke(&self, actor: &McpActor, params: serde_json::Value) -> Result<serde_json::Value, ToolError>;
+      }
+
+      // Typed errors propagated to MCP wire
+      pub enum ToolError {
+          BadParams { detail: String },
+          Unauthorized { missing_scope: Scope },
+          NotFound { resource: String },
+          RateLimited { retry_after_seconds: u32 },
+          UpstreamFailure { detail: String },
+          Internal { trace_id: String },
+      }
+      ```
+    - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes, invokes handler, records audit row, emits `McpToolInvoked` signal.
+    - `actor_policy.rs` (W1-A only owner) — scope/permission matrix for `Actor::McpClient`.
+    - `audit.rs` (W1-A only owner) — audit log writer.
+    - `taxonomy.rs` (DOS-478 / W1-B owner; W1-A creates empty placeholder).
+    - `handlers/*.rs` (each subsequent lane fills its own placeholder).
+  - ADR-0102 amendment file in `.docs/decisions/0102-*-amendment-v147.md` (W0 deliverable; W1-A inherits the merged version).
+  - New `SignalType::McpToolInvoked` variant added to `signals/policy_registry.rs` (function-level addition; same pattern as v1.4.6 W3-B).
+- **Don't touch:** `services/claims.rs`, `services/feedback.rs`, `services/actions.rs`, `services/workspace_ingestion/*` (consumer-only); existing MCP server entry points outside `services/mcp_v2/`; `actor.rs` (cycle 1 amendment for `Actor::McpClient` is already covered by the W0 ADR-0102 amendment which lands before W1-A starts).
+- **Depends on:** v1.4.6 fully merged; W0 ADR amendments merged.
+- **Security gate:** DOS-168 is security-annotated.
+  - Every MCP tool call validates `actor.scopes_required.is_subset(actor.granted_scopes)` BEFORE handler invocation.
+  - Audit row written transactionally with handler invocation (handler success ⊕ rollback).
+  - `McpToolInvoked` signal payload contains `tool_name`, `client_id`, `conversation_id` — NO raw parameters or response data (Suite S check).
+  - Per-actor + per-tool rate limits enforced at gateway BEFORE handler invocation.
+  - `/cso` at L0 plan AND L2 diff.
+- **`/plan-devex-review` gate:** the gateway pattern is the substrate every other v1.4.7 tool builds on. The `McpToolHandler` trait shape, error taxonomy, and tool-description type all need to be reviewer-quality DX before subsequent lanes start. `/plan-devex-review` at L0 plan.
+- **Intelligence Loop gate:**
+  1. *Claim model:* Gateway writes no claims. Tool handlers route through `services::claims` if they produce claims (W4 lanes do).
+  2. *Provenance + trust:* Audit log captures `(actor.client_id, tool_name, params_hash, response_hash, timestamp)`.
+  3. *Signals + invalidation:* `McpToolInvoked` signal emitted; consumed by tool-usage telemetry (out of scope) but registered in v1.4.7 W1-A for future use.
+  4. *Runtime + surfaces:* Gateway is the entry point for all MCP tools; no other surface bypasses it.
+  5. *Feedback loop:* Tool handlers that surface user-correctable claims route corrections through `services::feedback`.
+- **Tests required:** Gateway dispatches to registered handlers; rejects unknown tool names with `BadParams`; rejects unauthorized actors with `Unauthorized { missing_scope }`; transactional audit + handler test (rollback on handler error); rate limit test (burst, then `RateLimited`); `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** Gateway accepts tool calls, validates actor + scopes, dispatches through registered `McpToolHandler` impls, writes audit + emits `McpToolInvoked` signal; `services/mcp_v2/` skeleton fully populated with empty placeholders; `ToolDescription` + `McpToolHandler` + `ToolError` types in `contracts.rs`; CI lint script `check_mcp_tool_handler_allowlist.sh` in place; all tests green; `/cso` + `/plan-devex-review` L0 plan AND L2 diff approval recorded.
+
+### Agent W1-B — DOS-478: Tool taxonomy + host-selection contract
+
+- **Spec:** [DOS-478](https://linear.app/a8c/issue/DOS-478).
+- **Goal:** Define the v1.4.7 tool taxonomy + host-selection language as a versioned, reviewable artifact. This is the "tool descriptions are product copy" project principle made concrete: a YAML/Rust catalog of every v1.4.7 MCP tool with name, scopes, summary, when-to-call, when-NOT-to-call, examples. W1-B owns the catalog file + the host-selection contract document.
+- **Files owned (exclusive):**
+  - `src-tauri/src/services/mcp_v2/taxonomy.rs` (W1-B only owner of content; W1-A pre-created the empty placeholder).
+  - `src-tauri/resources/mcp_v2/tool_descriptions.yaml` (new YAML catalog of every v1.4.7 tool; loaded at runtime to populate the `ToolDescription` registry).
+  - `.docs/decisions/0128-*-amendment-v147.md` (W0 deliverable; W1-B may reference but does not modify after W0 close).
+- **Don't touch:** Gateway implementation (W1-A); per-handler implementations (subsequent lane owners); existing v1.4.0/v1.4.1/v1.4.2 ability descriptions (read-only references).
+- **Depends on:** W1-A merged (needs the `ToolDescription` struct + `Scope` + `ScopedName` types).
+- **`/plan-ceo-review` + `/plan-devex-review` gate:** taxonomy is product strategy — `/plan-ceo-review` validates the displacement use case framing ("DailyOS for the user's working professional world; NOT for broad corpus") at L0 plan. `/plan-devex-review` validates the tool-name + scope conventions at L0 plan.
+- **Tool-naming convention (proposed; finalized at L0 plan):**
+  - All v1.4.7 tools live under `dailyos.*` namespace.
+  - Read tools: `dailyos.<noun>_<query_kind>` — e.g., `dailyos.account_status`, `dailyos.portfolio_attention`, `dailyos.search_workspace_memory`.
+  - Write tools: `dailyos.<verb>_<noun>` — e.g., `dailyos.create_action`, `dailyos.update_action_status`, `dailyos.add_note`, `dailyos.place_document`.
+  - Resources (read-only browsable): `dailyos://<entity_type>/<id>` URI scheme.
+- **Tool-description content discipline:**
+  - `summary` is one sentence, surfaced verbatim to host models.
+  - `when_to_call` describes the user-question class: "When the user asks about an account, project, person, or meeting they have a working relationship with..."
+  - `when_NOT_to_call` is mandatory and explicit: "Do NOT call for broad enterprise search, web search, or generic Q&A — use other tools for those."
+  - `examples` includes 2-3 example invocations + expected response shapes.
+- **Intelligence Loop gate:**
+  1. *Claim model:* Taxonomy doesn't write claims; metadata only.
+  2. *Provenance + trust:* The taxonomy IS the trust surface for host model selection — sharp descriptions create the right boundary.
+  3. *Signals + invalidation:* No signals from the taxonomy itself.
+  4. *Runtime + surfaces:* Loaded by the gateway at startup; powers `dailyos://list_tools` resource.
+  5. *Feedback loop:* DOS-481 evaluation surfaces description quality issues; revisions flow back through `tool_descriptions.yaml`.
+- **Tests required:** YAML loads cleanly into `Vec<ToolDescription>`; every tool has non-empty `when_to_call` + `when_NOT_to_call`; every scope referenced exists in the canonical scope registry; every tool name conforms to the naming convention; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** Taxonomy YAML exists with entries for every v1.4.7 tool W2/W3/W4 will ship (placeholder descriptions OK; subsequent lanes refine in their own L0 plans); naming convention enforced by load-time validation; `/plan-ceo-review` + `/plan-devex-review` L0 plan approval recorded; all tests green.
+
+### W1 merge gate
+
+L0 → L2 → L3 cleared per the Review Ladder. Required artifacts:
+- L0 plan approvals: architect-reviewer + `/cso` + `/plan-devex-review` for W1-A; architect-reviewer + `/plan-ceo-review` + `/plan-devex-review` for W1-B.
+- L2 diff approvals on 2 PRs. `/cso` re-review on W1-A.
+- L3 wave adversarial: codex-challenge + architect-reviewer + Suite S (gateway scope enforcement; signal payload no-leak; audit transactional).
+- CI invariants now active: tool handler allowlist; tool-description struct enforcement.
+- Proof bundle at `.docs/plans/wave-W1-v147/proof-bundle.md`.
+- **Mandatory retro** (first wave; substrate decisions encoded).
+
+---
+
+## Wave 2 — Ability-Backed Reads
+
+Three agents. DOS-175 (briefing replacement — Bug priority Urgent) merges first; DOS-172 + DOS-173 run in parallel after.
+
+### Agent W2-A — DOS-175: Replace stale briefing MCP reads with ability-backed current context
+
+- **Spec:** [DOS-175](https://linear.app/a8c/issue/DOS-175).
+- **Goal:** The current MCP briefing path reads stale generated snapshots. Replace with ability-backed current intelligence so MCP is a co-equal head, not an export layer.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_briefing.rs` (W1-A pre-created placeholder; W2-A fills); legacy briefing snapshot read paths to deprecate (enumerated at L0 plan via grep).
+- **Don't touch:** Gateway / contracts / actor policy (W1 owners); other handlers (other lane owners).
+- **Depends on:** W1 merged.
+- **Done when:** `dailyos.daily_briefing` and `dailyos.meeting_briefing` tools dispatch to ability-backed current-context queries; legacy snapshot read code paths removed (or wrapped with deprecation warnings); response shape includes provenance + freshness per ADR-0108; `cargo test` + `cargo clippy -D warnings` clean.
+
+### Agent W2-B — DOS-172: Pagination + ranked discovery
+
+- **Spec:** [DOS-172](https://linear.app/a8c/issue/DOS-172).
+- **Goal:** Entity discovery tools (account list, person list, project list) get cursor-based pagination + ranked discovery so host workflows stay fast on large portfolios. **Cycle 1 amendment (preempt v1.4.6 cycle 8 lesson):** pagination cursor format frozen at L0 plan as opaque base64 (same convention as v1.4.6 W3-C `WorkspaceGraphResponse`). Page size capped at 200 default, 500 max.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_pagination.rs` (W1-A pre-created placeholder).
+- **Don't touch:** Other handlers; v1.4.6 graph projection (DOS-479 lane consumes that).
+- **Depends on:** W1 merged; W2-A merged (depends on the briefing replacement establishing the response-shape pattern with provenance/freshness for read tools).
+- **Done when:** Entity discovery tools support cursor pagination; ranked discovery returns top-N candidates ordered by recency × interaction × user-fit (existing v1.4.5-substrate scoring if present, else recency-only fallback); pagination cursor opaque + server-rotation-safe; `cargo test` + `cargo clippy -D warnings` clean.
+
+### Agent W2-C — DOS-173: Portfolio attention tool
+
+- **Spec:** [DOS-173](https://linear.app/a8c/issue/DOS-173).
+- **Goal:** One efficient MCP tool — `dailyos.portfolio_attention` — that asks "which accounts/projects/people/open loops need attention" without chaining many low-level calls. Ability-backed, claim/source-aware, trust-rendered.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_portfolio.rs` (W1-A pre-created placeholder); new ability `abilities-runtime/src/abilities/portfolio_attention.rs` if no existing ability covers it (confirm at L0 plan from grep).
+- **Don't touch:** Other handlers; v1.4.5 substrate (consume read-only).
+- **Depends on:** W1 merged; W2-A merged.
+- **Done when:** `dailyos.portfolio_attention` returns ranked attention items with claim/trust band + provenance refs + freshness; ability-backed (no direct DB queries); pagination via DOS-172's pattern; `cargo test` + `cargo clippy -D warnings` clean.
+
+### W2 merge gate
+
+L0 → L2 cleared. Required artifacts:
+- L0 plan approvals: architect-reviewer + `/plan-devex-review` for all three.
+- L2 diff approvals on 3 PRs.
+- L3 not required for W2 (read-side; lower risk).
+- Proof bundle at `.docs/plans/wave-W2-v147/proof-bundle.md`.
+
+---
+
+## Wave 3 — Workspace Memory Tools
+
+Three agents. DOS-479 (workspace memory search) merges first to establish the W3 pattern; DOS-171 (privacy-rendered resources) and DOS-480 (work-product placement) run in parallel after.
+
+### Agent W3-A — DOS-479: Workspace memory search + graph traversal + provenance tools over MCP
+
+- **Spec:** [DOS-479](https://linear.app/a8c/issue/DOS-479).
+- **Goal:** Expose v1.4.6's `WorkspaceGraphProjection v1` through MCP tools so host models can search workspace memory by entity, category, lifecycle state, freshness, etc. Honors v1.4.6 sensitivity rules: file paths absent unless caller has `read.entity_names`; raw claim text NEVER in aggregates.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_workspace_search.rs` (W1-A placeholder).
+- **Don't touch:** v1.4.6 `services::workspace_ingestion::*` (consumer-only); placement handler (DOS-480 owns); resource handler (DOS-171 owns).
+- **Depends on:** W1 + W2 merged; v1.4.6 W3-C (`WorkspaceGraphProjection v1`) frozen and merged.
+- **Tools shipped:** `dailyos.search_workspace_memory(entity_filter?, category_filter?, lifecycle_filter?, freshness_filter?)` returning the v1.4.6 `WorkspaceGraphProjection v1` shape unchanged (pagination cursor passes through). Plus `dailyos.workspace_source_provenance(file_id)` returning per-file provenance + ingestion run history + claim attribution.
+- **Security gate:** `/cso` at L0 plan AND L2 diff.
+  - Sensitivity rendering: caller must have `read.entity_names` to see entity names in response; otherwise null per v1.4.6 redaction rule.
+  - File paths NEVER returned (only `file_id`).
+  - Raw claim text NEVER returned in aggregate responses (use `claim_summary` from v1.4.6 schema).
+- **Done when:** Both tools dispatch through the v1.4.6 `workspace_graph` ability; sensitivity redaction enforced (negative test: caller without `read.entity_names` gets null entity names); pagination round-trips per v1.4.6 cursor contract; `cargo test` + `cargo clippy -D warnings` clean; `/cso` L0 plan AND L2 diff approval recorded.
+
+### Agent W3-B — DOS-480: Work-product placement + intake receipts over MCP
+
+- **Spec:** [DOS-480](https://linear.app/a8c/issue/DOS-480).
+- **Goal:** Expose v1.4.6's `place_document` ability through an MCP write tool — `dailyos.place_document(entity_id, filename_hint, content_b64, category?, client_dedup_key?)` — returning `PlaceDocumentReceipt v1`. Forwards to `place_document` ability with `Actor::McpClient` attribution.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_placement.rs` (W1-A placeholder).
+- **Don't touch:** v1.4.6 `place_document` ability (consumer-only — handler is a thin wrapper); other handlers.
+- **Depends on:** W3-A merged (establishes the W3 v1.4.6-substrate-consuming pattern); v1.4.6 W4-C frozen `PlaceDocumentInput / Receipt / Error` contract.
+- **Security gate:** `/cso` at L0 plan AND L2 diff.
+  - Caller must have `dailyos.write.place_document` scope.
+  - All v1.4.6 W4-C security rules apply: server-derived `source_asof`, transactional validation+write+enqueue, per-actor rate limits, idempotency by `(entity_id, content_sha256, client_dedup_key)`.
+  - The `resolved_path` field in the receipt is gated by `read.entity_names` per v1.4.6 W4-C cycle-9 amendment — MCP handler honors this without modification.
+- **Done when:** `dailyos.place_document` MCP tool delegates to v1.4.6's `place_document` ability; receipt serialization exact match for v1.4.6 `PlaceDocumentReceipt v1`; rate limits + idempotency tested; `/cso` L0 plan AND L2 diff approval recorded.
+
+### Agent W3-C — DOS-171: Privacy-rendered MCP resources for entity + source profiles
+
+- **Spec:** [DOS-171](https://linear.app/a8c/issue/DOS-171).
+- **Goal:** MCP resources (browsable, URL-shaped) for entity + source profiles. URI scheme `dailyos://account/{id}`, `dailyos://person/{id}`, `dailyos://source/{id}`. Privacy-rendered per ADR-0108 + v1.4.6 sensitivity rules.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_resources.rs` (W1-A placeholder).
+- **Don't touch:** Other handlers; v1.4.6 source registry (consumer-only).
+- **Depends on:** W3-A merged (consumes the workspace search ability for source resources); W3-B merged (consumes placement receipts for source resources that include recent ingestion runs).
+- **Security gate:** `/cso` at L0 plan AND L2 diff.
+  - Resource responses honor sensitivity rendering: PII redacted unless caller has appropriate scope; raw file paths absent; raw claim text absent (only summaries + chip representations).
+- **Done when:** Three resource handlers (`dailyos://account/*`, `dailyos://person/*`, `dailyos://source/*`) ship with privacy-rendered responses; URI scheme registered with the gateway; `/cso` L0 plan AND L2 diff approval recorded; `cargo test` + `cargo clippy -D warnings` clean.
+
+### W3 merge gate
+
+L0 → L2 → L3 cleared. Required artifacts:
+- L0 plan approvals: architect-reviewer + `/cso` + `/plan-devex-review` for all three.
+- L2 diff approvals on 3 PRs. `/cso` re-review on all three.
+- L3 wave adversarial: codex-challenge + `/cso` + Suite S (sensitivity rendering across all three tools/resources; v1.4.6 contract pass-through fidelity).
+- **Mandatory retro** (first MCP wave consuming v1.4.6 substrate; cross-version contract experience worth capturing).
+
+---
+
+## Wave 4 — Controlled Feedback & Writes
+
+Three agents in parallel (file-disjoint).
+
+### Agent W4-A — DOS-167: MCP note + observation capture
+
+- **Spec:** [DOS-167](https://linear.app/a8c/issue/DOS-167).
+- **Goal:** `dailyos.add_note(entity_id, content, sensitivity?, source_attribution?)` MCP tool that captures user observations from host conversations through `services::claims::commit_claim` (or a dedicated `services::notes` if present — confirm at L0 plan from grep). Lower default trust for AI-attributable note content.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_note.rs` (W1-A placeholder).
+- **Depends on:** W1 + W2 + W3 merged (note capture references workspace memory for source attribution).
+- **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.note` scope.
+- **Migration slots:** v225 if note-attribution audit needs new column.
+- **Done when:** Notes captured as claims through `services::claims`; `Actor::McpClient` attribution recorded; lower default trust enforced; rate-limited per W1-A budgets; `/cso` L0 plan AND L2 diff approval.
+
+### Agent W4-B — DOS-169: MCP create_action
+
+- **Spec:** [DOS-169](https://linear.app/a8c/issue/DOS-169).
+- **Goal:** `dailyos.create_action(entity_id, title, due?, priority?, source_attribution?)` MCP tool routing through `services::actions`. Receipt-based, signal-emitting.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs` (W1-A placeholder).
+- **Depends on:** W1 merged.
+- **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.action` scope.
+- **Migration slots:** v226 if action-attribution audit needs new column.
+- **Done when:** Action created through `services::actions`; receipt returned; signal emitted; `/cso` L0 plan AND L2 diff approval.
+
+### Agent W4-C — DOS-170: MCP update_action_status
+
+- **Spec:** [DOS-170](https://linear.app/a8c/issue/DOS-170).
+- **Goal:** `dailyos.update_action_status(action_id, new_status, note?)` MCP tool routing through `services::actions`. Preserves intent + provenance.
+- **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs` (W1-A placeholder).
+- **Depends on:** W4-B merged (consumes the action creation pattern + audit shape).
+- **Security gate:** `/cso` at L0 plan AND L2 diff. Actor must have `dailyos.submit.action_status` scope.
+- **Done when:** Action status updated through `services::actions`; lifecycle transition tested; signal emitted; `/cso` L0 plan AND L2 diff approval.
+
+### W4 merge gate
+
+L0 → L2 → L3 cleared. Required artifacts:
+- L0 plan approvals: architect-reviewer + `/cso` + `/plan-devex-review` for all three.
+- L2 diff approvals on 3 PRs. `/cso` re-review on all three.
+- L3 wave adversarial: codex-challenge + `/cso` + Suite S (write allowlist enforcement across all three; transactional behavior).
+- CI invariant now live: `check_mcp_write_allowlist.sh` covers v1.4.7 write tools.
+- **Mandatory retro** (first MCP write wave; allowlist + actor attribution patterns codified).
+
+---
+
+## Wave 5 — Evaluation & Release Gate
+
+Two agents, sequenced.
+
+### Agent W5-A — DOS-481: Tool-description eval + host-selection tests
+
+- **Spec:** [DOS-481](https://linear.app/a8c/issue/DOS-481).
+- **Goal:** Build the eval harness that validates v1.4.7 tool descriptions select correctly under realistic host-model prompts. Two test categories:
+  1. **Positive selection:** prompts that should select DailyOS tools (e.g., "What's the latest with the Acme renewal?", "Who attended the last meeting with Hooli?", "What did I write about the Q1 readout?") — assert correct tool name + parameters.
+  2. **Negative selection:** prompts that should NOT select DailyOS tools (e.g., "Search the web for SaaS pricing benchmarks", "What's the company's vacation policy?", "Find docs about React hooks") — assert no DailyOS tool selected.
+- **Files owned (exclusive):** `tests/v147_tool_eval/` (new test suite); fixture corpus at `tests/v147_tool_eval/fixtures/`.
+- **Depends on:** W1 + W2 + W3 + W4 all merged (every tool description finalized).
+- **`/plan-devex-review` + `/plan-ceo-review` gate at L0 plan:** the eval fixture corpus IS the product-strategy artifact for tool descriptions. Both reviewers validate fixture coverage at L0.
+- **Done when:** Eval harness runs on the v1.4.7 tool description corpus; positive + negative fixtures defined for every tool; pass rate threshold defined and met; CI integration; `/plan-devex-review` + `/plan-ceo-review` L0 plan approval recorded.
+
+### Agent W5-B — DOS-482: E2E MCP v2 validation with workspace memory
+
+- **Spec:** [DOS-482](https://linear.app/a8c/issue/DOS-482).
+- **Goal:** End-to-end validation of v1.4.7 MCP tools against real workspace data. Tools use DailyOS intelligence without bypassing abilities, source lifecycle, provenance, or privacy. v1.4.6 substrate consumed correctly.
+- **Files owned (exclusive):** `tests/v147_e2e/` (new validation suite); validation report at `.docs/plans/wave-W5-v147/validation-report.md`.
+- **Depends on:** W5-A merged (consumes the eval fixture corpus); v1.4.6 fully shipped (real workspace data dependency).
+- **Validation axes:**
+  1. **Tool correctness:** every v1.4.7 tool returns correct shape on real fixture entity/source/action data.
+  2. **Privacy rendering:** sensitivity boundaries enforced across every tool (file paths absent without `read.entity_names`; PII redacted; raw claim text never in aggregates).
+  3. **Cross-conversation continuity:** placeholder fixture for the named affordance — same MCP session asks two questions about the same entity; second response reflects state changes from first.
+  4. **v1.4.6 contract fidelity:** tools that consume `WorkspaceGraphProjection v1` / `PlaceDocumentReceipt v1` / etc. produce schema-conforming responses.
+  5. **Host-selection behavior:** runs the W5-A eval suite as a release gate (must pass at the threshold).
+- **Done when:** All five validation axes green; validation report written; `pnpm release-gate -- --mode hermetic` exits zero against bundles 1-18 + new v1.4.7 bundles; manual dogfood evidence captured against ≥5 host-model conversations exercising the v1.4.7 tools.
+
+### W5 merge gate = release gate
+
+L0 → L2 → L3 → L4 → L5 cleared. Required artifacts:
+- L0 plan approvals: architect-reviewer + qa-expert + `/plan-devex-review` + `/plan-ceo-review` for W5-A; architect-reviewer + qa-expert for W5-B.
+- L2 diff approvals on 2 PRs.
+- L3 wave adversarial: codex-challenge + architect-reviewer + Suite S (sensitivity boundaries across every tool) + Suite E (every v1.4.7 tool fixture passes).
+- L4 surface QA: tool-description text reviewed by `/plan-devex-review` as product copy.
+- L5 drift check: integrated state matches v1.4.7 project DoD verbatim AND v1.4.6 contract pass-through verified.
+- **Mandatory retro.**
+- Proof bundle at `.docs/plans/wave-W5-v147/proof-bundle.md`.
+
+---
+
+## Release gate
+
+```
+## v1.4.7 Release Gate
+
+### Substrate / service boundary
+- [ ] cargo clippy -D warnings && cargo test && pnpm tsc --noEmit green
+- [ ] CI invariant: every MCP tool routes through ability/service (check_mcp_tool_handler_allowlist.sh green)
+- [ ] CI invariant: every MCP write on the allowlist (check_mcp_write_allowlist.sh green)
+- [ ] CI invariant: ToolDescription struct enforced (no String-based descriptions)
+- [ ] CI invariant: actor attribution on every mutation
+- [ ] CI invariant: tool-description corpus has eval coverage (DOS-481 fixture-per-tool)
+
+### v1.4.6 contract pass-through
+- [ ] dailyos.search_workspace_memory returns WorkspaceGraphProjection v1 unchanged
+- [ ] dailyos.place_document delegates to v1.4.6 place_document ability with full PlaceDocumentReceipt v1 fidelity
+- [ ] Sensitivity rendering matches v1.4.6 (file paths absent without read.entity_names; raw claim text absent in aggregates)
+- [ ] Pagination cursor format matches v1.4.6 W3-C convention
+
+### Host selection (the displacement use case)
+- [ ] DOS-481 positive fixtures pass at threshold
+- [ ] DOS-481 negative fixtures pass at threshold (DailyOS NOT selected for broad corpus questions)
+- [ ] Manual dogfood: 5 host-model conversations exercising v1.4.7 tools
+
+### Security
+- [ ] DOS-168 gateway scope enforcement: negative tests green
+- [ ] DOS-167/169/170 write allowlist enforcement: ability not invocable without scope
+- [ ] DOS-479/480/171 sensitivity rendering: redaction tests green
+- [ ] /cso L2 approval recorded for all security-annotated lanes
+
+### Cross-conversation continuity
+- [ ] Manual fixture: same conversation asks two related questions; second reflects state from first
+
+### Linear hygiene
+- [ ] All 13 v1.4.7 issues closed Done
+- [ ] Per-wave proof bundles linked
+- [ ] Mandatory retros (W1, W3, W4, W5) merged
+- [ ] ADR-0102 amendment + ADR-0128 amendment merged
+
+### Tag
+- [ ] User release-checklist walked
+- [ ] Manual host-model validation by James
+- [ ] Tag v1.4.7 on trunk after dev merge
+```
+
+---
+
+## L0 questions table
+
+| # | Question | Consuming wave | Status |
+|---|---|---|---|
+| 1 | Does ADR-0102 need amendment for `Actor::McpClient` introduction + scope naming convention? | W0 | **Open** — defer to W0 ADR drafting; expected YES based on cycle 1 draft |
+| 2 | Does ADR-0128 need amendment for v2 expansion principles (tool-description as product copy, host-selection language, cross-conversation continuity)? | W0 | **Open** — defer to W0; expected YES |
+| 3 | Scope naming convention: `read.*` / `write.*` / `submit.*` taxonomy or align fully with existing `submit.*`? | W0 (folded into ADR-0102) | **Open** — DX consult preferred convention at L0 cycle 1 |
+| 4 | Does `services::notes` exist as a separate service from `services::claims`, or do notes flow through `commit_claim` with a `Note` claim_kind variant? | W4-A (DOS-167) | **Open** — defer to W4-A L0 plan with fresh grep |
+| 5 | Does `dailyos.portfolio_attention` consume an existing v1.4.5 salience ability (when v1.4.5 ships) or implement recency-only ranking as the v1.4.7 default? | W2-C (DOS-173) | **Open** — defer to W2-C L0 plan; v1.4.5 ship state determines |
+| 6 | Cross-conversation continuity: is conversation_id required on every MCP tool call, or optional? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan; ADR-0128 amendment likely speaks to this |
+| 7 | Does the v1.4.7 audit log re-use v1.4.6 audit substrate or introduce a separate MCP-specific audit table? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan with fresh grep against v1.4.6 audit code |
+| 8 | Confirm v1.4.6 frozen contracts (`WorkspaceGraphProjection v1`, `PlaceDocumentInput v1`, etc.) are merged on dev before v1.4.7 W3 implementation starts. | W3 | **Open** — coordination item; tracked at W0 close |
+| 9 | Does `Actor::McpClient` need rate-limit budgets distinct from `Actor::SurfaceClient`, or share the same v1.4.2 W2-D rate-limit registry? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan; expected: distinct budgets per actor variant |
+| 10 | Tool description text licensing / review process — who has authority to edit `tool_descriptions.yaml` post-merge (since it's product copy)? | W1-B (DOS-478) | **Open** — defer to W1-B L0 plan with `/plan-ceo-review` |
+
+---
+
+## Wave shape summary
+
+| | |
+|---|---|
+| Total issues | 13 implementation + W0 coordination |
+| Wave units | 6 (W0, W1, W2, W3, W4, W5) |
+| Total agents | 13 — W1=2, W2=3, W3=3, W4=3, W5=2 |
+| Migration slots | v220–v239 reserved (20 slots; few migrations expected — most issues are contract/handler layers) |
+| Mandatory retros | W1, W3, W4, W5 |
+| Estimated wall-clock | ~4 weeks across the wave ladder |
+| Security-annotated lanes | DOS-168, DOS-167, DOS-169, DOS-170, DOS-171, DOS-479, DOS-480 (carry `/cso` at L0 plan + L2 diff) |
+| DX-mandatory lanes | All 13 issues (entire project is a DX surface; heightened scrutiny on DOS-478, DOS-481, DOS-175, DOS-172, DOS-173) |
+| CEO-review lane | DOS-478 (tool taxonomy + host-selection language) |
+| v1.4.6-substrate-consuming lanes | DOS-171, DOS-479, DOS-480 (heaviest cross-version coupling) |
+| Definition of Done | Matches v1.4.7 project DoD verbatim; final gate is the W5 release gate checklist above |
+
+---
+
+## Cycle 1 dispatch notes (for codex L0 reviewers)
+
+This packet is the cycle 1 starting point. Codex Challenge / Eng / DX / CSO agents review BOTH:
+- **Project-scope L0:** mission-gate fit, scope-boundary clarity, non-goal coherence, predecessor-dependency citation accuracy.
+- **Wave-plan L0:** lane file ownership disjointness, depends-on chain validity, frozen contract surfaces, security/DX/CEO gate sufficiency, migration slot allocation, CI invariant enforceability.
+
+Class-A propagation discipline applied at draft time: every contract referenced is grepped for downstream references in the same edit. If reviewers find stale references anywhere, that's class-A regression and gets called out in the cycle 2 retro.
+
+Path-α discipline: theoretical hardening or scope-expansion findings file as DailyOS Maintenance Linear issues (`b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`) and don't block cycle progression.

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -1,5 +1,42 @@
 # v1.4.7 — MCP Server v2 (Abilities-First) — Wave Plan
 
+## Cycle 2 amendments (2026-05-14)
+
+Cycle 1 codex verdicts: Challenge **BLOCK** (5 HIGH); Eng **BLOCK** (3 HIGH + 2 MED, 4 overlap); DX **APPROVE-WITH-CONDITIONS** (1 HIGH + 4 MED + 1 LOW); CSO **BLOCK** (1 HIGH + 3 MED + 1 LOW). Deduplicated to ~14 unique findings across 6 classes. The biggest finding is Class S (MCP client trust boundary) — the only finding requiring substantive new design; rest is propagation/cleanup.
+
+Cycle 2 changes (folded in below):
+
+**Class S — MCP client trust boundary defined.**
+1. **`Actor::McpClient` ownership assigned to W0** — `actor.rs` change shipped as part of the ADR-0102 amendment commit, not a separate lane.
+2. **MCP client authentication + session contract added to W0/W1-A.** Server-issued `McpClientId` after pairing handshake (mirrors v1.4.2 SurfaceClient pairing pattern); HMAC-SHA256 transport signing for stdio/HTTP MCP transports; scoped grants loaded server-side from a per-client manifest (NOT caller-provided in `granted_scopes`); revocation path; per-actor + per-client + per-tool rate-limit registry. Closes CSO HIGH #1.
+
+**Class A — Staging contradictions resolved (class-wide propagation sweep).**
+3. **W3 serialized.** Stage 3a = W3-A only; 3b = W3-B; 3c = W3-C (DOS-171 depends on W3-B per its own contract).
+4. **W4 serialized.** Stage 4a = W4-B only (DOS-169 has simplest deps); 4b = W4-A + W4-C in parallel after W4-B (W4-A depends on W2+W3+W4-B; W4-C depends on W4-B).
+
+**Class B — W1-A skeleton compile-readiness.**
+5. **`handlers/mod.rs` added.** Top-level `mod.rs` declares `pub mod handlers;`; `handlers/mod.rs` declares `pub mod tool_*;` for each handler. W1-A creates both files.
+6. **`when_NOT_to_call` renamed to `when_not_to_call`** (clippy snake_case); wire field stays uppercase via `#[serde(rename = "when_NOT_to_call")]`.
+7. **`ParamSpec`, `ReturnSpec`, `ToolExample`, `ParamSchema`, `Side` types defined** in the same `contracts.rs` snippet.
+
+**Class C — Scope naming convention frozen + reconciled with v1.4.6.**
+8. **Canonical convention: `<dot-namespace>.<verb>.<noun>`** — e.g., `dailyos.read.account_status`, `dailyos.write.place_document`, `dailyos.submit.note`. v1.4.6 already shipped `write.workspace_place_document` for the AI placement ability; v1.4.7 W3-B's MCP tool reuses that exact scope verbatim (no rename). Scope-mapping table added to W0. Closes Challenge HIGH #5 + L0 question #3.
+
+**Class D — DX contract sharpness.**
+9. **Cross-conversation continuity contract pinned.** Server-minted `OpaqueConversationHandle` REQUIRED on every MCP write tool; optional but recommended on reads. Closes DX HIGH #1 + CSO MED #3 (raw caller-provided IDs forbidden in audit/signal payloads).
+10. **Read tool naming convention sharpened.** Allow small verb-read class explicitly: `search`, `list`, `get`, `prepare` are verb-prefix-allowed for reads. Naming becomes `dailyos.<verb>.<noun>` (verb may be `read` for property-style reads or one of the four read-verbs). `dailyos.search_workspace_memory` → `dailyos.search.workspace_memory` for consistency with the dot-separator convention.
+11. **Shared `Page<T>` envelope** added to W1-A `contracts.rs`. v1.4.6 `WorkspaceGraphResponse v1` is the documented pass-through exception (since v1.4.7 W3-A surfaces it unchanged for AI consumers).
+12. **DOS-481 fixture density.** Minimum ≥2 positive + ≥2 negative per tool: one broad-corpus negative (web/enterprise search) + one adjacent-DailyOS-but-wrong-tool negative.
+
+**Class E — CSO privacy hardening.**
+13. **Keyed HMAC for audit hashes** — `params_hash` and `response_hash` are HMAC-SHA256 over canonical JSON with a per-install audit key. Closes CSO MED #2.
+14. **Opaque resource IDs** — `dailyos://account/{id}` `id` is a server-minted opaque handle, not the underlying entity_id. Closes CSO MED #4.
+15. **DOS-171 redaction helper** — DOS-171 reuses the same redaction helper DOS-479 ships, with the same scope matrix (`read.entity_names`, `read.file_paths`, `read.claim_text` — none of which v1.4.7 grants by default). Closes CSO LOW #5.
+
+Cycle 2 is heavy — 15 changes across 6 classes — but most are propagation/cleanup. The single substantive new design (Class S MCP client trust boundary) ships as a W0 deliverable. No wave shape changes; no migration slot changes (still v220–v239); no new ADRs beyond the already-planned ADR-0102 + ADR-0128 amendments (Class S folds into ADR-0102 amendment scope).
+
+---
+
 ## L0 prep posture (2026-05-14)
 
 Unlike v1.4.6 (which carried an approved project-level L0 verdict in the Linear description), v1.4.7's project description has no prior L0 approve. Cycle 1 of the L0 loop folds **project-scope review and wave-plan review into one pass** — codex Challenge / Eng / DX / CSO agents review both dimensions simultaneously against this packet. The packet is structured so each lane block names its project-scope rationale (mission-gate fit, scope-boundary justification) alongside its wave-scope contract (files owned, depends-on, done-when), so the same review cycle can clear both.
@@ -132,12 +169,23 @@ Linear hygiene items to resolve before W0 closes:
 
 2. **Cross-version dependency confirmation — v1.4.6.** Confirm v1.4.6 has merged to `dev` with these specific contracts live and frozen: `WorkspaceGraphProjection v1` + `WorkspaceGraphQueryInput v1` + `WorkspaceGraphResponse v1` (W3-C); `PlaceDocumentInput v1` + `PlaceDocumentReceipt v1` + `PlacementError` typed enum (W4-C); `WorkspaceCategoryRegistry` + `WorkspaceCategory` enum slug serialization (W1-A `contracts.rs`); `pipeline::quarantine_source` (W2-A); `link::override_link(&dyn SignalEmitter, ...)` (W1-C); five new `WorkspaceFile*` SignalType variants + invalidation allowlist additions (W3-B); ADR-0107 `WorkspaceFile { kind: WorkspaceFileKind }` `DataSource` variant. **If any item is not yet merged, v1.4.7 implementation is blocked; document the gap on the affected v1.4.7 issue.**
 
-3. **ADR amendments needed.** Two likely:
-   - **ADR-0102 (abilities runtime)** — for any new actor variant (`Actor::McpClient`), new `mcp_exposure` modes if the existing tri-state `None | MetadataOnly | Invocable` proves insufficient, and any new scope-naming convention (see #4 below).
-   - **ADR-0128 (headless DailyOS)** — for v2 expansion principles: tool-description as product copy, host-selection language, cross-conversation continuity as a named affordance.
-   Both amendments drafted, reviewed, and merged before W1 L0 plans open. Resolves L0 questions #1 and #2.
+3. **ADR amendments needed.** Two:
+   - **ADR-0102 (abilities runtime) — expanded scope per cycle 2 Class S.** Covers: (a) `Actor::McpClient` enum variant added to `actor.rs` (the actual code change ships in this same PR — not deferred to W1-A); (b) MCP client authentication + session contract: `McpClientId` issued server-side after pairing handshake, HMAC-SHA256 transport signing, server-side scope manifest (no caller-provided granted scopes), revocation path, per-actor + per-client + per-tool rate-limit registry; (c) scope naming convention pinned (see #4); (d) `mcp_exposure` tri-state `None | MetadataOnly | Invocable` confirmed sufficient (no new variants needed).
+   - **ADR-0128 (headless DailyOS)** — for v2 expansion principles: tool-description as product copy, host-selection language, cross-conversation continuity contract (server-minted `OpaqueConversationHandle`, REQUIRED on writes, recommended on reads).
+   Both amendments drafted, reviewed, and merged before W1 L0 plans open. **The ADR-0102 amendment PR also lands the `Actor::McpClient` code change in `actor.rs`** — closes Eng cycle 1 HIGH #1 ownership gap. Resolves L0 questions #1, #2, #3, #6.
 
-4. **Scope naming convention decision (formerly v1.4.x maintenance issue DOS-618).** v1.4.7 introduces many new MCP-invocable abilities. Either align on the existing `submit.*` convention (v1.4.0/v1.4.1 user-correction-class writes), introduce a coherent `read.*` / `write.*` / `submit.*` taxonomy (`read.*` for non-mutating, `write.*` for system/AI-attributable creations, `submit.*` for user-attributable corrections), or ship v1.4.7 with both conventions and migrate later. **Decision recorded as part of the ADR-0102 amendment.**
+4. **Scope naming convention frozen (cycle 2 amendment closes Challenge HIGH #5 + L0 question #3).** v1.4.7 adopts `<dot-namespace>.<verb>.<noun>` convention. v1.4.6's already-shipped `write.workspace_place_document` scope is kept verbatim — v1.4.7 W3-B's `place_document` MCP tool reuses it without rename. Scope-mapping table:
+
+   | v1.4.6 scope (already shipped) | v1.4.7 reuse / extension |
+   |---|---|
+   | `write.workspace_place_document` | reused verbatim by `dailyos.place_document` MCP tool (W3-B) |
+   | `read.workspace_graph` | reused verbatim by `dailyos.search.workspace_memory` (W3-A) |
+   | `read.entity_names` | reused as gating scope for entity-name disclosure across all v1.4.7 read surfaces |
+   | `submit.feedback` / `submit.correction` / `submit.dismissal` | extended pattern for v1.4.7: `dailyos.submit.note` (W4-A), `dailyos.submit.action` (W4-B), `dailyos.submit.action_status` (W4-C) |
+   | (new) | `dailyos.read.account_status`, `dailyos.read.portfolio_attention`, `dailyos.read.briefing` (W2 lanes) |
+   | (new) | `dailyos.read.workspace_source_provenance` (W3-A), `dailyos.read.entity_resource` (W3-C) |
+
+   Verbs allowed: `read` (queries), `submit` (user-attributable corrections), `write` (system/AI-attributable creations). Read tools may optionally use `search` / `list` / `get` / `prepare` as verb-prefix when the action shape is more specific than generic `read`.
 
 5. **Shared Primitive and Service Ownership doc** — confirm Linear doc `c729429f-79c9-4131-a243-5500d6e2a605` (originally for v1.4.6) extends to v1.4.7 every-tool-routes-through-services discipline. Likely already does; reconcile.
 
@@ -166,8 +214,8 @@ Total: 13 implementation issues + 1 coordination wave. Estimated wall-clock: ~4 
 
 **Named exceptions:**
 - W2 internal staging: DOS-175 (replace stale briefing reads — Bug priority Urgent) ships first as it unblocks downstream parity. DOS-172 (pagination) and DOS-173 (portfolio attention) run in parallel after DOS-175 merges.
-- W3 internal staging: DOS-479 (workspace memory search) merges first as DOS-171 (privacy-rendered resources) and DOS-480 (work-product placement) both depend on the W3 ability-runtime patterns DOS-479 establishes.
-- W4 internal staging: DOS-167 (note capture), DOS-169 (create_action), DOS-170 (update_action_status) are file-disjoint and run in parallel after W1 gateway lands.
+- W3 internal staging (cycle 2 amendment serializes per Challenge HIGH #1 + Eng MED #4 — DOS-171 explicitly depends on DOS-480 merged): **stage 3a = W3-A (DOS-479) only**; **stage 3b = W3-B (DOS-480) only**; **stage 3c = W3-C (DOS-171) only**. Three sequential stages.
+- W4 internal staging (cycle 2 amendment serializes per Challenge HIGH #2 + Eng MED #5 — W4-A depends on W2+W3+W4-B, W4-C depends on W4-B): **stage 4a = W4-B (DOS-169 create_action) only**; **stage 4b = W4-A (DOS-167 note capture) + W4-C (DOS-170 update_action_status) in parallel** (file-disjoint; W4-A consumes workspace memory from W3 + action substrate from W4-B; W4-C consumes action substrate from W4-B).
 - W5 internal staging: DOS-481 (tool-description eval) ships first as DOS-482 (E2E validation) consumes the eval fixtures.
 
 ---
@@ -194,17 +242,19 @@ W0 is coordination + ADR work, not implementation. No migration slots consumed.
 **W0 open gate (before W1 L0 plans are written):**
 - [ ] v1.4.6 cross-version dependency confirmation recorded (all v1.4.6 contracts listed in §"What v1.4.0–v1.4.6 leave behind" confirmed merged on `dev`)
 - [ ] Issue-body renumbering cleanup completed for all v1.4.7 issues containing stale `v1.4.9` / `v1.4.10` references
-- [ ] ADR-0102 amendment drafted (covers `Actor::McpClient` introduction + scope naming convention decision)
-- [ ] ADR-0128 amendment drafted (covers v2 expansion principles: tool-description as product copy, host-selection language, cross-conversation continuity)
+- [ ] ADR-0102 amendment drafted (covers `Actor::McpClient` variant + MCP client auth/session contract + scope naming convention)
+- [ ] ADR-0128 amendment drafted (covers tool-description as product copy + host-selection language + cross-conversation continuity)
 - [ ] Shared Primitive and Service Ownership doc reviewed; v1.4.7 scope confirmed consistent
 - [ ] Migration slot reservation v220–v239 announced
-- [ ] Scope naming convention decision recorded (which of `read.*` / `write.*` / `submit.*` taxonomy v1.4.7 adopts; documented in ADR-0102 amendment)
+- [ ] Scope naming convention decision recorded (frozen as cycle 2 §"Scope naming convention frozen" table)
 
 **W0 close gate:**
-- [ ] Both ADR amendments merged
+- [ ] Both ADR amendments merged. **The ADR-0102 amendment PR also lands the `Actor::McpClient` enum variant code change in `src-tauri/abilities-runtime/src/actor.rs`** — no other lane is allowed to add this variant (cycle 2 fix for Eng HIGH #1 ownership gap).
+- [ ] MCP client authentication + session contract documented in ADR-0102 amendment with concrete pairing handshake spec, HMAC signing spec, server-side scope manifest schema, and revocation path. **No W1-A merge without this in place** (cycle 2 fix for CSO HIGH #1).
 - [ ] All issue bodies renumbered
 - [ ] L0 questions table reviewed; resolutions recorded
 - [ ] W1 agent lane contracts written and in L0 review
+- [ ] Path-α maintenance issues filed per the same DailyOS Maintenance project pattern v1.4.6 used (`b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`) for any non-blocking findings surfaced during cycle 1+
 
 ---
 
@@ -218,28 +268,94 @@ Two agents.
 - **Goal:** Build the MCP v2 gateway — the single entry point that receives MCP tool calls, validates `Actor::McpClient` policy, dispatches through the ability runtime, captures audit attribution, and emits signals. **W1-A pre-creates the entire `services/mcp_v2/` module skeleton** (per v1.4.6 lessons): `mod.rs` with all `pub mod` declarations, `contracts.rs` with shared types + traits + Null impls, empty placeholder files for every submodule that subsequent lanes fill.
 - **Files owned (exclusive):**
   - New migration(s) in `src-tauri/src/migrations.rs` (slots v220–v222 — actor attribution audit log + tool-call ledger if needed).
-  - Full submodule skeleton under `src-tauri/src/services/mcp_v2/`:
-    - `mod.rs` (W1-A only owner; contains all `pub mod` declarations: `pub mod contracts; pub mod gateway; pub mod handlers; pub mod taxonomy; pub mod actor_policy; pub mod audit;` + per-handler submodule decls added by W1-A in advance: `pub mod tool_briefing; pub mod tool_portfolio; pub mod tool_pagination; pub mod tool_resources; pub mod tool_workspace_search; pub mod tool_placement; pub mod tool_note; pub mod tool_create_action; pub mod tool_update_action_status; pub mod tool_eval;`).
-    - `contracts.rs` (W1-A only owner) — defines:
+  - Full submodule skeleton under `src-tauri/src/services/mcp_v2/` (cycle 2 amendment fixes module-tree mismatch):
+    - `mod.rs` (W1-A only owner) declares ONLY top-level submodules:
+      ```rust
+      pub mod contracts;
+      pub mod gateway;
+      pub mod handlers;
+      pub mod taxonomy;
+      pub mod actor_policy;
+      pub mod auth;        // MCP client authentication + session (cycle 2 Class S)
+      pub mod audit;
+      ```
+    - `handlers/mod.rs` (W1-A only owner) declares per-handler submodules:
+      ```rust
+      pub mod tool_briefing;
+      pub mod tool_portfolio;
+      pub mod tool_pagination;
+      pub mod tool_resources;
+      pub mod tool_workspace_search;
+      pub mod tool_workspace_source_provenance;
+      pub mod tool_placement;
+      pub mod tool_note;
+      pub mod tool_create_action;
+      pub mod tool_update_action_status;
+      ```
+    - W1-A pre-creates the file shells for all submodules; subsequent lanes fill content.
+    - `contracts.rs` (W1-A only owner) — defines (cycle 2 amendment makes the snippet compile-ready: renamed `when_NOT_to_call` to clippy-conforming `when_not_to_call` with serde rename for wire; defined `ParamSpec`/`ReturnSpec`/`ToolExample`/`ParamSchema`/`Side`; added shared `Page<T>` envelope; added `OpaqueConversationHandle`):
       ```rust
       // Tool description as typed product copy
+      #[derive(Serialize, Deserialize)]
       pub struct ToolDescription {
-          pub name: ScopedName,                // e.g., "dailyos.account_status"
+          pub name: ScopedName,                // e.g., "dailyos.read.account_status"
           pub summary: String,                 // 1-line summary surfaced to host models
           pub when_to_call: String,            // "for the user's working understanding of..."
-          pub when_NOT_to_call: String,        // "NOT for broad enterprise/web corpus search"
+          #[serde(rename = "when_NOT_to_call")]
+          pub when_not_to_call: String,        // "NOT for broad enterprise/web corpus search"
+          pub side: Side,                      // Read | SubmitCorrection | Write — host models use this for permission grouping
           pub parameters: Vec<ParamSpec>,
           pub returns: ReturnSpec,
           pub examples: Vec<ToolExample>,
           pub scopes_required: Vec<Scope>,
       }
-      pub struct ScopedName(pub String);       // e.g., "dailyos.search_workspace_memory"
-      pub struct Scope(pub String);            // canonical naming per W0 ADR-0102 amendment
 
-      // Actor for MCP-originated calls
-      pub enum McpActor {
-          Client { client_id: String, conversation_id: Option<String>, tool_name: ScopedName },
+      pub enum Side { Read, SubmitCorrection, Write }
+
+      pub struct ScopedName(pub String);       // canonical: "dailyos.<verb>.<noun>"
+      pub struct Scope(pub String);            // canonical: "<verb>.<noun>" or "dailyos.<verb>.<noun>"
+
+      pub struct ParamSpec {
+          pub name: String,
+          pub schema: ParamSchema,             // JSON-schema-shaped
+          pub required: bool,
+          pub description: String,
       }
+      pub struct ParamSchema(pub serde_json::Value);  // valid JSON Schema fragment
+
+      pub struct ReturnSpec {
+          pub schema: ParamSchema,             // JSON-schema-shaped response
+          pub description: String,
+      }
+
+      pub struct ToolExample {
+          pub prompt: String,                  // example user-facing prompt that should select this tool
+          pub invocation: serde_json::Value,   // example { "name": "...", "arguments": {...} }
+          pub expected_response_shape: serde_json::Value,  // truncated example response
+      }
+
+      // Shared pagination envelope (cycle 2 DX MED #5). v1.4.6 WorkspaceGraphResponse v1 is a documented pass-through exception.
+      pub struct Page<T> {
+          pub items: Vec<T>,
+          pub next_cursor: Option<String>,     // opaque base64; same format convention as v1.4.6 W3-C
+          pub page_size: u32,
+      }
+
+      // Server-minted opaque conversation handle (cycle 2 Class D #9 + CSO MED #3).
+      // Required on writes, recommended on reads. Server mints on first call in a conversation; host clients echo back.
+      // Replaces raw caller-provided conversation_id (which could leak PII through audit/signal payloads).
+      pub struct OpaqueConversationHandle(pub String);  // server-minted, non-PII, non-enumerable
+
+      // Actor for MCP-originated calls (cycle 2 Class S — McpClient enum variant lives in actor.rs, shipped as part of W0 ADR-0102 PR)
+      pub enum McpActor {
+          Client {
+              client_id: McpClientId,                    // server-issued after pairing
+              conversation: Option<OpaqueConversationHandle>,
+              tool_name: ScopedName,
+              granted_scopes: Vec<Scope>,                // loaded server-side from per-client manifest
+          },
+      }
+      pub struct McpClientId(pub String);    // server-issued during pairing; non-spoofable
 
       // Tool handler trait — every handler implements this; W1-A defines, subsequent lanes implement
       pub trait McpToolHandler: Send + Sync {
@@ -253,13 +369,15 @@ Two agents.
           Unauthorized { missing_scope: Scope },
           NotFound { resource: String },
           RateLimited { retry_after_seconds: u32 },
+          ConversationRequired,                // cycle 2: when a write tool gets no OpaqueConversationHandle
           UpstreamFailure { detail: String },
           Internal { trace_id: String },
       }
       ```
-    - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes, invokes handler, records audit row, emits `McpToolInvoked` signal.
-    - `actor_policy.rs` (W1-A only owner) — scope/permission matrix for `Actor::McpClient`.
-    - `audit.rs` (W1-A only owner) — audit log writer.
+    - `gateway.rs` (W1-A only owner) — `Gateway::handle_tool_call(actor, name, params) -> Result<Value, ToolError>`. Looks up handler in registry, validates actor scopes (against the server-side scope manifest loaded by `auth`, NOT caller-provided `granted_scopes`), validates `OpaqueConversationHandle` presence on `Side::Write` tools (returns `ConversationRequired` if absent), invokes handler, records audit row, emits `McpToolInvoked` signal.
+    - `auth.rs` (W1-A only owner; new per cycle 2 Class S) — MCP client authentication + session contract: `pair_client(handshake) -> McpClientId`; loads server-side scope manifest per `McpClientId`; revocation; transport HMAC verification helper; opaque conversation handle minting.
+    - `actor_policy.rs` (W1-A only owner) — scope/permission matrix for `Actor::McpClient` (consumed by `gateway.rs` after `auth.rs` resolves the actor).
+    - `audit.rs` (W1-A only owner) — audit log writer with **keyed HMAC-SHA256 hashes** for `params_hash` and `response_hash` (cycle 2 CSO MED #2). Per-install audit key + `key_id`. Raw params/responses stay out of logs.
     - `taxonomy.rs` (DOS-478 / W1-B owner; W1-A creates empty placeholder).
     - `handlers/*.rs` (each subsequent lane fills its own placeholder).
   - ADR-0102 amendment file in `.docs/decisions/0102-*-amendment-v147.md` (W0 deliverable; W1-A inherits the merged version).
@@ -376,7 +494,7 @@ Three agents. DOS-479 (workspace memory search) merges first to establish the W3
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_workspace_search.rs` (W1-A placeholder).
 - **Don't touch:** v1.4.6 `services::workspace_ingestion::*` (consumer-only); placement handler (DOS-480 owns); resource handler (DOS-171 owns).
 - **Depends on:** W1 + W2 merged; v1.4.6 W3-C (`WorkspaceGraphProjection v1`) frozen and merged.
-- **Tools shipped:** `dailyos.search_workspace_memory(entity_filter?, category_filter?, lifecycle_filter?, freshness_filter?)` returning the v1.4.6 `WorkspaceGraphProjection v1` shape unchanged (pagination cursor passes through). Plus `dailyos.workspace_source_provenance(file_id)` returning per-file provenance + ingestion run history + claim attribution.
+- **Tools shipped (cycle 2 amendment renames to canonical `<dot>.<verb>.<noun>` per Class C):** `dailyos.search.workspace_memory(entity_filter?, category_filter?, lifecycle_filter?, freshness_filter?)` returning the v1.4.6 `WorkspaceGraphProjection v1` shape unchanged (pagination cursor passes through; this is the documented v1.4.6 pass-through exception to v1.4.7's shared `Page<T>` envelope). Plus `dailyos.read.workspace_source_provenance(file_id)` returning per-file provenance + ingestion run history + claim attribution. Required scopes: `read.workspace_graph` (reused verbatim from v1.4.6 W3-C) for `dailyos.search.workspace_memory`; `read.workspace_source_provenance` (new) for the provenance tool.
 - **Security gate:** `/cso` at L0 plan AND L2 diff.
   - Sensitivity rendering: caller must have `read.entity_names` to see entity names in response; otherwise null per v1.4.6 redaction rule.
   - File paths NEVER returned (only `file_id`).
@@ -386,25 +504,27 @@ Three agents. DOS-479 (workspace memory search) merges first to establish the W3
 ### Agent W3-B — DOS-480: Work-product placement + intake receipts over MCP
 
 - **Spec:** [DOS-480](https://linear.app/a8c/issue/DOS-480).
-- **Goal:** Expose v1.4.6's `place_document` ability through an MCP write tool — `dailyos.place_document(entity_id, filename_hint, content_b64, category?, client_dedup_key?)` — returning `PlaceDocumentReceipt v1`. Forwards to `place_document` ability with `Actor::McpClient` attribution.
+- **Goal:** Expose v1.4.6's `place_document` ability through an MCP write tool — `dailyos.write.place_document(entity_id, filename_hint, content_b64, category?, client_dedup_key?)` — returning v1.4.6 `PlaceDocumentReceipt v1` unchanged. Forwards to `place_document` ability with `Actor::McpClient` attribution. **Scope reuses v1.4.6's `write.workspace_place_document` verbatim** (cycle 2 Class C — no rename).
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_placement.rs` (W1-A placeholder).
 - **Don't touch:** v1.4.6 `place_document` ability (consumer-only — handler is a thin wrapper); other handlers.
 - **Depends on:** W3-A merged (establishes the W3 v1.4.6-substrate-consuming pattern); v1.4.6 W4-C frozen `PlaceDocumentInput / Receipt / Error` contract.
 - **Security gate:** `/cso` at L0 plan AND L2 diff.
-  - Caller must have `dailyos.write.place_document` scope.
+  - Caller must have `write.workspace_place_document` scope (cycle 2: reused verbatim from v1.4.6).
   - All v1.4.6 W4-C security rules apply: server-derived `source_asof`, transactional validation+write+enqueue, per-actor rate limits, idempotency by `(entity_id, content_sha256, client_dedup_key)`.
   - The `resolved_path` field in the receipt is gated by `read.entity_names` per v1.4.6 W4-C cycle-9 amendment — MCP handler honors this without modification.
+  - `OpaqueConversationHandle` REQUIRED on this `Side::Write` tool (cycle 2 Class D #9). Gateway returns `ConversationRequired` if absent.
 - **Done when:** `dailyos.place_document` MCP tool delegates to v1.4.6's `place_document` ability; receipt serialization exact match for v1.4.6 `PlaceDocumentReceipt v1`; rate limits + idempotency tested; `/cso` L0 plan AND L2 diff approval recorded.
 
 ### Agent W3-C — DOS-171: Privacy-rendered MCP resources for entity + source profiles
 
 - **Spec:** [DOS-171](https://linear.app/a8c/issue/DOS-171).
-- **Goal:** MCP resources (browsable, URL-shaped) for entity + source profiles. URI scheme `dailyos://account/{id}`, `dailyos://person/{id}`, `dailyos://source/{id}`. Privacy-rendered per ADR-0108 + v1.4.6 sensitivity rules.
+- **Goal:** MCP resources (browsable, URL-shaped) for entity + source profiles. URI scheme `dailyos://account/{handle}`, `dailyos://person/{handle}`, `dailyos://source/{handle}` where `{handle}` is a **server-minted opaque resource handle** (cycle 2 CSO MED #4 — never the underlying entity_id which could be enumerable/PII). Privacy-rendered per ADR-0108 + v1.4.6 sensitivity rules using the SAME redaction helper DOS-479 ships (cycle 2 CSO LOW #5 — DOS-171 must not implement parallel redaction logic; reuse the W3-A helper exactly).
 - **Files owned (exclusive):** `src-tauri/src/services/mcp_v2/handlers/tool_resources.rs` (W1-A placeholder).
 - **Don't touch:** Other handlers; v1.4.6 source registry (consumer-only).
 - **Depends on:** W3-A merged (consumes the workspace search ability for source resources); W3-B merged (consumes placement receipts for source resources that include recent ingestion runs).
 - **Security gate:** `/cso` at L0 plan AND L2 diff.
-  - Resource responses honor sensitivity rendering: PII redacted unless caller has appropriate scope; raw file paths absent; raw claim text absent (only summaries + chip representations).
+  - Resource responses honor sensitivity rendering through the shared W3-A redaction helper (cycle 2 amendment): entity names null without `read.entity_names` scope; raw file paths NEVER returned; raw claim text NEVER returned (only `claim_summary` aggregates per v1.4.6 W3-C convention).
+  - Resource handles are server-minted opaque strings (cycle 2 CSO MED #4). The mapping `handle → entity_id` is server-side only; gateway authorizes every resource dereference against the actor's scopes.
 - **Done when:** Three resource handlers (`dailyos://account/*`, `dailyos://person/*`, `dailyos://source/*`) ship with privacy-rendered responses; URI scheme registered with the gateway; `/cso` L0 plan AND L2 diff approval recorded; `cargo test` + `cargo clippy -D warnings` clean.
 
 ### W3 merge gate
@@ -468,13 +588,14 @@ Two agents, sequenced.
 ### Agent W5-A — DOS-481: Tool-description eval + host-selection tests
 
 - **Spec:** [DOS-481](https://linear.app/a8c/issue/DOS-481).
-- **Goal:** Build the eval harness that validates v1.4.7 tool descriptions select correctly under realistic host-model prompts. Two test categories:
-  1. **Positive selection:** prompts that should select DailyOS tools (e.g., "What's the latest with the Acme renewal?", "Who attended the last meeting with Hooli?", "What did I write about the Q1 readout?") — assert correct tool name + parameters.
-  2. **Negative selection:** prompts that should NOT select DailyOS tools (e.g., "Search the web for SaaS pricing benchmarks", "What's the company's vacation policy?", "Find docs about React hooks") — assert no DailyOS tool selected.
+- **Goal:** Build the eval harness that validates v1.4.7 tool descriptions select correctly under realistic host-model prompts. **Cycle 2 fixture density (per DX MED #6): minimum ≥2 positive + ≥2 negative per tool**, where the negative fixtures must include BOTH a broad-corpus negative (web/enterprise search territory) AND an adjacent-DailyOS-but-wrong-tool negative (e.g., a prompt that should select `dailyos.read.account_status` but NOT `dailyos.search.workspace_memory` because they're adjacent). Three test categories:
+  1. **Positive selection:** prompts that should select THIS tool (e.g., "What's the latest with the Acme renewal?", "Who attended the last meeting with Hooli?", "What did I write about the Q1 readout?") — assert correct tool name + key parameters.
+  2. **Broad-corpus negative:** prompts that should NOT select any DailyOS tool (e.g., "Search the web for SaaS pricing benchmarks", "What's the company's vacation policy?", "Find docs about React hooks") — assert no DailyOS tool selected.
+  3. **Adjacent-tool negative:** prompts that select a DailyOS tool but NOT this one (e.g., for the `dailyos.search.workspace_memory` tool: a prompt like "What's Acme's renewal date?" should select `dailyos.read.account_status`, not workspace memory search).
 - **Files owned (exclusive):** `tests/v147_tool_eval/` (new test suite); fixture corpus at `tests/v147_tool_eval/fixtures/`.
 - **Depends on:** W1 + W2 + W3 + W4 all merged (every tool description finalized).
 - **`/plan-devex-review` + `/plan-ceo-review` gate at L0 plan:** the eval fixture corpus IS the product-strategy artifact for tool descriptions. Both reviewers validate fixture coverage at L0.
-- **Done when:** Eval harness runs on the v1.4.7 tool description corpus; positive + negative fixtures defined for every tool; pass rate threshold defined and met; CI integration; `/plan-devex-review` + `/plan-ceo-review` L0 plan approval recorded.
+- **Done when:** Eval harness runs on the v1.4.7 tool description corpus; **≥2 positive + ≥2 negative fixtures defined per tool**, with at least one broad-corpus negative AND one adjacent-tool negative per tool (cycle 2 amendment); pass rate threshold defined and met; CI integration; `/plan-devex-review` + `/plan-ceo-review` L0 plan approval recorded.
 
 ### Agent W5-B — DOS-482: E2E MCP v2 validation with workspace memory
 
@@ -485,7 +606,7 @@ Two agents, sequenced.
 - **Validation axes:**
   1. **Tool correctness:** every v1.4.7 tool returns correct shape on real fixture entity/source/action data.
   2. **Privacy rendering:** sensitivity boundaries enforced across every tool (file paths absent without `read.entity_names`; PII redacted; raw claim text never in aggregates).
-  3. **Cross-conversation continuity:** placeholder fixture for the named affordance — same MCP session asks two questions about the same entity; second response reflects state changes from first.
+  3. **Cross-conversation continuity (cycle 2 DX HIGH #1):** TWO fixtures — (a) **same-session continuity:** same MCP session asks two questions about the same entity; second response reflects state changes from first; (b) **cross-session continuity:** new MCP session passes a previously-issued `OpaqueConversationHandle`; server resolves it and surfaces the prior conversation's state. Validates the named affordance properly, not just same-session.
   4. **v1.4.6 contract fidelity:** tools that consume `WorkspaceGraphProjection v1` / `PlaceDocumentReceipt v1` / etc. produce schema-conforming responses.
   5. **Host-selection behavior:** runs the W5-A eval suite as a release gate (must pass at the threshold).
 - **Done when:** All five validation axes green; validation report written; `pnpm release-gate -- --mode hermetic` exits zero against bundles 1-18 + new v1.4.7 bundles; manual dogfood evidence captured against ≥5 host-model conversations exercising the v1.4.7 tools.
@@ -554,16 +675,17 @@ L0 → L2 → L3 → L4 → L5 cleared. Required artifacts:
 
 | # | Question | Consuming wave | Status |
 |---|---|---|---|
-| 1 | Does ADR-0102 need amendment for `Actor::McpClient` introduction + scope naming convention? | W0 | **Open** — defer to W0 ADR drafting; expected YES based on cycle 1 draft |
-| 2 | Does ADR-0128 need amendment for v2 expansion principles (tool-description as product copy, host-selection language, cross-conversation continuity)? | W0 | **Open** — defer to W0; expected YES |
-| 3 | Scope naming convention: `read.*` / `write.*` / `submit.*` taxonomy or align fully with existing `submit.*`? | W0 (folded into ADR-0102) | **Open** — DX consult preferred convention at L0 cycle 1 |
+| 1 | Does ADR-0102 need amendment for `Actor::McpClient` introduction + scope naming + MCP client auth? | W0 | **Resolved (cycle 2)** — yes; ADR-0102 amendment scope expanded per Class S to also cover MCP client authentication + session contract; PR also lands `Actor::McpClient` enum variant code change in `actor.rs` |
+| 2 | Does ADR-0128 need amendment for v2 expansion principles? | W0 | **Resolved (cycle 2)** — yes; covers tool-description as product copy + host-selection language + cross-conversation continuity contract |
+| 3 | Scope naming convention | W0 (folded into ADR-0102) | **Resolved (cycle 2)** — `<dot-namespace>.<verb>.<noun>`; v1.4.6's `write.workspace_place_document` reused verbatim; full mapping table in §"Scope naming convention frozen" |
 | 4 | Does `services::notes` exist as a separate service from `services::claims`, or do notes flow through `commit_claim` with a `Note` claim_kind variant? | W4-A (DOS-167) | **Open** — defer to W4-A L0 plan with fresh grep |
-| 5 | Does `dailyos.portfolio_attention` consume an existing v1.4.5 salience ability (when v1.4.5 ships) or implement recency-only ranking as the v1.4.7 default? | W2-C (DOS-173) | **Open** — defer to W2-C L0 plan; v1.4.5 ship state determines |
-| 6 | Cross-conversation continuity: is conversation_id required on every MCP tool call, or optional? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan; ADR-0128 amendment likely speaks to this |
+| 5 | Does `dailyos.read.portfolio_attention` consume an existing v1.4.5 salience ability or implement recency-only ranking? | W2-C (DOS-173) | **Open** — defer to W2-C L0 plan; v1.4.5 ship state determines |
+| 6 | Cross-conversation continuity: required vs optional? | W1-A | **Resolved (cycle 2)** — `OpaqueConversationHandle` REQUIRED on `Side::Write` tools; recommended on reads; server-minted (not caller-provided); cross-session lookup via separate ability |
 | 7 | Does the v1.4.7 audit log re-use v1.4.6 audit substrate or introduce a separate MCP-specific audit table? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan with fresh grep against v1.4.6 audit code |
-| 8 | Confirm v1.4.6 frozen contracts (`WorkspaceGraphProjection v1`, `PlaceDocumentInput v1`, etc.) are merged on dev before v1.4.7 W3 implementation starts. | W3 | **Open** — coordination item; tracked at W0 close |
-| 9 | Does `Actor::McpClient` need rate-limit budgets distinct from `Actor::SurfaceClient`, or share the same v1.4.2 W2-D rate-limit registry? | W1-A (DOS-168) | **Open** — defer to W1-A L0 plan; expected: distinct budgets per actor variant |
-| 10 | Tool description text licensing / review process — who has authority to edit `tool_descriptions.yaml` post-merge (since it's product copy)? | W1-B (DOS-478) | **Open** — defer to W1-B L0 plan with `/plan-ceo-review` |
+| 8 | Confirm v1.4.6 frozen contracts merged on dev before v1.4.7 W3 implementation starts | W3 | **Open** — coordination item; tracked at W0 close |
+| 9 | Does `Actor::McpClient` need rate-limit budgets distinct from `Actor::SurfaceClient`? | W1-A (DOS-168) | **Resolved (cycle 2 partially)** — yes, distinct per the ADR-0102 amendment Class S contract (per-actor + per-client + per-tool rate-limit registry); exact budget numbers defer to W1-A L0 plan |
+| 10 | Tool description text licensing / review process | W1-B (DOS-478) | **Open** — defer to W1-B L0 plan with `/plan-ceo-review` |
+| 11 (new) | What's the MCP pairing handshake protocol shape? Mirror v1.4.2 SurfaceClient pairing or use OAuth-style flow or stdio-transport simpler model? | W0 (ADR-0102 amendment) | **Open** — defer to W0 ADR drafting |
 
 ---
 


### PR DESCRIPTION
## Summary

L0-approved wave plan packet for **v1.4.7 — MCP Server v2 (Abilities-First)**. Doc-only, lands in \`.docs/plans/v1.4.7-waves.md\`. Implementation gates on v1.4.6 landing.

## L0 verdict

Unanimous APPROVE across all four lanes after 5 cycles:

| Lane | Final verdict | Last reviewed |
|---|---|---|
| CSO | APPROVE-WITH-CONDITIONS (W0 gate enforcement; in packet) | cycle 2 |
| Eng | APPROVE | cycle 4 |
| Challenge | APPROVE | cycle 4 |
| DX | APPROVE | cycle 5 |

Half v1.4.6's 10 cycles, as predicted. Full cycle history in the file's top-of-doc changelog (cycles 2–5).

## What ships

5 implementation waves + W0 coordination wave covering 13 issues:
- W0: ADR-0102 amendment (\`Actor::McpClient\` + MCP client auth/session contract + scope naming) + ADR-0128 amendment (tool-description as product copy + cross-conversation continuity)
- W1: Contract & Policy (DOS-168 gateway, DOS-478 taxonomy)
- W2: Ability-Backed Reads (DOS-175 briefing replacement, DOS-172 pagination, DOS-173 portfolio attention)
- W3: Workspace Memory Tools (DOS-479 search, DOS-480 placement, DOS-171 resources)
- W4: Controlled Feedback & Writes (DOS-167 notes, DOS-169 actions, DOS-170 status updates)
- W5: Evaluation & Release Gate (DOS-481 host-selection eval, DOS-482 E2E)

Migration slots reserved: v220–v239.

Class S architectural finding from cycle 1 (CSO): MCP client trust boundary undefined. Resolved by expanding ADR-0102 amendment scope to include server-issued \`McpClientId\` + HMAC transport signing + server-side scope manifest + revocation + rate-limit registry.

## Security

security_auditor_invoked: false

This PR is doc-only on \`.docs/plans/v1.4.7-waves.md\`. The plan itself was reviewed by /cso in L0 cycles 1+2 (cycle 2 verdict: APPROVE-WITH-CONDITIONS, conditions enumerated in the W0 close gate) but the doc landing itself does not trigger security-auditor per matrix.yml paths.

## Test plan

- [ ] Plan reviewers eyeball the wave shape + ADR-0102 + ADR-0128 amendment scopes
- [ ] W0 kickoff once v1.4.6 ships
- [ ] No code in this PR; nothing to test beyond doc render

🤖 Generated with [Claude Code](https://claude.com/claude-code)