### PR TITLE
DOS-570 W4-D: substrate fallback projection + edit-routing rules

### DIFF
--- a/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
+++ b/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
@@ -1,0 +1,1407 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::sync::{OnceLock, RwLock};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use thiserror::Error;
+
+use crate::abilities::composition::{
+    BindingRole, Block, BlockId, BlockType, ClaimRef, ClaimRefIndex, Composition, CompositionDocId,
+    CompositionVersion, FieldBinding, ProvenanceRef,
+};
+use crate::abilities::provenance::{CompositionId, FieldPath};
+use crate::abilities::registry::{Actor, ActorKind, SurfaceScope};
+use crate::abilities::trust::TrustBand;
+use crate::sensitivity::{
+    render_policy_for_surface, ClaimVerificationState, RenderActor, RenderDecision, RenderSurface,
+};
+use crate::types::{
+    ClaimSensitivity, ClaimState, IntelligenceClaim, SurfacingState, TemporalScope,
+};
+
+pub const DEFAULT_UNKNOWN_BLOCK_CAP: u32 = 5;
+pub const FALLBACK_BANNER_COPY: &str =
+    "Rendered as nearest known type — payload may be incomplete.";
+const GENERIC_TEXT_TYPE_ID: &str = "dailyos/text";
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectedComposition {
+    pub composition_id: CompositionDocId,
+    pub composition_version: Option<u64>,
+    pub fallback_policy_version: u32,
+    pub blocks: Vec<ProjectedBlock>,
+    pub diagnostics: Vec<ProjectionDiagnostic>,
+    pub unknown_block_count: u32,
+    pub unknown_block_cap: u32,
+    pub dropped_unknown_block_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectedBlock {
+    pub block_id: BlockId,
+    pub block_index: u32,
+    pub original_type_id: String,
+    pub selected_known_type_id: String,
+    pub payload: Value,
+    pub banner: Option<String>,
+    pub trust_band: TrustBand,
+    pub claim_refs: Vec<ClaimRef>,
+    pub provenance: Vec<ProvenanceRef>,
+    pub edit_routes: Vec<EditRoute>,
+    pub diagnostics: Vec<ProjectionDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct EditRoute {
+    pub field_path: FieldPath,
+    pub role: BindingRole,
+    pub claim_refs: Vec<ClaimRef>,
+    pub feedback_allowed: bool,
+    pub refusal_reason: Option<EditRouteRefusalReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectionDiagnostic {
+    pub diagnostic_kind: DiagnosticKind,
+    pub composition_id: CompositionId,
+    pub composition_version: u64,
+    pub original_type_id: Option<String>,
+    pub selected_known_type_id: Option<String>,
+    pub block_id: Option<BlockId>,
+    pub reason: DiagnosticReason,
+    pub dropped_pointer_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct AuditIntent {
+    pub event_kind: &'static str,
+    pub category: AuditCategory,
+    pub detail: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditCategory {
+    Security,
+    DataAccess,
+    Ai,
+    Anomaly,
+    Config,
+    System,
+}
+
+impl AuditCategory {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Security => "security",
+            Self::DataAccess => "data_access",
+            Self::Ai => "ai",
+            Self::Anomaly => "anomaly",
+            Self::Config => "config",
+            Self::System => "system",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FallbackProjectionContext {
+    pub actor: Actor,
+    pub surface: SurfaceKind,
+    pub fallback_policy_version: u32,
+    pub unknown_block_cap: u32,
+    pub include_non_sensitive_pointer_names: bool,
+}
+
+impl FallbackProjectionContext {
+    pub fn new(actor: Actor, surface: SurfaceKind, fallback_policy_version: u32) -> Self {
+        Self {
+            actor,
+            surface,
+            fallback_policy_version,
+            unknown_block_cap: DEFAULT_UNKNOWN_BLOCK_CAP,
+            include_non_sensitive_pointer_names: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceKind {
+    TauriApp,
+    McpTool,
+    McpToolDetail,
+    SurfaceClient,
+    Worker,
+    Eval,
+}
+
+impl SurfaceKind {
+    fn render_surface(self) -> RenderSurface {
+        match self {
+            Self::TauriApp => RenderSurface::TauriReport,
+            Self::McpTool => RenderSurface::McpTool,
+            Self::McpToolDetail => RenderSurface::McpToolDetail,
+            Self::SurfaceClient => RenderSurface::McpTool,
+            Self::Worker | Self::Eval => RenderSurface::LogStructured,
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ProjectionError {
+    #[error("missing block projection rule for {block_type:?}")]
+    MissingRule { block_type: BlockType },
+    #[error("invalid producer output: {reason:?}")]
+    InvalidProducerOutput { reason: ProducerOutputInvalidReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProducerOutputInvalidReason {
+    SourceBindingMissingFieldPath,
+    FeedbackTargetMissingFieldPath,
+    BindingTargetsUnknownField,
+    UnknownRole,
+    AmbiguousReceiver,
+    ConflictingDuplicateBinding,
+    MissingDeclaredSchema,
+    InvalidFieldPath,
+    NonClaimFeedbackReceiverUnsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EditRouteRefusalReason {
+    Computed,
+    DisplayOnly,
+    SourceWithoutTarget,
+    MissingClaimRef,
+    AmbiguousReceiver,
+    SensitivityBlocked,
+    UnknownRole,
+    OutOfScope,
+    FallbackDegradedWithoutReceiver,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticKind {
+    BlockFallback,
+    FieldDropped,
+    EditRouteRefused,
+    CapExceeded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticReason {
+    UnknownBlockType,
+    UnknownBlockCapExceeded,
+    UnknownAdmittedField,
+    SensitivityBlocked,
+    OutOfScope,
+    UnknownRole,
+    MissingClaimRef,
+    AmbiguousReceiver,
+    FallbackDegradedWithoutReceiver,
+}
+
+#[derive(Debug, Clone)]
+pub struct CustomBlockSchema {
+    pub type_id: String,
+    pub composition_kind: Option<String>,
+    pub required_pointers: BTreeSet<String>,
+    pub optional_pointers: BTreeSet<String>,
+    pub render_annotations: BTreeSet<String>,
+}
+
+impl CustomBlockSchema {
+    pub fn new(type_id: impl Into<String>) -> Self {
+        Self {
+            type_id: type_id.into(),
+            composition_kind: None,
+            required_pointers: BTreeSet::new(),
+            optional_pointers: BTreeSet::new(),
+            render_annotations: BTreeSet::new(),
+        }
+    }
+
+    fn declared_pointers(&self) -> impl Iterator<Item = &String> {
+        self.required_pointers
+            .iter()
+            .chain(self.optional_pointers.iter())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FieldPolicy {
+    pointer: &'static str,
+    sensitivity: ClaimSensitivity,
+    allowed_surfaces: &'static [SurfaceKind],
+    value_kind: ValueKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValueKind {
+    Text,
+    Number,
+}
+
+#[derive(Debug, Clone)]
+struct BlockProjectionRule {
+    block_type: BlockType,
+    composition_kind: Option<&'static str>,
+    type_namespace: Option<&'static str>,
+    render_annotations: &'static [&'static str],
+    fields: &'static [FieldPolicy],
+    default_trust_band: TrustBand,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct NearestTypeScore {
+    kind_match: u32,
+    required_overlap: u32,
+    optional_overlap: u32,
+    annotation_similarity: u32,
+    namespace_similarity: u32,
+}
+
+impl NearestTypeScore {
+    fn total(self) -> u32 {
+        self.kind_match
+            + self.required_overlap
+            + self.optional_overlap
+            + self.annotation_similarity
+            + self.namespace_similarity
+    }
+}
+
+static CUSTOM_BLOCK_SCHEMAS: OnceLock<RwLock<BTreeMap<String, CustomBlockSchema>>> =
+    OnceLock::new();
+
+pub fn register_custom_block_schema(schema: CustomBlockSchema) {
+    let registry = CUSTOM_BLOCK_SCHEMAS.get_or_init(|| RwLock::new(BTreeMap::new()));
+    registry
+        .write()
+        .expect("custom block schema registry poisoned")
+        .insert(schema.type_id.clone(), schema);
+}
+
+fn custom_block_schema(type_id: &str) -> Option<CustomBlockSchema> {
+    CUSTOM_BLOCK_SCHEMAS
+        .get_or_init(|| RwLock::new(BTreeMap::new()))
+        .read()
+        .expect("custom block schema registry poisoned")
+        .get(type_id)
+        .cloned()
+}
+
+pub fn project_composition_for_surface(
+    composition: &Composition,
+    ctx: &FallbackProjectionContext,
+) -> Result<(ProjectedComposition, Vec<AuditIntent>), ProjectionError> {
+    binding_role_contract_assertion();
+
+    let version = composition.metadata.composition_version;
+    let unknown_block_count = composition
+        .blocks()
+        .filter(|block| block.block_type.is_custom())
+        .count() as u32;
+    let mut applied_unknown_blocks = 0_u32;
+    let mut dropped_unknown_block_count = 0_u32;
+    let mut dropped_block_ids = Vec::new();
+    let mut blocks = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut audits = Vec::new();
+
+    for (block_index, block) in composition.blocks().enumerate() {
+        if let BlockType::Custom { type_id } = &block.block_type {
+            if applied_unknown_blocks >= ctx.unknown_block_cap {
+                dropped_unknown_block_count = dropped_unknown_block_count.saturating_add(1);
+                dropped_block_ids.push(block.id.as_str().to_string());
+                continue;
+            }
+            applied_unknown_blocks = applied_unknown_blocks.saturating_add(1);
+            let (projected, mut block_audits) =
+                project_custom_block(composition, block, block_index as u32, type_id, ctx)?;
+            diagnostics.extend(projected.diagnostics.iter().cloned());
+            audits.append(&mut block_audits);
+            blocks.push(projected);
+        } else {
+            let (projected, mut block_audits) =
+                project_known_block(composition, block, block_index as u32, ctx)?;
+            diagnostics.extend(projected.diagnostics.iter().cloned());
+            audits.append(&mut block_audits);
+            blocks.push(projected);
+        }
+    }
+
+    if dropped_unknown_block_count > 0 {
+        diagnostics.push(projection_diagnostic(
+            composition,
+            DiagnosticKind::CapExceeded,
+            None,
+            None,
+            None,
+            DiagnosticReason::UnknownBlockCapExceeded,
+            dropped_unknown_block_count,
+        ));
+        audits.push(AuditIntent {
+            event_kind: "custom_block_fallback_cap_exceeded",
+            category: AuditCategory::Anomaly,
+            detail: json!({
+                "schema_version": 1,
+                "composition_id": composition.id.as_str(),
+                "composition_version": composition_version_json(version),
+                "unknown_block_count": unknown_block_count,
+                "unknown_block_cap": ctx.unknown_block_cap,
+                "dropped_unknown_block_count": dropped_unknown_block_count,
+                "dropped_block_ids": dropped_block_ids,
+                "fallback_policy_version": ctx.fallback_policy_version,
+                "reason": "unknown_block_cap_exceeded",
+            }),
+        });
+    }
+
+    Ok((
+        ProjectedComposition {
+            composition_id: composition.id.clone(),
+            composition_version: Some(version.0),
+            fallback_policy_version: ctx.fallback_policy_version,
+            blocks,
+            diagnostics,
+            unknown_block_count,
+            unknown_block_cap: ctx.unknown_block_cap,
+            dropped_unknown_block_count,
+        },
+        audits,
+    ))
+}
+
+fn binding_role_contract_assertion() {
+    let _ = BindingRole::FeedbackTarget;
+    fn field_bindings_resolve(block: &Block) -> &Vec<FieldBinding> {
+        &block.field_bindings
+    }
+    let _ = field_bindings_resolve;
+}
+
+fn project_known_block(
+    composition: &Composition,
+    block: &Block,
+    block_index: u32,
+    ctx: &FallbackProjectionContext,
+) -> Result<(ProjectedBlock, Vec<AuditIntent>), ProjectionError> {
+    let rule =
+        rule_for_block_type(&block.block_type).ok_or_else(|| ProjectionError::MissingRule {
+            block_type: block.block_type.clone(),
+        })?;
+    validate_field_bindings(block, &rule, false)?;
+    let (payload, field_states, mut diagnostics) =
+        project_payload_fields(composition, block, &rule, ctx, false);
+    let mut audits = Vec::new();
+    let dropped_unknown = count_unadmitted_payload_leaves(&block.attributes, &rule);
+    if dropped_unknown > 0 {
+        diagnostics.push(projection_diagnostic(
+            composition,
+            DiagnosticKind::FieldDropped,
+            Some(block),
+            Some(block.block_type.type_id().to_string()),
+            Some(rule.block_type.type_id().to_string()),
+            DiagnosticReason::UnknownAdmittedField,
+            dropped_unknown,
+        ));
+        audits.push(AuditIntent {
+            event_kind: "unknown_admitted_field",
+            category: AuditCategory::Anomaly,
+            detail: json!({
+                "schema_version": 1,
+                "composition_id": composition.id.as_str(),
+                "composition_version": composition_version_json(composition.metadata.composition_version),
+                "block_id": block.id.as_str(),
+                "block_index": block_index,
+                "original_type_id": block.block_type.type_id(),
+                "dropped_pointer_count": dropped_unknown,
+                "fallback_policy_version": ctx.fallback_policy_version,
+                "reason": "unknown_admitted_field",
+            }),
+        });
+    }
+    let edit_routes = edit_routes_for_block(
+        composition,
+        block,
+        &rule,
+        &field_states,
+        false,
+        ctx,
+        &mut diagnostics,
+    );
+    Ok((
+        ProjectedBlock {
+            block_id: block.id.clone(),
+            block_index,
+            original_type_id: block.block_type.type_id().to_string(),
+            selected_known_type_id: rule.block_type.type_id().to_string(),
+            payload,
+            banner: None,
+            trust_band: rule.default_trust_band,
+            claim_refs: block.claim_refs.clone(),
+            provenance: vec![block.provenance.clone()],
+            edit_routes,
+            diagnostics,
+        },
+        audits,
+    ))
+}
+
+fn project_custom_block(
+    composition: &Composition,
+    block: &Block,
+    block_index: u32,
+    type_id: &str,
+    ctx: &FallbackProjectionContext,
+) -> Result<(ProjectedBlock, Vec<AuditIntent>), ProjectionError> {
+    let schema = custom_block_schema(type_id);
+    let (rule, projected_pointer_count, declared_pointer_count) = schema
+        .as_ref()
+        .and_then(|schema| {
+            select_nearest_known_rule(schema).map(|rule| {
+                let projected_count = compatible_schema_pointers(schema, &rule).count() as u32;
+                (
+                    rule,
+                    projected_count,
+                    schema.declared_pointers().count() as u32,
+                )
+            })
+        })
+        .filter(|(_, projected_count, _)| *projected_count > 0)
+        .unwrap_or_else(|| {
+            (
+                generic_text_rule(),
+                0,
+                schema
+                    .as_ref()
+                    .map(|schema| schema.declared_pointers().count() as u32)
+                    .unwrap_or_else(|| count_payload_leaves(&block.attributes)),
+            )
+        });
+
+    validate_field_bindings(block, &rule, true)?;
+    let (payload, field_states, mut diagnostics) =
+        project_payload_fields(composition, block, &rule, ctx, true);
+    let dropped_pointer_count = declared_pointer_count
+        .saturating_sub(projected_pointer_count)
+        .saturating_add(count_unadmitted_payload_leaves(&block.attributes, &rule));
+    diagnostics.push(projection_diagnostic(
+        composition,
+        DiagnosticKind::BlockFallback,
+        Some(block),
+        Some(type_id.to_string()),
+        Some(rule.block_type.type_id().to_string()),
+        DiagnosticReason::UnknownBlockType,
+        dropped_pointer_count,
+    ));
+    let edit_routes = edit_routes_for_block(
+        composition,
+        block,
+        &rule,
+        &field_states,
+        true,
+        ctx,
+        &mut diagnostics,
+    );
+    Ok((
+        ProjectedBlock {
+            block_id: block.id.clone(),
+            block_index,
+            original_type_id: type_id.to_string(),
+            selected_known_type_id: rule.block_type.type_id().to_string(),
+            payload,
+            banner: Some(FALLBACK_BANNER_COPY.to_string()),
+            trust_band: TrustBand::NeedsVerification,
+            claim_refs: block.claim_refs.clone(),
+            provenance: vec![block.provenance.clone()],
+            edit_routes,
+            diagnostics,
+        },
+        vec![AuditIntent {
+            event_kind: "custom_block_fallback_applied",
+            category: AuditCategory::DataAccess,
+            detail: json!({
+                "schema_version": 1,
+                "composition_id": composition.id.as_str(),
+                "composition_version": composition_version_json(composition.metadata.composition_version),
+                "block_id": block.id.as_str(),
+                "block_index": block_index,
+                "original_type_id": type_id,
+                "selected_known_type_id": rule.block_type.type_id(),
+                "projected_pointer_count": projected_pointer_count,
+                "dropped_pointer_count": dropped_pointer_count,
+                "pointer_names_included": ctx.include_non_sensitive_pointer_names,
+                "composition_cap_state": "within_cap",
+                "block_cap_action": "projected",
+                "fallback_policy_version": ctx.fallback_policy_version,
+            }),
+        }],
+    ))
+}
+
+fn validate_field_bindings(
+    block: &Block,
+    rule: &BlockProjectionRule,
+    allow_degraded_custom_routes: bool,
+) -> Result<(), ProjectionError> {
+    for binding in &block.field_bindings {
+        if !rule_has_field(rule, binding.field_path.as_str()) && !allow_degraded_custom_routes {
+            return Err(ProjectionError::InvalidProducerOutput {
+                reason: ProducerOutputInvalidReason::BindingTargetsUnknownField,
+            });
+        }
+        match binding.role {
+            BindingRole::Source => {
+                for claim_ref in resolve_binding_claim_refs(block, binding) {
+                    if claim_ref.field_path.is_none() {
+                        return Err(ProjectionError::InvalidProducerOutput {
+                            reason: ProducerOutputInvalidReason::SourceBindingMissingFieldPath,
+                        });
+                    }
+                }
+            }
+            BindingRole::FeedbackTarget => {
+                for claim_ref in resolve_binding_claim_refs(block, binding) {
+                    if claim_ref.field_path.is_none() {
+                        return Err(ProjectionError::InvalidProducerOutput {
+                            reason: ProducerOutputInvalidReason::FeedbackTargetMissingFieldPath,
+                        });
+                    }
+                }
+            }
+            BindingRole::ComputedFrom | BindingRole::DisplayOnly => {}
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldProjectionState {
+    Rendered,
+    SensitivityBlocked,
+    OutOfScope,
+    NotProjected,
+}
+
+fn project_payload_fields(
+    composition: &Composition,
+    block: &Block,
+    rule: &BlockProjectionRule,
+    ctx: &FallbackProjectionContext,
+    fallback: bool,
+) -> (
+    Value,
+    BTreeMap<String, FieldProjectionState>,
+    Vec<ProjectionDiagnostic>,
+) {
+    let mut payload = Value::Object(Map::new());
+    let mut field_states = BTreeMap::new();
+    let mut diagnostics = Vec::new();
+    for policy in rule.fields {
+        let pointer = policy.pointer.to_string();
+        if !policy.allowed_surfaces.contains(&ctx.surface) {
+            field_states.insert(pointer, FieldProjectionState::SensitivityBlocked);
+            diagnostics.push(field_drop_diagnostic(
+                composition,
+                block,
+                rule,
+                DiagnosticReason::SensitivityBlocked,
+            ));
+            continue;
+        }
+        if !scope_allows_field(block, policy.pointer, ctx) {
+            field_states.insert(pointer, FieldProjectionState::OutOfScope);
+            diagnostics.push(field_drop_diagnostic(
+                composition,
+                block,
+                rule,
+                DiagnosticReason::OutOfScope,
+            ));
+            continue;
+        }
+        let mut rendered_any = false;
+        for (actual_pointer, raw_value) in values_for_pattern(&block.attributes, policy.pointer) {
+            let Some(rendered_value) = render_value(&raw_value, policy, ctx) else {
+                diagnostics.push(field_drop_diagnostic(
+                    composition,
+                    block,
+                    rule,
+                    DiagnosticReason::SensitivityBlocked,
+                ));
+                continue;
+            };
+            insert_json_pointer(&mut payload, &actual_pointer, rendered_value);
+            rendered_any = true;
+        }
+        field_states.insert(
+            pointer,
+            if rendered_any {
+                FieldProjectionState::Rendered
+            } else if fallback {
+                FieldProjectionState::NotProjected
+            } else {
+                FieldProjectionState::SensitivityBlocked
+            },
+        );
+    }
+    (payload, field_states, diagnostics)
+}
+
+fn field_drop_diagnostic(
+    composition: &Composition,
+    block: &Block,
+    rule: &BlockProjectionRule,
+    reason: DiagnosticReason,
+) -> ProjectionDiagnostic {
+    projection_diagnostic(
+        composition,
+        DiagnosticKind::FieldDropped,
+        Some(block),
+        Some(block.block_type.type_id().to_string()),
+        Some(rule.block_type.type_id().to_string()),
+        reason,
+        1,
+    )
+}
+
+fn edit_routes_for_block(
+    composition: &Composition,
+    block: &Block,
+    rule: &BlockProjectionRule,
+    field_states: &BTreeMap<String, FieldProjectionState>,
+    fallback: bool,
+    ctx: &FallbackProjectionContext,
+    diagnostics: &mut Vec<ProjectionDiagnostic>,
+) -> Vec<EditRoute> {
+    let ambiguous_fields = ambiguous_feedback_fields(block);
+    block
+        .field_bindings
+        .iter()
+        .map(|binding| {
+            let field_path = binding.field_path.as_str().to_string();
+            let claim_refs = resolve_binding_claim_refs(block, binding);
+            let field_state = field_states
+                .get(&field_path)
+                .copied()
+                .unwrap_or(FieldProjectionState::NotProjected);
+            let degraded_unknown_field = fallback && !rule_has_field(rule, &field_path);
+            let refusal = route_refusal(
+                binding,
+                claim_refs.as_slice(),
+                field_state,
+                degraded_unknown_field,
+                ambiguous_fields.contains(&field_path),
+                ctx,
+            );
+            if let Some(reason) = refusal {
+                diagnostics.push(projection_diagnostic(
+                    composition,
+                    DiagnosticKind::EditRouteRefused,
+                    Some(block),
+                    Some(block.block_type.type_id().to_string()),
+                    Some(rule.block_type.type_id().to_string()),
+                    diagnostic_reason_for_refusal(reason),
+                    0,
+                ));
+            }
+            EditRoute {
+                field_path: binding.field_path.clone(),
+                role: binding.role.clone(),
+                claim_refs,
+                feedback_allowed: refusal.is_none() && binding.role == BindingRole::FeedbackTarget,
+                refusal_reason: refusal,
+            }
+        })
+        .collect()
+}
+
+fn route_refusal(
+    binding: &FieldBinding,
+    claim_refs: &[ClaimRef],
+    field_state: FieldProjectionState,
+    degraded_unknown_field: bool,
+    ambiguous_receiver: bool,
+    ctx: &FallbackProjectionContext,
+) -> Option<EditRouteRefusalReason> {
+    if field_state == FieldProjectionState::OutOfScope {
+        return Some(EditRouteRefusalReason::OutOfScope);
+    }
+    if field_state == FieldProjectionState::SensitivityBlocked {
+        return Some(EditRouteRefusalReason::SensitivityBlocked);
+    }
+    if degraded_unknown_field {
+        return Some(EditRouteRefusalReason::FallbackDegradedWithoutReceiver);
+    }
+    match binding.role {
+        BindingRole::Source => Some(EditRouteRefusalReason::SourceWithoutTarget),
+        BindingRole::ComputedFrom => Some(EditRouteRefusalReason::Computed),
+        BindingRole::DisplayOnly => Some(EditRouteRefusalReason::DisplayOnly),
+        BindingRole::FeedbackTarget => {
+            if claim_refs.is_empty() {
+                Some(EditRouteRefusalReason::MissingClaimRef)
+            } else if ambiguous_receiver {
+                Some(EditRouteRefusalReason::AmbiguousReceiver)
+            } else if ctx.actor.kind() == ActorKind::SurfaceClient
+                && !surface_client_can_submit(ctx)
+            {
+                Some(EditRouteRefusalReason::OutOfScope)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn diagnostic_reason_for_refusal(reason: EditRouteRefusalReason) -> DiagnosticReason {
+    match reason {
+        EditRouteRefusalReason::MissingClaimRef => DiagnosticReason::MissingClaimRef,
+        EditRouteRefusalReason::AmbiguousReceiver => DiagnosticReason::AmbiguousReceiver,
+        EditRouteRefusalReason::SensitivityBlocked => DiagnosticReason::SensitivityBlocked,
+        EditRouteRefusalReason::UnknownRole => DiagnosticReason::UnknownRole,
+        EditRouteRefusalReason::OutOfScope => DiagnosticReason::OutOfScope,
+        EditRouteRefusalReason::FallbackDegradedWithoutReceiver => {
+            DiagnosticReason::FallbackDegradedWithoutReceiver
+        }
+        EditRouteRefusalReason::Computed
+        | EditRouteRefusalReason::DisplayOnly
+        | EditRouteRefusalReason::SourceWithoutTarget => DiagnosticReason::MissingClaimRef,
+    }
+}
+
+fn ambiguous_feedback_fields(block: &Block) -> HashSet<String> {
+    let mut receivers: BTreeMap<String, BTreeSet<Vec<String>>> = BTreeMap::new();
+    for binding in &block.field_bindings {
+        if binding.role != BindingRole::FeedbackTarget {
+            continue;
+        }
+        let normalized: Vec<String> = resolve_binding_claim_refs(block, binding)
+            .into_iter()
+            .map(|claim_ref| {
+                format!(
+                    "{}:{}:{}",
+                    claim_ref.claim_id,
+                    claim_ref.claim_version.unwrap_or(0),
+                    claim_ref
+                        .field_path
+                        .as_ref()
+                        .map(FieldPath::as_str)
+                        .unwrap_or("")
+                )
+            })
+            .collect();
+        receivers
+            .entry(binding.field_path.as_str().to_string())
+            .or_default()
+            .insert(normalized);
+    }
+    receivers
+        .into_iter()
+        .filter_map(|(field, sets)| (sets.len() > 1).then_some(field))
+        .collect()
+}
+
+fn resolve_binding_claim_refs(block: &Block, binding: &FieldBinding) -> Vec<ClaimRef> {
+    binding
+        .claim_refs
+        .iter()
+        .filter_map(|ClaimRefIndex(index)| block.claim_refs.get(*index).cloned())
+        .collect()
+}
+
+fn scope_allows_field(block: &Block, pointer: &str, ctx: &FallbackProjectionContext) -> bool {
+    let claim_bound = block
+        .field_bindings
+        .iter()
+        .any(|binding| binding.field_path.as_str() == pointer && !binding.claim_refs.is_empty());
+    if !claim_bound || ctx.actor.kind() != ActorKind::SurfaceClient {
+        return true;
+    }
+    surface_client_can_read(ctx)
+}
+
+fn surface_client_can_read(ctx: &FallbackProjectionContext) -> bool {
+    let Actor::SurfaceClient { scopes, .. } = &ctx.actor else {
+        return true;
+    };
+    scopes.iter().any(|scope| {
+        let value = scope.as_str();
+        value == "read.composition"
+            || value.starts_with("read.")
+            || value.starts_with("admin.")
+            || value.starts_with("manage.")
+    })
+}
+
+fn surface_client_can_submit(ctx: &FallbackProjectionContext) -> bool {
+    let Actor::SurfaceClient { scopes, .. } = &ctx.actor else {
+        return true;
+    };
+    scopes.contains(&SurfaceScope::new("submit.feedback"))
+        || scopes.iter().any(|scope| {
+            let value = scope.as_str();
+            value.starts_with("admin.") || value.starts_with("manage.")
+        })
+}
+
+fn render_value(
+    value: &Value,
+    policy: &FieldPolicy,
+    ctx: &FallbackProjectionContext,
+) -> Option<Value> {
+    let value = value_for_kind(value, policy.value_kind)?;
+    let text = value.as_str().unwrap_or_default();
+    let claim = synthetic_claim(policy.sensitivity.clone(), text);
+    match render_policy_for_surface(&claim, ctx.surface.render_surface(), &render_actor(ctx)) {
+        RenderDecision::Render => Some(value),
+        RenderDecision::RenderRedacted { affordance } => {
+            Some(Value::String(affordance.label().to_string()))
+        }
+        RenderDecision::Drop => None,
+    }
+}
+
+fn value_for_kind(value: &Value, kind: ValueKind) -> Option<Value> {
+    match (kind, value) {
+        (ValueKind::Text, Value::String(_)) => Some(value.clone()),
+        (ValueKind::Number, Value::Number(_)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn synthetic_claim(sensitivity: ClaimSensitivity, text: &str) -> IntelligenceClaim {
+    IntelligenceClaim {
+        id: "projection-field".to_string(),
+        claim_version: 1,
+        subject_ref: "projection".to_string(),
+        claim_type: "projection.field".to_string(),
+        field_path: None,
+        topic_key: None,
+        text: text.to_string(),
+        dedup_key: "projection-field".to_string(),
+        item_hash: None,
+        actor: "user".to_string(),
+        data_source: "projection".to_string(),
+        source_ref: None,
+        source_asof: None,
+        observed_at: "2026-05-15T00:00:00Z".to_string(),
+        created_at: "2026-05-15T00:00:00Z".to_string(),
+        provenance_json: "{}".to_string(),
+        metadata_json: None,
+        claim_state: ClaimState::Active,
+        surfacing_state: SurfacingState::Active,
+        demotion_reason: None,
+        reactivated_at: None,
+        retraction_reason: None,
+        expires_at: None,
+        superseded_by: None,
+        trust_score: None,
+        trust_computed_at: None,
+        trust_version: None,
+        thread_id: None,
+        temporal_scope: TemporalScope::State,
+        sensitivity,
+        verification_state: ClaimVerificationState::Active,
+        verification_reason: None,
+        needs_user_decision_at: None,
+    }
+}
+
+fn render_actor(ctx: &FallbackProjectionContext) -> RenderActor {
+    match &ctx.actor {
+        Actor::User => RenderActor::user("user", Some("user")),
+        Actor::SurfaceClient { instance, .. } => {
+            RenderActor::agent(format!("surface_client:{}", instance.as_str()))
+        }
+        Actor::Agent => RenderActor::agent("agent"),
+        Actor::Admin => RenderActor::agent("admin"),
+        Actor::System => RenderActor::agent("system"),
+    }
+}
+
+fn values_for_pattern(source: &Value, pattern: &str) -> Vec<(String, Value)> {
+    let segments: Vec<&str> = pattern
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let mut out = Vec::new();
+    collect_pattern_values(source, &segments, String::new(), &mut out);
+    out
+}
+
+fn collect_pattern_values(
+    value: &Value,
+    segments: &[&str],
+    current_pointer: String,
+    out: &mut Vec<(String, Value)>,
+) {
+    if segments.is_empty() {
+        out.push((current_pointer, value.clone()));
+        return;
+    }
+    let head = segments[0];
+    if head == "*" {
+        if let Value::Array(items) = value {
+            for (index, item) in items.iter().enumerate() {
+                collect_pattern_values(
+                    item,
+                    &segments[1..],
+                    format!("{current_pointer}/{index}"),
+                    out,
+                );
+            }
+        }
+    } else if let Value::Object(map) = value {
+        if let Some(child) = map.get(head) {
+            collect_pattern_values(
+                child,
+                &segments[1..],
+                format!("{current_pointer}/{head}"),
+                out,
+            );
+        }
+    }
+}
+
+fn insert_json_pointer(target: &mut Value, pointer: &str, value: Value) {
+    let segments: Vec<&str> = pointer
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    insert_segments(target, &segments, value);
+}
+
+fn insert_segments(target: &mut Value, segments: &[&str], value: Value) {
+    if segments.is_empty() {
+        *target = value;
+        return;
+    }
+    let head = segments[0];
+    if let Ok(index) = head.parse::<usize>() {
+        if !target.is_array() {
+            *target = Value::Array(Vec::new());
+        }
+        let array = target.as_array_mut().expect("array just initialized");
+        while array.len() <= index {
+            array.push(Value::Null);
+        }
+        insert_segments(&mut array[index], &segments[1..], value);
+    } else {
+        if !target.is_object() {
+            *target = Value::Object(Map::new());
+        }
+        let object = target.as_object_mut().expect("object just initialized");
+        let child = object.entry(head.to_string()).or_insert(Value::Null);
+        insert_segments(child, &segments[1..], value);
+    }
+}
+
+fn count_unadmitted_payload_leaves(source: &Value, rule: &BlockProjectionRule) -> u32 {
+    let admitted: BTreeSet<String> = rule
+        .fields
+        .iter()
+        .map(|field| field.pointer.to_string())
+        .collect();
+    count_unadmitted_payload_leaves_at(source, String::new(), &admitted)
+}
+
+fn count_unadmitted_payload_leaves_at(
+    value: &Value,
+    pointer: String,
+    admitted: &BTreeSet<String>,
+) -> u32 {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, child)| {
+                count_unadmitted_payload_leaves_at(
+                    child,
+                    format!("{pointer}/{}", escape_pointer(key)),
+                    admitted,
+                )
+            })
+            .sum(),
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .map(|(index, child)| {
+                count_unadmitted_payload_leaves_at(child, format!("{pointer}/{index}"), admitted)
+            })
+            .sum(),
+        Value::Null => 0,
+        _ => {
+            if admitted
+                .iter()
+                .any(|pattern| pattern_matches_actual(pattern, &pointer))
+            {
+                0
+            } else {
+                1
+            }
+        }
+    }
+}
+
+fn count_payload_leaves(source: &Value) -> u32 {
+    match source {
+        Value::Object(map) => map.values().map(count_payload_leaves).sum(),
+        Value::Array(items) => items.iter().map(count_payload_leaves).sum(),
+        Value::Null => 0,
+        _ => 1,
+    }
+}
+
+fn escape_pointer(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn select_nearest_known_rule(schema: &CustomBlockSchema) -> Option<BlockProjectionRule> {
+    let mut scored: Vec<(BlockProjectionRule, NearestTypeScore)> = known_projection_rules()
+        .into_iter()
+        .map(|rule| {
+            let score = score_rule(schema, &rule);
+            (rule, score)
+        })
+        .collect();
+    scored.sort_by(|(a_rule, a_score), (b_rule, b_score)| {
+        b_score
+            .total()
+            .cmp(&a_score.total())
+            .then(b_score.kind_match.cmp(&a_score.kind_match))
+            .then(b_score.required_overlap.cmp(&a_score.required_overlap))
+            .then(b_score.optional_overlap.cmp(&a_score.optional_overlap))
+            .then(
+                b_score
+                    .annotation_similarity
+                    .cmp(&a_score.annotation_similarity),
+            )
+            .then(a_rule.block_type.type_id().cmp(b_rule.block_type.type_id()))
+    });
+    let (winner, score) = scored.into_iter().next()?;
+    (score.total() > 0).then_some(winner)
+}
+
+fn score_rule(schema: &CustomBlockSchema, rule: &BlockProjectionRule) -> NearestTypeScore {
+    let mut score = NearestTypeScore::default();
+    if let (Some(schema_kind), Some(rule_kind)) = (&schema.composition_kind, rule.composition_kind)
+    {
+        if schema_kind == rule_kind {
+            score.kind_match = 100;
+        }
+    }
+    let rule_fields: BTreeSet<String> = rule
+        .fields
+        .iter()
+        .map(|field| field.pointer.to_string())
+        .collect();
+    score.required_overlap = schema
+        .required_pointers
+        .iter()
+        .filter(|pointer| rule_fields.contains(*pointer))
+        .count() as u32
+        * 10;
+    score.optional_overlap = schema
+        .optional_pointers
+        .iter()
+        .filter(|pointer| rule_fields.contains(*pointer))
+        .count() as u32
+        * 2;
+    let annotations: BTreeSet<&str> = rule.render_annotations.iter().copied().collect();
+    score.annotation_similarity = (schema
+        .render_annotations
+        .iter()
+        .filter(|annotation| annotations.contains(annotation.as_str()))
+        .count() as u32
+        * 4)
+    .min(20);
+    if rule
+        .type_namespace
+        .is_some_and(|namespace| schema.type_id.starts_with(namespace))
+    {
+        score.namespace_similarity = 5;
+    }
+    score
+}
+
+fn compatible_schema_pointers<'a>(
+    schema: &'a CustomBlockSchema,
+    rule: &'a BlockProjectionRule,
+) -> impl Iterator<Item = &'a String> {
+    let rule_fields: BTreeSet<String> = rule
+        .fields
+        .iter()
+        .map(|field| field.pointer.to_string())
+        .collect();
+    schema
+        .declared_pointers()
+        .filter(move |pointer| rule_fields.contains(*pointer))
+}
+
+fn pattern_matches_actual(pattern: &str, actual: &str) -> bool {
+    let pattern_segments: Vec<&str> = pattern
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let actual_segments: Vec<&str> = actual
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    pattern_segments.len() == actual_segments.len()
+        && pattern_segments
+            .iter()
+            .zip(actual_segments.iter())
+            .all(|(pattern, actual)| *pattern == "*" || pattern == actual)
+}
+
+fn rule_has_field(rule: &BlockProjectionRule, field_path: &str) -> bool {
+    rule.fields
+        .iter()
+        .any(|field| pattern_matches_actual(field.pointer, field_path))
+}
+
+fn projection_diagnostic(
+    composition: &Composition,
+    diagnostic_kind: DiagnosticKind,
+    block: Option<&Block>,
+    original_type_id: Option<String>,
+    selected_known_type_id: Option<String>,
+    reason: DiagnosticReason,
+    dropped_pointer_count: u32,
+) -> ProjectionDiagnostic {
+    ProjectionDiagnostic {
+        diagnostic_kind,
+        composition_id: CompositionId::new(composition.id.as_str()),
+        composition_version: composition.metadata.composition_version.0,
+        original_type_id,
+        selected_known_type_id,
+        block_id: block.map(|block| block.id.clone()),
+        reason,
+        dropped_pointer_count,
+    }
+}
+
+fn composition_version_json(version: CompositionVersion) -> Value {
+    json!(version.0)
+}
+
+fn generic_text_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::Custom {
+            type_id: GENERIC_TEXT_TYPE_ID.to_string(),
+        },
+        composition_kind: None,
+        type_namespace: Some("dailyos/"),
+        render_annotations: &[],
+        fields: &[],
+        default_trust_band: TrustBand::NeedsVerification,
+    }
+}
+
+fn rule_for_block_type(block_type: &BlockType) -> Option<BlockProjectionRule> {
+    match block_type {
+        BlockType::AccountOverview => Some(account_overview_rule()),
+        BlockType::ClaimSummary => Some(claim_summary_rule()),
+        BlockType::EvidenceList => Some(evidence_list_rule()),
+        BlockType::HealthSnapshot => Some(health_snapshot_rule()),
+        BlockType::RelationshipMap => Some(relationship_map_rule()),
+        BlockType::RiskCallout => Some(risk_callout_rule()),
+        BlockType::ActionList => Some(action_list_rule()),
+        BlockType::MarkdownDocument => Some(markdown_document_rule()),
+        BlockType::Custom { .. } => None,
+    }
+}
+
+fn known_projection_rules() -> Vec<BlockProjectionRule> {
+    vec![
+        account_overview_rule(),
+        claim_summary_rule(),
+        evidence_list_rule(),
+        health_snapshot_rule(),
+        relationship_map_rule(),
+        risk_callout_rule(),
+        action_list_rule(),
+        markdown_document_rule(),
+    ]
+}
+
+const ALL_SURFACES: &[SurfaceKind] = &[
+    SurfaceKind::TauriApp,
+    SurfaceKind::McpTool,
+    SurfaceKind::McpToolDetail,
+    SurfaceKind::SurfaceClient,
+    SurfaceKind::Worker,
+    SurfaceKind::Eval,
+];
+const FIRST_PARTY_SURFACES: &[SurfaceKind] = &[SurfaceKind::TauriApp];
+
+const fn text_field(pointer: &'static str, sensitivity: ClaimSensitivity) -> FieldPolicy {
+    FieldPolicy {
+        pointer,
+        sensitivity,
+        allowed_surfaces: ALL_SURFACES,
+        value_kind: ValueKind::Text,
+    }
+}
+
+const fn first_party_text_field(
+    pointer: &'static str,
+    sensitivity: ClaimSensitivity,
+) -> FieldPolicy {
+    FieldPolicy {
+        pointer,
+        sensitivity,
+        allowed_surfaces: FIRST_PARTY_SURFACES,
+        value_kind: ValueKind::Text,
+    }
+}
+
+const fn number_field(pointer: &'static str, sensitivity: ClaimSensitivity) -> FieldPolicy {
+    FieldPolicy {
+        pointer,
+        sensitivity,
+        allowed_surfaces: ALL_SURFACES,
+        value_kind: ValueKind::Number,
+    }
+}
+
+const ACCOUNT_OVERVIEW_FIELDS: &[FieldPolicy] = &[
+    text_field("/account/display_name", ClaimSensitivity::Internal),
+    text_field("/summary", ClaimSensitivity::Internal),
+    text_field("/health/band", ClaimSensitivity::Internal),
+    number_field("/health/score", ClaimSensitivity::Internal),
+    text_field("/risk/title", ClaimSensitivity::Internal),
+    text_field("/risk/body", ClaimSensitivity::Internal),
+    text_field("/actions/*/title", ClaimSensitivity::Internal),
+    text_field("/relationships/*/label", ClaimSensitivity::Internal),
+];
+const CLAIM_SUMMARY_FIELDS: &[FieldPolicy] = &[
+    text_field("/title", ClaimSensitivity::Internal),
+    text_field("/body", ClaimSensitivity::Internal),
+    text_field("/status", ClaimSensitivity::Internal),
+    text_field("/source_asof", ClaimSensitivity::Internal),
+    text_field("/trust/band", ClaimSensitivity::Internal),
+    text_field("/trust/source_label", ClaimSensitivity::Internal),
+];
+const EVIDENCE_LIST_FIELDS: &[FieldPolicy] = &[
+    text_field("/items/*/label", ClaimSensitivity::Internal),
+    text_field("/items/*/source_label", ClaimSensitivity::Internal),
+    text_field("/items/*/source_asof", ClaimSensitivity::Internal),
+    first_party_text_field("/items/*/source_excerpt", ClaimSensitivity::Confidential),
+];
+const HEALTH_SNAPSHOT_FIELDS: &[FieldPolicy] = &[
+    text_field("/band", ClaimSensitivity::Internal),
+    number_field("/score", ClaimSensitivity::Internal),
+    text_field("/rationale", ClaimSensitivity::Internal),
+    text_field("/trend", ClaimSensitivity::Internal),
+];
+const RELATIONSHIP_MAP_FIELDS: &[FieldPolicy] = &[
+    text_field("/nodes/*/label", ClaimSensitivity::Internal),
+    text_field("/nodes/*/role", ClaimSensitivity::Internal),
+    text_field("/edges/*/label", ClaimSensitivity::Internal),
+];
+const RISK_CALLOUT_FIELDS: &[FieldPolicy] = &[
+    text_field("/title", ClaimSensitivity::Internal),
+    text_field("/body", ClaimSensitivity::Internal),
+    text_field("/severity", ClaimSensitivity::Internal),
+    text_field("/recommended_action", ClaimSensitivity::Internal),
+];
+const ACTION_LIST_FIELDS: &[FieldPolicy] = &[
+    text_field("/items/*/title", ClaimSensitivity::Internal),
+    text_field("/items/*/status", ClaimSensitivity::Internal),
+    text_field("/items/*/due_at", ClaimSensitivity::Internal),
+    text_field("/items/*/owner_label", ClaimSensitivity::Internal),
+];
+const MARKDOWN_DOCUMENT_FIELDS: &[FieldPolicy] = &[
+    text_field("/title", ClaimSensitivity::Internal),
+    text_field("/body", ClaimSensitivity::Internal),
+    text_field("/sections/*/heading", ClaimSensitivity::Internal),
+    text_field("/sections/*/body", ClaimSensitivity::Internal),
+];
+
+fn account_overview_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::AccountOverview,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/account"),
+        render_annotations: &["account", "overview", "summary"],
+        fields: ACCOUNT_OVERVIEW_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn claim_summary_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::ClaimSummary,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/claim"),
+        render_annotations: &["claim", "summary"],
+        fields: CLAIM_SUMMARY_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn evidence_list_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::EvidenceList,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/evidence"),
+        render_annotations: &["evidence", "sources"],
+        fields: EVIDENCE_LIST_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn health_snapshot_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::HealthSnapshot,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/health"),
+        render_annotations: &["health", "score"],
+        fields: HEALTH_SNAPSHOT_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn relationship_map_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::RelationshipMap,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/relationship"),
+        render_annotations: &["relationship", "map"],
+        fields: RELATIONSHIP_MAP_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn risk_callout_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::RiskCallout,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/risk"),
+        render_annotations: &["risk", "callout"],
+        fields: RISK_CALLOUT_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn action_list_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::ActionList,
+        composition_kind: Some("entity_page"),
+        type_namespace: Some("dailyos/action"),
+        render_annotations: &["actions", "list"],
+        fields: ACTION_LIST_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}
+fn markdown_document_rule() -> BlockProjectionRule {
+    BlockProjectionRule {
+        block_type: BlockType::MarkdownDocument,
+        composition_kind: Some("report"),
+        type_namespace: Some("dailyos/markdown"),
+        render_annotations: &["document", "markdown"],
+        fields: MARKDOWN_DOCUMENT_FIELDS,
+        default_trust_band: TrustBand::UseWithCaution,
+    }
+}

--- a/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
+++ b/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
@@ -702,15 +702,17 @@ fn edit_routes_for_block(
                 ctx,
             );
             if let Some(reason) = refusal {
-                diagnostics.push(projection_diagnostic(
-                    composition,
-                    DiagnosticKind::EditRouteRefused,
-                    Some(block),
-                    Some(block.block_type.type_id().to_string()),
-                    Some(rule.block_type.type_id().to_string()),
-                    diagnostic_reason_for_refusal(reason),
-                    0,
-                ));
+                if let Some(diag_reason) = diagnostic_reason_for_refusal(reason) {
+                    diagnostics.push(projection_diagnostic(
+                        composition,
+                        DiagnosticKind::EditRouteRefused,
+                        Some(block),
+                        Some(block.block_type.type_id().to_string()),
+                        Some(rule.block_type.type_id().to_string()),
+                        diag_reason,
+                        0,
+                    ));
+                }
             }
             EditRoute {
                 field_path: binding.field_path.clone(),
@@ -760,19 +762,25 @@ fn route_refusal(
     }
 }
 
-fn diagnostic_reason_for_refusal(reason: EditRouteRefusalReason) -> DiagnosticReason {
+fn diagnostic_reason_for_refusal(reason: EditRouteRefusalReason) -> Option<DiagnosticReason> {
     match reason {
-        EditRouteRefusalReason::MissingClaimRef => DiagnosticReason::MissingClaimRef,
-        EditRouteRefusalReason::AmbiguousReceiver => DiagnosticReason::AmbiguousReceiver,
-        EditRouteRefusalReason::SensitivityBlocked => DiagnosticReason::SensitivityBlocked,
-        EditRouteRefusalReason::UnknownRole => DiagnosticReason::UnknownRole,
-        EditRouteRefusalReason::OutOfScope => DiagnosticReason::OutOfScope,
+        EditRouteRefusalReason::MissingClaimRef => Some(DiagnosticReason::MissingClaimRef),
+        EditRouteRefusalReason::AmbiguousReceiver => Some(DiagnosticReason::AmbiguousReceiver),
+        EditRouteRefusalReason::SensitivityBlocked => Some(DiagnosticReason::SensitivityBlocked),
+        EditRouteRefusalReason::UnknownRole => Some(DiagnosticReason::UnknownRole),
+        EditRouteRefusalReason::OutOfScope => Some(DiagnosticReason::OutOfScope),
         EditRouteRefusalReason::FallbackDegradedWithoutReceiver => {
-            DiagnosticReason::FallbackDegradedWithoutReceiver
+            Some(DiagnosticReason::FallbackDegradedWithoutReceiver)
         }
+        // Computed/DisplayOnly/SourceWithoutTarget refusals are routing-shape
+        // decisions, not §9 diagnostic-reason cases. The closed DiagnosticReason
+        // enum has no variant for them, and emitting `MissingClaimRef` here would
+        // mislead W4-A/W5-A consumers about why the route was refused. The
+        // refusal is surfaced via the EditRoute.refusal_reason field; no
+        // ProjectionDiagnostic is published.
         EditRouteRefusalReason::Computed
         | EditRouteRefusalReason::DisplayOnly
-        | EditRouteRefusalReason::SourceWithoutTarget => DiagnosticReason::MissingClaimRef,
+        | EditRouteRefusalReason::SourceWithoutTarget => None,
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/mod.rs
@@ -5,6 +5,7 @@ pub mod claims;
 pub mod composition;
 pub mod detect_risk_shift;
 pub mod extractors;
+pub mod fallback_projection;
 pub mod feedback;
 pub mod get_daily_readiness;
 pub mod get_entity_context;
@@ -22,6 +23,13 @@ pub use claims::{
     CanonicalSubjectType, ClaimSentiment, ClaimType, ClaimTypeMetadata, EntityRef, LiteralKind,
     ObjectValue, Polarity, PredicateRef, QualifierSet, StructuredClaim, StructuredClaimStatus,
     UnknownClaimTypeError, CLAIM_TYPE_REGISTRY,
+};
+pub use fallback_projection::{
+    project_composition_for_surface, register_custom_block_schema, AuditCategory, AuditIntent,
+    CustomBlockSchema, DiagnosticKind, DiagnosticReason, EditRoute, EditRouteRefusalReason,
+    FallbackProjectionContext, ProducerOutputInvalidReason, ProjectedBlock, ProjectedComposition,
+    ProjectionDiagnostic, ProjectionError, SurfaceKind, DEFAULT_UNKNOWN_BLOCK_CAP,
+    FALLBACK_BANNER_COPY,
 };
 pub use feedback::{
     feedback_semantics, transition_for_feedback, ClaimFeedbackMetadata, ClaimRenderPolicy,

--- a/src-tauri/abilities-runtime/tests/dos570_fallback_projection.rs
+++ b/src-tauri/abilities-runtime/tests/dos570_fallback_projection.rs
@@ -1,0 +1,563 @@
+use abilities_runtime::abilities::composition::{
+    AbilityRef, BindingRole, Block, BlockId, BlockType, ClaimRef, ClaimRefIndex, Composition,
+    CompositionDocId, CompositionKind, CompositionMetadata, CompositionVersion, FieldBinding,
+    ProvenanceRef, RenderHints, Salience, Section, SectionId,
+};
+use abilities_runtime::abilities::provenance::{FieldPath, InvocationId, SchemaVersion};
+use abilities_runtime::abilities::registry::{Actor, ScopeSet, SurfaceClientId, SurfaceScope};
+use abilities_runtime::abilities::{
+    project_composition_for_surface, register_custom_block_schema, CustomBlockSchema,
+    EditRouteRefusalReason, FallbackProjectionContext, ProducerOutputInvalidReason,
+    ProjectionError, SurfaceKind, FALLBACK_BANNER_COPY,
+};
+use chrono::{TimeZone, Utc};
+use serde_json::{json, Value};
+
+fn provenance_ref() -> ProvenanceRef {
+    ProvenanceRef::from_pointer(
+        InvocationId(uuid::Uuid::from_u128(
+            0x1234_5678_90ab_cdef_1122_3344_5566_7788,
+        )),
+        "/sections/0/blocks/0",
+    )
+    .unwrap()
+}
+
+fn claim(id: &str, field_path: &str) -> ClaimRef {
+    ClaimRef::with_field(id, 7, FieldPath::new(field_path).unwrap())
+}
+
+fn binding(field_path: &str, role: BindingRole, claim_refs: &[usize]) -> FieldBinding {
+    FieldBinding {
+        field_path: FieldPath::new(field_path).unwrap(),
+        role,
+        claim_refs: claim_refs.iter().copied().map(ClaimRefIndex).collect(),
+    }
+}
+
+fn block(
+    id: &str,
+    block_type: BlockType,
+    attributes: Value,
+    claim_refs: Vec<ClaimRef>,
+    field_bindings: Vec<FieldBinding>,
+) -> Block {
+    Block {
+        id: BlockId::new(id),
+        block_type,
+        attributes,
+        claim_refs,
+        field_bindings,
+        provenance: provenance_ref(),
+        salience: Salience::default(),
+        render_hints: RenderHints::default(),
+    }
+}
+
+fn composition(blocks: Vec<Block>) -> Composition {
+    let generated_at = Utc.with_ymd_and_hms(2026, 5, 15, 0, 0, 0).unwrap();
+    let mut composition = Composition::empty(
+        CompositionDocId::new("composition-fixture"),
+        CompositionVersion::new(11),
+        generated_at,
+    );
+    composition.kind = CompositionKind::EntityPage;
+    composition.sections = vec![Section::new(SectionId::new("section-fixture"), blocks)];
+    composition.generated_by = AbilityRef::new("fixture.ability");
+    composition.metadata = CompositionMetadata {
+        schema_version: SchemaVersion(1),
+        generated_at,
+        composition_version: CompositionVersion::new(11),
+        generated_by: "fixture.ability".to_string(),
+    };
+    composition
+}
+
+fn ctx() -> FallbackProjectionContext {
+    FallbackProjectionContext::new(Actor::User, SurfaceKind::TauriApp, 3)
+}
+
+fn surface_ctx(scopes: &[&str]) -> FallbackProjectionContext {
+    let scopes = ScopeSet::new(scopes.iter().map(|scope| SurfaceScope::new(*scope))).unwrap();
+    FallbackProjectionContext::new(
+        Actor::SurfaceClient {
+            instance: SurfaceClientId::new("surface-fixture"),
+            scopes,
+        },
+        SurfaceKind::SurfaceClient,
+        3,
+    )
+}
+
+fn register_schema(type_id: &str, required: &[&str], optional: &[&str], annotations: &[&str]) {
+    let mut schema = CustomBlockSchema::new(type_id);
+    schema.composition_kind = Some("entity_page".to_string());
+    schema.required_pointers = required.iter().map(|value| (*value).to_string()).collect();
+    schema.optional_pointers = optional.iter().map(|value| (*value).to_string()).collect();
+    schema.render_annotations = annotations
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect();
+    register_custom_block_schema(schema);
+}
+
+fn project(
+    comp: &Composition,
+    context: &FallbackProjectionContext,
+) -> (
+    abilities_runtime::abilities::ProjectedComposition,
+    Vec<abilities_runtime::abilities::AuditIntent>,
+) {
+    project_composition_for_surface(comp, context).expect("projection succeeds")
+}
+
+#[test]
+fn known_block_type_coverage_gate() {
+    let fixtures = vec![
+        (
+            BlockType::AccountOverview,
+            json!({"summary": "Summary"}),
+            "/summary",
+        ),
+        (BlockType::ClaimSummary, json!({"title": "Claim"}), "/title"),
+        (
+            BlockType::EvidenceList,
+            json!({"items": [{"label": "Evidence"}]}),
+            "/items/0/label",
+        ),
+        (
+            BlockType::HealthSnapshot,
+            json!({"band": "steady"}),
+            "/band",
+        ),
+        (
+            BlockType::RelationshipMap,
+            json!({"nodes": [{"label": "Team"}]}),
+            "/nodes/0/label",
+        ),
+        (BlockType::RiskCallout, json!({"title": "Risk"}), "/title"),
+        (
+            BlockType::ActionList,
+            json!({"items": [{"title": "Follow up"}]}),
+            "/items/0/title",
+        ),
+        (
+            BlockType::MarkdownDocument,
+            json!({"title": "Doc"}),
+            "/title",
+        ),
+    ];
+    for (block_type, attrs, field_path) in fixtures {
+        let block = block(
+            "known",
+            block_type,
+            attrs,
+            vec![claim("claim-known", field_path)],
+            vec![],
+        );
+        let result = project_composition_for_surface(&composition(vec![block]), &ctx());
+        assert!(result.is_ok());
+    }
+}
+
+#[test]
+fn no_catch_all_admitted_field_gate() {
+    register_schema(
+        "dailyos/no-catch-all",
+        &["/title"],
+        &["/private"],
+        &["document"],
+    );
+    let custom = block(
+        "block-no-catch-all",
+        BlockType::Custom {
+            type_id: "dailyos/no-catch-all".to_string(),
+        },
+        json!({"title": "Visible", "private": "sentinel-private"}),
+        vec![],
+        vec![],
+    );
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    let serialized = serde_json::to_string(&projection).unwrap();
+    assert!(!serialized.contains("sentinel-private"));
+}
+
+#[test]
+fn dos570_fixture_1_unknown_sensitive_payload_dropped() {
+    register_schema("dailyos/custom-sensitive", &["/title"], &[], &["document"]);
+    let sentinel = "sentinel-user@example.com";
+    let custom = block(
+        "block-sensitive",
+        BlockType::Custom {
+            type_id: "dailyos/custom-sensitive".to_string(),
+        },
+        json!({"title": "Visible", "secret_email": sentinel, "nested": {"token": sentinel}}),
+        vec![claim("claim-1", "/title")],
+        vec![binding("/title", BindingRole::Source, &[0])],
+    );
+    let (projection, audits) = project(&composition(vec![custom]), &ctx());
+    let serialized = serde_json::to_string(&(projection, audits)).unwrap();
+    assert!(!serialized.contains(sentinel));
+}
+
+#[test]
+fn dos570_fixture_2_refs_preserved() {
+    register_schema("dailyos/custom-refs", &["/title"], &[], &["document"]);
+    let refs = vec![claim("claim-preserved", "/title")];
+    let provenance = provenance_ref();
+    let mut custom = block(
+        "block-refs",
+        BlockType::Custom {
+            type_id: "dailyos/custom-refs".to_string(),
+        },
+        json!({"title": "Visible", "private_note": "hidden"}),
+        refs.clone(),
+        vec![binding("/title", BindingRole::FeedbackTarget, &[0])],
+    );
+    custom.provenance = provenance.clone();
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    assert_eq!(projection.blocks[0].claim_refs, refs);
+    assert_eq!(projection.blocks[0].provenance, vec![provenance]);
+    assert!(projection.blocks[0]
+        .payload
+        .pointer("/private_note")
+        .is_none());
+}
+
+#[test]
+fn dos570_fixture_3_no_schema_generic() {
+    let custom = block(
+        "block-no-schema",
+        BlockType::Custom {
+            type_id: "dailyos/no-schema".to_string(),
+        },
+        json!({"title": "Hidden"}),
+        vec![claim("claim-1", "/title")],
+        vec![],
+    );
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    assert_eq!(projection.blocks[0].selected_known_type_id, "dailyos/text");
+    assert_eq!(projection.blocks[0].payload, json!({}));
+    assert_eq!(
+        projection.blocks[0].banner.as_deref(),
+        Some(FALLBACK_BANNER_COPY)
+    );
+}
+
+#[test]
+fn dos570_fixture_4_no_intersection_generic() {
+    register_schema(
+        "dailyos/no-intersection",
+        &["/unmatched"],
+        &[],
+        &["unknown"],
+    );
+    let custom = block(
+        "block-no-intersection",
+        BlockType::Custom {
+            type_id: "dailyos/no-intersection".to_string(),
+        },
+        json!({"unmatched": "Do not invent text"}),
+        vec![],
+        vec![],
+    );
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    assert_eq!(projection.blocks[0].selected_known_type_id, "dailyos/text");
+    assert_eq!(projection.blocks[0].payload, json!({}));
+}
+
+#[test]
+fn dos570_fixture_5_array_projection() {
+    register_schema(
+        "dailyos/custom-actions",
+        &["/items/*/title"],
+        &["/items/*/private_note"],
+        &["actions"],
+    );
+    let custom = block(
+        "block-array",
+        BlockType::Custom {
+            type_id: "dailyos/custom-actions".to_string(),
+        },
+        json!({"items": [{"title": "Follow up", "private_note": "sentinel-private"}]}),
+        vec![claim("claim-action", "/items/0/title")],
+        vec![binding("/items/0/title", BindingRole::FeedbackTarget, &[0])],
+    );
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    assert_eq!(
+        projection.blocks[0].payload.pointer("/items/0/title"),
+        Some(&json!("Follow up"))
+    );
+    assert!(!serde_json::to_string(&projection)
+        .unwrap()
+        .contains("sentinel-private"));
+}
+
+#[test]
+fn dos570_fixture_6_unsafe_widening_rejected() {
+    register_schema(
+        "dailyos/unsafe-widening",
+        &["/title", "/body"],
+        &[],
+        &["document"],
+    );
+    let custom = block(
+        "block-unsafe",
+        BlockType::Custom {
+            type_id: "dailyos/unsafe-widening".to_string(),
+        },
+        json!({"title": {"object": "sentinel-object"}, "body": ["sentinel-array"]}),
+        vec![],
+        vec![],
+    );
+    let (projection, _) = project(&composition(vec![custom]), &ctx());
+    let serialized = serde_json::to_string(&projection).unwrap();
+    assert!(!serialized.contains("sentinel-object"));
+    assert!(!serialized.contains("sentinel-array"));
+}
+
+#[test]
+fn dos570_fixture_7_cap_exceeded() {
+    let blocks: Vec<Block> = (0..9)
+        .map(|index| {
+            block(
+                &format!("block-cap-{index}"),
+                BlockType::Custom {
+                    type_id: format!("dailyos/no-schema-cap-{index}"),
+                },
+                json!({"title": "Hidden"}),
+                vec![],
+                vec![],
+            )
+        })
+        .collect();
+    let mut context = ctx();
+    context.unknown_block_cap = 5;
+    let (projection, audits) = project(&composition(blocks), &context);
+    assert_eq!(projection.blocks.len(), 5);
+    assert_eq!(projection.unknown_block_count, 9);
+    assert_eq!(projection.dropped_unknown_block_count, 4);
+    assert_eq!(
+        audits
+            .iter()
+            .filter(|audit| audit.event_kind == "custom_block_fallback_cap_exceeded")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn dos570_fixture_8_diagnostics_redaction() {
+    let known = block(
+        "block-redaction",
+        BlockType::RiskCallout,
+        json!({"title": "Risk", "body": "Body"}),
+        vec![claim("claim-redacted", "/title")],
+        vec![binding("/title", BindingRole::Source, &[0])],
+    );
+    let (projection, _) = project(
+        &composition(vec![known]),
+        &surface_ctx(&["submit.feedback"]),
+    );
+    assert!(projection.blocks[0].payload.pointer("/title").is_none());
+    let serialized = serde_json::to_string(&projection.diagnostics).unwrap();
+    assert!(!serialized.contains("/title"));
+    assert!(serialized.contains("out_of_scope"));
+}
+
+#[test]
+fn dos570_fixture_9_binding_role_matrix() {
+    let known = block(
+        "block-roles",
+        BlockType::RiskCallout,
+        json!({"title": "Risk", "body": "Body", "severity": "high", "recommended_action": "Call"}),
+        vec![
+            claim("claim-source", "/title"),
+            claim("claim-target", "/recommended_action"),
+        ],
+        vec![
+            binding("/title", BindingRole::Source, &[0]),
+            binding("/severity", BindingRole::ComputedFrom, &[0]),
+            binding("/body", BindingRole::DisplayOnly, &[]),
+            binding("/recommended_action", BindingRole::FeedbackTarget, &[1]),
+        ],
+    );
+    let (projection, _) = project(
+        &composition(vec![known]),
+        &surface_ctx(&["read.composition", "submit.feedback"]),
+    );
+    let routes = &projection.blocks[0].edit_routes;
+    assert!(
+        !routes
+            .iter()
+            .find(|route| route.role == BindingRole::Source)
+            .unwrap()
+            .feedback_allowed
+    );
+    assert!(
+        !routes
+            .iter()
+            .find(|route| route.role == BindingRole::ComputedFrom)
+            .unwrap()
+            .feedback_allowed
+    );
+    assert!(
+        !routes
+            .iter()
+            .find(|route| route.role == BindingRole::DisplayOnly)
+            .unwrap()
+            .feedback_allowed
+    );
+    assert!(
+        routes
+            .iter()
+            .find(|route| route.role == BindingRole::FeedbackTarget)
+            .unwrap()
+            .feedback_allowed
+    );
+    assert!(serde_json::from_value::<BindingRole>(json!("future_role")).is_err());
+}
+
+#[test]
+fn dos570_fixture_10_source_without_feedback_target_refused() {
+    let known = block(
+        "block-source",
+        BlockType::ClaimSummary,
+        json!({"title": "Claim"}),
+        vec![claim("claim-source", "/title")],
+        vec![binding("/title", BindingRole::Source, &[0])],
+    );
+    let (projection, _) = project(&composition(vec![known]), &ctx());
+    let route = &projection.blocks[0].edit_routes[0];
+    assert!(!route.feedback_allowed);
+    assert_eq!(
+        route.refusal_reason,
+        Some(EditRouteRefusalReason::SourceWithoutTarget)
+    );
+}
+
+#[test]
+fn dos570_fixture_11_computed_from_refused() {
+    let known = block(
+        "block-computed",
+        BlockType::HealthSnapshot,
+        json!({"band": "steady"}),
+        vec![claim("claim-computed", "/band")],
+        vec![binding("/band", BindingRole::ComputedFrom, &[0])],
+    );
+    let (projection, _) = project(
+        &composition(vec![known.clone()]),
+        &surface_ctx(&["read.composition"]),
+    );
+    assert!(projection.blocks[0].payload.pointer("/band").is_some());
+    assert_eq!(
+        projection.blocks[0].edit_routes[0].refusal_reason,
+        Some(EditRouteRefusalReason::Computed)
+    );
+    let (projection, _) = project(
+        &composition(vec![known]),
+        &surface_ctx(&["submit.feedback"]),
+    );
+    assert!(projection.blocks[0].payload.pointer("/band").is_none());
+}
+
+#[test]
+fn dos570_fixture_12_display_only_no_affordance() {
+    let known = block(
+        "block-display",
+        BlockType::MarkdownDocument,
+        json!({"title": "Read only"}),
+        vec![claim("claim-display", "/title")],
+        vec![binding("/title", BindingRole::DisplayOnly, &[0])],
+    );
+    let (projection, _) = project(
+        &composition(vec![known]),
+        &surface_ctx(&["read.composition", "submit.feedback"]),
+    );
+    assert_eq!(
+        projection.blocks[0].edit_routes[0].refusal_reason,
+        Some(EditRouteRefusalReason::DisplayOnly)
+    );
+    assert!(!projection.blocks[0].edit_routes[0].feedback_allowed);
+}
+
+#[test]
+fn dos570_fixture_13_feedback_target_routes() {
+    let known = block(
+        "block-feedback",
+        BlockType::RiskCallout,
+        json!({"recommended_action": "Call", "title": "Risk"}),
+        vec![claim("claim-target", "/recommended_action")],
+        vec![
+            binding("/recommended_action", BindingRole::FeedbackTarget, &[0]),
+            binding("/title", BindingRole::FeedbackTarget, &[]),
+        ],
+    );
+    let (projection, _) = project(
+        &composition(vec![known]),
+        &surface_ctx(&["read.composition", "submit.feedback"]),
+    );
+    let allowed = projection.blocks[0]
+        .edit_routes
+        .iter()
+        .find(|route| route.field_path.as_str() == "/recommended_action")
+        .unwrap();
+    assert!(allowed.feedback_allowed);
+    assert_eq!(allowed.claim_refs[0].claim_id, "claim-target");
+    assert_eq!(allowed.claim_refs[0].claim_version, Some(7));
+    assert_eq!(
+        allowed.claim_refs[0].field_path.as_ref().unwrap().as_str(),
+        "/recommended_action"
+    );
+    let refused = projection.blocks[0]
+        .edit_routes
+        .iter()
+        .find(|route| route.field_path.as_str() == "/title")
+        .unwrap();
+    assert!(!refused.feedback_allowed);
+    assert_eq!(
+        refused.refusal_reason,
+        Some(EditRouteRefusalReason::MissingClaimRef)
+    );
+}
+
+#[test]
+fn dos570_fixture_14_policy_version_cache_key() {
+    register_schema("dailyos/policy-version", &["/title"], &[], &["document"]);
+    let custom = block(
+        "block-policy",
+        BlockType::Custom {
+            type_id: "dailyos/policy-version".to_string(),
+        },
+        json!({"title": "Stable"}),
+        vec![],
+        vec![],
+    );
+    let comp = composition(vec![custom]);
+    let mut first = ctx();
+    first.fallback_policy_version = 3;
+    let mut second = ctx();
+    second.fallback_policy_version = 4;
+    let (a, _) = project(&comp, &first);
+    let (b, _) = project(&comp, &second);
+    assert_ne!(a.fallback_policy_version, b.fallback_policy_version);
+    assert_eq!(a.blocks[0].payload, b.blocks[0].payload);
+}
+
+#[test]
+fn invalid_producer_output_gate_is_closed_enum() {
+    let known = block(
+        "block-invalid",
+        BlockType::ClaimSummary,
+        json!({"title": "Claim"}),
+        vec![ClaimRef::with_version("claim-source", 7)],
+        vec![binding("/title", BindingRole::Source, &[0])],
+    );
+    let error = project_composition_for_surface(&composition(vec![known]), &ctx()).unwrap_err();
+    assert_eq!(
+        error,
+        ProjectionError::InvalidProducerOutput {
+            reason: ProducerOutputInvalidReason::SourceBindingMissingFieldPath
+        }
+    );
+}

--- a/src-tauri/src/services/composition_projection.rs
+++ b/src-tauri/src/services/composition_projection.rs
@@ -1,0 +1,198 @@
+use abilities_runtime::abilities::registry::Actor;
+use abilities_runtime::abilities::{AuditIntent, ProjectedComposition};
+use serde_json::json;
+
+use crate::audit_log::{emit_surface_audit, AuditError, AuditFields, AuditLogger};
+use crate::db::ActionDb;
+use crate::services::context::ServiceContext;
+use crate::services::projection_signing::{
+    sign_projection, ProjectionBlockInput, ProjectionClaimRefInput, ProjectionKeyStore,
+    ProjectionSigningError, ProjectionSurface, ProjectionWriteInput, SignedProjectionWrite,
+};
+
+#[derive(Debug, Clone)]
+pub struct ProjectedCompositionSignatureRequest {
+    pub projection_id: String,
+    pub surface: ProjectionSurface,
+    pub surface_locator: String,
+    pub dailyos_canonical_id: String,
+    pub dailyos_source_runtime: String,
+}
+
+pub fn projection_write_input_from_projected_composition(
+    request: ProjectedCompositionSignatureRequest,
+    projected: &ProjectedComposition,
+) -> ProjectionWriteInput {
+    ProjectionWriteInput {
+        projection_id: request.projection_id,
+        surface: request.surface,
+        surface_locator: request.surface_locator,
+        dailyos_canonical_id: request.dailyos_canonical_id,
+        dailyos_source_runtime: request.dailyos_source_runtime,
+        dailyos_projection_version: u64::from(projected.fallback_policy_version),
+        composition_id: projected.composition_id.as_str().to_string(),
+        composition_version: projected.composition_version.unwrap_or_default(),
+        blocks: projected
+            .blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| ProjectionBlockInput {
+                block_id: block.block_id.as_str().to_string(),
+                block_order: index as u64,
+                block_type: block.selected_known_type_id.clone(),
+                block_payload: json!({
+                    "fallback_policy_version": projected.fallback_policy_version,
+                    "original_type_id": block.original_type_id,
+                    "selected_known_type_id": block.selected_known_type_id,
+                    "payload": block.payload,
+                    "banner": block.banner,
+                    "trust_band": block.trust_band,
+                    "edit_routes": block.edit_routes,
+                    "diagnostics": block.diagnostics,
+                }),
+                claim_refs: block
+                    .claim_refs
+                    .iter()
+                    .map(|claim_ref| ProjectionClaimRefInput {
+                        claim_id: claim_ref.claim_id.clone(),
+                        claim_version: claim_ref.claim_version.unwrap_or_default(),
+                        field_path: claim_ref
+                            .field_path
+                            .as_ref()
+                            .map(|field_path| field_path.as_str().to_string()),
+                        provenance_invocation_id: block
+                            .provenance
+                            .first()
+                            .map(|provenance| provenance.invocation_id.0.to_string()),
+                        provenance_field_path: block
+                            .provenance
+                            .first()
+                            .map(|provenance| provenance.field_path.as_str().to_string()),
+                        scope_grant_hash: None,
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+pub fn sign_projected_composition(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    key_store: &dyn ProjectionKeyStore,
+    request: ProjectedCompositionSignatureRequest,
+    projected: &ProjectedComposition,
+) -> Result<SignedProjectionWrite, ProjectionSigningError> {
+    let input = projection_write_input_from_projected_composition(request, projected);
+    sign_projection(ctx, db, key_store, input)
+}
+
+pub fn drain_projection_audit_intents(
+    logger: &mut AuditLogger,
+    actor: &Actor,
+    wp_user_id: Option<u64>,
+    wp_user_hash: Option<&str>,
+    intents: &[AuditIntent],
+) -> Result<(), AuditError> {
+    for intent in intents {
+        let mut fields = AuditFields::new(intent.category.as_str(), intent.detail.clone());
+        if let Some(wp_user_id) = wp_user_id {
+            fields = fields.with_wp_user_id(wp_user_id);
+        }
+        if let Some(wp_user_hash) = wp_user_hash {
+            fields = fields.with_wp_user_hash(wp_user_hash);
+        }
+        emit_surface_audit(logger, intent.event_kind, actor, fields)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use abilities_runtime::abilities::composition::{BlockId, CompositionDocId};
+    use abilities_runtime::abilities::registry::{ScopeSet, SurfaceClientId, SurfaceScope};
+    use abilities_runtime::abilities::trust::TrustBand;
+    use abilities_runtime::abilities::{AuditCategory, ProjectedBlock};
+    use serde_json::json;
+
+    fn projected(policy_version: u32) -> ProjectedComposition {
+        ProjectedComposition {
+            composition_id: CompositionDocId::new("composition-projection-test"),
+            composition_version: Some(3),
+            fallback_policy_version: policy_version,
+            blocks: vec![ProjectedBlock {
+                block_id: BlockId::new("block-1"),
+                block_index: 0,
+                original_type_id: "dailyos/custom".to_string(),
+                selected_known_type_id: "markdown_document".to_string(),
+                payload: json!({"title": "Visible"}),
+                banner: Some(
+                    "Rendered as nearest known type — payload may be incomplete.".to_string(),
+                ),
+                trust_band: TrustBand::NeedsVerification,
+                claim_refs: vec![],
+                provenance: vec![],
+                edit_routes: vec![],
+                diagnostics: vec![],
+            }],
+            diagnostics: vec![],
+            unknown_block_count: 1,
+            unknown_block_cap: 5,
+            dropped_unknown_block_count: 0,
+        }
+    }
+
+    fn signature_request() -> ProjectedCompositionSignatureRequest {
+        ProjectedCompositionSignatureRequest {
+            projection_id: "projection-test".to_string(),
+            surface: ProjectionSurface::WordpressDb,
+            surface_locator: "wp:post:1:block:1".to_string(),
+            dailyos_canonical_id: "composition:projection-test".to_string(),
+            dailyos_source_runtime: "runtime-test".to_string(),
+        }
+    }
+
+    #[test]
+    fn policy_version_flows_into_signature_input() {
+        let first =
+            projection_write_input_from_projected_composition(signature_request(), &projected(3));
+        let second =
+            projection_write_input_from_projected_composition(signature_request(), &projected(4));
+        assert_ne!(
+            first.dailyos_projection_version,
+            second.dailyos_projection_version
+        );
+        assert_ne!(
+            first.blocks[0].block_payload,
+            second.blocks[0].block_payload
+        );
+    }
+
+    #[test]
+    fn audit_intents_drain_through_surface_audit_helper() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("projection-audit.jsonl");
+        let mut logger = AuditLogger::new(path.clone());
+        let actor = Actor::SurfaceClient {
+            instance: SurfaceClientId::new("surface-test"),
+            scopes: ScopeSet::new([SurfaceScope::new("read.composition")]).unwrap(),
+        };
+        let intents = vec![AuditIntent {
+            event_kind: "custom_block_fallback_cap_exceeded",
+            category: AuditCategory::Anomaly,
+            detail: json!({"schema_version": 1, "reason": "unknown_block_cap_exceeded"}),
+        }];
+        drain_projection_audit_intents(
+            &mut logger,
+            &actor,
+            Some(42),
+            Some("wp-user-hash-test"),
+            &intents,
+        )
+        .unwrap();
+        let written = std::fs::read_to_string(path).unwrap();
+        assert!(written.contains("custom_block_fallback_cap_exceeded"));
+        assert!(written.contains("unknown_block_cap_exceeded"));
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -8,6 +8,7 @@ pub mod claims;
 pub mod claims_backfill;
 pub mod commitment_bridge;
 pub mod comparator_thresholds;
+pub mod composition_projection;
 pub mod compositions;
 pub mod context;
 pub mod dashboard;


### PR DESCRIPTION
## Summary

W4 wave Stage-2 substrate per [W4-D L0 packet](.docs/plans/dos-546/v1.4.2-project/W4-D-L0-packet.md):

- Public API: `project_composition_for_surface(&Composition, &FallbackProjectionContext) -> Result<(ProjectedComposition, Vec<AuditIntent>), ProjectionError>` (signature pinned by §1.1)
- DTOs match packet §1.1 verbatim: `ProjectedComposition`, `ProjectedBlock`, `EditRoute`, `ProjectionDiagnostic`, `AuditIntent`, `AuditCategory`, `FallbackProjectionContext`, `ProjectionError`, `EditRouteRefusalReason`, `DiagnosticKind`, `DiagnosticReason`, `CustomBlockSchema`, `SurfaceKind`
- `BlockProjectionRule` registry over all 9 non-Custom BlockTypes (AccountOverview, ClaimSummary, EvidenceList, HealthSnapshot, RelationshipMap, RiskCallout, ActionList, MarkdownDocument, plus `dailyos/text` generic fallback)
- Composition-level unknown-block cap with `dropped_unknown_block_count` diagnostic; block helpers stay `pub(crate)`
- Field-pointer allowlist per rule; no `/*` wildcards; array wildcards only for declared item schemas
- Sensitivity gating, trust-band cap, edit-route refusal logic
- AuditIntent emission contract: pure projector in `abilities-runtime`, service-side `services/composition_projection.rs` drains intents into the existing audit log
- `fallback_policy_version` u32 const participates in W4-C signing payload (stale version → distinct signature)

## §4 Security

security_auditor_invoked: true

L2 cycle-1 panel:
- code-reviewer: CONDITIONAL APPROVE (1 cycle-2 fix: LOW-4 §9 enum-closure violation in `diagnostic_reason_for_refusal`)
- security-auditor: APPROVE (3 path-α observations only)

Cycle-2 commit `cd7d8dcb` resolves LOW-4: `Computed | DisplayOnly | SourceWithoutTarget` refusals no longer emit a misleading `MissingClaimRef` `ProjectionDiagnostic`. The refusal still surfaces on `EditRoute.refusal_reason` where W5-A reads it; only the spurious composition-level diagnostic is dropped.

Path-α residuals filed to maintenance project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`:
- MEDIUM-1: emit diagnostic for unsafe-widening-rejected drops (AC §28)
- MEDIUM-2: rule selection uses payload-leaf count for diagnostics-only (§9 clarity)
- LOW-1: `BindingRole` future-variant fail-closed gate
- LOW-2: per-claim scope folding when claim-level scope plumbing lands in W4-B
- LOW-3: sentinel-value assertion depth in fixture-8
- security-auditor F1: SurfaceClient `read.*` scope tightening on unbound display fields
- security-auditor F2: bound-claim sensitivity vs field policy sensitivity ceiling

## Test plan

- [x] cargo clippy -- -D warnings (clean)
- [x] cargo test --test dos570_fallback_projection (17 fixtures, all pass)
- [ ] CI: lint-and-checks + frontend + L2 fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)