### PR TITLE
ci(rust): release-only — push to main, no PR triggers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,30 +1,23 @@
 # Rust CI — macOS only because Tauri externalBin validation + macOS keychain
-# integration paths require it. Triggers are deliberately narrow:
+# integration paths require it.
 #
-# - Pushes/PRs to trunk: always run (release branch — full safety).
-# - PRs to dev: only when src-tauri/**, Cargo.*, or workflow files change.
-#   Frontend-only PRs to dev skip this job entirely (the cost saving).
+# Triggers (intentionally narrow per 2026-05-15 amendment):
+# - Pushes to main: always run (release branch — full safety on the
+#   versioned release path).
+# - No PR triggers. Dev-side coverage is owned entirely by the
+#   .githooks/pre-commit gate (clippy + cargo test --lib + tsc) plus L2
+#   review on every PR. The macos-latest Rust workflow was costing ~10x
+#   the Linux cost per run for redundant signal — local clippy is the
+#   real gate; CI-on-every-Rust-touching-PR was overhead, not safety.
 #
-# Rationale: the .githooks/pre-commit gate runs clippy + cargo test --lib
-# + tsc locally on every commit post-hook-wiring. L2 review catches
-# anything the local gate misses before merge. CI-on-every-dev-PR was
-# redundant + expensive (10x Linux cost on macos-latest).
+# If a regression slips through the local gate, it is caught at the
+# release-cut push to main.
 name: Rust
 
 on:
   push:
     branches:
-      - trunk
-    paths:
-      - 'src-tauri/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/rust.yml'
-      - '.github/workflows/test.yml'
-  pull_request:
-    branches:
-      - dev
-      - trunk
+      - main
     paths:
       - 'src-tauri/**'
       - 'Cargo.toml'
@@ -34,7 +27,7 @@ on:
 
 concurrency:
   group: rust-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   rust:


### PR DESCRIPTION
## Summary

Removes the dev-PR Rust CI trigger entirely. Rust CI now runs **only on push to \`main\`** (the release branch on the public remote). Renames \`trunk\` → \`main\` to match the actual remote branch name.

Other CI workflows are untouched: \`l2-review.yml\`, \`l3-review.yml\`, \`load-test.yml\`, \`release.yml\`, \`security-audit.yml\`, \`test.yml\`, \`wp-plugin.yml\` all stay as-is.

## Why

- macos-latest Rust workflow costs ~10x the Linux cost per job.
- Local \`.githooks/pre-commit\` gate already runs \`cargo clippy -D warnings\` + \`cargo test --lib\` + \`pnpm tsc --noEmit\` on every commit.
- L2 review catches anything the local gate misses before merge.
- CI-on-every-Rust-touching-dev-PR was overhead, not safety.

## Backstop

Regressions that slip through the local gate are caught at the release-cut push to \`main\`. Local clippy is the real gate.

## Branch protection note

\`dev\` has no branch protection on this repo (verified via gh API), so removing the workflow trigger immediately stops Rust CI from running on dev PRs without further repo-config changes.

## Security

security_auditor_invoked: true

Reviewed against the trust-boundary impact of removing a CI safety net:

- **No new attack surface added.** This change removes a verification layer; it does not introduce new code paths, new privileged surfaces, new untrusted input, or new dependencies.
- **Defense-in-depth posture preserved.** The local pre-commit gate (clippy -D warnings + cargo test --lib + tsc --noEmit) is the primary verification layer for Rust correctness on dev. L2 review is the human gate. Release-cut push to \`main\` retains the full macos-latest Rust workflow as the final verification before any tagged release.
- **Threat model:** a regression that (a) bypasses local clippy on the contributor's machine (e.g., hook disabled, IDE-only edit), (b) is missed by L2 reviewers, AND (c) lands on dev without anyone catching it locally. Such a regression is then caught at the next release-cut push to main, before any user installs it. The increased detection latency is from "PR-time" to "release-cut-time" — which on this repo is days-to-weeks, not months.
- **No bypass of existing security controls.** The L2 / l2-summary, L2 / validate-pr-template, L2 / config-fence, frontend, lint-and-checks, security-audit, and test workflows all remain in place. The change targets only \`.github/workflows/rust.yml\`.

The change is a deliberate cost-vs-safety trade — accepted because the local clippy gate is high-confidence and the release-cut backstop is short-latency.

## Test plan

- [ ] Workflow YAML is syntactically valid (GitHub will parse on PR push)
- [ ] After merge: next Rust-touching PR to dev does NOT trigger Rust CI
- [ ] After release-cut push to main: Rust CI runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)