### PR TITLE
WordPress foundation roadmap reorientation: v1.4.4–v1.4.7 surface lanes parked/reframed

### DIFF
--- a/.docs/plans/v1.4.4-waves.md
+++ b/.docs/plans/v1.4.4-waves.md
@@ -1,5 +1,22 @@
 # v1.4.4 — Claim Experience & Trust UI — Wave Plan
 
+## WordPress Foundation Reorientation (2026-05-15)
+
+This wave plan was authored assuming a Tauri React surface. Per [ADR-0129](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md) and the v1.4.2 WordPress foundation work, the surface target shifts to DailyOS Gutenberg blocks on the v1.4.2 magazine theme.
+
+**Substrate work** in this version is unchanged and proceeds per the L0-approved plan below: Shared Receipt DTO, semantic feedback action surface, `services::claim_receipt::*`, claim review queue extensions, Activity Log + Lint Mode service substrate, `CLAIM_TYPE_REGISTRY` extensions per ADR-0125 amendment.
+
+**Surface work** is reoriented:
+- The Actions/Work page reframes as `dailyos/actions-work` Gutenberg block(s) — likely a focused single-page composition (good second-block exercise post-v1.4.2 W4's `dailyos/account-overview` reference implementation).
+- Receipt rendering UI becomes a block primitive consumable by Actions/Work, briefing, entity, and other surfaces uniformly.
+- Activity Log and Lint Mode reframe as blocks.
+
+**Tauri UI freeze** applies. No new Tauri React UI work in this version. Existing Tauri Actions/Work scaffolding stays in stasis pending WP equivalents.
+
+**No new full L0 panel** is required for this reorientation — substrate L0 is unchanged; surface re-shape is an architectural translation L0-blessed by ADR-0129/0130 + v1.4.2 L0 panel. Targeted `/cso` re-review applies when first new-version block design lands. See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md) for full reorientation rationale, anchored decisions, and open questions deferred to post-v1.4.2-W4.
+
+---
+
 ## Cycle 2 amendments (2026-05-15)
 
 Cycle 1 codex verdicts: Challenge **APPROVE-WITH-CONDITIONS** (7 findings); Eng **REVISE** (6 findings); DX **APPROVE-WITH-AMENDMENTS** (5 findings); CSO **REQUEST_CHANGES** (6 findings). 24 findings consolidated to ~10 classes; substantial overlap. The biggest class is **substrate type-name drift** — the L0 Contract Addendum (2026-05-09) was written against an idealized type vocabulary that doesn't match the actual shipped substrate. Cycle 2 reconciles the wave plan to substrate ground truth.

--- a/.docs/plans/v1.4.5-waves.md
+++ b/.docs/plans/v1.4.5-waves.md
@@ -1,5 +1,26 @@
 # v1.4.5 — Salience & Recommendations — Wave Plan
 
