### PR TITLE
Improve pre-push gauntlet: silence cargo output + cache tree-SHA

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -218,4 +218,18 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 "$ROOT_DIR/scripts/check_prompt_template_registry.sh"
 "$ROOT_DIR/scripts/check_prompt_fingerprint_boundary.sh"
 
+# Cache tree-SHA: lets pre-push short-circuit its duplicate gauntlet when
+# HEAD's tree hasn't drifted from what pre-commit just verified. Only write
+# the marker when the heavy gauntlet actually ran (not WIP mode) AND
+# everything passed. Pre-push compares HEAD's tree to this marker.
+# Use `git rev-parse --git-dir` so the marker is per-worktree (in worktrees
+# the path `.git` is a file pointing at `.git/worktrees/<name>/`).
+if [ "$WIP_MODE" = false ]; then
+  GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null)"
+  if [ -n "$GIT_DIR_RESOLVED" ]; then
+    mkdir -p "${GIT_DIR_RESOLVED}/hooks-state" 2>/dev/null || true
+    git write-tree > "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" 2>/dev/null || true
+  fi
+fi
+
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -80,20 +80,25 @@ if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ] && [ -f "${BACKEND_DIR}/scrip
 fi
 
 if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ]; then
+  # Silence cargo output. When git push wraps the hook, ~2500 lines of
+  # cargo test stdout streamed through git push's stdio caused git push
+  # to die with SIGPIPE (exit 141) before reaching the transmit phase,
+  # even though the hook itself returned 0 standalone. Matches the
+  # pattern pre-commit already uses for the same reason.
   echo "pre-push: cargo clippy -- -D warnings" >&2
-  if ! cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings; then
+  if ! cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings >/dev/null 2>&1; then
     append_error "❌ cargo clippy -- -D warnings FAILED"
   fi
 
   echo "pre-push: cargo test --lib" >&2
-  if ! cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml"; then
+  if ! cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml" >/dev/null 2>&1; then
     append_error "❌ cargo test --lib FAILED"
   fi
 fi
 
 if [ "$HAS_FRONTEND" = true ] && [ -f "${CWD}/package.json" ]; then
   echo "pre-push: pnpm tsc --noEmit" >&2
-  if ! pnpm tsc --noEmit; then
+  if ! pnpm tsc --noEmit >/dev/null 2>&1; then
     append_error "❌ pnpm tsc --noEmit FAILED"
   fi
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,6 +79,23 @@ if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ] && [ -f "${BACKEND_DIR}/scrip
   fi
 fi
 
+# Cache check: if pre-commit just ran the gauntlet against the same tree
+# that's now at HEAD, skip the duplicate run. Pre-commit writes the tree
+# SHA to <git-dir>/hooks-state/last-green-tree after a clean gauntlet
+# pass. Pushing an unmodified commit takes pre-push to ~0s; WIP=1 commits
+# and amended trees still pay the full gauntlet cost. Use --git-dir so
+# the marker is per-worktree.
+GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null)"
+LAST_GREEN_TREE=""
+if [ -n "$GIT_DIR_RESOLVED" ] && [ -f "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" ]; then
+  LAST_GREEN_TREE="$(tr -d '[:space:]' < "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" 2>/dev/null || echo "")"
+fi
+CURRENT_TREE="$(git rev-parse HEAD^{tree} 2>/dev/null || echo "")"
+if [ -n "$LAST_GREEN_TREE" ] && [ -n "$CURRENT_TREE" ] && [ "$LAST_GREEN_TREE" = "$CURRENT_TREE" ]; then
+  echo "pre-push: HEAD tree ${CURRENT_TREE} already passed pre-commit gauntlet — skipping clippy/test/tsc" >&2
+  exit 0
+fi
+
 if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ]; then
   # Silence cargo output. When git push wraps the hook, ~2500 lines of
   # cargo test stdout streamed through git push's stdio caused git push


### PR DESCRIPTION
## Summary

Two related fixes to `.githooks/pre-commit` and `.githooks/pre-push` discovered while pushing PR #298 (W4-F L4 read-path). Both land here as a separate PR because `.githooks/` is fenced under L2 config-fence — hook changes can't be merged through a PR those hooks are reviewing.

## What's in the diff

**1. Silence cargo output in pre-push (`b1bb5b8e`)**

The pre-push hook ran `cargo clippy` and `cargo test --lib` without redirecting stdout/stderr. When git push wraps the hook, the ~2500 lines of cargo test output streamed through git push's stdio caused git push to die with SIGPIPE (exit 141) before reaching the transmit phase, even though the hook returned 0 when invoked standalone. Pre-commit already silences cargo output for the same reason; this commit mirrors that pattern in pre-push.

**2. Cache tree-SHA across pre-commit → pre-push (`bcd4fbcf`)**

Pre-commit and pre-push both ran cargo clippy + cargo test --lib against the same tree. The duplicate ran ~13 minutes for nothing whenever a contributor used the normal commit-then-push flow. With GitHub's SSH idle timeout, the duplicate also held git push's SSH socket idle past the limit, causing transmission to fail even after the hook returned 0 ("Connection to github.com closed by remote host").

Pre-commit now writes the verified tree SHA to `<git-dir>/hooks-state/last-green-tree` after the gauntlet passes (only in non-WIP mode). Pre-push compares HEAD's tree to that marker and short-circuits when they match.

Cache semantics:

- Tree-keyed (not commit-keyed) so amends with no content change still hit the cache.
- Written only when `WIP_MODE=false`, so explicit `WIP=1` commits still pay the pre-push gauntlet cost — preserves the documented "safety net for WIP=1 skips" contract.
- Per-worktree (uses `git rev-parse --git-dir`, not the literal `.git` path which is a file in worktrees).
- Stale markers are safe: tree SHAs from prior heads won't match HEAD's tree, so the gauntlet runs.

**Measured:** push went from ~13 min cargo test + SSH timeout failure to **1.4 seconds** for the cache-hit path. Tested on PR #298's branch immediately after the cache commit landed (since reverted to a separate PR).

## Effect matrix

| Flow | Before | After |
|---|---|---|
| Normal commit-then-push | 13 min + frequent SSH timeout | ~0s |
| WIP=1 commit-then-push | 13 min | 13 min (unchanged) |
| Amended commit (content changed) | 13 min | 13 min (tree differs, cache miss) |
| Multiple commits in one push | 13 min × N | ~0s if HEAD's tree was last-green; full gauntlet otherwise |

## Test plan

- [x] Verified standalone hook trace exits 0 with ref-list on stdin
- [x] Verified pre-commit writes marker after gauntlet pass; marker matches `git rev-parse HEAD^{tree}`
- [x] Verified pre-push short-circuits with "HEAD tree X already passed pre-commit gauntlet — skipping" message
- [x] Verified WIP=1 commit does NOT write marker (gauntlet still runs on push)
- [x] Verified cache file location is per-worktree (`git rev-parse --git-dir`, not literal `.git`)
- [ ] CI: pre-merge

## Closes

[DOS-676](https://linear.app/a8c/issue/DOS-676) — Pre-push hook structurally blocks pushes via GitHub SSH idle timeout (cargo test --lib too slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)