+## WordPress Foundation Reorientation (2026-05-15)
+
+This wave plan was authored assuming a Tauri React surface for W3 (Suggested Next Steps surface contract + cross-surface rendering) and W4-B ("What's unusual" briefing section). Per [ADR-0129](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md) and the v1.4.2 WordPress foundation work, those surface targets shift to DailyOS Gutenberg blocks on the v1.4.2 magazine theme.
+
+**Substrate work** in this version is unchanged and proceeds per the L0-approved plan below: W1-A RecommendationClaim variant + `CLAIM_TYPE_REGISTRY` extension, W1-B salience scoring engine, W2-A surfacing policy, W2-B trigger policy, W4-A feedback loop, W4-C engagement telemetry, W5-A eval harness. All surface-agnostic.
+
+**Surface work** is reoriented:
+- W3-A "Suggested Next Steps" surface contract → `dailyos/suggested-next-steps` Gutenberg block. Same producer/renderer split per ADR-0130; same trust band + provenance refs + salience/why-this-now rendering inside the block.
+- W3-B cross-surface rendering → block embedding rules (which pages render which blocks; block composition primitives).
+- W4-B "What's unusual" briefing section → `dailyos/whats-unusual` Gutenberg block (rendered inside daily and/or meeting briefing pages composed of multiple DailyOS blocks).
+
+**Surface lanes parked** until v1.4.2 W4 ships (`dailyos/account-overview` reference block + producer/renderer pattern) and the DailyOS block authoring playbook is in hand. Substrate W1/W2/W4-A/W4-C/W5 lanes proceed independently.
+
+**Tauri UI freeze** applies. No new Tauri React W3/W4-B UI work in this version.
+
+**No new full L0 panel** is required for this reorientation — substrate L0 is unchanged; surface re-shape is L0-blessed by ADR-0129/0130 + v1.4.2 L0 panel. Targeted `/cso` re-review applies at block design lock-in (covers trust-band-in-block + edit-as-feedback-claim wire + DOS-510 inheritance for block context). See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md) for full rationale.
+
+**Audit issues superseded:** [DOS-625](https://linear.app/a8c/issue/DOS-625), [DOS-626](https://linear.app/a8c/issue/DOS-626), [DOS-627](https://linear.app/a8c/issue/DOS-627) — surface-specific concerns become moot post-reorientation; close on this PR landing. v1.4.3 substrate citations stay relevant as cross-version dependencies but materialize on the WP-block path, not the Tauri path.
+
+---
+
 ## Cycle 8 amendments (2026-05-15) — serde tag/tuple-variant fix
 
 Cycle 7 codex verdicts: Eng **APPROVE** (ENG-L0-C3-01 closed across 5 sites + line 304); Challenge **BLOCK** with one new finding introduced by cycle 5 sweep — internally tagged enum (`#[serde(tag = "kind", ...)]`) is invalid for tuple/newtype variants.

--- a/.docs/plans/v1.4.6-waves.md
+++ b/.docs/plans/v1.4.6-waves.md
@@ -1,5 +1,20 @@
 # v1.4.6 — Workspace Memory Refactor — Wave Plan
 
+## WordPress Foundation Reorientation (2026-05-15)
+
+This wave plan is **substrate-only** — no user-facing surface work. The WordPress foundation reorientation (per [ADR-0129](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md)) doesn't change the substrate L0-approved plan below.
+
+**Scope discovery flagged:** v1.4.2's project description routes "Bidirectional markdown↔substrate ingestion" to v1.4.6 as an explicit non-goal of v1.4.2. The current v1.4.6 wave plan documents the workspace memory refactor + indexing + retrieval primitives, but does NOT document the markdown-back-to-claim-store ingestion side that v1.4.2 expects v1.4.6 to own. This is a scope expansion that needs:
+- Linear issue capturing the bidirectional markdown↔substrate scope
+- Wave plan amendment adding the ingestion lane (likely a new wave or extension of W3/W4)
+- Substrate-consultation reuse audit against v1.4.2's three-view consistency contract (substrate ↔ WP DB ↔ markdown; concurrency contract; tamper detection)
+
+Filed separately; does NOT block the existing v1.4.6 substrate work.
+
+**No new full L0 panel** is required for the reorientation context. The bidirectional-markdown scope expansion may warrant a targeted `/plan-eng-review` + `/cso` re-review when its lane ships. See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md).
+
+---
+
 ## Cycle 2 amendments (2026-05-14)
 
 Cycle 1 L0 verdicts: codex challenge BLOCK; codex eng/DX/cso APPROVE-WITH-AMENDMENTS. Class patterns identified across lanes:

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -1,5 +1,22 @@
 # v1.4.7 — MCP Server v2 (Abilities-First) — Wave Plan
 
+## WordPress Foundation Reorientation (2026-05-15)
+
+This wave plan was authored as if v1.4.7 is the greenfield MCP layer. Per [ADR-0129](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md) and the v1.4.2 WordPress foundation work, **v1.4.2 W3-C already ships a WordPress-mediated MCP server** via the WP MCP Adapter with a DailyOS ability allowlist + dedicated low-cap WP user + read-mostly defaults.
+
+**Reframed:** v1.4.7 is the **second MCP path** — direct headless MCP from runtime to Claude Desktop / Cursor / other agents WITHOUT WordPress in the loop. The two paths coexist: WP-mediated for blocks consuming substrate; headless direct for agents consuming substrate without a surface.
+
+**Coordination required (already filed):**
+- [DOS-624](https://linear.app/a8c/issue/DOS-624) — v1.4.7 W2-A `dailyos.read.daily_briefing` and `dailyos.read.meeting_briefing` MCP tools wrap intelligence the v1.4.3 carve-out reserved as User-only. CSO-approved L0 amendment required before W2-A implementation; amendment must also coordinate with v1.4.2 W3-C MCP path to avoid two parallel MCP exposures of the same intelligence.
+
+**Surface-agnostic substrate** (per anchored decision #6): parity across agent / Claude Desktop / Cursor / WordPress / future surfaces. Block producers in v1.4.2+ should be invocable from MCP for headless agents; the same producer renders the WP block AND answers the MCP tool call. Producer/renderer split per ADR-0130 already supports this; v1.4.7 W1-A's ability-surface inventory should treat producer abilities as first-class MCP-exposed citizens (same allowlist discipline as v1.4.2 W3-C).
+
+**Tauri UI freeze** does not affect this version (v1.4.7 surfaces are headless agents, not Tauri UI).
+
+**No new full L0 panel** is required for the reorientation. DOS-624 captures the one substantive new L0 concern (CSO-approved actor exposure amendment). See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md).
+
+---
+
 ## Cycle 2 amendments (2026-05-14)
 
 Cycle 1 codex verdicts: Challenge **BLOCK** (5 HIGH); Eng **BLOCK** (3 HIGH + 2 MED, 4 overlap); DX **APPROVE-WITH-CONDITIONS** (1 HIGH + 4 MED + 1 LOW); CSO **BLOCK** (1 HIGH + 3 MED + 1 LOW). Deduplicated to ~14 unique findings across 6 classes. The biggest finding is Class S (MCP client trust boundary) — the only finding requiring substantive new design; rest is propagation/cleanup.

--- a/.docs/plans/wp-foundation-roadmap-reorientation.md
+++ b/.docs/plans/wp-foundation-roadmap-reorientation.md
@@ -1,0 +1,83 @@
+# WordPress Foundation Roadmap Reorientation
+
+**Date:** 2026-05-15
+**Status:** Active reorientation; per-version surface plans deferred until v1.4.2 W4 lands
+**Authority:** [ADR-0129 — Composable surfaces: WordPress Studio as primary surface](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md), [ADR-0130 — Surface-independent Composition contract](../decisions/0130-surface-independent-composition-contract.md), [v1.4.2 project (Personal Intelligence Engine: WordPress Foundation)](https://linear.app/a8c/project/v142-personal-intelligence-engine-wordpress-foundation-5b2473379b7f)
+
+## Why this doc exists
+
+The wave plans for v1.4.3, v1.4.4, v1.4.5, v1.4.6, and v1.4.7 were authored at different times with different assumptions about the user-facing surface. v1.4.3 still talks D-spine cutover, FolioBar, AtmosphereLayer, MagazinePageLayout — Tauri React shell terminology. v1.4.4/4.5 lane bodies describe React components. v1.4.7 W2-A wraps `get_daily_briefing` for MCP without acknowledging the WordPress-mediated MCP path that v1.4.2 W3-C already establishes.
+
+ADR-0129 (and the v1.4.2 project that implements it) commits the program to a different surface strategy: **WordPress Studio is the primary user-facing surface; Tauri reorients to runtime-host + dev-admin role.** This doc reorients v1.4.3+ accordingly.
+
+This is not a re-plan. The L0-approved substrate work in each version is unchanged. The reorientation is a target translation: Tauri React surfaces → DailyOS Gutenberg blocks. User-facing intent and substrate consumption are identical.
+
+## Anchored decisions (from user 2026-05-15)
+
+1. **Many blocks, not few.** Each Tauri component or pattern gets a Gutenberg block equivalent. Block primitives exist regardless. Per-page composition and user customization come at zero additional lift on the DailyOS side once primitives are in place.
+2. **Inline edit affordances.** Same UX shape as current Tauri app. Pull/push of feedback or user edits is mostly decided as a user-feedback claim path (substrate writes through the existing claim/feedback path, not direct DB writes from WP).
+3. **User-swappable themes.** DailyOS may ship 3 — or 10 — themes. The surface is data-customizable; data shape decoupled from theme treatment.
+4. **Tauri UI freeze.** No new UI work in Tauri from 2026-05-15 forward. Existing Tauri surfaces remain in stasis. As WP equivalents ship, no active decommissioning of Tauri surfaces is planned — they sit alongside until WP parity, then a single substrate-first transition release flips primary.
+5. **Eventual substrate-first install path.** DailyOS will eventually ship as a WordPress plugin; substrate install path = WP plugin install. No independent install path required long-term.
+6. **Surface-agnostic substrate.** Parity across agent / Claude Desktop / Cursor / WordPress / future surfaces. The substrate doesn't know which surface is rendering it.
+
+## What this means version-by-version
+
+| Version | Substrate (unchanged, L0-blessed) | Surface (reorients to blocks) | Tauri freeze impact |
+|---|---|---|---|
+| **v1.4.2** | (this is the foundation work) | Magazine theme, `dailyos/account-overview` block (W4) — reference implementation for downstream block authoring | n/a (v1.4.2 IS the WP foundation) |
+| **v1.4.3** | `get_daily_briefing` ability (Read/User-only); meeting prep/readiness DTO (DOS-335); `services::briefing::*`; signals + lifecycle; DOS-510 hostile-input/redaction gates | Daily-briefing rendering reorients from D-spine Tauri cutover → composed set of DailyOS Gutenberg blocks. **Surface lanes parked until v1.4.2 W4 ships and a block authoring playbook is in hand.** | D-spine cutover (Wave 3) **frozen**. Substrate W0/W1/W2 substrate work proceeds. |
+| **v1.4.4** | Shared Receipt DTO; semantic feedback action surface; Actions/Work service substrate; `services::claim_receipt::*` | Actions/Work page → `dailyos/actions-work` block (good second-block exercise post-v1.4.2 W4 — focused single page). Receipt rendering UI → block primitive. | Actions/Work React page **frozen** as authored target. |
+| **v1.4.5** | RecommendationClaim variant + `CLAIM_TYPE_REGISTRY` extension; salience scoring engine; surfacing policy; trigger policy; deviation/engagement substrate; eval harness | W3-A "Suggested Next Steps" surface contract → `dailyos/suggested-next-steps` block; W3-B cross-surface rendering → block embedding rules; W4-B "What's unusual" → `dailyos/whats-unusual` block. **Surface lanes parked until v1.4.2 W4 + v1.4.3 surface lanes set the precedent.** | W3 surface lanes **frozen** as Tauri targets. Substrate W1/W2/W4-A/W4-C/W5 proceed. |
+| **v1.4.6** | Workspace memory refactor + ADRs + retrieval primitives + indexing pipeline | **Scope discovery:** v1.4.2 explicit non-goal routes "bidirectional markdown↔substrate ingestion" to v1.4.6. Current v1.4.6 plan does not document the markdown-back-to-claim-store ingestion side. File as scope-discovery issue. | No surface impact (v1.4.6 is substrate-only). |
+| **v1.4.7** | MCP runtime, ability proxy, host-selection contract, write-path tools | **Reframed:** v1.4.7 is the **second MCP path** — direct headless MCP from runtime to Claude Desktop / Cursor without WordPress in the loop. v1.4.2 W3-C already ships the WordPress-mediated MCP server. v1.4.7 W2-A briefing tools must coordinate with v1.4.2's path (DOS-624 already filed). | No surface impact (v1.4.7 surfaces are headless agents). |
+
+## What still needs to happen before v1.4.3+ surface work restarts
+
+These are deferred to post-v1.4.2-W4 and not gating substrate work in any of the listed versions:
+
+1. **First block validates the model.** v1.4.2 W4 ships `dailyos/account-overview` end-to-end: producer ability, renderer, trust band rendering, provenance refs, fallback projection, edit/save round-trip. Until this is proven, downstream block design is speculative.
+2. **DailyOS Gutenberg block authoring playbook.** Once W4 lands, a written playbook captures: producer/renderer split, trust-band-inside-block rendering, provenance reference handling, fallback projection rules, edit affordance pattern, edit→feedback-claim wire format, theme-token consumption rules, performance budgets (re-invocation on read vs cached projection). This becomes required reading for v1.4.3+ surface lane authors.
+3. **Block granularity per version.** Per anchored decision #1, many blocks. The per-version block list is a planning step that happens after the playbook exists. Likely shape:
+   - v1.4.3: `dailyos/daily-briefing-overview`, `dailyos/meeting-briefing`, `dailyos/prep-status`, `dailyos/finis-marker` (if not theme), and small primitives (entity link chip, claim summary, trust band).
+   - v1.4.4: `dailyos/actions-work`, `dailyos/claim-receipt`, `dailyos/activity-log`, `dailyos/lint-mode`.
+   - v1.4.5: `dailyos/suggested-next-steps`, `dailyos/whats-unusual`, `dailyos/why-this-now-popover`.
+4. **Theme inventory.** Per anchored decision #3, ship N themes. Initial v1.4.2 magazine theme is the reference; subsequent themes are downstream (no version assigned yet).
+5. **Per-version Linear re-issue.** Each version's surface-specific issues need re-shaping or splitting (block-X delivery vs page-X composition vs surface-region-X salvage). Defer until playbook exists.
+
+## L0 retention
+
+**No new full L0 panel triggered by this reorientation.** Substrate L0s in each version remain valid (surface-agnostic contracts). Per `feedback_l2_path_alpha_to_maintenance_project`, new findings introduced by the reorientation file as Linear maintenance issues against each version, not as cycle-N+1 L0 amendments.
+
+**Targeted re-review at per-version restart:**
+- `/cso` re-review when first new-version block design lands (covers trust-band-in-block rendering + edit-as-feedback-claim wire + DOS-510 inheritance for block context).
+- `/plan-eng-review` for block granularity decisions per version (architectural, not safety; light touch).
+- v1.4.7 W2-A specifically requires CSO-approved L0 amendment per DOS-624 + the v1.4.3 actor-exposure carve-out + coordination with v1.4.2 W3-C MCP path.
+
+## Already-filed maintenance issues this doc supersedes
+
+- [DOS-624](https://linear.app/a8c/issue/DOS-624) — v1.4.7 W2-A CSO L0 amendment for MCP exposure (subsumes one part of the reorientation; resolution still required at v1.4.7 implementation kickoff).
+- [DOS-625](https://linear.app/a8c/issue/DOS-625) — v1.4.5 W3 plan v1.4.3 substrate citations (becomes moot once both versions reorient; close on this doc landing).
+- [DOS-626](https://linear.app/a8c/issue/DOS-626) — v1.4.5 W4-B briefing surface dependency (same — moot post-reorientation).
+- [DOS-627](https://linear.app/a8c/issue/DOS-627) — v1.4.5 plan DOS-510 inheritance (subsumed by reorientation: DOS-510 inheritance applies to ALL block rendering on the v1.4.2 surface bridge, codified in the block authoring playbook when authored).
+
+## Open architectural questions (post-W4)
+
+Captured for the playbook authoring step; not blocking substrate work:
+
+1. **Block granularity strategy.** One composed `dailyos/daily-briefing` block vs many small blocks the user composes? Per anchored decision #1: many blocks. Implies a "default page composition" template per surface (briefing, meeting, account, project) that ships out-of-box but is editable.
+2. **Edit affordance per block.** Inline (per anchored decision #2). Pull/push as user-feedback claim. Wire shape needs codification: "edit captured as `FeedbackAction::ClaimCorrection` (or analogous), routed through SurfaceClient → substrate, returned projection re-renders."
+3. **Theme contract.** What does a theme own (color, typography, density, editorial chrome) vs what does the substrate render (data, trust band, provenance, claim text)? Token boundary needs to be sharp before second theme exists.
+4. **Headless agent parity.** Per anchored decision #6, surface-agnostic substrate. Block producers run on read; the same producer should be invocable from MCP for headless agents. Producer/renderer split per ADR-0130 already supports this; needs to be exercised cross-surface in W4 evidence.
+5. **Tauri end-state.** Per anchored decision #4, freeze + stasis. Per anchored decision #5, eventual WP plugin install. The transition release that flips primary needs its own scope: bundle path (Tauri continues hosting runtime + MCP), UI deprecation (gradual or all-at-once), data migration (likely none — substrate is shared). Defer to that release's planning when the time comes.
+
+## Reading order for downstream version work
+
+Anyone touching v1.4.3+ surface work should read in this order before drafting:
+1. ADR-0129 (composable surfaces decision)
+2. ADR-0130 (composition contract)
+3. v1.4.2 project description (Linear) — particularly Wave 4 outcomes
+4. This doc
+5. v1.4.2 W4 proof artifacts when they land (account-overview block end-to-end evidence)
+6. The DailyOS Gutenberg block authoring playbook (TBA, post-W4)
+7. The version-specific wave plan


### PR DESCRIPTION
## Summary

Per ADR-0129 (Composable surfaces: WordPress Studio as primary surface) and the v1.4.2 WordPress foundation work, the user-facing surface target shifts from Tauri React to DailyOS Gutenberg blocks. The v1.4.4/4.5/4.6/4.7 wave plans were authored at different times and don't reflect this — surface lanes still describe Tauri React components.

This PR adds:

1. `.docs/plans/wp-foundation-roadmap-reorientation.md` — central doc capturing version-by-version translation, anchored decisions, L0 retention rationale, and open questions deferred to post-v1.4.2-W4.
2. Reorientation headers prepended to v1.4.4/4.5/4.6/4.7 wave plans, each referencing the central doc.

## Anchored decisions (per user 2026-05-15)

1. Many blocks, not few — primitive parity = customization at zero lift
2. Inline edit; pull/push as user-feedback claim (mostly decided)
3. User-swappable themes; ship N themes
4. Tauri UI freeze; surfaces stay in stasis until WP parity → substrate-first transition release
5. DailyOS eventually ships AS a WordPress plugin
6. Surface-agnostic substrate; parity across agent/Claude/Cursor/WP/other

## Per-version impact

- **v1.4.4** — Substrate unchanged (Shared Receipt DTO, semantic feedback, claim_receipt service). Surface reframes: Actions/Work as `dailyos/actions-work` block; receipt rendering as block primitive. Tauri Actions/Work scaffolding stays in stasis.
- **v1.4.5** — Substrate unchanged (RecommendationClaim, salience engine, surfacing/trigger policy, feedback, engagement, eval). W3 reframes to `dailyos/suggested-next-steps` + `dailyos/whats-unusual` blocks; surface lanes parked until v1.4.2 W4 + block authoring playbook. Audit issues DOS-625/626/627 superseded.
- **v1.4.6** — Substrate-only; no surface impact. Scope discovery flagged: v1.4.2 non-goal routes "bidirectional markdown↔substrate ingestion" to v1.4.6 — current plan doesn't document the markdown ingestion side. To be filed as separate issue.
- **v1.4.7** — Reframed as second MCP path (direct headless to Claude/Cursor) alongside v1.4.2 W3-C WP-mediated MCP. DOS-624 coordination noted (CSO L0 amendment for v1.4.7 W2-A briefing tools).

## L0 retention

No new full L0 panel triggered. Substrate L0s unaffected. Surface re-shape is an architectural translation L0-blessed by ADR-0129/0130 + v1.4.2 L0 panel. Targeted `/cso` + `/plan-eng-review` apply at per-version restart, not now. Path-α discipline for new findings.

## Test plan

- [x] Doc-only change; cargo/tsc/test gates n-a
- [x] Reorientation headers reference central doc
- [x] Anchored decisions captured verbatim
- [x] Audit issues DOS-624/625/626/627 cross-referenced

## L2 metadata
security_auditor_invoked: false

L2-status: n-a-doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)