### PR TITLE
v1.4.3 W0 Packet B: WP preview/runtime render stabilization (DOS-671/672)

### DIFF
--- a/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
+++ b/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
@@ -1,6 +1,6 @@
 # L0 Packet B — WP preview/runtime render stabilization
 
-**Current revision: V1.1 (cycle-1 fold + key reframing, 2026-05-17). See §2 Changelog.**
+**Current revision: V1.1.1 (cycle-2 text fixes, 2026-05-17). See §2 Changelog.**
 
 ## 1. Header
 
@@ -41,6 +41,79 @@ lifecycle hardening (DOS-673/674/675) — that is L0 Packet A, separate review
 track, separate PR.
 
 ## 2. Changelog
+
+- **V1.1.1 (2026-05-17, cycle-2 text fixes):** All 4 cycle-2 reviewers
+  returned non-BLOCK (CSO APPROVE, codex challenge CONDITIONAL APPROVE,
+  code-reviewer CONDITIONAL APPROVE, codex consult CONDITIONAL APPROVE).
+  All CONDITIONAL APPROVE findings are text-only — no architecture change.
+  Folded inline:
+  - **§5.3 + §5.4 clarification** (codex challenge LOW): "state movement"
+    means `composition_versions` row advancement through
+    `commit_composition`; upstream claim/source movement reaches this
+    cache through the existing DOS-589 / W4-A0 recomposition contract.
+    The cache invalidation proof is exact for committed composition-version
+    movement.
+  - **§5.5 type-shape correction** (codex consult): the existing substrate
+    `charge_ability_scope` is a boolean (`surface_client.rs:642`), not an
+    enum. V1.1.1 specifies a boolean parameter. Also cites the existing
+    precedent at `surface_client.rs:936` where another helper already
+    constructs requests with `charge_ability_scope=false`.
+  - **§5.2 ESLint suppression note** (codex consult): WP-side
+    `wp-scripts lint-js` may warn on `useEffect([reloadTrigger])` omitting
+    `reload` from the dep list. Spec: use an explicit ESLint disable
+    comment with rationale — or, if `react-hooks/exhaustive-deps` is set
+    to `warn` rather than `error`, the warning is non-blocking. Both
+    options preserve the architectural shape.
+  - **§5.6 `consistency_failure` marked as fail-safe-only** (codex consult):
+    `consistency_failure` is not verified as an emittable runtime code in
+    the current Rust surface. V1.1.1 keeps it as a renderer fail-safe
+    bucket (for any future code that maps to consistency) rather than
+    claiming it's an active runtime code. Removed from fixture #14's
+    code-matrix list.
+  - **§5.6 AC #14 / fixture #14 sync** (codex consult): AC #14 listed
+    `missing_expected_claim_version` and `mid_flight_mutation`; fixture
+    #14's 11-code matrix omitted both. V1.1.1 adds them to fixture #14's
+    enumeration. Now AC #14 and fixture #14 cover the same 13-code set
+    (11 from V1.1 + 2 omitted).
+  - **§5.6 session-repair arm extended** (code-reviewer F2 residual):
+    extend switch's session-repair arm to include `identity_mismatch`,
+    `wp_user_mismatch`, `pairing_code_invalid`, `pairing_code_expired`,
+    `pairing_code_consumed`, `pairing_code_limited`, `pairing_suspended`,
+    `pairing_revoked`, `pairing_expired`, `site_binding_mismatch`,
+    `session_expired`, `session_throttled`, `restored_stale_pairing`,
+    `scope_denied`, `auth_missing`. Plus a new "renderer-input-invalid"
+    arm for `request_body_too_large`, `request_body_unreadable`,
+    `handshake_body_invalid`, `session_refresh_body_invalid`,
+    `surface_invoke_invalid`, `event_log_id_invalid`. Reasoning: V1.1's
+    "unknown code → verification banner" fail-safe was functionally
+    correct but mis-attributed pairing/identity failures to projection
+    consistency. The extended arms route them to user-actionable notices.
+    Verification banner stays reserved for true projection-consistency
+    failures + unknown-code fail-safe.
+  - **§8 new fixture #17 — AC #16 coverage** (code-reviewer F8): Rust
+    test `dos672_authorize_local_render_enforces_scope` — when validated
+    session lacks `read.account_overview` scope, `authorize_local_render`
+    rejects with `ScopeDenied`, proving `charge_ability_scope=false` only
+    bypasses rate-budget consumption, NOT authorization gates.
+  - **§8 new fixture #18 — external composition-version invalidation**
+    (codex challenge LOW): Rust test that seeds cache at version N,
+    advances current DB composition_version outside the request watermark
+    (e.g., via an external producer path), renders with stale
+    `request.composition_version=N`, asserts lookup misses old key,
+    producer path runs, cache stored at the emitted version, subsequent
+    render hits. Concrete proof of the §5.4 reframe's invalidation claim.
+  - **§8.1 AC↔fixture mapping table added** (codex consult Validation 6 +
+    code-reviewer): the V1.1 "16 ACs ↔ 16 fixtures, 1:1" claim was
+    overstated — several ACs map to CI invariants or are covered by
+    multiple fixtures. V1.1.1 adds an explicit mapping table (Packet A
+    V1.1.1 §8.1 pattern). After fixture #17 + #18 additions, count is
+    18 fixtures covering 16 ACs + 2 CI-only invariants.
+  - **§9 whitespace tolerance note** (code-reviewer F7): invariants #2/#3
+    grep gates must tolerate whitespace inside dep array literals (e.g.,
+    `[ x, y ]` vs `[x, y]`). Spec: collapse whitespace before regex
+    match, or use a normalized-AST check via simple JS parse. L1
+    implementer detail; documented here so the gate doesn't become a
+    brittle literal-substring grep.
 
 - **V1.1 (2026-05-17, cycle-1 fold + key reframing):** Cycle-1 verdicts:
   codex challenge BLOCK, CSO CA, code-reviewer CA, codex consult CA. The
@@ -326,6 +399,22 @@ useEffect(() => {
 - Show an `error` notice in the editor but do NOT replace rendered content
   with the verification banner envelope.
 
+**ESLint suppression note (V1.1.1 per codex consult):** WP-side
+`wp-scripts lint-js` may emit `react-hooks/exhaustive-deps` warnings on
+`useEffect([reloadTrigger])` because `reload` is reachable from the body
+but not in the dep list. Two L1 implementer options, both architecturally
+correct:
+- Explicit ESLint disable comment with rationale (preferred for clarity):
+  ```js
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional:
+  // reload's identity is recomputed every render (full dep list); the
+  // auto-reload trigger gate is the derived reloadTrigger string. See
+  // L0 Packet B V1.1 §5.2.
+  useEffect(() => { reload(); }, [reloadTrigger]);
+  ```
+- OR set `react-hooks/exhaustive-deps` to `warn` not `error` at the WP
+  project level (root project already does this at `eslint.config.js:74`).
+
 ### 5.3 Runtime cache-key correction — option (a) picked (V1.1)
 
 At `src-tauri/src/surface_runtime/mod.rs:2317-2321` and `:2425-2430`, the cache
@@ -371,6 +460,20 @@ producer invocations are serialized by the SurfaceClient bridge's writer
 mutex; there is effectively no concurrent commit race. For
 federation/multi-writer scenarios, this would need the invalidation API
 from option (b) — out of scope for v1.4.3.
+
+**"State movement" definition** (added V1.1.1 per codex challenge cycle-2
+LOW): "state movement" in this packet means `composition_versions` row
+advancement through `commit_composition`. Upstream claim/source movement
+(claim version, source freshness, account_subject signals) reaches this
+cache through the existing DOS-589 / W4-A0 recomposition contract:
+upstream signal → producer re-invocation by some path → producer commits
+new composition version → next render's `current_db_version` read returns
+the new value → cache lookup misses old key → producer runs (this time
+from the actual render path) → cache populated at new version → subsequent
+renders hit. The cache invalidation proof is exact for committed
+composition-version movement; pre-commit upstream movement is invisible to
+this cache by design (and that's correct — without a committed projection
+to serve, there's nothing to invalidate or refresh).
 
 ### 5.4 Render-path producer behavior — V1.1 reframe: producer commits preserved
 
@@ -448,7 +551,11 @@ AC #15 ("local-render decharge emits zero `rate_limit_audit_event` entries
 for the ability/scope bucket"). Maintenance ticket filed for operator
 observability of local-render volume.
 
-**Implementation shape:**
+**Implementation shape (V1.1.1 — corrected type-shape per codex consult):**
+
+The existing substrate uses a **boolean** `charge_ability_scope` field
+(`surface_client.rs:642`), not an enum. V1.1's pseudo-code naming
+`ChargeAbilityScope::Off` was misleading; corrected:
 
 ```rust
 // New variant — same descriptor/actor/mode/scope checks, then bypass-ability-scope rate-limit
@@ -464,10 +571,15 @@ pub fn authorize_local_render(
         validated,
         ability_name,
         request_id,
-        ChargeAbilityScope::Off,  // existing internal flag; today hardcoded to On
+        false,  // charge_ability_scope — today hardcoded to true at :387/:409
     )
 }
 ```
+
+**Precedent:** there is already an identity-only helper at
+`surface_client.rs:936` that constructs requests with
+`charge_ability_scope=false`. V1.1.1's `authorize_local_render` follows
+the same pattern.
 
 Route handler at `surface_runtime/mod.rs:2288-2311` calls
 `authorize_local_render` instead of `authorize` for the `project_composition`
@@ -500,21 +612,50 @@ if ( isset( $response['ok'] ) && $response['ok'] === false ) {
     switch ( $code ) {
         case 'rate_limited':
             return dailyos_account_overview_render_throttled_notice();
+        // Session-repair-shaped: user action needed to restore pairing/session.
         case 'session_requires_repair':
         case 'session_not_found':
+        case 'session_expired':
+        case 'session_throttled':
+        case 'identity_mismatch':
+        case 'wp_user_mismatch':
+        case 'pairing_code_invalid':
+        case 'pairing_code_expired':
+        case 'pairing_code_consumed':
+        case 'pairing_code_limited':
+        case 'pairing_suspended':
+        case 'pairing_revoked':
+        case 'pairing_expired':
+        case 'site_binding_mismatch':
+        case 'restored_stale_pairing':
+        case 'scope_denied':
+        case 'auth_missing':
             return dailyos_account_overview_render_session_repair_notice();
+        // Runtime-unavailable: transient infrastructure problem; retry.
         case 'runtime_unavailable':
         case 'runtime_request_failed':
         case 'runtime_invalid_json':
         case 'runtime_http_error':
+        case 'host_invalid':
+        case 'browser_origin_forbidden':
+        case 'route_not_found':
             return dailyos_account_overview_render_runtime_unavailable_notice();
+        // Renderer-input-invalid: defensive — the renderer or its caller
+        // produced something the runtime can't process. Operator
+        // notice; not a user-actionable retry.
+        case 'request_body_too_large':
+        case 'request_body_unreadable':
+        case 'handshake_body_invalid':
+        case 'session_refresh_body_invalid':
+        case 'surface_invoke_invalid':
+        case 'event_log_id_invalid':
+            return dailyos_account_overview_render_invalid_request_notice();
+        // Projection-consistency failures — verification banner correct.
         case 'projection_tampered':
         case 'projection_version_rollback':
         case 'stale_composition_watermark':
         case 'missing_expected_claim_version':
         case 'mid_flight_mutation':
-        case 'consistency_failure':
-            // Genuine projection-consistency failure — verification banner correct.
             return dailyos_account_overview_render_verification_banner();
         default:
             // Unknown code: fail-safe to verification banner. Operator
@@ -536,9 +677,20 @@ New helpers (small, local copy):
 - `dailyos_account_overview_render_throttled_notice()` — "Runtime is throttling; retry shortly."
 - `dailyos_account_overview_render_session_repair_notice()` — "Surface session needs repair; reconnect from DailyOS settings."
 - `dailyos_account_overview_render_runtime_unavailable_notice()` — "Runtime unavailable; retry."
+- `dailyos_account_overview_render_invalid_request_notice()` — "Editor sent a request the runtime couldn't process. Reload the editor."
 
 The verification banner stays reserved for genuine projection-consistency
 failures + unknown codes (fail-safe).
+
+**Note on `consistency_failure` (V1.1.1 per codex consult):**
+`consistency_failure` is not verified as an actively emitted runtime code
+in the current Rust surface. The 5 specific consistency codes in the
+verification-banner switch arm (`projection_tampered`,
+`projection_version_rollback`, `stale_composition_watermark`,
+`missing_expected_claim_version`, `mid_flight_mutation`) ARE emittable
+(`surface_runtime/mod.rs:3010-3049`). The renderer's fail-safe default
+arm catches any new consistency code added later — including a future
+`consistency_failure` if introduced.
 
 ## 6. Directional decisions resolved at L0
 
@@ -620,7 +772,7 @@ its rendered state. No runtime contract change for this rule.
 11. Second consecutive manual reload succeeds (returns projection, not banner) — assuming first reload succeeded.
 12. Failed reload (any cause) preserves last-good `preview` state in the editor.
 13. Failed reload surfaces an `error` notice; does NOT replace rendered content with verification-banner HTML.
-14. PHP renderer maps `error.code` via switch table: `rate_limited` → throttled notice; `session_requires_repair` / `session_not_found` → session-repair notice; `runtime_unavailable` / `runtime_request_failed` / `runtime_invalid_json` / `runtime_http_error` → runtime-unavailable notice; consistency codes (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`, `consistency_failure`) → verification banner; unknown codes → verification banner (fail-safe).
+14. PHP renderer maps `error.code` via switch table (V1.1.1 expanded coverage): `rate_limited` → throttled notice; session-repair-shaped codes (`session_requires_repair`, `session_not_found`, `session_expired`, `session_throttled`, `identity_mismatch`, `wp_user_mismatch`, `pairing_*`, `site_binding_mismatch`, `restored_stale_pairing`, `scope_denied`, `auth_missing`) → session-repair notice; runtime-unavailable codes (`runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `host_invalid`, `browser_origin_forbidden`, `route_not_found`) → runtime-unavailable notice; renderer-input-invalid codes (`request_body_*`, `handshake_body_invalid`, `session_refresh_body_invalid`, `surface_invoke_invalid`, `event_log_id_invalid`) → invalid-request notice; projection-consistency codes (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`) → verification banner; unknown codes → verification banner (fail-safe).
 15. **Local-render decharge by construction:** `authorize_local_render` calls `check_and_consume` with `charge_ability_scope=false`. Ability/scope buckets (`standard_read_composition`, `scope.read`) are NOT consumed; identity buckets (`surface_client`, `wp_user`, `wp_site`) ARE consumed. As a direct consequence, the `RateLimitOutcome::Allowed.audit_events` "tightened" emission for ability/scope is OMITTED — no observability event for that bucket because no consumption happens.
 16. Auth/scope mandatory checks (descriptor, actor, mode, experimental, required scopes, browser-direct guard) are NOT bypassed; only rate-budget consumption for ability/scope changes.
 
@@ -645,17 +797,44 @@ injection) for editor-side behavior assertions — no net-new jest setup (code-r
 | 11 | `dos671_local_render_no_tighten_event` | Rust test: 100 paired-loopback render reads produce ZERO `rate_limit_audit_event` entries (ability/scope bucket bypassed → no rejection → no tightening) |
 | 12 | `dos672_manual_reload_single_request` | PHP integration test: simulated button click via REST → exactly one runtime call (not two) |
 | 13 | `dos672_failed_reload_preserves_last_good` | PHP integration test: first reload succeeds → preview HTML rendered; second reload fails (mocked error) → response body returns error notice + last-good preview HTML unchanged in the response shape |
-| 14 | `dos672_typed_error_mapping` | PHP test matrix: each of the 11 error codes (`rate_limited`, `session_requires_repair`, `session_not_found`, `runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `consistency_failure`) → expected user-facing string (throttled / repair / unavailable / verification banner per §5.6 table) |
+| 14 | `dos672_typed_error_mapping` | PHP test matrix (V1.1.1 expanded): per-arm grouping — throttled (`rate_limited`); session-repair (`session_requires_repair`, `session_not_found`, `session_expired`, `session_throttled`, `identity_mismatch`, `wp_user_mismatch`, `pairing_code_invalid`, `pairing_code_expired`, `pairing_code_consumed`, `pairing_code_limited`, `pairing_suspended`, `pairing_revoked`, `pairing_expired`, `site_binding_mismatch`, `restored_stale_pairing`, `scope_denied`, `auth_missing`); runtime-unavailable (`runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `host_invalid`, `browser_origin_forbidden`, `route_not_found`); invalid-request (`request_body_too_large`, `request_body_unreadable`, `handshake_body_invalid`, `session_refresh_body_invalid`, `surface_invoke_invalid`, `event_log_id_invalid`); verification banner (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`). Each emittable code → expected user-facing string per §5.6 table. |
 | 15 | `dos672_unknown_code_failsafe` | PHP test: runtime response `{ok:false, error:{code:'unknown_xyz'}}` → verification banner renders (fail-safe) |
 | 16 | `dos671_l4_hands_on_log` | Hands-on log captured: initial render → wait 60s → focus switch x2 → manual reload x2; content remains visible throughout (the user-visible L4 target) |
+| 17 | `dos672_authorize_local_render_enforces_scope` | Rust test (added V1.1.1 for AC #16): when validated session lacks `read.account_overview` scope, `authorize_local_render` rejects with `ScopeDenied`; proves `charge_ability_scope=false` only bypasses rate-budget consumption, NOT authorization gates. Negative-control fixture against the §5.5 decharge. |
+| 18 | `dos671_external_version_advance_invalidates_cache` | Rust test (added V1.1.1 per codex challenge LOW): seed cache at version N for composition_id X; advance current_db_version for X outside the render request (e.g., external producer commit via a different ability path); render with `request.composition_version=N` (stale watermark); assert (a) cache lookup misses the V1.1 key `(actor, X, N+, scopes)` because current_db_version is now N+; (b) producer path runs and commits the projection at version N+; (c) cache is stored at N+; (d) immediately-subsequent render hits the cache. Proof of the §5.4 reframe's invalidation claim end-to-end.
+
+### 8.1 AC → fixture / invariant mapping (added V1.1.1 per codex consult + code-reviewer)
+
+V1.1's "16 ACs ↔ 16 fixtures, 1:1" claim was overstated. Explicit mapping:
+
+| AC | Coverage |
+|---|---|
+| AC #1 (single-fetch — wrapper + preview) | Fixtures #1 (preview single-fetch) + #2 (wrapper preserves single-fetch). Two-fixture coverage because the AC has two clauses. |
+| AC #2 (`reload` callback dep list) | §9 CI invariant #2 (grep gate) — not a runtime fixture |
+| AC #3 (useEffect trigger key) | §9 CI invariant #3 (grep gate) |
+| AC #4 (success no-retrigger) | Inferred from fixture #5 (first-mount fires ONE reload + V1.1.1 ESLint suppression note ensures Gutenberg attribute writes don't refire). For explicit assertion, fixture #5 should also assert no second reload happens within N ms of the first success — fold into fixture #5 description for L1. |
+| AC #5 (first-mount fires one reload) | Fixture #5 |
+| AC #6 (cache lookup keyed by current_db_version) | Fixtures #6, #7, #8, #18 + §9 CI invariant #4 (grep gate) |
+| AC #7 (cache store uses projection.composition_version) | Fixture #8 |
+| AC #8 (60s visibility + 2 focus changes) | Fixture #16 (L4 hands-on) |
+| AC #9 (manual reload single request) | Fixture #12 |
+| AC #10 (window-focus no reload) | Covered in fixture #16 hands-on log. For explicit automated assertion, fold into a sub-step of fixture #5 or add as L1 hardening. |
+| AC #11 (second manual reload succeeds) | Covered implicitly by fixture #12's repeatable-call shape + fixture #16 hands-on log |
+| AC #12 (failed reload preserves last-good) | Fixture #13 (PHP integration test asserts response shape contains last-good HTML; the editor-side React state preservation is exercised via fixture #5's React harness if available, else proven in fixture #16 hands-on) |
+| AC #13 (failed reload surfaces error notice) | Fixture #13 |
+| AC #14 (typed error switch — full coverage) | Fixture #14 (V1.1.1-expanded code matrix) + fixture #15 (unknown-code fail-safe) |
+| AC #15 (decharge omits tighten-event) | Fixtures #9 (no `rate_limited` failure) + #11 (zero `rate_limit_audit_event` entries) |
+| AC #16 (auth/scope checks not bypassed) | Fixture #17 (V1.1.1 — `authorize_local_render` still rejects on scope denial) |
+
+Total: 18 fixtures (was 16) covering 16 ACs + 4 CI invariants (§9 #2/#3/#4 — grep-gate enforcement of ACs that aren't runtime-testable).
 
 ## 9. CI invariants
 
 | # | Invariant | Enforcement |
 |---|---|---|
 | 1 | `account_overview_preview` calls `dailyos_account_overview_render_from_projection` directly; does NOT route the response back through `render_block_with_filter` → `dailyos_account_overview_render` | grep gate on `account_overview_preview` body |
-| 2 | Editor `reload` callback dep list keeps composition_id + composition_version + cache_hint_token + setAttributes (preserves manual-reload correctness) | grep gate on `edit.js` for the literal dep array shape (code-reviewer F7 — recommends grep over ESLint authoring; proper ESLint rule filed to maintenance) |
-| 3 | Editor `useEffect` for auto-reload depends on `[reloadTrigger]` (NOT `[reload]`) | grep gate on `edit.js` |
+| 2 | Editor `reload` callback dep list keeps composition_id + composition_version + cache_hint_token + setAttributes (preserves manual-reload correctness) | grep gate on `edit.js` for the literal dep array shape (V1.1.1: regex MUST collapse whitespace inside brackets — current `edit.js:82` uses prettier-style spaces `[ x, y ]`. Implementer detail per code-reviewer F7 / cycle-2 note: use `\s*` between tokens, or normalize via a small AST parse step. Brittle literal-substring grep will fail.) |
+| 3 | Editor `useEffect` for auto-reload depends on `[reloadTrigger]` (NOT `[reload]`) | grep gate on `edit.js` (same whitespace tolerance as invariant #2) |
 | 4 | Runtime `project_composition` cache lookup is keyed by current_db_version (NOT request.composition_version) | grep gate on `mod.rs` cache_lookup call site — verify the version argument is the current_db_version variable |
 | 5 | Cache hit rate ≥ 95% under workload that varies `request.composition_version` but holds `composition_id` constant | Rust integration test in existing `rust.yml` workflow |
 | 6 | `authorize_local_render` uses `charge_ability_scope=false`; main `authorize` continues to use `true` | grep gate on `surface_client.rs` for both variants |
@@ -789,12 +968,12 @@ change is withdrawn.
 
 ## 15. Acceptance for L0 closure
 
-- [ ] All 4 reviewers returned APPROVE (cycle 2 or later).
-- [ ] All 16 acceptance criteria (§7 V1.1) are testable; per-criterion fixture mapped to §8 (16 fixtures, 1:1 mapping verified).
-- [ ] All 7 CI invariants (§9 V1.1) have concrete grep/AST/runtime enforcement.
+- [ ] All 4 reviewers returned APPROVE (cycle 2 or later — V1.1.1 cycle-2 text fixes folded inline).
+- [ ] All 16 acceptance criteria (§7) testable; coverage mapped to §8 fixtures (18) + §9 CI invariants per §8.1 mapping table.
+- [ ] All 7 CI invariants (§9 V1.1.1) have concrete grep/AST/runtime enforcement.
 - [ ] All §12 V1.0 open questions resolved in V1.1 (6/6 — see §12).
 - [ ] §5.3 cache key shape picked: option (a) — current_db_version key.
-- [ ] §5.5 render-read decharge approach picked: option (a) — `charge_ability_scope=false`.
+- [ ] §5.5 render-read decharge approach picked: option (a) — `charge_ability_scope=false` boolean.
 - [ ] §5.4 producer-commit-removal WITHDRAWN — no architectural contest remains.
 - [ ] V1.1 deferred items filed as Linear maintenance tickets under project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb` (DailyOS Maintenance & Production Quality). 6 deferral ticket titles in §2 V1.1 changelog.
 - [ ] Landing shape (§10) confirmed: single PR with 4 commit groups (was 5; removed the producer-commit-removal group), no split.

--- a/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
+++ b/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
@@ -1,6 +1,6 @@
 # L0 Packet B — WP preview/runtime render stabilization
 
-**Current revision: V1.1.1 (cycle-2 text fixes, 2026-05-17). See §2 Changelog.**
+**Current revision: V1.0 (initial draft, 2026-05-17). See §2 Changelog.**
 
 ## 1. Header
 
@@ -21,245 +21,24 @@ Primary code:
 - `src-tauri/src/bridges/surface_client.rs`
 Primary anchor: `.docs/plans/dos-546/v1.4.2-project/01-project-description.md` §"Threat model: local-to-local"
 Diagnostic anchor: `.docs/plans/v1.4.3-wp-foundation/stabilization-investigation.md`
+Architectural anchor (CHALLENGED): `src-tauri/src/surface_runtime/mod.rs:2348-2353` — the v1.4.2 "producer always advances composition_version monotonically and commits unconditionally" comment.
 
 This packet covers two confirmed defects in the WP editor → preview → runtime
 render path surfaced by v1.4.2 W4-F L4 hands-on (PR #298 merged
 2026-05-17). Both root causes are confirmed in code (not session TTL — the
 investigation explicitly rejects that framing).
 
-**Intelligence Loop integration check — exempt.** No claim/table/surface
-added; no provenance/trust impact; no signal change; no runtime context
-surface consumes new state; no feedback loop change. Purely render-path
-operational hardening on existing primitives. CLAUDE.md §"Critical Rules —
-Intelligence Loop integration check" does not apply. (Acknowledgement: the
-v1.4.3 fix preserves signal-propagation triggers for the producer — see
-§5.4 V1.1; nothing about the existing producer/projection/renderer contract
-changes.)
+This packet challenges one architectural decision from v1.4.2 W4-F: the
+"always advance composition_version on render" pattern at `surface_runtime/mod.rs:2348`.
+That pattern violates the local-to-local read contract (reads don't write).
+The L0 reviewers — particularly CSO — MUST evaluate whether removing it
+breaks the producer's OCC invariant that v1.4.2 was repairing.
 
 This packet is intentionally narrow. It does NOT include the keychain +
 lifecycle hardening (DOS-673/674/675) — that is L0 Packet A, separate review
 track, separate PR.
 
 ## 2. Changelog
-
-- **V1.1.1 (2026-05-17, cycle-2 text fixes):** All 4 cycle-2 reviewers
-  returned non-BLOCK (CSO APPROVE, codex challenge CONDITIONAL APPROVE,
-  code-reviewer CONDITIONAL APPROVE, codex consult CONDITIONAL APPROVE).
-  All CONDITIONAL APPROVE findings are text-only — no architecture change.
-  Folded inline:
-  - **§5.3 + §5.4 clarification** (codex challenge LOW): "state movement"
-    means `composition_versions` row advancement through
-    `commit_composition`; upstream claim/source movement reaches this
-    cache through the existing DOS-589 / W4-A0 recomposition contract.
-    The cache invalidation proof is exact for committed composition-version
-    movement.
-  - **§5.5 type-shape correction** (codex consult): the existing substrate
-    `charge_ability_scope` is a boolean (`surface_client.rs:642`), not an
-    enum. V1.1.1 specifies a boolean parameter. Also cites the existing
-    precedent at `surface_client.rs:936` where another helper already
-    constructs requests with `charge_ability_scope=false`.
-  - **§5.2 ESLint suppression note** (codex consult): WP-side
-    `wp-scripts lint-js` may warn on `useEffect([reloadTrigger])` omitting
-    `reload` from the dep list. Spec: use an explicit ESLint disable
-    comment with rationale — or, if `react-hooks/exhaustive-deps` is set
-    to `warn` rather than `error`, the warning is non-blocking. Both
-    options preserve the architectural shape.
-  - **§5.6 `consistency_failure` marked as fail-safe-only** (codex consult):
-    `consistency_failure` is not verified as an emittable runtime code in
-    the current Rust surface. V1.1.1 keeps it as a renderer fail-safe
-    bucket (for any future code that maps to consistency) rather than
-    claiming it's an active runtime code. Removed from fixture #14's
-    code-matrix list.
-  - **§5.6 AC #14 / fixture #14 sync** (codex consult): AC #14 listed
-    `missing_expected_claim_version` and `mid_flight_mutation`; fixture
-    #14's 11-code matrix omitted both. V1.1.1 adds them to fixture #14's
-    enumeration. Now AC #14 and fixture #14 cover the same 13-code set
-    (11 from V1.1 + 2 omitted).
-  - **§5.6 session-repair arm extended** (code-reviewer F2 residual):
-    extend switch's session-repair arm to include `identity_mismatch`,
-    `wp_user_mismatch`, `pairing_code_invalid`, `pairing_code_expired`,
-    `pairing_code_consumed`, `pairing_code_limited`, `pairing_suspended`,
-    `pairing_revoked`, `pairing_expired`, `site_binding_mismatch`,
-    `session_expired`, `session_throttled`, `restored_stale_pairing`,
-    `scope_denied`, `auth_missing`. Plus a new "renderer-input-invalid"
-    arm for `request_body_too_large`, `request_body_unreadable`,
-    `handshake_body_invalid`, `session_refresh_body_invalid`,
-    `surface_invoke_invalid`, `event_log_id_invalid`. Reasoning: V1.1's
-    "unknown code → verification banner" fail-safe was functionally
-    correct but mis-attributed pairing/identity failures to projection
-    consistency. The extended arms route them to user-actionable notices.
-    Verification banner stays reserved for true projection-consistency
-    failures + unknown-code fail-safe.
-  - **§8 new fixture #17 — AC #16 coverage** (code-reviewer F8): Rust
-    test `dos672_authorize_local_render_enforces_scope` — when validated
-    session lacks `read.account_overview` scope, `authorize_local_render`
-    rejects with `ScopeDenied`, proving `charge_ability_scope=false` only
-    bypasses rate-budget consumption, NOT authorization gates.
-  - **§8 new fixture #18 — external composition-version invalidation**
-    (codex challenge LOW): Rust test that seeds cache at version N,
-    advances current DB composition_version outside the request watermark
-    (e.g., via an external producer path), renders with stale
-    `request.composition_version=N`, asserts lookup misses old key,
-    producer path runs, cache stored at the emitted version, subsequent
-    render hits. Concrete proof of the §5.4 reframe's invalidation claim.
-  - **§8.1 AC↔fixture mapping table added** (codex consult Validation 6 +
-    code-reviewer): the V1.1 "16 ACs ↔ 16 fixtures, 1:1" claim was
-    overstated — several ACs map to CI invariants or are covered by
-    multiple fixtures. V1.1.1 adds an explicit mapping table (Packet A
-    V1.1.1 §8.1 pattern). After fixture #17 + #18 additions, count is
-    18 fixtures covering 16 ACs + 2 CI-only invariants.
-  - **§9 whitespace tolerance note** (code-reviewer F7): invariants #2/#3
-    grep gates must tolerate whitespace inside dep array literals (e.g.,
-    `[ x, y ]` vs `[x, y]`). Spec: collapse whitespace before regex
-    match, or use a normalized-AST check via simple JS parse. L1
-    implementer detail; documented here so the gate doesn't become a
-    brittle literal-substring grep.
-
-- **V1.1 (2026-05-17, cycle-1 fold + key reframing):** Cycle-1 verdicts:
-  codex challenge BLOCK, CSO CA, code-reviewer CA, codex consult CA. The
-  BLOCK was justified — V1.0 misdiagnosed the §5.4 fix. Key insight from
-  codex consult HIGH #2: **`commit_composition` does not persist a reusable
-  composition payload; it only updates `composition_versions` row + emits a
-  version event.** Removing producer commit-on-render leaves nothing in the
-  DB to project from on cache miss. The producer commit IS the
-  materialization step — it cannot be removed without inventing persistent
-  projection storage.
-
-  The actual local fix: **make the cache key effective (option a) so cache
-  HITS dominate**. Producer runs only on true cache miss; under steady-state
-  rendering, producer runs rarely; commit_composition fires rarely; no write
-  flood. The render-loop symptom comes from the cache key using the surface's
-  stale watermark (`request.composition_version`), which guarantees a cache
-  miss on every render and re-invokes the producer every time.
-
-  V1.1 trims §5.4 from "remove producer commit" to "fix the cache key so
-  producer runs only when needed". The architecturally contested removal is
-  withdrawn; the substrate's W4-F producer contract is unchanged. CSO + codex
-  challenge cycle-1 concerns about signal-propagation invalidation become
-  moot — signal-driven producer invocations still commit and naturally
-  populate the cache for the next render.
-
-  - **FOLDED (real local issues):**
-    - **§5.4 reframed** — producer commit STAYS on cache miss; the fix is
-      cache key correction (§5.3), not commit removal. The §5.4 "remove
-      render-path producer-commit" architecturally contested change is
-      withdrawn. The W4-F producer contract at `mod.rs:2348-2353` is left
-      intact; the comment's claim that "the producer always advances
-      composition_version" remains true (it just runs less often now).
-    - **§5.3 picks option (a)** — cache key `(actor, composition_id,
-      current_db_version, scopes_canonical_id)`. Codex consult cycle-1
-      recommended (a) on implementation grounds (option (b) requires a new
-      invalidation API on the orchestrator that doesn't exist). Move
-      `current_composition_version_for_composition_id` read BEFORE cache
-      lookup. Trade-off: +1 `db_read` per warm-path render — acceptable for
-      local-to-local (code-reviewer F5). Store cache by
-      `projection.composition_version.unwrap_or(current_db_version)`.
-    - **§5.2 stale-closure fix** — keep `reload` callback's full dep list
-      (`[composition_id, composition_version, cache_hint_token,
-      setAttributes]` — preserves manual-reload correctness per codex
-      challenge HIGH #2 + codex consult MEDIUM). Add a separate effect
-      trigger:
-      ```js
-      const reloadTrigger = `${attributes.account_id}|${attributes.composition_id ? '1' : '0'}`;
-      useEffect(() => { reload(); }, [reloadTrigger]);
-      ```
-      The trigger key changes only when account_id or composition_id-presence
-      changes — NOT when version+token change. Manual button keeps using the
-      live `reload` closure (latest deps). No stale-closure risk; no
-      auto-reload loop.
-    - **§5.2 Gutenberg lifecycle enumeration** (code-reviewer F4) —
-      expected-fire: initial mount, account_id change, composition_id
-      empty→non-empty transition. Expected-not-fire: window focus, autosave,
-      undo of cache_hint_token write, block-list reorder remount (which
-      fires the effect with current attributes once — benign). Add positive
-      fixture "first-mount fires exactly one reload" alongside the negative
-      fixtures.
-    - **§5.1 wrapper preservation** (code-reviewer F1) — `dailyos_account_overview_render`
-      retains its single-fetch contract for the block.json front-end render
-      path (`wp/dailyos/blocks/account-overview/render.php:20-25`) and the 6
-      test fixtures (`tests/blocks/AccountOverviewBlockTest.php` at lines 52,
-      61, 96, 131, 169, 189). The new pure helper
-      `dailyos_account_overview_render_from_projection($response, $attributes)`
-      is called ONLY by `account_overview_preview`, replacing the
-      `render_block_with_filter` re-entry that caused the double-fetch.
-    - **§5.6 error envelope rewrite** (code-reviewer F2 + codex consult
-      MEDIUM) — runtime returns `{"error":{"code","message","request_id",...}}`
-      NOT top-level `{ok:false, code:...}`. PHP transport
-      (`class-dailyos-runtime-client.php:393-509`) re-wraps non-2xx as
-      `{ok:false, error:{code, message}}`. Renderer's mapping table reworked
-      against this two-channel surface (WP_Error from transport-layer failure
-      vs runtime envelope from non-2xx). Match `error.code` by string —
-      `session_requires_repair` is a `SurfacePairingError` variant
-      (`surface_pairing.rs:277`) surfaced via `from_pairing_error`, not a
-      dedicated `SurfaceHttpError` constructor.
-    - **§5.5 narrow to `charge_ability_scope=false`** (codex consult MEDIUM
-      + code-reviewer F3 + CSO LOW) — add an `authorize_local_render`
-      variant of `authorize` that passes `charge_ability_scope=false` to
-      `check_and_consume`. Identity buckets (surface_client, wp_user,
-      wp_site) continue to be consumed; ability bucket
-      (`standard_read_composition`) and scope bucket (`scope.read`) are
-      bypassed. Authorization (descriptor, actor, mode, scope check,
-      browser-direct-executable guard) remains mandatory. AC explicitly
-      states "local-render decharge omits the
-      `RateLimitOutcome::Allowed.audit_events` tighten-event emission by
-      construction" (code-reviewer F3 acceptance).
-    - **§8 JS fixtures → PHP equivalents** (code-reviewer F6) — switch
-      fixtures #2, #3, #8, #10 to PHP integration tests against the existing
-      fake-runtime-client pattern at `tests/blocks/AccountOverviewBlockTest.php`.
-      Assertions: request count to runtime, payload shape, post-render HTML
-      shape. Avoids adding wp-scripts jest setup as net-new infrastructure.
-    - **§9 grep gates instead of ESLint rules** (code-reviewer F7) —
-      replace ESLint rule invariants #2 and #3 with grep gates on
-      `edit.js` (literal dep array shape + literal trigger key shape).
-      ESLint authoring filed to maintenance.
-    - **§5.4 framing narrowed** (code-reviewer F9) — the contested anchor
-      at `mod.rs:2348-2353` is a DOS-670 producer-side OCC workaround, NOT
-      a v1.4.2 W4-F V3.2 contract. The reframed V1.1 §5.4 (cache fix, not
-      commit removal) doesn't contest either; the substrate keeps its
-      always-forward-version behavior, just running less often. Removed the
-      "L6 trigger" prose from §14 since the §5.4 reframe eliminates the
-      contested decision.
-  - **DEFERRED to v1.x-federation maintenance:**
-    - **Signal-propagation cache invalidation bus** (CSO MEDIUM + codex
-      challenge MEDIUM cycle-1): moot in V1.1 because §5.4 reframed keeps
-      producer commits as the invalidation channel. Federation/multi-writer
-      scenarios where producer commits can occur from non-local sources
-      would benefit from an explicit invalidation API; v1.4.3 local-single-
-      runtime doesn't need it. **Maintenance ticket title:** "Signal-driven
-      cache invalidation API for composition_render_orchestrator (federation
-      scope)".
-    - **Hostile co-resident plugin error-code fingerprinting** (codex
-      challenge LOW cycle-1): the WP plugin is a trusted same-UID surface
-      principal in v1.4.3 local-to-local. A hostile co-resident plugin with
-      PHP execution already has ambient keychain/DB/loopback access. Finer
-      error-code redaction would be remote-shape defense. Filed as
-      maintenance ticket "Bounded error taxonomy for multi-tenant /
-      multi-plugin WordPress deployments".
-    - **Render-volume audit signal** (code-reviewer F3 maintenance note):
-      operator observability for local-render-decharge volume tracking
-      isn't security-load-bearing locally. Filed as maintenance ticket
-      "Local-render audit signal for operator observability".
-    - **ESLint rule authoring** for editor `useEffect` dep arrays
-      (code-reviewer F7): grep gates cover L0 closure; proper ESLint rule
-      is maintenance.
-
-  - **REJECTED (not findings against V1.1):**
-    - Codex challenge cycle-1 HIGH #1 "no replacement materialization
-      path" — moot because V1.1 doesn't remove the materialization path.
-    - Codex challenge cycle-1 MEDIUM "cache option (b) needs invalidation
-      bus" — moot because V1.1 picks option (a).
-    - V1.0 §12 Q1, Q2, Q3 — all resolved by the V1.1 reframe / picks.
-
-  - **NET V1.1 RESULT:** packet acceptance criteria count: 16 (was 15;
-    +1 for the decharge tighten-event acceptance, +1 for first-mount fixture,
-    -1 because AC #15 "merge no longer combines" becomes tautological after
-    §5.1). Fixtures: 14 (was 13; +1 first-mount-fires-once,
-    JS-to-PHP equivalents add no count change). §5.4 collapses from 5
-    architecturally contested sub-bullets to "preserved unchanged from W4-F";
-    the §5.4 architectural-contest section is replaced with "no architectural
-    contest". The CORE remains: single-fetch PHP, editor reload guard,
-    effective cache key, decharge for local render, typed error mapping. That
-    CORE is the right local fix for the user-visible render-loop bug.
 
 - **V1.0 (2026-05-17):** Initial L0 draft. Authored from
   `stabilization-investigation.md` plus direct verification of the cited
@@ -303,394 +82,109 @@ introduced; every change is an in-place modification of existing functions:
 
 ## 5. What this packet authors net-new
 
-### 5.1 Single-fetch PHP preview (DOS-671 + DOS-672) — V1.1 wrapper preservation
+### 5.1 Single-fetch PHP preview (DOS-671 + DOS-672, shared)
 
-V1.0's framing made the wrapper "optional" — code-reviewer F1 caught this is
-wrong. `dailyos_account_overview_render` has TWO production callers (not
-just the preview route):
-1. `wp/dailyos/blocks/account-overview/render.php:20-25` — block.json
-   front-end render path. This MUST keep the single-fetch behavior (one
-   runtime call per render request).
-2. `wp/dailyos/includes/class-dailyos-plugin.php:587-612` — preview REST
-   route. THIS is where the double-fetch happens (preview-endpoint calls
-   runtime, then re-enters `dailyos_account_overview_render` via
-   `render_block_with_filter` at `:682-690`, causing a second runtime call).
-
-Plus 6 test fixtures at `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php`
-(lines 52, 61, 96, 131, 169, 189) that call `dailyos_account_overview_render`
-directly and rely on the single-fetch wrapper behavior.
-
-**V1.1 refactor preserves the wrapper, adds a pure helper:**
+Refactor `dailyos_account_overview_render` so the runtime call is **optional**:
 
 ```php
 function dailyos_account_overview_render( array $attributes ): string {
-    // Existing wrapper — unchanged behavior for render.php + 6 test fixtures.
-    // Validates composition_id, fetches runtime client, calls
-    // project_composition_for_surface once, delegates to
-    // dailyos_account_overview_render_from_projection.
+    // ... validation as today ...
     $response = dailyos_account_overview_fetch_projection( $attributes );
     return dailyos_account_overview_render_from_projection( $response, $attributes );
 }
 
 function dailyos_account_overview_render_from_projection( $response, $attributes ): string {
-    // Pure projection-to-HTML — no runtime call.
-    // Accepts both runtime success envelope (top-level `projection`,
-    // `cache_hint_token`, `served_from_cache`) AND WP transport error
-    // envelope (`{ok:false, error:{code,message}}` from class-dailyos-
-    // runtime-client.php:393-509) and WP_Error from transport-layer
-    // failure.
+    // pure projection-to-HTML — no runtime call
 }
 ```
 
-`account_overview_preview` (at `class-dailyos-plugin.php:587-612`) is the
-ONLY caller that switches: it calls `project_composition_for_surface` once,
-then calls `dailyos_account_overview_render_from_projection` directly with
-the response (NOT `render_block_with_filter` → `dailyos_account_overview_render`).
-One preview = one runtime call.
+`account_overview_preview` calls `project_composition_for_surface` once, then
+calls `dailyos_account_overview_render_from_projection` directly (NOT
+`render_block_with_filter` → `dailyos_account_overview_render` which would
+re-call the runtime). One preview = one runtime call.
 
-The existing test fixtures at `AccountOverviewBlockTest.php` continue to
-call `dailyos_account_overview_render($attributes)` unchanged. They keep
-passing because the wrapper's behavior is unchanged for them.
+### 5.2 Editor reload guard (DOS-671 + DOS-672, shared)
 
-### 5.2 Editor reload guard (DOS-671 + DOS-672, shared) — V1.1 stale-closure-safe
+Replace `useEffect( () => reload(), [reload] )` at
+`wp/dailyos/blocks/account-overview/edit.js:84-86` with an explicit trigger
+that fires ONLY when:
+- `attributes.composition_id` transitions from empty to non-empty, OR
+- `attributes.account_id` changes,
+- but NOT when `composition_version` or `cache_hint_token` change.
 
-V1.0's approach (remove `composition_version` and `cache_hint_token` from
-the `reload` callback's dep list) was unsafe — `reload` reads those values
-when building the POST body (`edit.js:54-56`), so a manual reload after a
-successful render would send STALE version/token (codex challenge HIGH #2 +
-codex consult MEDIUM).
+The `reload` callback's dependency list at `:82` is also trimmed:
+- Remove `attributes.composition_version` and `attributes.cache_hint_token` from deps.
+- Reload reads them at call time via the latest `attributes` reference.
 
-**V1.1 keeps `reload`'s full dep list AND adds a separate trigger key for
-the useEffect:**
-
-```js
-const reload = useCallback(() => {
-    // ... existing body, reads composition_id, composition_version, cache_hint_token
-}, [attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes]);
-
-const reloadTrigger = `${attributes.account_id || ''}|${attributes.composition_id ? '1' : '0'}`;
-useEffect(() => {
-    reload();
-}, [reloadTrigger]);
-```
-
-- `reloadTrigger` is a derived string that changes ONLY when `account_id`
-  changes OR `composition_id` transitions empty↔non-empty.
-- Successful reload's `setAttributes` write of `composition_version` /
-  `watermarks` / `cache_hint_token` does NOT change `reloadTrigger` → no
-  auto-reload retrigger.
-- Manual button continues to use the live `reload` closure (always has
-  latest deps including version+token) — no stale POST body.
-
-**Gutenberg lifecycle enumeration** (code-reviewer F4):
-- **Expected to fire:** initial mount (React effect fires on first render
-  with current attributes); `account_id` change via account selector;
-  `composition_id` empty→non-empty transition (i.e., user picks an account
-  for the first time).
-- **Expected NOT to fire:** window focus (no remount, dep value unchanged);
-  autosave (no edit.js dep change); undo/redo that only flips
-  `cache_hint_token` or `composition_version` (those aren't in the trigger
-  key); block-list reorder remount (effect fires once on remount with the
-  current `reloadTrigger`, which equals the pre-reorder value — benign
-  no-op if `account_id` and `composition_id` are unchanged).
-
-**Failed-reload behavior:**
+Failed-reload behavior:
 - Preserve last-good `preview` state.
-- Show an `error` notice in the editor but do NOT replace rendered content
-  with the verification banner envelope.
+- Show an `error` notice in the editor but do NOT replace rendered content with the verification banner envelope.
 
-**ESLint suppression note (V1.1.1 per codex consult):** WP-side
-`wp-scripts lint-js` may emit `react-hooks/exhaustive-deps` warnings on
-`useEffect([reloadTrigger])` because `reload` is reachable from the body
-but not in the dep list. Two L1 implementer options, both architecturally
-correct:
-- Explicit ESLint disable comment with rationale (preferred for clarity):
-  ```js
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional:
-  // reload's identity is recomputed every render (full dep list); the
-  // auto-reload trigger gate is the derived reloadTrigger string. See
-  // L0 Packet B V1.1 §5.2.
-  useEffect(() => { reload(); }, [reloadTrigger]);
-  ```
-- OR set `react-hooks/exhaustive-deps` to `warn` not `error` at the WP
-  project level (root project already does this at `eslint.config.js:74`).
-
-### 5.3 Runtime cache-key correction — option (a) picked (V1.1)
+### 5.3 Runtime cache-key correction (DOS-671 + DOS-672)
 
 At `src-tauri/src/surface_runtime/mod.rs:2317-2321` and `:2425-2430`, the cache
 is keyed on the request's `composition_version` (which is the surface's stale
-watermark — every render misses the cache, forcing producer invocation).
+watermark). After the fix, cache is keyed on the **effective projection
+version** (the one the producer is about to emit or has just emitted), so
+repeated requests with stale watermarks all hit the same cache entry.
 
-**V1.1 picks option (a)** — cache key by current DB version. Codex consult
-cycle-1 recommended this on implementation grounds (option (b) requires a
-new orchestrator invalidation API that doesn't exist; option (a) uses the
-existing `current_composition_version_for_composition_id` reader).
+Two viable shapes — pick one in L0:
+- **(a)** Look up cache by `(actor, composition_id, current_db_version)`, not request version. Store by the projection's actual version (already fetched at `:2355-2370`).
+- **(b)** Cache becomes version-agnostic: lookup by `(actor, composition_id)`, invalidate when producer commits a new version.
 
-**Concrete implementation:**
+§12 Q1 picks between (a) and (b).
 
-1. Move the existing `current_composition_version_for_composition_id` read
-   (`mod.rs:2355-2370`) from "after cache miss, before producer invocation"
-   to "BEFORE cache lookup". This adds one `db_read` per warm-path render —
-   accepted trade-off for local-to-local (code-reviewer F5).
+### 5.4 Render-path producer-commit removal (DOS-671 — ARCHITECTURAL CHALLENGE)
 
-2. Cache lookup key becomes `(actor, composition_id, current_db_version,
-   scopes_canonical_id)` (the orchestrator's existing key shape with
-   `composition_version` replaced from `request.composition_version` to
-   `current_db_version`). Lookup at `mod.rs:2317-2321`.
+This is the contested change. Today at `surface_runtime/mod.rs:2348-2353`:
 
-3. Cache store key uses
-   `projection.composition_version.unwrap_or(current_db_version)`. Store
-   at `mod.rs:2425-2430`. `ProjectedComposition.composition_version` is
-   defined at `abilities-runtime/src/abilities/fallback_projection.rs:29-35`
-   and is set after producer invocation.
+> The producer always advances composition_version monotonically and commits unconditionally. The surface's previously-rendered version is structurally meaningless as an OCC token because the surface has no write path — only the producer mutates compositions. Forward the current substrate version on every render so the producer's commit step never trips its own watermark check on stale surface claims.
 
-4. The orchestrator's existing `(composition_id, composition_version,
-   scopes_canonical_id)` key tuple at
-   `composition_render_orchestrator.rs:51-56` is preserved — only the
-   value passed for `composition_version` changes.
+The local-to-local threat model says reads don't write to `surface_client_sessions`,
+audit tables, rate-limit buckets, **or any other DB state**. The composition
+table is "any other DB state" — and producer commit on every render writes to it.
 
-**Trade-off analysis** (code-reviewer F5):
-- V1.0 / current: warm-path is "zero DB-touch, cache hit" but ALSO "cache miss every time because key uses stale watermark".
-- V1.1 / option (a): warm-path is "one `db_read`, then cache hit". Net win: producer commits stop firing on every render.
-- Option (b) would preserve zero-DB-touch on warm path BUT requires net-new invalidation infrastructure (CSO recommended this; codex consult rejected on implementation cost). Deferred to v1.x-federation maintenance.
+The investigation proposes:
+- Render path reads existing projected state from cache or DB.
+- Producer commit happens ONLY on:
+  - Explicit user-initiated refresh (the editor's "Reload from runtime" button),
+  - Signal-propagation invalidation (a watermark moved upstream — `account_subject.claim_changed`, `claim.lifecycle`, etc).
+  - Initial composition creation (first request for a composition_id).
 
-**Race analysis:** between the new `current_db_version` read and the
-cache lookup, a concurrent commit could occur. For local single-runtime,
-producer invocations are serialized by the SurfaceClient bridge's writer
-mutex; there is effectively no concurrent commit race. For
-federation/multi-writer scenarios, this would need the invalidation API
-from option (b) — out of scope for v1.4.3.
+The producer's OCC-token issue that v1.4.2 W4-F was repairing (DOS-670 substrate-side fix) had a narrower scope: the producer's commit step needs the current DB version, not a stale surface watermark. That requirement is still satisfied if we only commit on triggers, not on every read.
 
-**"State movement" definition** (added V1.1.1 per codex challenge cycle-2
-LOW): "state movement" in this packet means `composition_versions` row
-advancement through `commit_composition`. Upstream claim/source movement
-(claim version, source freshness, account_subject signals) reaches this
-cache through the existing DOS-589 / W4-A0 recomposition contract:
-upstream signal → producer re-invocation by some path → producer commits
-new composition version → next render's `current_db_version` read returns
-the new value → cache lookup misses old key → producer runs (this time
-from the actual render path) → cache populated at new version → subsequent
-renders hit. The cache invalidation proof is exact for committed
-composition-version movement; pre-commit upstream movement is invisible to
-this cache by design (and that's correct — without a committed projection
-to serve, there's nothing to invalidate or refresh).
+**§12 Q2** is the explicit reviewer prompt for whether removing render-path
+commit breaks DOS-670's substrate fix.
 
-### 5.4 Render-path producer behavior — V1.1 reframe: producer commits preserved
+### 5.5 Render-read decharge from `standard_read_composition` budget (DOS-672)
 
-**V1.0 proposed removing producer commit from the render path.** V1.1
-withdraws that proposal. The reframe rationale is in §2 changelog V1.1:
-- `commit_composition` does not persist a reusable projection payload (only
-  `composition_versions` row + version event — `services/compositions.rs:271-368`).
-- Removing producer commit-on-render leaves nothing in the DB to project from
-  on cache miss.
-- The producer commit IS the materialization step; it cannot be removed
-  without inventing persistent projection storage (which would be substantial
-  net-new infrastructure, federation-scale).
+At `src-tauri/src/bridges/surface_client.rs:213`, the default budget is 60/min
++ burst 5. Even on a single user with one editor open, the auto-reload loop
+plus PHP double-fetch can exhaust the 5-burst within seconds.
 
-**The actual local fix is §5.3 — make the cache key effective.** Under V1.1:
-- Producer runs ONLY on cache miss (unchanged from today).
-- Cache misses become RARE once the cache key uses current_db_version
-  instead of the surface's stale watermark.
-- Under steady-state rendering with stable account state, all renders after
-  the first hit the cache → producer doesn't run → commit_composition doesn't
-  fire → no write flood.
-- Producer commits naturally fire when account state actually moves (signal
-  propagation triggers a new producer invocation through other paths, that
-  invocation commits a new version, which invalidates the cache via the
-  cache-key-by-current-db-version pattern).
+Two viable changes — pick one in L0:
+- **(a)** Local-render reads from `surface_client` actor on a paired loopback session are NOT gated by `standard_read_composition`. Authorization (scope check, actor allowlist) remains mandatory.
+- **(b)** The budget is raised significantly for local sessions (e.g. 600/min / burst 50), keeping the gate but sizing it for local.
 
-**The W4-F producer contract at `mod.rs:2348-2353` is preserved.** The
-comment's claim that "the producer always advances composition_version" stays
-true. The DOS-670 substrate-side fix (always forward current DB version to
-the producer) stays. Nothing about the producer's OCC contract changes.
-There is no architectural contest; V1.0's framing was wrong.
+§12 Q3 picks between (a) and (b).
 
-**What V1.1 §5.4 actually contains:** nothing net-new. The previous V1.0
-§5.4 "remove producer commit on render path" is withdrawn. The fix surface
-is entirely §5.3 (cache key correction). This section exists in V1.1 only to
-document the reframe rationale.
+### 5.6 Typed transport/session error mapping (DOS-672)
 
-**Removed in V1.1 (from V1.0):**
-- "Render path reads existing projected state from cache or DB" — DB doesn't have it; cache is the only read source, and cache-miss must invoke the producer.
-- "Producer commit happens ONLY on explicit refresh / signal-propagation / initial creation" — withdrawn. Producer commit happens on cache miss, which becomes rare once §5.3 lands.
-- The `§12 Q2` open question about "does removing render-path commit break the DOS-670 producer OCC contract" — moot; nothing is being removed.
-- The "L6 escalation trigger if CSO and codex challenge disagree on §5.4" — moot; no contested change remains.
+At `wp/dailyos/blocks/account-overview/render-functions.php:61-70`, ALL error
+states currently collapse into the verification banner (
+"Something about this account doesn't line up. Verify before acting.").
 
-### 5.5 Render-read decharge — V1.1: option (a) with `charge_ability_scope=false`
+The fix: distinguish at minimum:
+- `rate_limited` (HTTP 429) → "Runtime is throttling; retry shortly."
+- `session_requires_repair` (per W4-F error code) → "Surface session needs repair; reconnect."
+- `session_not_found` → same as repair.
+- `runtime_request_failed` (transport / timeout / 5xx) → "Runtime unavailable; retry."
+- consistency-failure (the actual case the banner was written for: projection inconsistency, contradicting evidence) → keep the verification banner.
 
-V1.1 picks option (a) (codex consult cycle-1 implementation guidance):
-local-render reads use a new `authorize_local_render` variant that calls
-`check_and_consume` with `charge_ability_scope=false`. Identity buckets
-(`surface_client`, `wp_user`, `wp_site`) continue to be consumed; ability
-bucket (`standard_read_composition`) and scope bucket (`scope.read`) are
-bypassed for paired-loopback local render reads.
-
-**Mandatory checks preserved** (codex consult evidence — `surface_client.rs:301-355`):
-- Descriptor exists (ability is registered).
-- Actor / mode / experimental gates.
-- Required scopes (the actor must have read.account_overview etc).
-- Browser-direct-executable guard.
-
-**Decharge contract — bypass scope:**
-- `charge_ability_scope=false` (codex consult evidence — `surface_client.rs:409`,
-  `:795-822`) skips the ability_class and scope candidates inside
-  `check_and_consume`.
-- Identity candidates (surface_client/wp_user/wp_site read budgets at
-  `:766-793`) are STILL consumed. These remain as a per-principal limit on
-  total local-render volume — DoS protection without blocking normal usage.
-
-**Acceptance: tighten-event emission omitted by construction** (code-reviewer
-F3 + CSO LOW):
-`RateLimitOutcome::Allowed.audit_events` carries `rate_limit_audit_event(...,
-"tightened", ...)` when a previously-rejected window enters early-retry
-tightening (`surface_client.rs:411-415`, `:742-752`). When ability/scope
-candidates are bypassed, no consumption happens for those candidates → no
-rejection possible for them → no tightening → no tightened-event emitted.
-This is internally consistent for local-to-local. V1.1 codifies this with
-AC #15 ("local-render decharge emits zero `rate_limit_audit_event` entries
-for the ability/scope bucket"). Maintenance ticket filed for operator
-observability of local-render volume.
-
-**Implementation shape (V1.1.1 — corrected type-shape per codex consult):**
-
-The existing substrate uses a **boolean** `charge_ability_scope` field
-(`surface_client.rs:642`), not an enum. V1.1's pseudo-code naming
-`ChargeAbilityScope::Off` was misleading; corrected:
-
-```rust
-// New variant — same descriptor/actor/mode/scope checks, then bypass-ability-scope rate-limit
-pub fn authorize_local_render(
-    &self,
-    registry: &AbilityRegistry,
-    validated: &SignedSessionContext,
-    ability_name: &str,
-    request_id: &str,
-) -> Result<Authorization, SurfaceClientBridgeError> {
-    self.authorize_for_path(
-        registry,
-        validated,
-        ability_name,
-        request_id,
-        false,  // charge_ability_scope — today hardcoded to true at :387/:409
-    )
-}
-```
-
-**Precedent:** there is already an identity-only helper at
-`surface_client.rs:936` that constructs requests with
-`charge_ability_scope=false`. V1.1.1's `authorize_local_render` follows
-the same pattern.
-
-Route handler at `surface_runtime/mod.rs:2288-2311` calls
-`authorize_local_render` instead of `authorize` for the `project_composition`
-read path. Other surface client routes continue to use `authorize`.
-
-### 5.6 Typed transport/session error mapping (DOS-672) — V1.1 envelope rewrite
-
-V1.0's error envelope shape was wrong. Per code-reviewer F2 + codex consult
-MEDIUM:
-- Runtime returns `{"error":{"code","message","request_id","remediation",...}}` (NOT top-level `{ok:false, code:...}`). HTTP status conveys success/failure. Defined at `src-tauri/src/surface_runtime/mod.rs:3514-3548`.
-- WP transport (`wp/dailyos/includes/transport/class-dailyos-runtime-client.php:393-509`) re-wraps non-2xx responses as `{ok:false, error:{code, message}}`.
-- Local transport failures (signing failure before request, `wp_remote_post` failure, JSON parse) produce `WP_Error` OR `{ok:false, error:{code, message}}` with codes like `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`.
-
-`session_requires_repair` is a `SurfacePairingError` variant
-(`surface_pairing.rs:277`) surfaced via `from_pairing_error`; there is NO
-dedicated `SurfaceHttpError::session_requires_repair()` constructor. Match
-by string on `error.code`.
-
-**V1.1 renderer mapping (replaces `render-functions.php:61-70` blanket banner):**
-
-```php
-// In dailyos_account_overview_render_from_projection(...)
-if ( is_wp_error( $response ) ) {
-    // Transport-layer failure (signing, network). No runtime envelope.
-    return dailyos_account_overview_render_runtime_unavailable_notice();
-}
-
-if ( isset( $response['ok'] ) && $response['ok'] === false ) {
-    $code = isset( $response['error']['code'] ) ? (string) $response['error']['code'] : 'runtime_request_failed';
-    switch ( $code ) {
-        case 'rate_limited':
-            return dailyos_account_overview_render_throttled_notice();
-        // Session-repair-shaped: user action needed to restore pairing/session.
-        case 'session_requires_repair':
-        case 'session_not_found':
-        case 'session_expired':
-        case 'session_throttled':
-        case 'identity_mismatch':
-        case 'wp_user_mismatch':
-        case 'pairing_code_invalid':
-        case 'pairing_code_expired':
-        case 'pairing_code_consumed':
-        case 'pairing_code_limited':
-        case 'pairing_suspended':
-        case 'pairing_revoked':
-        case 'pairing_expired':
-        case 'site_binding_mismatch':
-        case 'restored_stale_pairing':
-        case 'scope_denied':
-        case 'auth_missing':
-            return dailyos_account_overview_render_session_repair_notice();
-        // Runtime-unavailable: transient infrastructure problem; retry.
-        case 'runtime_unavailable':
-        case 'runtime_request_failed':
-        case 'runtime_invalid_json':
-        case 'runtime_http_error':
-        case 'host_invalid':
-        case 'browser_origin_forbidden':
-        case 'route_not_found':
-            return dailyos_account_overview_render_runtime_unavailable_notice();
-        // Renderer-input-invalid: defensive — the renderer or its caller
-        // produced something the runtime can't process. Operator
-        // notice; not a user-actionable retry.
-        case 'request_body_too_large':
-        case 'request_body_unreadable':
-        case 'handshake_body_invalid':
-        case 'session_refresh_body_invalid':
-        case 'surface_invoke_invalid':
-        case 'event_log_id_invalid':
-            return dailyos_account_overview_render_invalid_request_notice();
-        // Projection-consistency failures — verification banner correct.
-        case 'projection_tampered':
-        case 'projection_version_rollback':
-        case 'stale_composition_watermark':
-        case 'missing_expected_claim_version':
-        case 'mid_flight_mutation':
-            return dailyos_account_overview_render_verification_banner();
-        default:
-            // Unknown code: fail-safe to verification banner. Operator
-            // should add a typed mapping when a new code appears.
-            return dailyos_account_overview_render_verification_banner();
-    }
-}
-
-if ( ! isset( $response['projection'] ) || ! is_array( $response['projection'] ) ) {
-    // Successful response shape without projection — defensive fallback.
-    return dailyos_account_overview_render_verification_banner();
-}
-
-// Success path — render the projection.
-return dailyos_account_overview_render_projection_payload( $response, $attributes );
-```
-
-New helpers (small, local copy):
-- `dailyos_account_overview_render_throttled_notice()` — "Runtime is throttling; retry shortly."
-- `dailyos_account_overview_render_session_repair_notice()` — "Surface session needs repair; reconnect from DailyOS settings."
-- `dailyos_account_overview_render_runtime_unavailable_notice()` — "Runtime unavailable; retry."
-- `dailyos_account_overview_render_invalid_request_notice()` — "Editor sent a request the runtime couldn't process. Reload the editor."
-
-The verification banner stays reserved for genuine projection-consistency
-failures + unknown codes (fail-safe).
-
-**Note on `consistency_failure` (V1.1.1 per codex consult):**
-`consistency_failure` is not verified as an actively emitted runtime code
-in the current Rust surface. The 5 specific consistency codes in the
-verification-banner switch arm (`projection_tampered`,
-`projection_version_rollback`, `stale_composition_watermark`,
-`missing_expected_claim_version`, `mid_flight_mutation`) ARE emittable
-(`surface_runtime/mod.rs:3010-3049`). The renderer's fail-safe default
-arm catches any new consistency code added later — including a future
-`consistency_failure` if introduced.
+The PHP renderer needs a typed error shape from the runtime response (already
+present — runtime returns `{ ok: false, code: "...", ... }`); the renderer
+maps `code` → user-facing string. The verification banner is reserved for
+true consistency failures.
 
 ## 6. Directional decisions resolved at L0
 
@@ -721,22 +215,15 @@ attributes (`edit.js:62-68`); those are dependencies of `reload`
 with the 5/sec burst budget, this exhausts rate limits and produces the
 "reload-on-window-switch" symptom.
 
-### 6.4 V1.1: producer-commit-on-render is PRESERVED; the fix is cache effectiveness
+### 6.4 Removing render-path producer-commit is the right local-shaped fix — but is L0-CONTESTED
 
-V1.0 framed this as "the contested change" requiring L6 escalation. V1.1
-withdraws the contest entirely. Codex consult cycle-1 surfaced the key fact:
-`commit_composition` does not persist a reusable projection payload, so
-removing producer-commit-on-render breaks materialization. The producer
-commit IS the materialization step.
+The investigation argues for removal. v1.4.2 W4-F explicitly chose
+"always-forward DB version + producer commits unconditionally" as the
+DOS-670 substrate-side fix. The two appear to conflict.
 
-**Decision (V1.1):** producer commit on cache miss stays unchanged. The
-render-loop user-visible bug is fixed by §5.3 cache key correction, which
-causes cache hits to dominate → producer rarely runs → commit rarely fires.
-The W4-F producer contract at `mod.rs:2348-2353` is preserved. No
-architectural contest with v1.4.2 / W4-F remains. The DOS-670 producer-side
-OCC workaround is intact.
-
-**§12 Q2 RESOLVED** — moot; nothing is being removed.
+**§12 Q2** is the explicit L0 question for the reviewer panel: does the
+DOS-670 producer OCC contract require commit-on-render, or only
+commit-on-trigger?
 
 ### 6.5 Render-read decharge does not weaken authorization
 
@@ -756,95 +243,54 @@ its rendered state. No runtime contract change for this rule.
 
 ### DOS-671 (block content disappearance ≤30s)
 
-1. PHP preview makes exactly one `project_composition_for_surface` runtime call per preview request. `dailyos_account_overview_render` (the wrapper) keeps its single-fetch behavior for `render.php` + existing test fixtures.
-2. Editor `reload` callback's dep list keeps `[composition_id, composition_version, cache_hint_token, setAttributes]` — manual reload reads latest version+token, NO stale-closure risk.
-3. Editor `useEffect`-driven auto-reload fires ONLY when a separate derived `reloadTrigger` string changes — i.e., on `account_id` change OR `composition_id` empty↔non-empty transition. NOT when `composition_version` or `cache_hint_token` change.
-4. Successful reload's attribute write does NOT schedule another reload (the `reloadTrigger` value is unchanged).
-5. First-mount fires exactly ONE reload (initial materialization).
-6. Runtime `project_composition` cache lookup uses key `(actor, composition_id, current_db_version, scopes_canonical_id)` (NOT `request.composition_version`). Stale watermarks no longer cause cache misses.
-7. Runtime cache store uses `projection.composition_version.unwrap_or(current_db_version)` so the stored entry's version matches what the producer actually emitted.
-8. After initial render, the block remains visible for ≥60 seconds without further user action AND across two browser-window focus changes (the L4 user-visible target).
+1. PHP preview makes exactly one `project_composition_for_surface` runtime call per preview request.
+2. Editor `useEffect`-driven auto-reload fires ONLY on `composition_id` empty→non-empty or `account_id` change.
+3. Editor `reload` callback's dependency list does NOT include `composition_version` or `cache_hint_token`.
+4. Successful reload's attribute write does NOT schedule another reload.
+5. Runtime `project_composition` route does NOT commit a new composition on every render. Commit happens on: explicit refresh, signal-propagation invalidation, initial composition creation.
+6. Runtime cache lookup hits regardless of stale request `composition_version` (cache keyed on current DB version OR version-agnostic per §5.3 outcome).
+7. Local-render reads from paired-loopback `surface_client` sessions do NOT consume `standard_read_composition` rate budget (or budget is raised per §5.5 outcome).
+8. After initial render, the block remains visible for ≥60 seconds without further user action AND across two browser-window focus changes.
 
 ### DOS-672 (reload-on-window-switch + second-reload verification banner)
 
 9. Manual "Reload from runtime" fires exactly one preview request per click.
-10. Window-focus change does NOT trigger reload (no remount, no auto-reload retrigger).
+10. Window-focus change does NOT trigger reload (no remount).
 11. Second consecutive manual reload succeeds (returns projection, not banner) — assuming first reload succeeded.
 12. Failed reload (any cause) preserves last-good `preview` state in the editor.
 13. Failed reload surfaces an `error` notice; does NOT replace rendered content with verification-banner HTML.
-14. PHP renderer maps `error.code` via switch table (V1.1.1 expanded coverage): `rate_limited` → throttled notice; session-repair-shaped codes (`session_requires_repair`, `session_not_found`, `session_expired`, `session_throttled`, `identity_mismatch`, `wp_user_mismatch`, `pairing_*`, `site_binding_mismatch`, `restored_stale_pairing`, `scope_denied`, `auth_missing`) → session-repair notice; runtime-unavailable codes (`runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `host_invalid`, `browser_origin_forbidden`, `route_not_found`) → runtime-unavailable notice; renderer-input-invalid codes (`request_body_*`, `handshake_body_invalid`, `session_refresh_body_invalid`, `surface_invoke_invalid`, `event_log_id_invalid`) → invalid-request notice; projection-consistency codes (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`) → verification banner; unknown codes → verification banner (fail-safe).
-15. **Local-render decharge by construction:** `authorize_local_render` calls `check_and_consume` with `charge_ability_scope=false`. Ability/scope buckets (`standard_read_composition`, `scope.read`) are NOT consumed; identity buckets (`surface_client`, `wp_user`, `wp_site`) ARE consumed. As a direct consequence, the `RateLimitOutcome::Allowed.audit_events` "tightened" emission for ability/scope is OMITTED — no observability event for that bucket because no consumption happens.
-16. Auth/scope mandatory checks (descriptor, actor, mode, experimental, required scopes, browser-direct guard) are NOT bypassed; only rate-budget consumption for ability/scope changes.
+14. PHP renderer maps `rate_limited`, `session_requires_repair`, `session_not_found`, `runtime_request_failed` to distinct typed messages; verification banner reserved for true consistency-failure (projection contradiction / missing evidence).
+15. PHP preview response merge (`class-dailyos-plugin.php:613-618`) does NOT combine successful first-call projection with failed second-call banner HTML. After §5.1, there IS no second call.
 
 ## 8. Negative fixtures
 
-All fixtures use PHP test infrastructure (existing
-`tests/blocks/AccountOverviewBlockTest.php` pattern with fake-runtime-client
-injection) for editor-side behavior assertions — no net-new jest setup (code-reviewer F6).
-
 | # | Fixture | Asserts |
 |---|---|---|
-| 1 | `dos671_preview_single_fetch` | PHP test: preview REST route's fake runtime client receives exactly ONE `project_composition_for_surface` call per preview request (not two as today via `render_block_with_filter` re-entry) |
-| 2 | `dos671_wrapper_preserves_single_fetch` | PHP test: `dailyos_account_overview_render($attrs)` called by `render.php` triggers exactly one runtime call (regression guard for the wrapper) |
-| 3 | `dos671_editor_dep_array_literal` | PHP/grep gate: `edit.js` `reload` useCallback dep array literal contains `[attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes]` (manual reload reads latest) |
-| 4 | `dos671_editor_trigger_key_literal` | PHP/grep gate: `edit.js` defines `reloadTrigger` and `useEffect([reloadTrigger])` shape — trigger derived from account_id + composition_id-presence ONLY |
-| 5 | `dos671_first_mount_fires_one_reload` | PHP integration test simulating editor mount: exactly ONE reload request issued (initial materialization) |
-| 6 | `dos671_cache_key_uses_current_db_version` | Rust test: lookup with stale `request.composition_version=1` HITS cache when current_db_version=5 and prior render populated cache at version 5 |
-| 7 | `dos671_cache_hit_avoids_producer` | Rust test: cache hit returns projection WITHOUT invoking producer (verified by producer-invocation counter) |
-| 8 | `dos671_cache_miss_invokes_producer_and_commits` | Rust test: cache miss DOES invoke producer; producer commits a new version; cache is populated with the new version's projection (the materialization path is preserved) |
-| 9 | `dos671_local_render_no_ability_scope_consumption` | Rust test: tight `standard_read_composition` budget (1/min); 50 paired-loopback render reads do NOT fail with `rate_limited`; the ability_class bucket counter shows zero consumption |
-| 10 | `dos671_local_render_consumes_identity_buckets` | Rust test: paired-loopback render reads DO consume `surface_client_read` bucket (identity bucket still gated) |
-| 11 | `dos671_local_render_no_tighten_event` | Rust test: 100 paired-loopback render reads produce ZERO `rate_limit_audit_event` entries (ability/scope bucket bypassed → no rejection → no tightening) |
-| 12 | `dos672_manual_reload_single_request` | PHP integration test: simulated button click via REST → exactly one runtime call (not two) |
-| 13 | `dos672_failed_reload_preserves_last_good` | PHP integration test: first reload succeeds → preview HTML rendered; second reload fails (mocked error) → response body returns error notice + last-good preview HTML unchanged in the response shape |
-| 14 | `dos672_typed_error_mapping` | PHP test matrix (V1.1.1 expanded): per-arm grouping — throttled (`rate_limited`); session-repair (`session_requires_repair`, `session_not_found`, `session_expired`, `session_throttled`, `identity_mismatch`, `wp_user_mismatch`, `pairing_code_invalid`, `pairing_code_expired`, `pairing_code_consumed`, `pairing_code_limited`, `pairing_suspended`, `pairing_revoked`, `pairing_expired`, `site_binding_mismatch`, `restored_stale_pairing`, `scope_denied`, `auth_missing`); runtime-unavailable (`runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `host_invalid`, `browser_origin_forbidden`, `route_not_found`); invalid-request (`request_body_too_large`, `request_body_unreadable`, `handshake_body_invalid`, `session_refresh_body_invalid`, `surface_invoke_invalid`, `event_log_id_invalid`); verification banner (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`). Each emittable code → expected user-facing string per §5.6 table. |
-| 15 | `dos672_unknown_code_failsafe` | PHP test: runtime response `{ok:false, error:{code:'unknown_xyz'}}` → verification banner renders (fail-safe) |
-| 16 | `dos671_l4_hands_on_log` | Hands-on log captured: initial render → wait 60s → focus switch x2 → manual reload x2; content remains visible throughout (the user-visible L4 target) |
-| 17 | `dos672_authorize_local_render_enforces_scope` | Rust test (added V1.1.1 for AC #16): when validated session lacks `read.account_overview` scope, `authorize_local_render` rejects with `ScopeDenied`; proves `charge_ability_scope=false` only bypasses rate-budget consumption, NOT authorization gates. Negative-control fixture against the §5.5 decharge. |
-| 18 | `dos671_external_version_advance_invalidates_cache` | Rust test (added V1.1.1 per codex challenge LOW): seed cache at version N for composition_id X; advance current_db_version for X outside the render request (e.g., external producer commit via a different ability path); render with `request.composition_version=N` (stale watermark); assert (a) cache lookup misses the V1.1 key `(actor, X, N+, scopes)` because current_db_version is now N+; (b) producer path runs and commits the projection at version N+; (c) cache is stored at N+; (d) immediately-subsequent render hits the cache. Proof of the §5.4 reframe's invalidation claim end-to-end.
-
-### 8.1 AC → fixture / invariant mapping (added V1.1.1 per codex consult + code-reviewer)
-
-V1.1's "16 ACs ↔ 16 fixtures, 1:1" claim was overstated. Explicit mapping:
-
-| AC | Coverage |
-|---|---|
-| AC #1 (single-fetch — wrapper + preview) | Fixtures #1 (preview single-fetch) + #2 (wrapper preserves single-fetch). Two-fixture coverage because the AC has two clauses. |
-| AC #2 (`reload` callback dep list) | §9 CI invariant #2 (grep gate) — not a runtime fixture |
-| AC #3 (useEffect trigger key) | §9 CI invariant #3 (grep gate) |
-| AC #4 (success no-retrigger) | Inferred from fixture #5 (first-mount fires ONE reload + V1.1.1 ESLint suppression note ensures Gutenberg attribute writes don't refire). For explicit assertion, fixture #5 should also assert no second reload happens within N ms of the first success — fold into fixture #5 description for L1. |
-| AC #5 (first-mount fires one reload) | Fixture #5 |
-| AC #6 (cache lookup keyed by current_db_version) | Fixtures #6, #7, #8, #18 + §9 CI invariant #4 (grep gate) |
-| AC #7 (cache store uses projection.composition_version) | Fixture #8 |
-| AC #8 (60s visibility + 2 focus changes) | Fixture #16 (L4 hands-on) |
-| AC #9 (manual reload single request) | Fixture #12 |
-| AC #10 (window-focus no reload) | Covered in fixture #16 hands-on log. For explicit automated assertion, fold into a sub-step of fixture #5 or add as L1 hardening. |
-| AC #11 (second manual reload succeeds) | Covered implicitly by fixture #12's repeatable-call shape + fixture #16 hands-on log |
-| AC #12 (failed reload preserves last-good) | Fixture #13 (PHP integration test asserts response shape contains last-good HTML; the editor-side React state preservation is exercised via fixture #5's React harness if available, else proven in fixture #16 hands-on) |
-| AC #13 (failed reload surfaces error notice) | Fixture #13 |
-| AC #14 (typed error switch — full coverage) | Fixture #14 (V1.1.1-expanded code matrix) + fixture #15 (unknown-code fail-safe) |
-| AC #15 (decharge omits tighten-event) | Fixtures #9 (no `rate_limited` failure) + #11 (zero `rate_limit_audit_event` entries) |
-| AC #16 (auth/scope checks not bypassed) | Fixture #17 (V1.1.1 — `authorize_local_render` still rejects on scope denial) |
-
-Total: 18 fixtures (was 16) covering 16 ACs + 4 CI invariants (§9 #2/#3/#4 — grep-gate enforcement of ACs that aren't runtime-testable).
+| 1 | `dos671_preview_single_fetch` | PHP fake runtime returns projection on first call, asserts no second call happens during preview render |
+| 2 | `dos671_editor_no_reload_on_cache_token_change` | JS test with fake `apiFetch`: setAttributes({cache_hint_token: 'new'}) does NOT trigger a reload |
+| 3 | `dos671_editor_no_reload_on_version_change` | JS test with fake `apiFetch`: setAttributes({composition_version: 5}) does NOT trigger a reload |
+| 4 | `dos671_render_path_no_commit` | Rust test: 10 consecutive `project_composition` calls without external signal → no composition commit, no version advance |
+| 5 | `dos671_render_path_commits_on_trigger` | Rust test: signal propagation (`account_subject.claim_changed`) → next render commits new version |
+| 6 | `dos671_cache_hits_with_stale_request_version` | Rust test: lookup with request_version=1 hits cache populated by request_version=5 (or version-agnostic) |
+| 7 | `dos671_local_render_no_rate_consumption` | Rust test: tight `standard_read_composition` budget (1/min), 50 render reads from paired-loopback do NOT fail with `rate_limited` |
+| 8 | `dos672_manual_reload_single_request` | JS test: button click → exactly one `apiFetch` call |
+| 9 | `dos672_second_reload_returns_projection_not_banner` | PHP fake runtime returns projection on both calls; HTML output of second preview render contains block payload, NOT verification banner |
+| 10 | `dos672_failed_reload_preserves_last_good` | JS test: first reload succeeds → preview set; second reload fails (mocked error) → preview unchanged, error notice shown |
+| 11 | `dos672_typed_error_mapping` | PHP test: runtime response `{ok: false, code: "rate_limited"}` → user-facing string "Runtime is throttling..."; NOT the verification banner |
+| 12 | `dos672_verification_banner_reserved_for_consistency` | PHP test: runtime response `{ok: false, code: "consistency_failure"}` → verification banner DOES render |
+| 13 | `dos671_l4_hands_on_log` | Hands-on log captured: initial render → wait 60s → focus switch x2 → manual reload x2; content remains visible throughout |
 
 ## 9. CI invariants
 
 | # | Invariant | Enforcement |
 |---|---|---|
-| 1 | `account_overview_preview` calls `dailyos_account_overview_render_from_projection` directly; does NOT route the response back through `render_block_with_filter` → `dailyos_account_overview_render` | grep gate on `account_overview_preview` body |
-| 2 | Editor `reload` callback dep list keeps composition_id + composition_version + cache_hint_token + setAttributes (preserves manual-reload correctness) | grep gate on `edit.js` for the literal dep array shape (V1.1.1: regex MUST collapse whitespace inside brackets — current `edit.js:82` uses prettier-style spaces `[ x, y ]`. Implementer detail per code-reviewer F7 / cycle-2 note: use `\s*` between tokens, or normalize via a small AST parse step. Brittle literal-substring grep will fail.) |
-| 3 | Editor `useEffect` for auto-reload depends on `[reloadTrigger]` (NOT `[reload]`) | grep gate on `edit.js` (same whitespace tolerance as invariant #2) |
-| 4 | Runtime `project_composition` cache lookup is keyed by current_db_version (NOT request.composition_version) | grep gate on `mod.rs` cache_lookup call site — verify the version argument is the current_db_version variable |
-| 5 | Cache hit rate ≥ 95% under workload that varies `request.composition_version` but holds `composition_id` constant | Rust integration test in existing `rust.yml` workflow |
-| 6 | `authorize_local_render` uses `charge_ability_scope=false`; main `authorize` continues to use `true` | grep gate on `surface_client.rs` for both variants |
-| 7 | PHP error mapping uses the typed switch table in §5.6; verification banner is emitted ONLY from the consistency-failure branch + unknown-code fail-safe | grep gate on `render-functions.php` for `dailyos_account_overview_render_verification_banner` call sites — verify all callers are inside the consistency-failure switch arm or the unknown-code default arm |
-
-V1.0 invariant #4 ("Runtime `project_composition` handler does NOT call
-`commit_composition` on the steady-state read path") REMOVED in V1.1: the
-§5.4 reframe preserves producer-commit-on-cache-miss. The user-visible
-write-flood reduction comes from §5.3 (cache hits dominate), measurable by
-invariant #5 above.
+| 1 | `dailyos_account_overview_render` is called at most once per preview request | grep / lint: `account_overview_preview` body does not call `render_block_with_filter` for the block-render path; calls `dailyos_account_overview_render_from_projection` directly |
+| 2 | Editor `reload` callback dep list contains exactly `[attributes.composition_id, attributes.account_id, setAttributes]` | ESLint rule or test that asserts the dep array literal |
+| 3 | `useEffect` for auto-reload depends on a narrow trigger value, not `reload` | ESLint rule or test |
+| 4 | Runtime `project_composition` handler does NOT call `commit_composition` on the steady-state read path | grep / AST check on the read-path branch body — no `commit_composition` call without a `requires_commit` guard |
+| 5 | Projection cache key (effective shape per §5.3 outcome) is invariant under request_version changes | runtime test asserts cache hit rate ≥ 95% in a workload that varies request_version but holds composition_id constant |
+| 6 | Local-render read decharge: `standard_read_composition` budget is not consumed for paired-loopback render | runtime test with tight budget (already enumerated as fixture #7) |
+| 7 | PHP error mapping uses a typed code → string lookup table | grep for `dailyos_account_overview_render_verification_banner` outside the consistency-failure branch fails CI |
 
 ## 10. Interlocks
 
@@ -853,20 +299,19 @@ DOS-671 and DOS-672 share every file in scope (`edit.js`,
 `class-dailyos-runtime-client.php`, `surface_runtime/mod.rs`,
 `composition_render_orchestrator.rs`, `surface_client.rs`).
 
-**Landing shape (V1.1):** single v1.4.3 stabilization-B PR with four commit groups:
-1. PHP single-fetch refactor (§5.1) + typed error mapping (§5.6) — wraps the wrapper, adds the pure helper, adds the typed switch table.
-2. Editor reload guard + last-good preserve (§5.2) — reloadTrigger pattern, full reload dep list, Gutenberg lifecycle handling.
-3. Runtime cache-key correction (§5.3) — move current_db_version read upstream, switch lookup/store keys to current_db_version / projection.composition_version.
-4. Render-read decharge (§5.5) — new `authorize_local_render` variant, route handler switches.
-
-V1.0's commit group #4 "render-path producer-commit removal" REMOVED — the
-§5.4 reframe withdraws the architecturally contested change.
+**Landing shape:** single v1.4.3 stabilization-B PR with five commit groups:
+1. PHP single-fetch refactor (DOS-671 §5.1).
+2. Editor reload guard + last-good preserve (DOS-671 §5.2, DOS-672 §5.6 editor side).
+3. Runtime cache-key correction (DOS-671 §5.3).
+4. Render-path producer-commit removal (DOS-671 §5.4) — **the architecturally contested one**.
+5. Render-read decharge + typed error mapping (DOS-672 §5.5, §5.6 runtime side).
 
 Splitting this PR is NOT viable. Each fix in isolation produces false
 confidence: fix the editor without the PHP double-fetch and 50% of reloads
 still hang; fix PHP without the cache-key issue and the cache stays useless;
-etc. The investigation §"Coordination — Recommended Landing Shape" calls
-this out explicitly.
+fix the cache without removing render-path commit and you still write
+unnecessarily on read; etc. The investigation §"Coordination — Recommended
+Landing Shape" calls this out explicitly.
 
 **Cross-packet interlock:** Packet A (lifecycle hardening) and Packet B
 (render stabilization) touch `src-tauri/src/surface_runtime/mod.rs` but in
@@ -893,49 +338,15 @@ order; rebase cost is minimal.
   follow.
 - **Studio sandbox runtime discovery** (C3 in v1.4.3 project description).
   Distinct work track.
-- **Signal-propagation cache invalidation bus.** Cycle-1 CSO MEDIUM +
-  codex challenge MEDIUM — moot in V1.1 because §5.4 reframe preserves
-  producer-commit-on-cache-miss as the invalidation channel. Federation /
-  multi-writer deployments would benefit from an explicit invalidation API
-  on `composition_render_orchestrator`. Filed as v1.x-federation maintenance.
-- **Hostile co-resident WordPress plugin error-code fingerprinting.**
-  Cycle-1 codex challenge LOW — under same-UID local model, a co-resident
-  plugin with PHP execution already has ambient keychain/DB/loopback
-  access; finer error-code redaction would be remote-shape defense. Filed
-  as v1.x-federation maintenance ("Bounded error taxonomy for
-  multi-tenant / multi-plugin WordPress deployments").
-- **Render-volume audit signal for operator observability.** Cycle-1
-  code-reviewer F3 maintenance note — local-render-decharge volume
-  observability isn't security-load-bearing locally. Filed as v1.x
-  maintenance ("Local-render audit signal for operator observability").
-- **ESLint rule authoring for editor `useEffect` dep arrays.** Cycle-1
-  code-reviewer F7 — grep gates cover L0 closure; a proper ESLint rule is
-  maintenance.
-- **Persistent projection storage** (would enable producer-commit removal —
-  not v1.4.3 scope). Filed as v1.x-federation maintenance — substantial
-  new infrastructure, only beneficial when render-path mutation needs to
-  be strictly eliminated (federation / multi-writer).
-- **Hot-path performance budgeting** — cache hit rate ≥95% is the L0
-  invariant target; actual latency budgeting (warm-path p95, cold-path
-  p95) is operational tuning, not L0 scope.
 
-## 12. Open questions for L0 reviewers — all V1.0 questions RESOLVED in V1.1
+## 12. Open questions for L0 reviewers
 
-1. **V1.0 Q1 (cache key shape):** RESOLVED — V1.1 picks option (a), key by `current_db_version`. Codex consult cycle-1 recommended on implementation grounds; CSO recommended (b) but that requires net-new invalidation API filed to maintenance.
-2. **V1.0 Q2 (producer-commit removal vs DOS-670):** RESOLVED — moot. V1.1 withdraws the proposed removal. Producer commit stays on cache miss; the user-visible write reduction comes from §5.3 cache effectiveness.
-3. **V1.0 Q3 (render-read decharge shape):** RESOLVED — V1.1 picks option (a) with `charge_ability_scope=false`. Identity buckets still charge; ability/scope buckets bypassed.
-4. **V1.0 Q4 (30s disappearance reproduction):** Partially RESOLVED — the L4 fixture #16 captures the user-visible target. Concrete timing-chain reproduction script can be authored during implementation as part of the L1 self-validation; not L0 closure-blocking.
-5. **V1.0 Q5 (typed error fingerprinting):** RESOLVED — same-UID local model; deferred to v1.x-federation maintenance per §11.
-6. **V1.0 Q6 (explicit refresh trigger surface):** RESOLVED — moot, since V1.1 doesn't require distinguishing "explicit refresh" from "render read". All triggers route through the same `project_composition` route; cache key determines whether producer runs.
-
-### New open questions for V1.1 cycle 2
-
-V1.1 has no new open questions — all cycle-1 findings folded with explicit
-disposition (FOLD / DEFER / REJECT). Cycle 2 reviewers should validate that:
-- The §5.4 reframe (producer commit preserved) correctly resolves the cycle-1 BLOCK without reintroducing the user-visible loop.
-- The §5.3 option (a) implementation correctly avoids the cache-miss-on-stale-watermark loop.
-- The §5.2 reloadTrigger pattern + full reload dep list correctly resolves the stale-closure risk.
-- The §5.6 envelope rewrite matches the actual two-channel error surface (WP_Error from transport, runtime envelope from non-2xx).
+1. **(For codex consult + code-reviewer):** Cache key shape per §5.3 — (a) key on `current_db_version` (lookup races: between current_db_version read and cache_lookup, producer could commit) vs (b) version-agnostic key with explicit invalidation on commit. Pick one with implementation cost + correctness analysis.
+2. **(For CSO + codex challenge):** Removing render-path producer-commit per §5.4 — does this break the DOS-670 substrate-side OCC contract that v1.4.2 W4-F shipped? Specifically: when the producer commits on EXPLICIT refresh, can the surface still receive a projection that reflects the committed version, or does the commit-then-read window introduce a new race?
+3. **(For code-reviewer + codex consult):** Render-read decharge per §5.5 — (a) bypass `standard_read_composition` for paired-loopback render entirely vs (b) raise the budget significantly. Pick one.
+4. **(For codex challenge):** The investigation says "30s disappearance" is "the 30s signed-post timeout plus retrigger". Can codex propose a concrete reproduction script that confirms the timing chain end-to-end (browser DevTools network + Tauri audit log)?
+5. **(For CSO):** Typed error mapping per §5.6 — does exposing distinct error codes (`rate_limited`, `session_requires_repair`, etc) to the WP-side give an attacker a fingerprinting channel? Local-to-local says yes-because-WP-is-trusted, but please verify against any threat model that contemplates a hostile WP plugin co-resident on the same machine.
+6. **(For codex consult):** What's the actual user-trigger surface for "explicit refresh"? Today the editor has a button (`reload`); is there also a Gutenberg context that auto-saves, and does auto-save count as explicit refresh?
 
 ## 13. Linear dependency edges
 
@@ -946,37 +357,32 @@ disposition (FOLD / DEFER / REJECT). Cycle 2 reviewers should validate that:
 
 ## 14. L0 reviewer panel — required runners
 
-| Reviewer | Mode | V1.1 cycle-2 focus |
+| Reviewer | Mode | Why |
 |---|---|---|
-| `/codex challenge` | adversarial | Re-verify the §5.4 reframe (producer commit preserved + cache effectiveness fix). Is there a scenario where the §5.3 option (a) cache fails to invalidate when state actually moves? Stress the stale-closure resolution in §5.2 — is `reloadTrigger`'s derived-string pattern actually stable across React's render cycle? Confirm the V1.1 deferrals are correctly classified as remote/federation, not local-shipping. |
-| `code-reviewer` (claude) | domain | Verify §5.1 wrapper preservation against the 6 existing test fixtures. Verify the §5.6 typed-error switch table is exhaustive against existing runtime error codes. Verify the §9 grep gates are enforceable. |
-| `/codex consult` | implementation feasibility | Walk the §5.3 option (a) implementation through `composition_render_orchestrator::cache_lookup` / `cache_store` and `mod.rs:2317-2430`. Verify §5.5 `authorize_local_render` plumbing through `authorize_for_path` with the new flag. Verify the §5.6 PHP switch table compiles cleanly with the existing renderer error helpers. |
-| `/cso` | **mandatory** | Confirm the §5.4 reframe preserves the W4-F producer contract without weakening any trust boundary. Specifically: (a) cache-key-by-current-db-version still requires authorization BEFORE lookup (same as today); (b) `charge_ability_scope=false` decharge does NOT bypass scope check or authorization; (c) the typed error mapping does not expose any new attack vector under same-UID local model. |
+| `/codex challenge` | adversarial | Specifically: stress the producer-commit-removal claim. Construct a scenario where the cache returns a projection that doesn't match the substrate's current state because the producer hasn't run yet. Stress the cache-key change for stale-version + concurrent commit races. |
+| `code-reviewer` (claude) | domain | The render route is the hottest path in the system. Independent read by the domain reviewer catches places where the fix shape conflicts with existing patterns (request-id propagation, audit emission, error envelope shape, http status code semantics). |
+| `/codex consult` | implementation feasibility | Walk the proposed single-fetch refactor through every existing caller of `dailyos_account_overview_render` (block render path, REST preview, any new caller v1.4.3+ might introduce); confirm no behavioral break. |
+| `/cso` | **mandatory** | Render-path authorization (must NOT be bypassed), rate-budget consumption semantics (the decharge is policy-load-bearing), producer-commit semantics (write-on-read removal touches the substrate's trust-of-its-own-version invariant), and typed-error-mapping (fingerprinting risk vs operability). Every one of these is trust-boundary. |
 
 **Convergence rule:** unanimous APPROVE required before code lands. Any reviewer
-returning CONDITIONAL APPROVE → fold finding into V1.2 (or maintenance backlog
-if remote-shape) and re-run all four reviewers. Cycle cap: 3 cycles before
-escalation to L6.
+returning CONDITIONAL APPROVE → fold finding into V2 of this packet, re-run all
+four reviewers. Cycle cap: 3 cycles before escalation to L6.
 
-**Cycle 2 special handling for codex challenge:** if codex challenge re-flags
-the V1.1 deferred items as local-blocking, the deferral classification must
-be re-examined — but the L0 reviewer panel is not allowed to overturn a
-Path-α trim that aligns with the v1.4.2 explicit threat-model commitment.
-Persistent disagreement → L6 (James) decides. The §5.4 architecturally
-contested-change L6 trigger from V1.0 is removed in V1.1 since the contested
-change is withdrawn.
+**Specific L6 trigger:** if CSO and codex challenge disagree on §5.4 (render-path
+producer-commit removal), escalate to L6 immediately. This is the contested
+architectural call, and the v1.4.2 W4-F authors deliberately chose the current
+shape. James decides.
 
 ## 15. Acceptance for L0 closure
 
-- [ ] All 4 reviewers returned APPROVE (cycle 2 or later — V1.1.1 cycle-2 text fixes folded inline).
-- [ ] All 16 acceptance criteria (§7) testable; coverage mapped to §8 fixtures (18) + §9 CI invariants per §8.1 mapping table.
-- [ ] All 7 CI invariants (§9 V1.1.1) have concrete grep/AST/runtime enforcement.
-- [ ] All §12 V1.0 open questions resolved in V1.1 (6/6 — see §12).
-- [ ] §5.3 cache key shape picked: option (a) — current_db_version key.
-- [ ] §5.5 render-read decharge approach picked: option (a) — `charge_ability_scope=false` boolean.
-- [ ] §5.4 producer-commit-removal WITHDRAWN — no architectural contest remains.
-- [ ] V1.1 deferred items filed as Linear maintenance tickets under project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb` (DailyOS Maintenance & Production Quality). 6 deferral ticket titles in §2 V1.1 changelog.
-- [ ] Landing shape (§10) confirmed: single PR with 4 commit groups (was 5; removed the producer-commit-removal group), no split.
+- [ ] All 4 reviewers returned APPROVE.
+- [ ] All 15 acceptance criteria (§7) are testable; per-criterion fixture mapped (§8 has 13 — gap analysis in cycle 1).
+- [ ] All 7 CI invariants (§9) have concrete grep/AST/runtime enforcement.
+- [ ] All §12 open questions resolved.
+- [ ] §5.4 producer-commit-removal explicitly approved by CSO (not just non-blocking).
+- [ ] §5.3 cache key shape picked (a or b) with implementation rationale recorded.
+- [ ] §5.5 render-read decharge approach picked (a or b) with implementation rationale recorded.
+- [ ] Landing shape (§10) confirmed: single PR with 5 commit groups, no split.
 - [ ] No outstanding L0-cycle findings; packet is implementation-ready.
 
 When all nine boxes check, L0 is closed and implementation begins. L1 (self)

--- a/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
+++ b/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md
@@ -1,6 +1,6 @@
 # L0 Packet B — WP preview/runtime render stabilization
 
-**Current revision: V1.0 (initial draft, 2026-05-17). See §2 Changelog.**
+**Current revision: V1.1 (cycle-1 fold + key reframing, 2026-05-17). See §2 Changelog.**
 
 ## 1. Header
 
@@ -21,24 +21,172 @@ Primary code:
 - `src-tauri/src/bridges/surface_client.rs`
 Primary anchor: `.docs/plans/dos-546/v1.4.2-project/01-project-description.md` §"Threat model: local-to-local"
 Diagnostic anchor: `.docs/plans/v1.4.3-wp-foundation/stabilization-investigation.md`
-Architectural anchor (CHALLENGED): `src-tauri/src/surface_runtime/mod.rs:2348-2353` — the v1.4.2 "producer always advances composition_version monotonically and commits unconditionally" comment.
 
 This packet covers two confirmed defects in the WP editor → preview → runtime
 render path surfaced by v1.4.2 W4-F L4 hands-on (PR #298 merged
 2026-05-17). Both root causes are confirmed in code (not session TTL — the
 investigation explicitly rejects that framing).
 
-This packet challenges one architectural decision from v1.4.2 W4-F: the
-"always advance composition_version on render" pattern at `surface_runtime/mod.rs:2348`.
-That pattern violates the local-to-local read contract (reads don't write).
-The L0 reviewers — particularly CSO — MUST evaluate whether removing it
-breaks the producer's OCC invariant that v1.4.2 was repairing.
+**Intelligence Loop integration check — exempt.** No claim/table/surface
+added; no provenance/trust impact; no signal change; no runtime context
+surface consumes new state; no feedback loop change. Purely render-path
+operational hardening on existing primitives. CLAUDE.md §"Critical Rules —
+Intelligence Loop integration check" does not apply. (Acknowledgement: the
+v1.4.3 fix preserves signal-propagation triggers for the producer — see
+§5.4 V1.1; nothing about the existing producer/projection/renderer contract
+changes.)
 
 This packet is intentionally narrow. It does NOT include the keychain +
 lifecycle hardening (DOS-673/674/675) — that is L0 Packet A, separate review
 track, separate PR.
 
 ## 2. Changelog
+
+- **V1.1 (2026-05-17, cycle-1 fold + key reframing):** Cycle-1 verdicts:
+  codex challenge BLOCK, CSO CA, code-reviewer CA, codex consult CA. The
+  BLOCK was justified — V1.0 misdiagnosed the §5.4 fix. Key insight from
+  codex consult HIGH #2: **`commit_composition` does not persist a reusable
+  composition payload; it only updates `composition_versions` row + emits a
+  version event.** Removing producer commit-on-render leaves nothing in the
+  DB to project from on cache miss. The producer commit IS the
+  materialization step — it cannot be removed without inventing persistent
+  projection storage.
+
+  The actual local fix: **make the cache key effective (option a) so cache
+  HITS dominate**. Producer runs only on true cache miss; under steady-state
+  rendering, producer runs rarely; commit_composition fires rarely; no write
+  flood. The render-loop symptom comes from the cache key using the surface's
+  stale watermark (`request.composition_version`), which guarantees a cache
+  miss on every render and re-invokes the producer every time.
+
+  V1.1 trims §5.4 from "remove producer commit" to "fix the cache key so
+  producer runs only when needed". The architecturally contested removal is
+  withdrawn; the substrate's W4-F producer contract is unchanged. CSO + codex
+  challenge cycle-1 concerns about signal-propagation invalidation become
+  moot — signal-driven producer invocations still commit and naturally
+  populate the cache for the next render.
+
+  - **FOLDED (real local issues):**
+    - **§5.4 reframed** — producer commit STAYS on cache miss; the fix is
+      cache key correction (§5.3), not commit removal. The §5.4 "remove
+      render-path producer-commit" architecturally contested change is
+      withdrawn. The W4-F producer contract at `mod.rs:2348-2353` is left
+      intact; the comment's claim that "the producer always advances
+      composition_version" remains true (it just runs less often now).
+    - **§5.3 picks option (a)** — cache key `(actor, composition_id,
+      current_db_version, scopes_canonical_id)`. Codex consult cycle-1
+      recommended (a) on implementation grounds (option (b) requires a new
+      invalidation API on the orchestrator that doesn't exist). Move
+      `current_composition_version_for_composition_id` read BEFORE cache
+      lookup. Trade-off: +1 `db_read` per warm-path render — acceptable for
+      local-to-local (code-reviewer F5). Store cache by
+      `projection.composition_version.unwrap_or(current_db_version)`.
+    - **§5.2 stale-closure fix** — keep `reload` callback's full dep list
+      (`[composition_id, composition_version, cache_hint_token,
+      setAttributes]` — preserves manual-reload correctness per codex
+      challenge HIGH #2 + codex consult MEDIUM). Add a separate effect
+      trigger:
+      ```js
+      const reloadTrigger = `${attributes.account_id}|${attributes.composition_id ? '1' : '0'}`;
+      useEffect(() => { reload(); }, [reloadTrigger]);
+      ```
+      The trigger key changes only when account_id or composition_id-presence
+      changes — NOT when version+token change. Manual button keeps using the
+      live `reload` closure (latest deps). No stale-closure risk; no
+      auto-reload loop.
+    - **§5.2 Gutenberg lifecycle enumeration** (code-reviewer F4) —
+      expected-fire: initial mount, account_id change, composition_id
+      empty→non-empty transition. Expected-not-fire: window focus, autosave,
+      undo of cache_hint_token write, block-list reorder remount (which
+      fires the effect with current attributes once — benign). Add positive
+      fixture "first-mount fires exactly one reload" alongside the negative
+      fixtures.
+    - **§5.1 wrapper preservation** (code-reviewer F1) — `dailyos_account_overview_render`
+      retains its single-fetch contract for the block.json front-end render
+      path (`wp/dailyos/blocks/account-overview/render.php:20-25`) and the 6
+      test fixtures (`tests/blocks/AccountOverviewBlockTest.php` at lines 52,
+      61, 96, 131, 169, 189). The new pure helper
+      `dailyos_account_overview_render_from_projection($response, $attributes)`
+      is called ONLY by `account_overview_preview`, replacing the
+      `render_block_with_filter` re-entry that caused the double-fetch.
+    - **§5.6 error envelope rewrite** (code-reviewer F2 + codex consult
+      MEDIUM) — runtime returns `{"error":{"code","message","request_id",...}}`
+      NOT top-level `{ok:false, code:...}`. PHP transport
+      (`class-dailyos-runtime-client.php:393-509`) re-wraps non-2xx as
+      `{ok:false, error:{code, message}}`. Renderer's mapping table reworked
+      against this two-channel surface (WP_Error from transport-layer failure
+      vs runtime envelope from non-2xx). Match `error.code` by string —
+      `session_requires_repair` is a `SurfacePairingError` variant
+      (`surface_pairing.rs:277`) surfaced via `from_pairing_error`, not a
+      dedicated `SurfaceHttpError` constructor.
+    - **§5.5 narrow to `charge_ability_scope=false`** (codex consult MEDIUM
+      + code-reviewer F3 + CSO LOW) — add an `authorize_local_render`
+      variant of `authorize` that passes `charge_ability_scope=false` to
+      `check_and_consume`. Identity buckets (surface_client, wp_user,
+      wp_site) continue to be consumed; ability bucket
+      (`standard_read_composition`) and scope bucket (`scope.read`) are
+      bypassed. Authorization (descriptor, actor, mode, scope check,
+      browser-direct-executable guard) remains mandatory. AC explicitly
+      states "local-render decharge omits the
+      `RateLimitOutcome::Allowed.audit_events` tighten-event emission by
+      construction" (code-reviewer F3 acceptance).
+    - **§8 JS fixtures → PHP equivalents** (code-reviewer F6) — switch
+      fixtures #2, #3, #8, #10 to PHP integration tests against the existing
+      fake-runtime-client pattern at `tests/blocks/AccountOverviewBlockTest.php`.
+      Assertions: request count to runtime, payload shape, post-render HTML
+      shape. Avoids adding wp-scripts jest setup as net-new infrastructure.
+    - **§9 grep gates instead of ESLint rules** (code-reviewer F7) —
+      replace ESLint rule invariants #2 and #3 with grep gates on
+      `edit.js` (literal dep array shape + literal trigger key shape).
+      ESLint authoring filed to maintenance.
+    - **§5.4 framing narrowed** (code-reviewer F9) — the contested anchor
+      at `mod.rs:2348-2353` is a DOS-670 producer-side OCC workaround, NOT
+      a v1.4.2 W4-F V3.2 contract. The reframed V1.1 §5.4 (cache fix, not
+      commit removal) doesn't contest either; the substrate keeps its
+      always-forward-version behavior, just running less often. Removed the
+      "L6 trigger" prose from §14 since the §5.4 reframe eliminates the
+      contested decision.
+  - **DEFERRED to v1.x-federation maintenance:**
+    - **Signal-propagation cache invalidation bus** (CSO MEDIUM + codex
+      challenge MEDIUM cycle-1): moot in V1.1 because §5.4 reframed keeps
+      producer commits as the invalidation channel. Federation/multi-writer
+      scenarios where producer commits can occur from non-local sources
+      would benefit from an explicit invalidation API; v1.4.3 local-single-
+      runtime doesn't need it. **Maintenance ticket title:** "Signal-driven
+      cache invalidation API for composition_render_orchestrator (federation
+      scope)".
+    - **Hostile co-resident plugin error-code fingerprinting** (codex
+      challenge LOW cycle-1): the WP plugin is a trusted same-UID surface
+      principal in v1.4.3 local-to-local. A hostile co-resident plugin with
+      PHP execution already has ambient keychain/DB/loopback access. Finer
+      error-code redaction would be remote-shape defense. Filed as
+      maintenance ticket "Bounded error taxonomy for multi-tenant /
+      multi-plugin WordPress deployments".
+    - **Render-volume audit signal** (code-reviewer F3 maintenance note):
+      operator observability for local-render-decharge volume tracking
+      isn't security-load-bearing locally. Filed as maintenance ticket
+      "Local-render audit signal for operator observability".
+    - **ESLint rule authoring** for editor `useEffect` dep arrays
+      (code-reviewer F7): grep gates cover L0 closure; proper ESLint rule
+      is maintenance.
+
+  - **REJECTED (not findings against V1.1):**
+    - Codex challenge cycle-1 HIGH #1 "no replacement materialization
+      path" — moot because V1.1 doesn't remove the materialization path.
+    - Codex challenge cycle-1 MEDIUM "cache option (b) needs invalidation
+      bus" — moot because V1.1 picks option (a).
+    - V1.0 §12 Q1, Q2, Q3 — all resolved by the V1.1 reframe / picks.
+
+  - **NET V1.1 RESULT:** packet acceptance criteria count: 16 (was 15;
+    +1 for the decharge tighten-event acceptance, +1 for first-mount fixture,
+    -1 because AC #15 "merge no longer combines" becomes tautological after
+    §5.1). Fixtures: 14 (was 13; +1 first-mount-fires-once,
+    JS-to-PHP equivalents add no count change). §5.4 collapses from 5
+    architecturally contested sub-bullets to "preserved unchanged from W4-F";
+    the §5.4 architectural-contest section is replaced with "no architectural
+    contest". The CORE remains: single-fetch PHP, editor reload guard,
+    effective cache key, decharge for local render, typed error mapping. That
+    CORE is the right local fix for the user-visible render-loop bug.
 
 - **V1.0 (2026-05-17):** Initial L0 draft. Authored from
   `stabilization-investigation.md` plus direct verification of the cited
@@ -82,109 +230,315 @@ introduced; every change is an in-place modification of existing functions:
 
 ## 5. What this packet authors net-new
 
-### 5.1 Single-fetch PHP preview (DOS-671 + DOS-672, shared)
+### 5.1 Single-fetch PHP preview (DOS-671 + DOS-672) — V1.1 wrapper preservation
 
-Refactor `dailyos_account_overview_render` so the runtime call is **optional**:
+V1.0's framing made the wrapper "optional" — code-reviewer F1 caught this is
+wrong. `dailyos_account_overview_render` has TWO production callers (not
+just the preview route):
+1. `wp/dailyos/blocks/account-overview/render.php:20-25` — block.json
+   front-end render path. This MUST keep the single-fetch behavior (one
+   runtime call per render request).
+2. `wp/dailyos/includes/class-dailyos-plugin.php:587-612` — preview REST
+   route. THIS is where the double-fetch happens (preview-endpoint calls
+   runtime, then re-enters `dailyos_account_overview_render` via
+   `render_block_with_filter` at `:682-690`, causing a second runtime call).
+
+Plus 6 test fixtures at `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php`
+(lines 52, 61, 96, 131, 169, 189) that call `dailyos_account_overview_render`
+directly and rely on the single-fetch wrapper behavior.
+
+**V1.1 refactor preserves the wrapper, adds a pure helper:**
 
 ```php
 function dailyos_account_overview_render( array $attributes ): string {
-    // ... validation as today ...
+    // Existing wrapper — unchanged behavior for render.php + 6 test fixtures.
+    // Validates composition_id, fetches runtime client, calls
+    // project_composition_for_surface once, delegates to
+    // dailyos_account_overview_render_from_projection.
     $response = dailyos_account_overview_fetch_projection( $attributes );
     return dailyos_account_overview_render_from_projection( $response, $attributes );
 }
 
 function dailyos_account_overview_render_from_projection( $response, $attributes ): string {
-    // pure projection-to-HTML — no runtime call
+    // Pure projection-to-HTML — no runtime call.
+    // Accepts both runtime success envelope (top-level `projection`,
+    // `cache_hint_token`, `served_from_cache`) AND WP transport error
+    // envelope (`{ok:false, error:{code,message}}` from class-dailyos-
+    // runtime-client.php:393-509) and WP_Error from transport-layer
+    // failure.
 }
 ```
 
-`account_overview_preview` calls `project_composition_for_surface` once, then
-calls `dailyos_account_overview_render_from_projection` directly (NOT
-`render_block_with_filter` → `dailyos_account_overview_render` which would
-re-call the runtime). One preview = one runtime call.
+`account_overview_preview` (at `class-dailyos-plugin.php:587-612`) is the
+ONLY caller that switches: it calls `project_composition_for_surface` once,
+then calls `dailyos_account_overview_render_from_projection` directly with
+the response (NOT `render_block_with_filter` → `dailyos_account_overview_render`).
+One preview = one runtime call.
 
-### 5.2 Editor reload guard (DOS-671 + DOS-672, shared)
+The existing test fixtures at `AccountOverviewBlockTest.php` continue to
+call `dailyos_account_overview_render($attributes)` unchanged. They keep
+passing because the wrapper's behavior is unchanged for them.
 
-Replace `useEffect( () => reload(), [reload] )` at
-`wp/dailyos/blocks/account-overview/edit.js:84-86` with an explicit trigger
-that fires ONLY when:
-- `attributes.composition_id` transitions from empty to non-empty, OR
-- `attributes.account_id` changes,
-- but NOT when `composition_version` or `cache_hint_token` change.
+### 5.2 Editor reload guard (DOS-671 + DOS-672, shared) — V1.1 stale-closure-safe
 
-The `reload` callback's dependency list at `:82` is also trimmed:
-- Remove `attributes.composition_version` and `attributes.cache_hint_token` from deps.
-- Reload reads them at call time via the latest `attributes` reference.
+V1.0's approach (remove `composition_version` and `cache_hint_token` from
+the `reload` callback's dep list) was unsafe — `reload` reads those values
+when building the POST body (`edit.js:54-56`), so a manual reload after a
+successful render would send STALE version/token (codex challenge HIGH #2 +
+codex consult MEDIUM).
 
-Failed-reload behavior:
+**V1.1 keeps `reload`'s full dep list AND adds a separate trigger key for
+the useEffect:**
+
+```js
+const reload = useCallback(() => {
+    // ... existing body, reads composition_id, composition_version, cache_hint_token
+}, [attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes]);
+
+const reloadTrigger = `${attributes.account_id || ''}|${attributes.composition_id ? '1' : '0'}`;
+useEffect(() => {
+    reload();
+}, [reloadTrigger]);
+```
+
+- `reloadTrigger` is a derived string that changes ONLY when `account_id`
+  changes OR `composition_id` transitions empty↔non-empty.
+- Successful reload's `setAttributes` write of `composition_version` /
+  `watermarks` / `cache_hint_token` does NOT change `reloadTrigger` → no
+  auto-reload retrigger.
+- Manual button continues to use the live `reload` closure (always has
+  latest deps including version+token) — no stale POST body.
+
+**Gutenberg lifecycle enumeration** (code-reviewer F4):
+- **Expected to fire:** initial mount (React effect fires on first render
+  with current attributes); `account_id` change via account selector;
+  `composition_id` empty→non-empty transition (i.e., user picks an account
+  for the first time).
+- **Expected NOT to fire:** window focus (no remount, dep value unchanged);
+  autosave (no edit.js dep change); undo/redo that only flips
+  `cache_hint_token` or `composition_version` (those aren't in the trigger
+  key); block-list reorder remount (effect fires once on remount with the
+  current `reloadTrigger`, which equals the pre-reorder value — benign
+  no-op if `account_id` and `composition_id` are unchanged).
+
+**Failed-reload behavior:**
 - Preserve last-good `preview` state.
-- Show an `error` notice in the editor but do NOT replace rendered content with the verification banner envelope.
+- Show an `error` notice in the editor but do NOT replace rendered content
+  with the verification banner envelope.
 
-### 5.3 Runtime cache-key correction (DOS-671 + DOS-672)
+### 5.3 Runtime cache-key correction — option (a) picked (V1.1)
 
 At `src-tauri/src/surface_runtime/mod.rs:2317-2321` and `:2425-2430`, the cache
 is keyed on the request's `composition_version` (which is the surface's stale
-watermark). After the fix, cache is keyed on the **effective projection
-version** (the one the producer is about to emit or has just emitted), so
-repeated requests with stale watermarks all hit the same cache entry.
+watermark — every render misses the cache, forcing producer invocation).
 
-Two viable shapes — pick one in L0:
-- **(a)** Look up cache by `(actor, composition_id, current_db_version)`, not request version. Store by the projection's actual version (already fetched at `:2355-2370`).
-- **(b)** Cache becomes version-agnostic: lookup by `(actor, composition_id)`, invalidate when producer commits a new version.
+**V1.1 picks option (a)** — cache key by current DB version. Codex consult
+cycle-1 recommended this on implementation grounds (option (b) requires a
+new orchestrator invalidation API that doesn't exist; option (a) uses the
+existing `current_composition_version_for_composition_id` reader).
 
-§12 Q1 picks between (a) and (b).
+**Concrete implementation:**
 
-### 5.4 Render-path producer-commit removal (DOS-671 — ARCHITECTURAL CHALLENGE)
+1. Move the existing `current_composition_version_for_composition_id` read
+   (`mod.rs:2355-2370`) from "after cache miss, before producer invocation"
+   to "BEFORE cache lookup". This adds one `db_read` per warm-path render —
+   accepted trade-off for local-to-local (code-reviewer F5).
 
-This is the contested change. Today at `surface_runtime/mod.rs:2348-2353`:
+2. Cache lookup key becomes `(actor, composition_id, current_db_version,
+   scopes_canonical_id)` (the orchestrator's existing key shape with
+   `composition_version` replaced from `request.composition_version` to
+   `current_db_version`). Lookup at `mod.rs:2317-2321`.
 
-> The producer always advances composition_version monotonically and commits unconditionally. The surface's previously-rendered version is structurally meaningless as an OCC token because the surface has no write path — only the producer mutates compositions. Forward the current substrate version on every render so the producer's commit step never trips its own watermark check on stale surface claims.
+3. Cache store key uses
+   `projection.composition_version.unwrap_or(current_db_version)`. Store
+   at `mod.rs:2425-2430`. `ProjectedComposition.composition_version` is
+   defined at `abilities-runtime/src/abilities/fallback_projection.rs:29-35`
+   and is set after producer invocation.
 
-The local-to-local threat model says reads don't write to `surface_client_sessions`,
-audit tables, rate-limit buckets, **or any other DB state**. The composition
-table is "any other DB state" — and producer commit on every render writes to it.
+4. The orchestrator's existing `(composition_id, composition_version,
+   scopes_canonical_id)` key tuple at
+   `composition_render_orchestrator.rs:51-56` is preserved — only the
+   value passed for `composition_version` changes.
 
-The investigation proposes:
-- Render path reads existing projected state from cache or DB.
-- Producer commit happens ONLY on:
-  - Explicit user-initiated refresh (the editor's "Reload from runtime" button),
-  - Signal-propagation invalidation (a watermark moved upstream — `account_subject.claim_changed`, `claim.lifecycle`, etc).
-  - Initial composition creation (first request for a composition_id).
+**Trade-off analysis** (code-reviewer F5):
+- V1.0 / current: warm-path is "zero DB-touch, cache hit" but ALSO "cache miss every time because key uses stale watermark".
+- V1.1 / option (a): warm-path is "one `db_read`, then cache hit". Net win: producer commits stop firing on every render.
+- Option (b) would preserve zero-DB-touch on warm path BUT requires net-new invalidation infrastructure (CSO recommended this; codex consult rejected on implementation cost). Deferred to v1.x-federation maintenance.
 
-The producer's OCC-token issue that v1.4.2 W4-F was repairing (DOS-670 substrate-side fix) had a narrower scope: the producer's commit step needs the current DB version, not a stale surface watermark. That requirement is still satisfied if we only commit on triggers, not on every read.
+**Race analysis:** between the new `current_db_version` read and the
+cache lookup, a concurrent commit could occur. For local single-runtime,
+producer invocations are serialized by the SurfaceClient bridge's writer
+mutex; there is effectively no concurrent commit race. For
+federation/multi-writer scenarios, this would need the invalidation API
+from option (b) — out of scope for v1.4.3.
 
-**§12 Q2** is the explicit reviewer prompt for whether removing render-path
-commit breaks DOS-670's substrate fix.
+### 5.4 Render-path producer behavior — V1.1 reframe: producer commits preserved
 
-### 5.5 Render-read decharge from `standard_read_composition` budget (DOS-672)
+**V1.0 proposed removing producer commit from the render path.** V1.1
+withdraws that proposal. The reframe rationale is in §2 changelog V1.1:
+- `commit_composition` does not persist a reusable projection payload (only
+  `composition_versions` row + version event — `services/compositions.rs:271-368`).
+- Removing producer commit-on-render leaves nothing in the DB to project from
+  on cache miss.
+- The producer commit IS the materialization step; it cannot be removed
+  without inventing persistent projection storage (which would be substantial
+  net-new infrastructure, federation-scale).
 
-At `src-tauri/src/bridges/surface_client.rs:213`, the default budget is 60/min
-+ burst 5. Even on a single user with one editor open, the auto-reload loop
-plus PHP double-fetch can exhaust the 5-burst within seconds.
+**The actual local fix is §5.3 — make the cache key effective.** Under V1.1:
+- Producer runs ONLY on cache miss (unchanged from today).
+- Cache misses become RARE once the cache key uses current_db_version
+  instead of the surface's stale watermark.
+- Under steady-state rendering with stable account state, all renders after
+  the first hit the cache → producer doesn't run → commit_composition doesn't
+  fire → no write flood.
+- Producer commits naturally fire when account state actually moves (signal
+  propagation triggers a new producer invocation through other paths, that
+  invocation commits a new version, which invalidates the cache via the
+  cache-key-by-current-db-version pattern).
 
-Two viable changes — pick one in L0:
-- **(a)** Local-render reads from `surface_client` actor on a paired loopback session are NOT gated by `standard_read_composition`. Authorization (scope check, actor allowlist) remains mandatory.
-- **(b)** The budget is raised significantly for local sessions (e.g. 600/min / burst 50), keeping the gate but sizing it for local.
+**The W4-F producer contract at `mod.rs:2348-2353` is preserved.** The
+comment's claim that "the producer always advances composition_version" stays
+true. The DOS-670 substrate-side fix (always forward current DB version to
+the producer) stays. Nothing about the producer's OCC contract changes.
+There is no architectural contest; V1.0's framing was wrong.
 
-§12 Q3 picks between (a) and (b).
+**What V1.1 §5.4 actually contains:** nothing net-new. The previous V1.0
+§5.4 "remove producer commit on render path" is withdrawn. The fix surface
+is entirely §5.3 (cache key correction). This section exists in V1.1 only to
+document the reframe rationale.
 
-### 5.6 Typed transport/session error mapping (DOS-672)
+**Removed in V1.1 (from V1.0):**
+- "Render path reads existing projected state from cache or DB" — DB doesn't have it; cache is the only read source, and cache-miss must invoke the producer.
+- "Producer commit happens ONLY on explicit refresh / signal-propagation / initial creation" — withdrawn. Producer commit happens on cache miss, which becomes rare once §5.3 lands.
+- The `§12 Q2` open question about "does removing render-path commit break the DOS-670 producer OCC contract" — moot; nothing is being removed.
+- The "L6 escalation trigger if CSO and codex challenge disagree on §5.4" — moot; no contested change remains.
 
-At `wp/dailyos/blocks/account-overview/render-functions.php:61-70`, ALL error
-states currently collapse into the verification banner (
-"Something about this account doesn't line up. Verify before acting.").
+### 5.5 Render-read decharge — V1.1: option (a) with `charge_ability_scope=false`
 
-The fix: distinguish at minimum:
-- `rate_limited` (HTTP 429) → "Runtime is throttling; retry shortly."
-- `session_requires_repair` (per W4-F error code) → "Surface session needs repair; reconnect."
-- `session_not_found` → same as repair.
-- `runtime_request_failed` (transport / timeout / 5xx) → "Runtime unavailable; retry."
-- consistency-failure (the actual case the banner was written for: projection inconsistency, contradicting evidence) → keep the verification banner.
+V1.1 picks option (a) (codex consult cycle-1 implementation guidance):
+local-render reads use a new `authorize_local_render` variant that calls
+`check_and_consume` with `charge_ability_scope=false`. Identity buckets
+(`surface_client`, `wp_user`, `wp_site`) continue to be consumed; ability
+bucket (`standard_read_composition`) and scope bucket (`scope.read`) are
+bypassed for paired-loopback local render reads.
 
-The PHP renderer needs a typed error shape from the runtime response (already
-present — runtime returns `{ ok: false, code: "...", ... }`); the renderer
-maps `code` → user-facing string. The verification banner is reserved for
-true consistency failures.
+**Mandatory checks preserved** (codex consult evidence — `surface_client.rs:301-355`):
+- Descriptor exists (ability is registered).
+- Actor / mode / experimental gates.
+- Required scopes (the actor must have read.account_overview etc).
+- Browser-direct-executable guard.
+
+**Decharge contract — bypass scope:**
+- `charge_ability_scope=false` (codex consult evidence — `surface_client.rs:409`,
+  `:795-822`) skips the ability_class and scope candidates inside
+  `check_and_consume`.
+- Identity candidates (surface_client/wp_user/wp_site read budgets at
+  `:766-793`) are STILL consumed. These remain as a per-principal limit on
+  total local-render volume — DoS protection without blocking normal usage.
+
+**Acceptance: tighten-event emission omitted by construction** (code-reviewer
+F3 + CSO LOW):
+`RateLimitOutcome::Allowed.audit_events` carries `rate_limit_audit_event(...,
+"tightened", ...)` when a previously-rejected window enters early-retry
+tightening (`surface_client.rs:411-415`, `:742-752`). When ability/scope
+candidates are bypassed, no consumption happens for those candidates → no
+rejection possible for them → no tightening → no tightened-event emitted.
+This is internally consistent for local-to-local. V1.1 codifies this with
+AC #15 ("local-render decharge emits zero `rate_limit_audit_event` entries
+for the ability/scope bucket"). Maintenance ticket filed for operator
+observability of local-render volume.
+
+**Implementation shape:**
+
+```rust
+// New variant — same descriptor/actor/mode/scope checks, then bypass-ability-scope rate-limit
+pub fn authorize_local_render(
+    &self,
+    registry: &AbilityRegistry,
+    validated: &SignedSessionContext,
+    ability_name: &str,
+    request_id: &str,
+) -> Result<Authorization, SurfaceClientBridgeError> {
+    self.authorize_for_path(
+        registry,
+        validated,
+        ability_name,
+        request_id,
+        ChargeAbilityScope::Off,  // existing internal flag; today hardcoded to On
+    )
+}
+```
+
+Route handler at `surface_runtime/mod.rs:2288-2311` calls
+`authorize_local_render` instead of `authorize` for the `project_composition`
+read path. Other surface client routes continue to use `authorize`.
+
+### 5.6 Typed transport/session error mapping (DOS-672) — V1.1 envelope rewrite
+
+V1.0's error envelope shape was wrong. Per code-reviewer F2 + codex consult
+MEDIUM:
+- Runtime returns `{"error":{"code","message","request_id","remediation",...}}` (NOT top-level `{ok:false, code:...}`). HTTP status conveys success/failure. Defined at `src-tauri/src/surface_runtime/mod.rs:3514-3548`.
+- WP transport (`wp/dailyos/includes/transport/class-dailyos-runtime-client.php:393-509`) re-wraps non-2xx responses as `{ok:false, error:{code, message}}`.
+- Local transport failures (signing failure before request, `wp_remote_post` failure, JSON parse) produce `WP_Error` OR `{ok:false, error:{code, message}}` with codes like `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`.
+
+`session_requires_repair` is a `SurfacePairingError` variant
+(`surface_pairing.rs:277`) surfaced via `from_pairing_error`; there is NO
+dedicated `SurfaceHttpError::session_requires_repair()` constructor. Match
+by string on `error.code`.
+
+**V1.1 renderer mapping (replaces `render-functions.php:61-70` blanket banner):**
+
+```php
+// In dailyos_account_overview_render_from_projection(...)
+if ( is_wp_error( $response ) ) {
+    // Transport-layer failure (signing, network). No runtime envelope.
+    return dailyos_account_overview_render_runtime_unavailable_notice();
+}
+
+if ( isset( $response['ok'] ) && $response['ok'] === false ) {
+    $code = isset( $response['error']['code'] ) ? (string) $response['error']['code'] : 'runtime_request_failed';
+    switch ( $code ) {
+        case 'rate_limited':
+            return dailyos_account_overview_render_throttled_notice();
+        case 'session_requires_repair':
+        case 'session_not_found':
+            return dailyos_account_overview_render_session_repair_notice();
+        case 'runtime_unavailable':
+        case 'runtime_request_failed':
+        case 'runtime_invalid_json':
+        case 'runtime_http_error':
+            return dailyos_account_overview_render_runtime_unavailable_notice();
+        case 'projection_tampered':
+        case 'projection_version_rollback':
+        case 'stale_composition_watermark':
+        case 'missing_expected_claim_version':
+        case 'mid_flight_mutation':
+        case 'consistency_failure':
+            // Genuine projection-consistency failure — verification banner correct.
+            return dailyos_account_overview_render_verification_banner();
+        default:
+            // Unknown code: fail-safe to verification banner. Operator
+            // should add a typed mapping when a new code appears.
+            return dailyos_account_overview_render_verification_banner();
+    }
+}
+
+if ( ! isset( $response['projection'] ) || ! is_array( $response['projection'] ) ) {
+    // Successful response shape without projection — defensive fallback.
+    return dailyos_account_overview_render_verification_banner();
+}
+
+// Success path — render the projection.
+return dailyos_account_overview_render_projection_payload( $response, $attributes );
+```
+
+New helpers (small, local copy):
+- `dailyos_account_overview_render_throttled_notice()` — "Runtime is throttling; retry shortly."
+- `dailyos_account_overview_render_session_repair_notice()` — "Surface session needs repair; reconnect from DailyOS settings."
+- `dailyos_account_overview_render_runtime_unavailable_notice()` — "Runtime unavailable; retry."
+
+The verification banner stays reserved for genuine projection-consistency
+failures + unknown codes (fail-safe).
 
 ## 6. Directional decisions resolved at L0
 
@@ -215,15 +569,22 @@ attributes (`edit.js:62-68`); those are dependencies of `reload`
 with the 5/sec burst budget, this exhausts rate limits and produces the
 "reload-on-window-switch" symptom.
 
-### 6.4 Removing render-path producer-commit is the right local-shaped fix — but is L0-CONTESTED
+### 6.4 V1.1: producer-commit-on-render is PRESERVED; the fix is cache effectiveness
 
-The investigation argues for removal. v1.4.2 W4-F explicitly chose
-"always-forward DB version + producer commits unconditionally" as the
-DOS-670 substrate-side fix. The two appear to conflict.
+V1.0 framed this as "the contested change" requiring L6 escalation. V1.1
+withdraws the contest entirely. Codex consult cycle-1 surfaced the key fact:
+`commit_composition` does not persist a reusable projection payload, so
+removing producer-commit-on-render breaks materialization. The producer
+commit IS the materialization step.
 
-**§12 Q2** is the explicit L0 question for the reviewer panel: does the
-DOS-670 producer OCC contract require commit-on-render, or only
-commit-on-trigger?
+**Decision (V1.1):** producer commit on cache miss stays unchanged. The
+render-loop user-visible bug is fixed by §5.3 cache key correction, which
+causes cache hits to dominate → producer rarely runs → commit rarely fires.
+The W4-F producer contract at `mod.rs:2348-2353` is preserved. No
+architectural contest with v1.4.2 / W4-F remains. The DOS-670 producer-side
+OCC workaround is intact.
+
+**§12 Q2 RESOLVED** — moot; nothing is being removed.
 
 ### 6.5 Render-read decharge does not weaken authorization
 
@@ -243,54 +604,68 @@ its rendered state. No runtime contract change for this rule.
 
 ### DOS-671 (block content disappearance ≤30s)
 
-1. PHP preview makes exactly one `project_composition_for_surface` runtime call per preview request.
-2. Editor `useEffect`-driven auto-reload fires ONLY on `composition_id` empty→non-empty or `account_id` change.
-3. Editor `reload` callback's dependency list does NOT include `composition_version` or `cache_hint_token`.
-4. Successful reload's attribute write does NOT schedule another reload.
-5. Runtime `project_composition` route does NOT commit a new composition on every render. Commit happens on: explicit refresh, signal-propagation invalidation, initial composition creation.
-6. Runtime cache lookup hits regardless of stale request `composition_version` (cache keyed on current DB version OR version-agnostic per §5.3 outcome).
-7. Local-render reads from paired-loopback `surface_client` sessions do NOT consume `standard_read_composition` rate budget (or budget is raised per §5.5 outcome).
-8. After initial render, the block remains visible for ≥60 seconds without further user action AND across two browser-window focus changes.
+1. PHP preview makes exactly one `project_composition_for_surface` runtime call per preview request. `dailyos_account_overview_render` (the wrapper) keeps its single-fetch behavior for `render.php` + existing test fixtures.
+2. Editor `reload` callback's dep list keeps `[composition_id, composition_version, cache_hint_token, setAttributes]` — manual reload reads latest version+token, NO stale-closure risk.
+3. Editor `useEffect`-driven auto-reload fires ONLY when a separate derived `reloadTrigger` string changes — i.e., on `account_id` change OR `composition_id` empty↔non-empty transition. NOT when `composition_version` or `cache_hint_token` change.
+4. Successful reload's attribute write does NOT schedule another reload (the `reloadTrigger` value is unchanged).
+5. First-mount fires exactly ONE reload (initial materialization).
+6. Runtime `project_composition` cache lookup uses key `(actor, composition_id, current_db_version, scopes_canonical_id)` (NOT `request.composition_version`). Stale watermarks no longer cause cache misses.
+7. Runtime cache store uses `projection.composition_version.unwrap_or(current_db_version)` so the stored entry's version matches what the producer actually emitted.
+8. After initial render, the block remains visible for ≥60 seconds without further user action AND across two browser-window focus changes (the L4 user-visible target).
 
 ### DOS-672 (reload-on-window-switch + second-reload verification banner)
 
 9. Manual "Reload from runtime" fires exactly one preview request per click.
-10. Window-focus change does NOT trigger reload (no remount).
+10. Window-focus change does NOT trigger reload (no remount, no auto-reload retrigger).
 11. Second consecutive manual reload succeeds (returns projection, not banner) — assuming first reload succeeded.
 12. Failed reload (any cause) preserves last-good `preview` state in the editor.
 13. Failed reload surfaces an `error` notice; does NOT replace rendered content with verification-banner HTML.
-14. PHP renderer maps `rate_limited`, `session_requires_repair`, `session_not_found`, `runtime_request_failed` to distinct typed messages; verification banner reserved for true consistency-failure (projection contradiction / missing evidence).
-15. PHP preview response merge (`class-dailyos-plugin.php:613-618`) does NOT combine successful first-call projection with failed second-call banner HTML. After §5.1, there IS no second call.
+14. PHP renderer maps `error.code` via switch table: `rate_limited` → throttled notice; `session_requires_repair` / `session_not_found` → session-repair notice; `runtime_unavailable` / `runtime_request_failed` / `runtime_invalid_json` / `runtime_http_error` → runtime-unavailable notice; consistency codes (`projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `missing_expected_claim_version`, `mid_flight_mutation`, `consistency_failure`) → verification banner; unknown codes → verification banner (fail-safe).
+15. **Local-render decharge by construction:** `authorize_local_render` calls `check_and_consume` with `charge_ability_scope=false`. Ability/scope buckets (`standard_read_composition`, `scope.read`) are NOT consumed; identity buckets (`surface_client`, `wp_user`, `wp_site`) ARE consumed. As a direct consequence, the `RateLimitOutcome::Allowed.audit_events` "tightened" emission for ability/scope is OMITTED — no observability event for that bucket because no consumption happens.
+16. Auth/scope mandatory checks (descriptor, actor, mode, experimental, required scopes, browser-direct guard) are NOT bypassed; only rate-budget consumption for ability/scope changes.
 
 ## 8. Negative fixtures
 
+All fixtures use PHP test infrastructure (existing
+`tests/blocks/AccountOverviewBlockTest.php` pattern with fake-runtime-client
+injection) for editor-side behavior assertions — no net-new jest setup (code-reviewer F6).
+
 | # | Fixture | Asserts |
 |---|---|---|
-| 1 | `dos671_preview_single_fetch` | PHP fake runtime returns projection on first call, asserts no second call happens during preview render |
-| 2 | `dos671_editor_no_reload_on_cache_token_change` | JS test with fake `apiFetch`: setAttributes({cache_hint_token: 'new'}) does NOT trigger a reload |
-| 3 | `dos671_editor_no_reload_on_version_change` | JS test with fake `apiFetch`: setAttributes({composition_version: 5}) does NOT trigger a reload |
-| 4 | `dos671_render_path_no_commit` | Rust test: 10 consecutive `project_composition` calls without external signal → no composition commit, no version advance |
-| 5 | `dos671_render_path_commits_on_trigger` | Rust test: signal propagation (`account_subject.claim_changed`) → next render commits new version |
-| 6 | `dos671_cache_hits_with_stale_request_version` | Rust test: lookup with request_version=1 hits cache populated by request_version=5 (or version-agnostic) |
-| 7 | `dos671_local_render_no_rate_consumption` | Rust test: tight `standard_read_composition` budget (1/min), 50 render reads from paired-loopback do NOT fail with `rate_limited` |
-| 8 | `dos672_manual_reload_single_request` | JS test: button click → exactly one `apiFetch` call |
-| 9 | `dos672_second_reload_returns_projection_not_banner` | PHP fake runtime returns projection on both calls; HTML output of second preview render contains block payload, NOT verification banner |
-| 10 | `dos672_failed_reload_preserves_last_good` | JS test: first reload succeeds → preview set; second reload fails (mocked error) → preview unchanged, error notice shown |
-| 11 | `dos672_typed_error_mapping` | PHP test: runtime response `{ok: false, code: "rate_limited"}` → user-facing string "Runtime is throttling..."; NOT the verification banner |
-| 12 | `dos672_verification_banner_reserved_for_consistency` | PHP test: runtime response `{ok: false, code: "consistency_failure"}` → verification banner DOES render |
-| 13 | `dos671_l4_hands_on_log` | Hands-on log captured: initial render → wait 60s → focus switch x2 → manual reload x2; content remains visible throughout |
+| 1 | `dos671_preview_single_fetch` | PHP test: preview REST route's fake runtime client receives exactly ONE `project_composition_for_surface` call per preview request (not two as today via `render_block_with_filter` re-entry) |
+| 2 | `dos671_wrapper_preserves_single_fetch` | PHP test: `dailyos_account_overview_render($attrs)` called by `render.php` triggers exactly one runtime call (regression guard for the wrapper) |
+| 3 | `dos671_editor_dep_array_literal` | PHP/grep gate: `edit.js` `reload` useCallback dep array literal contains `[attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes]` (manual reload reads latest) |
+| 4 | `dos671_editor_trigger_key_literal` | PHP/grep gate: `edit.js` defines `reloadTrigger` and `useEffect([reloadTrigger])` shape — trigger derived from account_id + composition_id-presence ONLY |
+| 5 | `dos671_first_mount_fires_one_reload` | PHP integration test simulating editor mount: exactly ONE reload request issued (initial materialization) |
+| 6 | `dos671_cache_key_uses_current_db_version` | Rust test: lookup with stale `request.composition_version=1` HITS cache when current_db_version=5 and prior render populated cache at version 5 |
+| 7 | `dos671_cache_hit_avoids_producer` | Rust test: cache hit returns projection WITHOUT invoking producer (verified by producer-invocation counter) |
+| 8 | `dos671_cache_miss_invokes_producer_and_commits` | Rust test: cache miss DOES invoke producer; producer commits a new version; cache is populated with the new version's projection (the materialization path is preserved) |
+| 9 | `dos671_local_render_no_ability_scope_consumption` | Rust test: tight `standard_read_composition` budget (1/min); 50 paired-loopback render reads do NOT fail with `rate_limited`; the ability_class bucket counter shows zero consumption |
+| 10 | `dos671_local_render_consumes_identity_buckets` | Rust test: paired-loopback render reads DO consume `surface_client_read` bucket (identity bucket still gated) |
+| 11 | `dos671_local_render_no_tighten_event` | Rust test: 100 paired-loopback render reads produce ZERO `rate_limit_audit_event` entries (ability/scope bucket bypassed → no rejection → no tightening) |
+| 12 | `dos672_manual_reload_single_request` | PHP integration test: simulated button click via REST → exactly one runtime call (not two) |
+| 13 | `dos672_failed_reload_preserves_last_good` | PHP integration test: first reload succeeds → preview HTML rendered; second reload fails (mocked error) → response body returns error notice + last-good preview HTML unchanged in the response shape |
+| 14 | `dos672_typed_error_mapping` | PHP test matrix: each of the 11 error codes (`rate_limited`, `session_requires_repair`, `session_not_found`, `runtime_unavailable`, `runtime_request_failed`, `runtime_invalid_json`, `runtime_http_error`, `projection_tampered`, `projection_version_rollback`, `stale_composition_watermark`, `consistency_failure`) → expected user-facing string (throttled / repair / unavailable / verification banner per §5.6 table) |
+| 15 | `dos672_unknown_code_failsafe` | PHP test: runtime response `{ok:false, error:{code:'unknown_xyz'}}` → verification banner renders (fail-safe) |
+| 16 | `dos671_l4_hands_on_log` | Hands-on log captured: initial render → wait 60s → focus switch x2 → manual reload x2; content remains visible throughout (the user-visible L4 target) |
 
 ## 9. CI invariants
 
 | # | Invariant | Enforcement |
 |---|---|---|
-| 1 | `dailyos_account_overview_render` is called at most once per preview request | grep / lint: `account_overview_preview` body does not call `render_block_with_filter` for the block-render path; calls `dailyos_account_overview_render_from_projection` directly |
-| 2 | Editor `reload` callback dep list contains exactly `[attributes.composition_id, attributes.account_id, setAttributes]` | ESLint rule or test that asserts the dep array literal |
-| 3 | `useEffect` for auto-reload depends on a narrow trigger value, not `reload` | ESLint rule or test |
-| 4 | Runtime `project_composition` handler does NOT call `commit_composition` on the steady-state read path | grep / AST check on the read-path branch body — no `commit_composition` call without a `requires_commit` guard |
-| 5 | Projection cache key (effective shape per §5.3 outcome) is invariant under request_version changes | runtime test asserts cache hit rate ≥ 95% in a workload that varies request_version but holds composition_id constant |
-| 6 | Local-render read decharge: `standard_read_composition` budget is not consumed for paired-loopback render | runtime test with tight budget (already enumerated as fixture #7) |
-| 7 | PHP error mapping uses a typed code → string lookup table | grep for `dailyos_account_overview_render_verification_banner` outside the consistency-failure branch fails CI |
+| 1 | `account_overview_preview` calls `dailyos_account_overview_render_from_projection` directly; does NOT route the response back through `render_block_with_filter` → `dailyos_account_overview_render` | grep gate on `account_overview_preview` body |
+| 2 | Editor `reload` callback dep list keeps composition_id + composition_version + cache_hint_token + setAttributes (preserves manual-reload correctness) | grep gate on `edit.js` for the literal dep array shape (code-reviewer F7 — recommends grep over ESLint authoring; proper ESLint rule filed to maintenance) |
+| 3 | Editor `useEffect` for auto-reload depends on `[reloadTrigger]` (NOT `[reload]`) | grep gate on `edit.js` |
+| 4 | Runtime `project_composition` cache lookup is keyed by current_db_version (NOT request.composition_version) | grep gate on `mod.rs` cache_lookup call site — verify the version argument is the current_db_version variable |
+| 5 | Cache hit rate ≥ 95% under workload that varies `request.composition_version` but holds `composition_id` constant | Rust integration test in existing `rust.yml` workflow |
+| 6 | `authorize_local_render` uses `charge_ability_scope=false`; main `authorize` continues to use `true` | grep gate on `surface_client.rs` for both variants |
+| 7 | PHP error mapping uses the typed switch table in §5.6; verification banner is emitted ONLY from the consistency-failure branch + unknown-code fail-safe | grep gate on `render-functions.php` for `dailyos_account_overview_render_verification_banner` call sites — verify all callers are inside the consistency-failure switch arm or the unknown-code default arm |
+
+V1.0 invariant #4 ("Runtime `project_composition` handler does NOT call
+`commit_composition` on the steady-state read path") REMOVED in V1.1: the
+§5.4 reframe preserves producer-commit-on-cache-miss. The user-visible
+write-flood reduction comes from §5.3 (cache hits dominate), measurable by
+invariant #5 above.
 
 ## 10. Interlocks
 
@@ -299,19 +674,20 @@ DOS-671 and DOS-672 share every file in scope (`edit.js`,
 `class-dailyos-runtime-client.php`, `surface_runtime/mod.rs`,
 `composition_render_orchestrator.rs`, `surface_client.rs`).
 
-**Landing shape:** single v1.4.3 stabilization-B PR with five commit groups:
-1. PHP single-fetch refactor (DOS-671 §5.1).
-2. Editor reload guard + last-good preserve (DOS-671 §5.2, DOS-672 §5.6 editor side).
-3. Runtime cache-key correction (DOS-671 §5.3).
-4. Render-path producer-commit removal (DOS-671 §5.4) — **the architecturally contested one**.
-5. Render-read decharge + typed error mapping (DOS-672 §5.5, §5.6 runtime side).
+**Landing shape (V1.1):** single v1.4.3 stabilization-B PR with four commit groups:
+1. PHP single-fetch refactor (§5.1) + typed error mapping (§5.6) — wraps the wrapper, adds the pure helper, adds the typed switch table.
+2. Editor reload guard + last-good preserve (§5.2) — reloadTrigger pattern, full reload dep list, Gutenberg lifecycle handling.
+3. Runtime cache-key correction (§5.3) — move current_db_version read upstream, switch lookup/store keys to current_db_version / projection.composition_version.
+4. Render-read decharge (§5.5) — new `authorize_local_render` variant, route handler switches.
+
+V1.0's commit group #4 "render-path producer-commit removal" REMOVED — the
+§5.4 reframe withdraws the architecturally contested change.
 
 Splitting this PR is NOT viable. Each fix in isolation produces false
 confidence: fix the editor without the PHP double-fetch and 50% of reloads
 still hang; fix PHP without the cache-key issue and the cache stays useless;
-fix the cache without removing render-path commit and you still write
-unnecessarily on read; etc. The investigation §"Coordination — Recommended
-Landing Shape" calls this out explicitly.
+etc. The investigation §"Coordination — Recommended Landing Shape" calls
+this out explicitly.
 
 **Cross-packet interlock:** Packet A (lifecycle hardening) and Packet B
 (render stabilization) touch `src-tauri/src/surface_runtime/mod.rs` but in
@@ -338,15 +714,49 @@ order; rebase cost is minimal.
   follow.
 - **Studio sandbox runtime discovery** (C3 in v1.4.3 project description).
   Distinct work track.
+- **Signal-propagation cache invalidation bus.** Cycle-1 CSO MEDIUM +
+  codex challenge MEDIUM — moot in V1.1 because §5.4 reframe preserves
+  producer-commit-on-cache-miss as the invalidation channel. Federation /
+  multi-writer deployments would benefit from an explicit invalidation API
+  on `composition_render_orchestrator`. Filed as v1.x-federation maintenance.
+- **Hostile co-resident WordPress plugin error-code fingerprinting.**
+  Cycle-1 codex challenge LOW — under same-UID local model, a co-resident
+  plugin with PHP execution already has ambient keychain/DB/loopback
+  access; finer error-code redaction would be remote-shape defense. Filed
+  as v1.x-federation maintenance ("Bounded error taxonomy for
+  multi-tenant / multi-plugin WordPress deployments").
+- **Render-volume audit signal for operator observability.** Cycle-1
+  code-reviewer F3 maintenance note — local-render-decharge volume
+  observability isn't security-load-bearing locally. Filed as v1.x
+  maintenance ("Local-render audit signal for operator observability").
+- **ESLint rule authoring for editor `useEffect` dep arrays.** Cycle-1
+  code-reviewer F7 — grep gates cover L0 closure; a proper ESLint rule is
+  maintenance.
+- **Persistent projection storage** (would enable producer-commit removal —
+  not v1.4.3 scope). Filed as v1.x-federation maintenance — substantial
+  new infrastructure, only beneficial when render-path mutation needs to
+  be strictly eliminated (federation / multi-writer).
+- **Hot-path performance budgeting** — cache hit rate ≥95% is the L0
+  invariant target; actual latency budgeting (warm-path p95, cold-path
+  p95) is operational tuning, not L0 scope.
 
-## 12. Open questions for L0 reviewers
+## 12. Open questions for L0 reviewers — all V1.0 questions RESOLVED in V1.1
 
-1. **(For codex consult + code-reviewer):** Cache key shape per §5.3 — (a) key on `current_db_version` (lookup races: between current_db_version read and cache_lookup, producer could commit) vs (b) version-agnostic key with explicit invalidation on commit. Pick one with implementation cost + correctness analysis.
-2. **(For CSO + codex challenge):** Removing render-path producer-commit per §5.4 — does this break the DOS-670 substrate-side OCC contract that v1.4.2 W4-F shipped? Specifically: when the producer commits on EXPLICIT refresh, can the surface still receive a projection that reflects the committed version, or does the commit-then-read window introduce a new race?
-3. **(For code-reviewer + codex consult):** Render-read decharge per §5.5 — (a) bypass `standard_read_composition` for paired-loopback render entirely vs (b) raise the budget significantly. Pick one.
-4. **(For codex challenge):** The investigation says "30s disappearance" is "the 30s signed-post timeout plus retrigger". Can codex propose a concrete reproduction script that confirms the timing chain end-to-end (browser DevTools network + Tauri audit log)?
-5. **(For CSO):** Typed error mapping per §5.6 — does exposing distinct error codes (`rate_limited`, `session_requires_repair`, etc) to the WP-side give an attacker a fingerprinting channel? Local-to-local says yes-because-WP-is-trusted, but please verify against any threat model that contemplates a hostile WP plugin co-resident on the same machine.
-6. **(For codex consult):** What's the actual user-trigger surface for "explicit refresh"? Today the editor has a button (`reload`); is there also a Gutenberg context that auto-saves, and does auto-save count as explicit refresh?
+1. **V1.0 Q1 (cache key shape):** RESOLVED — V1.1 picks option (a), key by `current_db_version`. Codex consult cycle-1 recommended on implementation grounds; CSO recommended (b) but that requires net-new invalidation API filed to maintenance.
+2. **V1.0 Q2 (producer-commit removal vs DOS-670):** RESOLVED — moot. V1.1 withdraws the proposed removal. Producer commit stays on cache miss; the user-visible write reduction comes from §5.3 cache effectiveness.
+3. **V1.0 Q3 (render-read decharge shape):** RESOLVED — V1.1 picks option (a) with `charge_ability_scope=false`. Identity buckets still charge; ability/scope buckets bypassed.
+4. **V1.0 Q4 (30s disappearance reproduction):** Partially RESOLVED — the L4 fixture #16 captures the user-visible target. Concrete timing-chain reproduction script can be authored during implementation as part of the L1 self-validation; not L0 closure-blocking.
+5. **V1.0 Q5 (typed error fingerprinting):** RESOLVED — same-UID local model; deferred to v1.x-federation maintenance per §11.
+6. **V1.0 Q6 (explicit refresh trigger surface):** RESOLVED — moot, since V1.1 doesn't require distinguishing "explicit refresh" from "render read". All triggers route through the same `project_composition` route; cache key determines whether producer runs.
+
+### New open questions for V1.1 cycle 2
+
+V1.1 has no new open questions — all cycle-1 findings folded with explicit
+disposition (FOLD / DEFER / REJECT). Cycle 2 reviewers should validate that:
+- The §5.4 reframe (producer commit preserved) correctly resolves the cycle-1 BLOCK without reintroducing the user-visible loop.
+- The §5.3 option (a) implementation correctly avoids the cache-miss-on-stale-watermark loop.
+- The §5.2 reloadTrigger pattern + full reload dep list correctly resolves the stale-closure risk.
+- The §5.6 envelope rewrite matches the actual two-channel error surface (WP_Error from transport, runtime envelope from non-2xx).
 
 ## 13. Linear dependency edges
 
@@ -357,32 +767,37 @@ order; rebase cost is minimal.
 
 ## 14. L0 reviewer panel — required runners
 
-| Reviewer | Mode | Why |
+| Reviewer | Mode | V1.1 cycle-2 focus |
 |---|---|---|
-| `/codex challenge` | adversarial | Specifically: stress the producer-commit-removal claim. Construct a scenario where the cache returns a projection that doesn't match the substrate's current state because the producer hasn't run yet. Stress the cache-key change for stale-version + concurrent commit races. |
-| `code-reviewer` (claude) | domain | The render route is the hottest path in the system. Independent read by the domain reviewer catches places where the fix shape conflicts with existing patterns (request-id propagation, audit emission, error envelope shape, http status code semantics). |
-| `/codex consult` | implementation feasibility | Walk the proposed single-fetch refactor through every existing caller of `dailyos_account_overview_render` (block render path, REST preview, any new caller v1.4.3+ might introduce); confirm no behavioral break. |
-| `/cso` | **mandatory** | Render-path authorization (must NOT be bypassed), rate-budget consumption semantics (the decharge is policy-load-bearing), producer-commit semantics (write-on-read removal touches the substrate's trust-of-its-own-version invariant), and typed-error-mapping (fingerprinting risk vs operability). Every one of these is trust-boundary. |
+| `/codex challenge` | adversarial | Re-verify the §5.4 reframe (producer commit preserved + cache effectiveness fix). Is there a scenario where the §5.3 option (a) cache fails to invalidate when state actually moves? Stress the stale-closure resolution in §5.2 — is `reloadTrigger`'s derived-string pattern actually stable across React's render cycle? Confirm the V1.1 deferrals are correctly classified as remote/federation, not local-shipping. |
+| `code-reviewer` (claude) | domain | Verify §5.1 wrapper preservation against the 6 existing test fixtures. Verify the §5.6 typed-error switch table is exhaustive against existing runtime error codes. Verify the §9 grep gates are enforceable. |
+| `/codex consult` | implementation feasibility | Walk the §5.3 option (a) implementation through `composition_render_orchestrator::cache_lookup` / `cache_store` and `mod.rs:2317-2430`. Verify §5.5 `authorize_local_render` plumbing through `authorize_for_path` with the new flag. Verify the §5.6 PHP switch table compiles cleanly with the existing renderer error helpers. |
+| `/cso` | **mandatory** | Confirm the §5.4 reframe preserves the W4-F producer contract without weakening any trust boundary. Specifically: (a) cache-key-by-current-db-version still requires authorization BEFORE lookup (same as today); (b) `charge_ability_scope=false` decharge does NOT bypass scope check or authorization; (c) the typed error mapping does not expose any new attack vector under same-UID local model. |
 
 **Convergence rule:** unanimous APPROVE required before code lands. Any reviewer
-returning CONDITIONAL APPROVE → fold finding into V2 of this packet, re-run all
-four reviewers. Cycle cap: 3 cycles before escalation to L6.
+returning CONDITIONAL APPROVE → fold finding into V1.2 (or maintenance backlog
+if remote-shape) and re-run all four reviewers. Cycle cap: 3 cycles before
+escalation to L6.
 
-**Specific L6 trigger:** if CSO and codex challenge disagree on §5.4 (render-path
-producer-commit removal), escalate to L6 immediately. This is the contested
-architectural call, and the v1.4.2 W4-F authors deliberately chose the current
-shape. James decides.
+**Cycle 2 special handling for codex challenge:** if codex challenge re-flags
+the V1.1 deferred items as local-blocking, the deferral classification must
+be re-examined — but the L0 reviewer panel is not allowed to overturn a
+Path-α trim that aligns with the v1.4.2 explicit threat-model commitment.
+Persistent disagreement → L6 (James) decides. The §5.4 architecturally
+contested-change L6 trigger from V1.0 is removed in V1.1 since the contested
+change is withdrawn.
 
 ## 15. Acceptance for L0 closure
 
-- [ ] All 4 reviewers returned APPROVE.
-- [ ] All 15 acceptance criteria (§7) are testable; per-criterion fixture mapped (§8 has 13 — gap analysis in cycle 1).
-- [ ] All 7 CI invariants (§9) have concrete grep/AST/runtime enforcement.
-- [ ] All §12 open questions resolved.
-- [ ] §5.4 producer-commit-removal explicitly approved by CSO (not just non-blocking).
-- [ ] §5.3 cache key shape picked (a or b) with implementation rationale recorded.
-- [ ] §5.5 render-read decharge approach picked (a or b) with implementation rationale recorded.
-- [ ] Landing shape (§10) confirmed: single PR with 5 commit groups, no split.
+- [ ] All 4 reviewers returned APPROVE (cycle 2 or later).
+- [ ] All 16 acceptance criteria (§7 V1.1) are testable; per-criterion fixture mapped to §8 (16 fixtures, 1:1 mapping verified).
+- [ ] All 7 CI invariants (§9 V1.1) have concrete grep/AST/runtime enforcement.
+- [ ] All §12 V1.0 open questions resolved in V1.1 (6/6 — see §12).
+- [ ] §5.3 cache key shape picked: option (a) — current_db_version key.
+- [ ] §5.5 render-read decharge approach picked: option (a) — `charge_ability_scope=false`.
+- [ ] §5.4 producer-commit-removal WITHDRAWN — no architectural contest remains.
+- [ ] V1.1 deferred items filed as Linear maintenance tickets under project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb` (DailyOS Maintenance & Production Quality). 6 deferral ticket titles in §2 V1.1 changelog.
+- [ ] Landing shape (§10) confirmed: single PR with 4 commit groups (was 5; removed the producer-commit-removal group), no split.
 - [ ] No outstanding L0-cycle findings; packet is implementation-ready.
 
 When all nine boxes check, L0 is closed and implementation begins. L1 (self)

--- a/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-code-reviewer.md
+++ b/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-code-reviewer.md
@@ -1,0 +1,96 @@
+# Packet B — L2 code-reviewer pass (claude domain)
+
+**Branch:** `dos-671-672-render-stabilization` (3 commits since `a594cd4d`)
+**Anchor:** L0 Packet B V1.1.1
+**Scope:** AC-adjacent. Findings outside §7 ACs / ADRs / PR-introduced regressions go to maintenance project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`.
+
+## Verdict: APPROVE
+
+All 16 §7 ACs implemented; 18 fixtures landed; 4 of 7 §9 CI invariants enforced by grep/test gates in this diff (the remaining 3 are either runtime-test-style invariants that exist as behavioral fixtures or pre-existing CI workflow assertions). No PR-introduced regressions. Services/ ownership intact. Authorization preserved.
+
+Two path-α findings (below). Neither is an AC violation; both file to maintenance.
+
+---
+
+## 1. Commits-vs-L0-§5 mapping
+
+| L0 §5 section | Commit | Status |
+|---|---|---|
+| §5.1 single-fetch PHP preview (wrapper preserved) | `84bc4baa` | OK — wrapper present at `render-functions.php:32-34`; `render.php` still calls wrapper; preview route at `class-dailyos-plugin.php:587-621` calls `render_from_projection` directly (no `render_block_with_filter` re-entry). |
+| §5.2 editor reloadTrigger pattern | `5d125fee` | OK — `edit.js:94` keeps full `reload` dep list `[composition_id, composition_version, cache_hint_token, setAttributes]`; `:96` defines `reloadTrigger` exactly per L0; `:97-102` `useEffect([reloadTrigger])` with eslint-disable + rationale. |
+| §5.3 cache key by current_db_version | `ee1805f5` | OK — `mod.rs:2336-2354` moves the `current_composition_version_for_composition_id` read upstream of cache lookup; lookup at `:2361` uses `current_db_version`; store at `:2444-2448` uses `projection.composition_version.unwrap_or(current_db_version)`. |
+| §5.4 producer-commit reframe (no-op) | n/a | OK — withdrawn in L0 V1.1; nothing to implement. The producer commit path is preserved; only the cache-key correction affects how often it fires. |
+| §5.5 `authorize_local_render` decharge | `ee1805f5` | OK — new pub fn at `surface_client.rs:277-291` delegates to `authorize_for_path` with `charge_ability_scope=false`; route handler `mod.rs:2317` switches to it. |
+| §5.6 typed error switch | `84bc4baa` | OK — full code matrix from L0 §5.6 lives at `render-functions.php:85-141` with 4 typed notice helpers + verification banner reserved for consistency-failure / unknown-code branches. |
+
+## 2. Substrate reuse (§4)
+
+Confirmed: no net-new primitives. The diff uses `compositions::current_composition_version_for_composition_id` (existing), `CompositionRenderOrchestrator::cache_lookup`/`cache_store` (existing, key shape unchanged at `composition_render_orchestrator.rs:51-56`), `authorize_for_path` (existing private helper — new `authorize_local_render` is just a thin variant), and existing `RuntimeNotice` design-system pattern. Wrapper preservation for `dailyos_account_overview_render` keeps all 6 prior test fixtures intact (verified by inspection of `AccountOverviewBlockTest.php`).
+
+## 3. §9 CI invariants enforcement in diff
+
+| # | Invariant | Status |
+|---|---|---|
+| 1 | preview route bypasses `render_block_with_filter` re-entry | Behavioral fixture `test_preview_route_uses_single_runtime_request` asserts `$GLOBALS['dailyos_test_remote_post_calls']` count==1. No grep gate, but the runtime-call assertion is stronger. |
+| 2 | editor `reload` callback dep array | `test_editor_reload_callback_dep_array_literal` regex matches the dep literal with prettier-tolerant whitespace `\s*` per L0 V1.1.1 note. |
+| 3 | `useEffect([reloadTrigger])` (NOT `[reload]`) | `test_editor_reload_trigger_key_literal` matches the trigger string + `useEffect([reloadTrigger])` shape + `assertDoesNotMatchRegularExpression` on `[reload]`. |
+| 4 | cache lookup keyed by `current_db_version` | Rust grep gate `dos671_project_composition_cache_lookup_current_db_version_grep_gate` at `mod.rs:5465-5485` — positive + negative assertions both present. |
+| 5 | Cache hit rate ≥95% under varying request.composition_version | Not added as a workload test in this diff; behavioral coverage exists via `dos671_cache_key_uses_current_db_version` + `dos671_external_version_advance_invalidates_cache`. Path-α — fold quantitative gate into workload test in maintenance backlog. |
+| 6 | `authorize_local_render`=false; `authorize`=true | `dos672_project_composition_route_uses_local_render_authorization_grep_gate` confirms route uses `authorize_local_render`; behavioral coverage via `authorize_local_render_does_not_charge_ability_or_scope_buckets` (and the symmetric `authorize` test in the same file). No grep gate asserts that `authorize_for_path` is called with `true` from the main `authorize` and `false` from `authorize_local_render`. Path-α — add a literal grep gate (minor reinforcement). |
+| 7 | verification banner only from consistency / default branches | Three call sites confirmed: consistency-failure switch arm, default arm, and the "successful response without projection" defensive branch (`render-functions.php:133, 135, 143`). The third call site is technically outside the §9 #7 wording ("emitted ONLY from the consistency-failure branch + unknown-code fail-safe") but is a fail-safe for malformed success envelope — semantically equivalent intent. Path-α — clarify §9 #7 to include "defensive shape-mismatch fail-safe" OR remove this branch in favor of `RuntimeUnavailableNotice`. Maintenance, not a block. |
+
+## 4. PHP code quality
+
+- Wrapper preservation: `dailyos_account_overview_render($attributes)` retained with identical signature at `render-functions.php:32-34`. All 6 prior test fixtures continue to call the wrapper. Verified inline in the test diff.
+- `dailyos_account_overview_fetch_projection` and `dailyos_account_overview_render_from_projection` split is clean; `render_from_projection` is pure (no runtime call).
+- `is_string($response)` first-line guard at `:82-84` handles the empty-state HTML return from `fetch_projection` (composition_id missing, runtime-client construction failure, etc.) — sane and matches L0 §5.1 contract.
+- Notice helpers use existing `RuntimeNotice` design-system tier with stable `data-ds-name` slugs — token-only, no inline CSS.
+
+## 5. JS code quality — reloadTrigger pattern
+
+The `reloadTrigger = `${account_id || ''}|${composition_id ? '1' : '0'}`` derives a stable string from primitives. Successful reload's `setAttributes` write of `composition_version`/`watermarks`/`cache_hint_token` does NOT change `reloadTrigger` value → no re-trigger loop. No infinite re-render risk. Manual reload via `reload()` continues to read latest `composition_version`/`cache_hint_token` from attrs because `reload`'s dep list is unchanged. The eslint-disable carries the required rationale.
+
+Failed-reload path (`response.ok === false`) takes an early return BEFORE `setPreview(response)`, preserving prior `preview` state. AC #12/#13 satisfied.
+
+## 6. Rust code quality — cache key change + authorize_local_render
+
+**Cache key change does NOT bypass authorization.** Order in `surface_project_composition_response`:
+1. Registry resolution (`mod.rs:2289-2300`).
+2. `authorize_local_render` call (`:2317`) — scope check, descriptor check, actor/mode gates ALL preserved (Cf. `surface_client.rs:277-291` → `authorize_for_path` → existing `check_and_consume` gating).
+3. THEN current_db_version read (`:2336-2354`).
+4. THEN cache lookup (`:2361`).
+
+Authorization gates the request before cache is touched. The `scopes_canonical_id` in the cache key (`composition_render_orchestrator.rs:55,96`) already prevents cross-actor cache poisoning — change to version dimension only affects same-actor staleness. Correct.
+
+**`authorize_local_render` preserves scope check.** Confirmed by fixture `authorize_local_render_enforces_required_scope` (AC #16). The `charge_ability_scope=false` boolean only short-circuits ability/scope rate-budget consumption inside `check_and_consume`; the required-scope gate (`surface_client.rs:301-355` per L0 §5.5 evidence) executes before. Identity bucket consumption preserved per `authorize_local_render_still_charges_identity_buckets`.
+
+**Race analysis:** between the new DB read and cache lookup, a concurrent producer commit could land. For local single-runtime, producer invocations are serialized by the SurfaceClient writer mutex (per L0 §5.3). Worst case is one stale serve, healed on next render. Acceptable per L0.
+
+## 7. Cross-commit regressions
+
+Read `git diff a594cd4d..HEAD` end-to-end. No regressions identified:
+- `linear_issue_signals.rs` change routes bus emit through `services::signals::emit_and_propagate` — actually a services/-ownership improvement aligned with CLAUDE.md "all mutations go through services/". Out of L0 §5 scope but defensible per commit message ("guards … so the requested validation gates can run on this worktree"). NOT a regression.
+- `v178_dos_285_linear_issue_state.rs` adds a `table_exists` guard so the migration is idempotent when run on worktrees without the `linear_issues` table (other test contexts). NOT a regression — strictly additive safety.
+- `check_claim_writer_allowlist.sh` extension for `W6-A-meta-*` fixture path is unrelated to packet B (looks like cross-branch contamination from a different worktree). Strictly additive to the allowlist. NOT a regression but flagged as scope-creep below.
+
+## 8. Services/ ownership
+
+Mutating call (`commit_composition` in test infra at `mod.rs:5247-5285`) routed through `services::compositions::commit_composition`. Cache reads/writes use `services::composition_render_orchestrator` API. Linear signal emission now goes through `services::signals::emit_and_propagate` (the change in commit 1 actually closes a previous direct-bus call). All compliant with CLAUDE.md Critical Rules.
+
+---
+
+## Path-α findings → maintenance project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`
+
+1. **§9 invariant #5 quantitative workload gate not added.** L0 spec calls for "Rust integration test in existing rust.yml workflow" asserting cache hit rate ≥95% under workload with varying `request.composition_version`. The diff provides behavioral coverage (3 deterministic cache-hit/miss tests + 1 external-advance invalidation test) but no quantitative workload assertion. File maintenance ticket: "Add cache-hit-rate workload integration test for project_composition route".
+
+2. **§9 invariant #6 reinforcement grep gate.** Behavioral coverage exists. A literal grep asserting `authorize_for_path(..., true)` in `authorize`/`authorize_signed_invoke` and `authorize_for_path(..., false)` in `authorize_local_render` would harden against future drift where a refactor flips the boolean. File maintenance ticket: "Add grep gate for `authorize_for_path` charge_ability_scope literal per surface_client variant".
+
+3. **§9 invariant #7 third-banner-call-site.** `render-functions.php:143` emits the verification banner on a successful runtime response that lacks a `projection` key (defensive fail-safe). Strictly outside L0 §9 #7 wording. Either widen the invariant text OR replace with `RuntimeUnavailableNotice` in a follow-up. File maintenance ticket: "Clarify §9 invariant #7 or migrate shape-mismatch fail-safe to RuntimeUnavailableNotice".
+
+4. **Scope-creep observation (not a finding).** Commit 1 includes `check_claim_writer_allowlist.sh` `W6-A-meta-*` extension + `linear_issue_signals.rs` + `v178` migration guard. None of these are L0 §5 work for Packet B. They appear to be local-worktree validation-gate enablers per commit message. The migration guard and signals refactor are net-positive; the W6 fixture allowlist looks like cross-branch contamination. Author should confirm provenance before merge; no action required from L2 reviewer.
+
+---
+
+## Summary
+
+L0 §5.1 / §5.2 / §5.3 / §5.5 / §5.6 implementation is complete and matches plan. §5.4 is correctly a no-op. ACs #1-#16 all have coverage (4 ACs via grep gates per L0 §8.1 mapping, 12 via runtime fixtures, 1 via L4 hands-on log placeholder). Authorization preserved. Services/ ownership preserved. No PR-introduced regressions. Approve for L2 close pending other reviewers.

--- a/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md
+++ b/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md
@@ -1,0 +1,205 @@
+# Packet B - L2 Codex Challenge Review
+
+Branch: `dos-671-672-render-stabilization`
+Base: `a594cd4d`
+Diff reviewed: `git -C /private/tmp/dailyos-pb diff a594cd4d..HEAD`
+Anchor: `L0-packet-B-render-stabilization.md` V1.1.1, §7 ACs 1-16
+
+## Verdict: APPROVE
+
+The PHP single-fetch split, editor `reloadTrigger`, cache-key correction, and
+`authorize_local_render` decharge are directionally correct. One AC-linked
+block remains: the typed PHP error switch is not exhaustive against codes the
+actual project-composition/signed runtime path can already emit, so existing
+non-consistency failures still fall through to the verification banner.
+
+## Findings by severity
+
+### Critical
+
+None.
+
+### High
+
+1. `wp/dailyos/blocks/account-overview/render-functions.php:90`
+   What: `dailyos_account_overview_render_from_projection()` switches on
+   `error.code`, but the handled matrix at `render-functions.php:93-135` omits
+   already-emittable project-composition/signed-runtime codes. Examples:
+   `project_composition_invalid`, `project_composition_unknown_producer`, and
+   `project_composition_invalid_id` are emitted by
+   `src-tauri/src/surface_runtime/mod.rs:2243-2275`; signed transport can emit
+   `signature_invalid`, `canonicalization_mismatch`, `timestamp_stale`,
+   `timestamp_future`, `key_not_found`, `key_rotated`, `token_invalid`,
+   `nonce_replay`, and `transport_abuse_limited` via
+   `src-tauri/src/surface_runtime/hmac.rs:792-803`; pairing validation can emit
+   `unknown_runtime_anchor`, `session_invalid`, and
+   `pairing_authority_unavailable` via
+   `src-tauri/src/services/surface_pairing.rs:260-281`; the route can emit
+   `composition_version_overflow` via
+   `src-tauri/src/surface_runtime/mod.rs:3071-3076`.
+   Why it matters: these are not unknown future codes. Today they hit the
+   `default` arm at `render-functions.php:134-135`, returning
+   `dailyos_account_overview_render_verification_banner()` for auth/signing,
+   request-shape, pairing-authority, and overflow failures. That violates the
+   packet intent that the verification banner is reserved for projection
+   consistency plus true unknown-code fail-safe, and it leaves a path for the
+   DOS-672 "second reload returns verification banner" symptom under real
+   non-consistency failures.
+   AC-linked: AC #14 typed error switch exhaustive coverage.
+
+2. `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:448`
+   What: fixture `test_typed_error_mapping` uses
+   `typed_error_mapping_provider()` at
+   `AccountOverviewBlockTest.php:448-505`, but the provider mirrors the same
+   incomplete matrix as the PHP switch and never exercises the existing
+   runtime codes listed above. In particular, no fixture row covers
+   `project_composition_invalid`, `project_composition_unknown_producer`,
+   `project_composition_invalid_id`, signed-transport errors from
+   `hmac.rs:792-803`, `session_invalid`, `unknown_runtime_anchor`,
+   `pairing_authority_unavailable`, or `composition_version_overflow`.
+   Why it matters: fixture #14 is the stated AC #14 proof point, so the suite
+   can pass while an existing runtime error still renders as a consistency
+   banner. This is a test coverage gap for the same blocking behavior above,
+   not an independent product issue.
+   AC-linked: AC #14 / fixture #14.
+
+### Medium
+
+None.
+
+### Low
+
+1. `src-tauri/src/surface_runtime/mod.rs:2336`
+   What: the route reads `current_db_version_for_producer` at
+   `mod.rs:2336-2352`, then performs cache lookup at `mod.rs:2360-2362`, then
+   invokes the producer on miss at `mod.rs:2396-2410`. There is no route-level
+   mutex across read -> cache lookup -> producer invocation; the actual
+   serialization is only at DB writer-call granularity
+   (`src-tauri/src/state.rs:1493-1524`, `src-tauri/src/db_service.rs:116-172`).
+   Two concurrent cold local renders for the same composition can both read
+   version N, miss cache, and race into producer commits; `commit_composition`
+   accepts exactly one expected-version writer and rejects the loser as stale
+   (`src-tauri/src/services/compositions.rs:270-310`).
+   Why it matters: this contradicts the L0 race-analysis sentence that local
+   producer invocations are serialized by a SurfaceClient writer mutex. It is
+   local-single-runtime relevant, but not a literal §7 blocker because the ACs
+   and fixtures cover sequential render/manual reload behavior; the editor also
+   disables the manual reload button while loading at
+   `wp/dailyos/blocks/account-overview/edit.js:149-154`.
+   AC-linked or path-alpha: path-α.
+   → Linear maintenance: Serialize cold project-composition misses per composition
+
+2. `src-tauri/src/surface_runtime/mod.rs:5317`
+   What: fixture `dos671_external_version_advance_invalidates_cache` proves the
+   route does not serve the stale key by observing `served_from_cache=false`,
+   but it also asserts the old cache key remains present at
+   `mod.rs:5371-5378`. That is acceptable for the current orchestrator API, yet
+   it does not harden cache eviction or coalescing around external version
+   advancement.
+   Why it matters: this is fine for the L0 option-a keying contract, but it
+   leaves future maintainers with a cache full of stale-but-addressable entries
+   until TTL. Not a block; TTL is 60s and route lookup uses current DB version.
+   AC-linked or path-alpha: path-α.
+   → Linear maintenance: Add stale project-composition cache pruning or coalescing
+
+3. `src-tauri/scripts/check_claim_writer_allowlist.sh:28`
+   What: Packet B includes an allowlist expansion for
+   `tests/fixtures/W6-A-meta-[0-9]+/state.sql`, plus unrelated Linear migration
+   and signal-facade changes at
+   `src-tauri/src/migrations/v178_dos_285_linear_issue_state.rs:16-19` and
+   `src-tauri/src/services/linear_issue_signals.rs:98-144`.
+   Why it matters: I found no AC regression in those changes, but they are
+   outside Packet B's render-stabilization ownership and increase review
+   coupling.
+   AC-linked or path-alpha: path-α.
+   → Linear maintenance: Split validation-gate rebase artifacts out of Packet B
+
+## Axis results
+
+- Axis 1: pass. Wrapper signature remains
+  `dailyos_account_overview_render( array $attributes ): string` at
+  `wp/dailyos/blocks/account-overview/render-functions.php:31`; `render.php`
+  still calls it at `wp/dailyos/blocks/account-overview/render.php:24-25`;
+  the direct fixture file is
+  `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php`, with wrapper calls at
+  `:53`, `:62`, `:83`, `:114`, `:233`, `:271`, and `:291`.
+- Axis 2: pass. `reload` keeps live manual inputs at
+  `wp/dailyos/blocks/account-overview/edit.js:43-94`; `reloadTrigger` is
+  derived from account id plus composition-id presence at `edit.js:96`; the
+  auto effect depends on `[ reloadTrigger ]` at `edit.js:97-102`; successful
+  writes update only version/watermarks/token at `edit.js:72-80`.
+- Axis 3: conditional pass with path-α note above. The AC key correction is
+  present: current DB version read at `mod.rs:2336-2352`, lookup uses it at
+  `mod.rs:2360-2362`, and store uses
+  `projection.composition_version.unwrap_or(current_db_version_for_producer)`
+  at `mod.rs:2443-2453`.
+- Axis 4: pass. `authorize_local_render` delegates with
+  `charge_ability_scope=false` at
+  `src-tauri/src/bridges/surface_client.rs:277-291`; required-scope check runs
+  before rate consumption at `surface_client.rs:363-374`; ability/scope
+  candidates alone are gated by `charge_ability_scope` at
+  `surface_client.rs:815-843`; identity buckets are unconditional at
+  `surface_client.rs:786-813`.
+- Axis 5: fail. See High findings 1-2.
+- Axis 6: no additional AC-blocking cross-commit regression found beyond the
+  PHP typed-error matrix failing to absorb runtime codes surfaced by the later
+  Rust route/cache/decharge commit.
+
+## Cycle 2 re-verify
+
+1. §5.6 switch verdict: PASS — the targeted runtime codes are now handled
+   before the default verification-banner fail-safe.
+   Evidence: `src-tauri/src/surface_runtime/mod.rs:2247`,
+   `src-tauri/src/surface_runtime/mod.rs:2255`,
+   `src-tauri/src/surface_runtime/mod.rs:2268`, and
+   `src-tauri/src/surface_runtime/mod.rs:2274` emit
+   `project_composition_invalid`, `runtime_unavailable`,
+   `project_composition_unknown_producer`, and
+   `project_composition_invalid_id`.
+   Evidence: `wp/dailyos/blocks/account-overview/render-functions.php:127`
+   handles `runtime_unavailable`; `wp/dailyos/blocks/account-overview/render-functions.php:142-144`
+   handles all three `project_composition_*` codes.
+   Evidence: `src-tauri/src/surface_runtime/hmac.rs:794-802` emits
+   `signature_invalid`, `canonicalization_mismatch`, `timestamp_stale`,
+   `timestamp_future`, `key_not_found`, `key_rotated`, `token_invalid`,
+   `nonce_replay`, and `transport_abuse_limited`.
+   Evidence: `wp/dailyos/blocks/account-overview/render-functions.php:94`
+   handles `transport_abuse_limited`; `wp/dailyos/blocks/account-overview/render-functions.php:117-124`
+   handles the remaining signed-transport codes.
+   Evidence: `src-tauri/src/services/surface_pairing.rs:264-280` emits
+   pairing/session/scope codes including `unknown_runtime_anchor`,
+   `session_invalid`, and `pairing_authority_unavailable`; those are handled
+   at `wp/dailyos/blocks/account-overview/render-functions.php:97-115`.
+   Evidence: `src-tauri/src/surface_runtime/mod.rs:3071-3076` emits
+   `composition_version_overflow`; `wp/dailyos/blocks/account-overview/render-functions.php:152`
+   maps it to the verification banner intentionally.
+   Missing from switch: none from the requested literal/code ranges.
+
+2. Fixture `typed_error_mapping_provider` verdict: PASS — fixture #14 covers
+   the same targeted code set as the §5.6 switch.
+   Evidence: `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:450`
+   covers `transport_abuse_limited`.
+   Evidence: `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:459-486`
+   covers the pairing/session/signed-transport set, including
+   `session_invalid`, `unknown_runtime_anchor`, `pairing_authority_unavailable`,
+   `signature_invalid`, `canonicalization_mismatch`, `timestamp_*`, `key_*`,
+   `token_invalid`, and `nonce_replay`.
+   Evidence: `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:491`
+   covers `runtime_unavailable`; `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:508-510`
+   covers all three `project_composition_*` codes; `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:520`
+   covers `composition_version_overflow`.
+   Missing from fixture: none from the requested literal/code ranges.
+
+3. Remaining path-α findings verdict: PASS — they remain filed as path-α
+   maintenance notes and are not Packet B blockers.
+   Evidence: the cold-miss serialization finding is marked path-α at
+   `.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md:72-90`,
+   with non-blocking rationale at
+   `.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md:83-89`.
+   Evidence: the stale cache pruning finding is marked path-α at
+   `.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md:92-103`,
+   with non-blocking TTL/current-version rationale at
+   `.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-challenge.md:99-102`.
+
+Final verdict: APPROVE — commit `97db0de2` satisfies AC #14, and the two
+remaining path-α items are already documented as non-blocking maintenance.

--- a/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-consult.md
+++ b/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-codex-consult.md
@@ -1,0 +1,24 @@
+Verdict = APPROVE
+
+1. PASS - §5.1 wrapper preservation: current `dailyos_account_overview_render( array $attributes ): string` matches pre-PR signature exactly.
+Evidence: `a594cd4d:wp/dailyos/blocks/account-overview/render-functions.php:32`; `wp/dailyos/blocks/account-overview/render-functions.php:31-33`.
+The six pre-PR direct fixture calls are still wrapper calls, shifted to current lines `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php:53,62,83,233,271,291`; an added wrapper-regression fixture calls it at `:114`.
+
+2. PASS - §5.3 cache key: current composition version is read before cache lookup.
+Evidence: `current_composition_version_for_composition_id` is read at `src-tauri/src/surface_runtime/mod.rs:2335-2352`, before `orchestrator.cache_lookup(... current_db_version)` at `:2360-2362`.
+Pre-PR had lookup before the read: `a594cd4d:src-tauri/src/surface_runtime/mod.rs:2317-2321` vs read at `:2354-2371`.
+
+3. PASS - §5.5 `authorize_local_render`: required-scope authorization is preserved; only ability/scope rate-limit buckets are bypassed.
+Evidence: `authorize_local_render` delegates with `charge_ability_scope=false` at `src-tauri/src/bridges/surface_client.rs:277-291`, while `ensure_required_scopes` still runs at `:363-374`.
+The flag reaches `check_and_consume` at `:407-430`; identity candidates are unconditional at `:786-813`, and only scope/ability candidates are gated by `charge_ability_scope` at `:815-843`.
+
+4. PASS - §5.2 reloadTrigger: `reload` keeps the full manual-reload dependency list.
+Evidence: `useCallback` deps are `[ attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes ]` at `wp/dailyos/blocks/account-overview/edit.js:43-94`.
+Auto-reload is separately gated by `reloadTrigger` and `useEffect(..., [ reloadTrigger ])` at `wp/dailyos/blocks/account-overview/edit.js:96-102`.
+
+5. PASS - §5.6 switch coverage: the renderer includes the V1.1.1 expanded session-repair arm.
+Evidence: L0 requires `identity_mismatch`, `wp_user_mismatch`, `pairing_*`, `site_binding_mismatch`, `restored_stale_pairing`, `scope_denied`, and `auth_missing` at `.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md:616-633`.
+Current switch maps that expanded arm to `dailyos_account_overview_render_session_repair_notice()` at `wp/dailyos/blocks/account-overview/render-functions.php:95-112`.
+
+Path-α
+None.

--- a/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-cso.md
+++ b/.docs/plans/v1.4.3-wp-foundation/reviews/packet-B-L2-cso.md
@@ -1,0 +1,73 @@
+# Packet B — L2 CSO security review
+
+**Branch:** `dos-671-672-render-stabilization` (3 commits since `a594cd4d`)
+**Anchor:** L0 Packet B V1.1.1 (L0-closed; cycle-2 CSO unanimous APPROVE)
+**Threat model:** local-to-local, same-UID; v1.4.3 WP surface is loopback to Tauri runtime on the same machine.
+**Scope:** AC-adjacent. Path-α → Linear maintenance `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`. Not a BLOCK.
+
+## Verdict: APPROVE
+
+All trust-boundary invariants from L0 §5.5 / §11 are preserved. The §5.3 cache-key correction does not introduce a new authorization-bypass surface: authorization runs strictly before cache lookup, and the lookup key now refers to substrate-owned state (`current_db_version`) rather than client-supplied watermark. The §5.5 `authorize_local_render` variant is a surgical decharge of the *rate-limit buckets only* for ability + scope axes — every mandatory check (descriptor lookup, actor/mode/experimental gate, required-scope CHECK, browser-direct guard) is preserved. The §5.6 typed-error switch maps codes already on the wire and is renderer-side only; no new attack surface under same-UID local model. No remote-shape defenses reintroduced.
+
+---
+
+## Trust-boundary checks against L0 plan
+
+| # | Invariant | Status |
+|---|---|---|
+| 1 | §5.4 reframe preserved: producer commit on cache miss is KEPT | OK — `surface_runtime/mod.rs:2389-2410` invokes the W4-F producer on cache miss; `commit_composition` semantics in the producer are untouched. No removal of producer state-advance. |
+| 2 | Cache lookup keyed by `current_db_version`, not `request.composition_version` | OK — `mod.rs:2336-2352` reads `current_composition_version_for_composition_id` from substrate; `:2361` uses `current_db_version`. Grep-gate test `dos671_project_composition_cache_lookup_current_db_version_grep_gate` enforces both positive and negative assertion. |
+| 3 | Authorization runs BEFORE cache lookup | OK — `authorize_local_render` is invoked at `mod.rs:2304-2327` (rejects on `RateLimited` / `ScopeDenied` / `AbilityUnavailable` with audit emission); cache lookup at `:2360-2381` is only reachable past the early-returns. A cache hit cannot bypass auth. |
+| 4 | `authorize_local_render` preserves scope CHECK; only scope/ability BUCKETS bypassed | OK — `bridges/surface_client.rs:277-291` delegates to `authorize_for_path` with `charge_ability_scope=false`. `authorize_for_path:363-371` runs `ensure_required_scopes` unconditionally and short-circuits on failure with `ScopeDenied`. Descriptor lookup (`:321`), allowed_actors / allowed_modes / experimental (`:338`), `BrowserDirectJs` policy.client_side_executable guard (`:374`) all unconditional. Test `authorize_local_render_enforces_required_scope` proves rejection on insufficient scope. |
+| 5 | Identity buckets still consumed | OK — rate limiter `candidates()` at `surface_client.rs:780-813` adds SurfaceClient / WpSite / WpUser candidates unconditionally; only the `Scope` and `Ability` axis candidates at `:815-843` are gated by `charge_ability_scope`. Test `authorize_local_render_still_charges_identity_buckets` proves SurfaceClient throttle still trips with budget=1. |
+| 6 | §5.6 typed error switch introduces no new attack vector | OK — all 30 error codes mapped (`render-functions.php:85-141`) are already emitted by `SurfaceHttpError` and observable to any client of the loopback runtime. The switch is renderer mapping only: it does not branch on payload contents, does not leak server internals beyond the existing taxonomy, and does not change which codes are wire-visible. Hostile co-resident plugin fingerprinting is the V1.1 deferred maintenance item, which is correct for local-to-local. |
+| 7 | Editor `reloadTrigger` contains no secrets | OK — `edit.js:96` derives `reloadTrigger = "${account_id || ''}|${composition_id ? '1' : '0'}"`. Account ID is a user-typed identifier already visible in the editor UI, sidebar inspector, and DOM attributes; composition presence is a single bit. No tokens, session IDs, claim IDs, scopes, or watermarks appear. |
+| 8 | `render.php` front-end path inherits page auth context; no new CSRF surface | OK — `wp/dailyos/blocks/account-overview/render.php` calls the wrapper `dailyos_account_overview_render($attributes)` exactly as before. The wrapper now delegates internally to `fetch_projection` → `render_from_projection`, but the entrypoint and the trust context (page render under normal WP capability checks) are unchanged. The REST preview route at `class-dailyos-plugin.php:587-621` already enforces `current_user_can('edit_posts')` upstream; this commit changes how it renders the projection, not who can call it. |
+
+## Deferred items (V1.1) — still DEFERRED in implementation
+
+Verified by diff inspection: none of these were silently reintroduced.
+
+- **Signal-propagation cache invalidation bus** — not present; invalidation continues to flow through producer commits advancing `current_db_version`.
+- **Hostile co-resident plugin error-code fingerprinting** — error taxonomy unchanged from `SurfaceHttpError`; no redaction layer added.
+- **Render-volume audit signal** — no new audit-event types emitted from the decharge path; existing identity-bucket audits are preserved through `audit_events` returned from the limiter.
+- **ESLint authoring** — `edit.js:99-101` uses `eslint-disable-next-line react-hooks/exhaustive-deps` with rationale comment; grep gates enforce the pattern.
+- **Persistent projection storage** — in-memory `CompositionRenderOrchestrator` unchanged.
+- **Perf budgeting** — no new perf budget assertions; behavioral fixtures cover the warm-path producer-skip claim.
+
+## Cross-packet interlock (Packet A ↔ Packet B)
+
+The L0 packet description called the regions disjoint. Empirically there is one **textual** overlap inside `surface_project_composition_response` (the cache_lookup call site):
+
+- **Packet A** reformats lines 2317-2322 as a rustfmt-only cosmetic change (compresses multi-line call onto a single line; same arguments).
+- **Packet B** rewrites the same call to use `current_db_version` and adds the upstream `db_read` for that value.
+
+Either landing order works. Whichever lands second produces a trivial textual conflict that resolves to Packet B's semantics (Packet A's hunk becomes a no-op because the new shape no longer matches rustfmt's "long form" trigger). No security risk — both edits preserve the same authorization-precedes-cache invariant.
+
+## Path-α findings (file to maintenance, not BLOCK)
+
+1. **§9 invariant #6 grep gate is one-sided.** The test `dos672_project_composition_route_uses_local_render_authorization_grep_gate` asserts the route uses `authorize_local_render` and does NOT call `authorize`. It does not assert that `authorize_local_render` itself passes `charge_ability_scope=false` to `authorize_for_path` (an attacker editing `surface_client.rs:285` could silently flip the bool back to `true` and still pass the route-level grep gate). Behavioral test `authorize_local_render_does_not_charge_ability_or_scope_buckets` covers the regression, but a literal grep gate inside `bridges/surface_client.rs` would harden the boundary.
+   → Linear maintenance: "Add grep gate for authorize_local_render charge_ability_scope=false delegation in surface_client.rs"
+
+2. **`render_from_projection` fallback branches.** The `default:` arm and `consistency_failure` arm both fall through to `dailyos_account_overview_render_verification_banner()` (`render-functions.php:139-141`). This is correct fail-safe behavior, but the third call site at `:143` (`is_array($projection)` defensive guard for malformed success envelopes) is also reachable. The verification banner is reserved language with claim-trust semantics; using it for "the runtime returned a non-array projection" muddles the trust-band signal. Either route this case to `RuntimeUnavailableNotice` or clarify §9 #7 to include the shape-mismatch fail-safe.
+   → Linear maintenance: "Disambiguate verification banner vs runtime-unavailable notice for malformed projection envelope"
+
+## Out-of-scope changes (rebase artifacts, not security-relevant)
+
+Three files in the diff are enabling changes for validation gates on this worktree, not part of the render-stabilization work:
+
+- `src-tauri/scripts/check_claim_writer_allowlist.sh` — adds `W6-A-meta-N/state.sql` to the allowlist regex (extension of the existing pattern; same authorization model).
+- `src-tauri/src/migrations/v178_dos_285_linear_issue_state.rs` — adds an `if !table_exists` guard so v178 is idempotent on DBs without `linear_issues`. Defensive; can only narrow what the migration does.
+- `src-tauri/src/services/linear_issue_signals.rs` — routes signal emission through `services::signals::emit_and_propagate` instead of `signals::bus::emit_signal_and_propagate`. Service-facade compliance fix, not a trust-boundary change.
+
+None of these affect the surface trust boundary, claim authorization, or runtime auth path. Noted for completeness; not flagged.
+
+## Files referenced
+
+- `/private/tmp/dailyos-pb/src-tauri/src/surface_runtime/mod.rs:2275-2473` (project-composition route)
+- `/private/tmp/dailyos-pb/src-tauri/src/bridges/surface_client.rs:270-440,815-843` (authorize_local_render + bucket gating)
+- `/private/tmp/dailyos-pb/wp/dailyos/blocks/account-overview/render-functions.php:32-141` (split + typed error switch)
+- `/private/tmp/dailyos-pb/wp/dailyos/blocks/account-overview/render.php` (front-end entrypoint, unchanged shape)
+- `/private/tmp/dailyos-pb/wp/dailyos/blocks/account-overview/edit.js:81-102` (reloadTrigger)
+- `/private/tmp/dailyos-pb/wp/dailyos/includes/class-dailyos-plugin.php:587-625` (preview route uses render_from_projection)
+- `/private/tmp/dailyos-pb/.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md` V1.1.1

--- a/src-tauri/scripts/check_claim_writer_allowlist.sh
+++ b/src-tauri/scripts/check_claim_writer_allowlist.sh
@@ -48,7 +48,7 @@ if [[ -n "$matches" ]]; then
   echo "  - src-tauri/src/migrations/{129,130,131}_dos_7_*.sql"
   echo "  - src-tauri/tests/dos7_d{1,3a1,3a2}_*.rs (test seeding via execute_batch)"
   echo "  - src-tauri/tests/fixtures/bundle-N/state.sql (DOS-384 adversarial bundle fixtures)"
-  echo "  - src-tauri/tests/fixtures/W6-A-meta-N/state.sql (DOS-567 metadata fixtures)"
+  echo "  - src-tauri/tests/fixtures/W6-A-meta-N/state.sql (W6 metadata eval fixtures)"
   echo
   echo "$matches"
   exit 1

--- a/src-tauri/src/bridges/surface_client.rs
+++ b/src-tauri/src/bridges/surface_client.rs
@@ -270,6 +270,24 @@ impl SurfaceClientBridge {
             session,
             ability_name,
             request_id,
+            true,
+        )
+    }
+
+    pub fn authorize_local_render(
+        &self,
+        registry: &AbilityRegistry,
+        session: &ValidatedSurfaceSession,
+        ability_name: &str,
+        request_id: &str,
+    ) -> Result<SurfaceClientAuthorization, SurfaceClientBridgeError> {
+        self.authorize_for_path(
+            SurfaceClientInvocationPath::SignedServer,
+            registry,
+            session,
+            ability_name,
+            request_id,
+            false,
         )
     }
 
@@ -286,6 +304,7 @@ impl SurfaceClientBridge {
             session,
             ability_name,
             request_id,
+            true,
         )
     }
 
@@ -296,6 +315,7 @@ impl SurfaceClientBridge {
         session: &ValidatedSurfaceSession,
         ability_name: &str,
         request_id: &str,
+        charge_ability_scope: bool,
     ) -> Result<SurfaceClientAuthorization, SurfaceClientBridgeError> {
         let audit_hash_secret = format!("{}:{}", session.session_id, session.site_nonce);
         let Some(descriptor) = registry
@@ -406,7 +426,7 @@ impl SurfaceClientBridge {
                 policy_rate_limit: descriptor.policy.rate_limit,
                 wp_user_id: session.wp_user_id,
                 actor_scopes: session.granted_scopes.clone(),
-                charge_ability_scope: true,
+                charge_ability_scope,
             }) {
             RateLimitOutcome::Allowed { audit_events } => Ok(SurfaceClientAuthorization {
                 canonical_ability_name: descriptor.name.to_string(),
@@ -1113,14 +1133,21 @@ fn duration_ms(duration: Duration) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::abilities::provenance::CompositionId;
     use crate::abilities::registry::{
-        AbilityContext, AbilityPolicy, ErasedAbilityFuture, McpExposure, ScopeSet, SignalPolicy,
-        SurfaceClientId,
+        AbilityContext, AbilityPolicy, ComposesEntry, ErasedAbilityFuture, McpExposure, ScopeSet,
+        SignalPolicy, SurfaceClientId,
     };
     use crate::abilities::ActorKind;
     use serde_json::json;
     use std::sync::Barrier;
     use std::thread;
+
+    static GET_ACCOUNT_CONTEXT_COMPOSES: [ComposesEntry; 1] = [ComposesEntry {
+        id: CompositionId::from_static("dailyos/get-account-context"),
+        ability: "dailyos/get-account-context",
+        optional: false,
+    }];
 
     #[derive(Clone)]
     struct FixedClock {
@@ -1535,6 +1562,97 @@ mod tests {
             "dailyos/account-overview"
         );
         assert_eq!(authorization.request_class, SurfaceClientRequestClass::Read);
+    }
+
+    #[test]
+    fn authorize_local_render_enforces_required_scope() {
+        let clock = FixedClock::new(Instant::now());
+        let bridge = bridge_with(test_config(), clock);
+        let registry =
+            AbilityRegistry::from_descriptors_unchecked_for_runtime_validation_tests(vec![
+                descriptor(
+                    "dailyos/account-overview",
+                    AbilityCategory::Read,
+                    &["read.account_overview"],
+                    None,
+                ),
+            ]);
+        let session = session(&["submit.feedback"]);
+
+        assert!(matches!(
+            bridge
+                .authorize_local_render(&registry, &session, "dailyos/account-overview", "req_1")
+                .unwrap_err(),
+            SurfaceClientBridgeError::ScopeDenied
+        ));
+    }
+
+    #[test]
+    fn authorize_local_render_does_not_charge_ability_or_scope_buckets() {
+        let clock = FixedClock::new(Instant::now());
+        let mut config = test_config();
+        let one_per_second = SurfaceClientRateLimitBudget::new(60, 1);
+        config.scope.read = one_per_second;
+        config.ability.standard_read_composition = one_per_second;
+        let bridge = bridge_with(config, clock);
+        let mut overview = descriptor(
+            "dailyos/account-overview",
+            AbilityCategory::Read,
+            &["read.account_overview"],
+            None,
+        );
+        overview.composes = &GET_ACCOUNT_CONTEXT_COMPOSES;
+        let registry =
+            AbilityRegistry::from_descriptors_unchecked_for_runtime_validation_tests(vec![
+                overview,
+            ]);
+        let session = session(&["read.account_overview"]);
+
+        assert!(bridge
+            .authorize_local_render(&registry, &session, "dailyos/account-overview", "req_1")
+            .is_ok());
+        assert!(bridge
+            .authorize_local_render(&registry, &session, "dailyos/account-overview", "req_2")
+            .is_ok());
+        assert!(bridge
+            .authorize(&registry, &session, "dailyos/account-overview", "req_3")
+            .is_ok());
+        assert!(matches!(
+            bridge
+                .authorize(&registry, &session, "dailyos/account-overview", "req_4")
+                .unwrap_err(),
+            SurfaceClientBridgeError::RateLimited(rejection)
+                if rejection.axis == SurfaceClientRateLimitAxis::Scope
+        ));
+    }
+
+    #[test]
+    fn authorize_local_render_still_charges_identity_buckets() {
+        let clock = FixedClock::new(Instant::now());
+        let mut config = test_config();
+        config.surface_client.read = SurfaceClientRateLimitBudget::new(60, 1);
+        let bridge = bridge_with(config, clock);
+        let registry =
+            AbilityRegistry::from_descriptors_unchecked_for_runtime_validation_tests(vec![
+                descriptor(
+                    "dailyos/account-overview",
+                    AbilityCategory::Read,
+                    &["read.account_overview"],
+                    None,
+                ),
+            ]);
+        let session = session(&["read.account_overview"]);
+
+        assert!(bridge
+            .authorize_local_render(&registry, &session, "dailyos/account-overview", "req_1")
+            .is_ok());
+        assert!(matches!(
+            bridge
+                .authorize_local_render(&registry, &session, "dailyos/account-overview", "req_2")
+                .unwrap_err(),
+            SurfaceClientBridgeError::RateLimited(rejection)
+                if rejection.axis == SurfaceClientRateLimitAxis::SurfaceClient
+        ));
     }
 
     #[test]

--- a/src-tauri/src/migrations/v178_dos_285_linear_issue_state.rs
+++ b/src-tauri/src/migrations/v178_dos_285_linear_issue_state.rs
@@ -7,7 +7,7 @@
 //! v162 repair regression tests) can re-apply v178 without tripping
 //! `duplicate column name`.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 
 use super::MigrationError;
 
@@ -58,6 +58,17 @@ fn add_column_if_missing(
     )
     .map_err(|e| format!("add {LINEAR_ISSUES_TABLE}.{column_name}: {e}"))?;
     Ok(())
+}
+
+fn table_exists(conn: &Connection, table_name: &str) -> Result<bool, MigrationError> {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table_name],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+    .map_err(|e| format!("check table {table_name}: {e}"))
 }
 
 fn column_exists(

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -52,7 +52,6 @@ use crate::services::surface_pairing::{
     SignedTransportFailureInput, SurfacePairingAuditEvent, SurfacePairingError,
     SurfaceSessionRefreshIdentity, SurfaceSessionRefreshInput, ValidatedSurfaceSession,
 };
-use crate::services::surface_session_keychain::SessionKeyLookup;
 use crate::state::AppState;
 use abilities_runtime::abilities::registry::{Actor, ScopeSet, SurfaceClientId};
 
@@ -328,7 +327,7 @@ impl SurfaceEndpointState {
                         run_listener(listener, runtime, shutdown_rx).await;
                         // Remove the runtime sentinel on shutdown so a stale
                         // port doesn't redirect WP after restart.
-                        explicit_sentinel_cleanup();
+                        remove_runtime_sentinel();
                         // Lazy-flush last_seen_at + last_used_at on graceful
                         // shutdown. Coalesced UPDATE — sets all non-revoked
                         // sessions' last_seen_at and their pairings'
@@ -412,7 +411,6 @@ impl SurfaceEndpointState {
         };
 
         if let Some(endpoint) = running {
-            explicit_sentinel_cleanup();
             if endpoint.shutdown.send(true).is_err() {
                 log::debug!("surface endpoint shutdown signal had no active listener");
             }
@@ -469,7 +467,6 @@ impl Drop for SurfaceEndpointState {
     fn drop(&mut self) {
         let running = self.inner.get_mut().running.take();
         if let Some(endpoint) = running {
-            explicit_sentinel_cleanup();
             if endpoint.shutdown.send(true).is_err() {
                 log::debug!("surface endpoint drop found no active listener");
             }
@@ -664,13 +661,12 @@ async fn rehydrate_sessions_from_keychain(
     // Step 2-4: per-row keychain load + register-or-revoke.
     let mut rehydrated = 0usize;
     let mut missing = Vec::new();
-    let mut unavailable = Vec::new();
     for row in rows {
         match crate::services::surface_session_keychain::load_session_master_key(
             &row.surface_client_id,
             &row.session_id,
         ) {
-            SessionKeyLookup::Found(master_key) => {
+            Some(master_key) => {
                 let session = hmac::SignedSurfaceSession::new_active(
                     row.session_id.clone(),
                     row.surface_client_id.clone(),
@@ -682,40 +678,14 @@ async fn rehydrate_sessions_from_keychain(
                 }
                 rehydrated += 1;
             }
-            SessionKeyLookup::NotFound => {
+            None => {
                 missing.push(row);
-            }
-            SessionKeyLookup::Unavailable { reason } => {
-                unavailable.push((row, reason));
             }
         }
     }
     if rehydrated > 0 {
         log::info!(
             "surface session rehydrate: {rehydrated} active sessions restored from keychain"
-        );
-    }
-    if !unavailable.is_empty() {
-        for (row, reason) in &unavailable {
-            let event = surface_pairing::SurfacePairingAuditEvent {
-                event_kind: "pairing.session.key_unavailable",
-                category: "surface_pairing",
-                actor: abilities_runtime::abilities::registry::Actor::System,
-                wp_user_id: None,
-                wp_user_hash: None,
-                detail: serde_json::json!({
-                    "session_id": row.session_id,
-                    "surface_client_id": row.surface_client_id,
-                    "reason": reason,
-                    "decision": "left_active",
-                    "remediation": "retry_rehydrate_or_repair",
-                }),
-            };
-            emit_pairing_audit_event(app_state, &event);
-        }
-        log::warn!(
-            "surface session rehydrate: {} sessions left active because keychain was unavailable",
-            unavailable.len()
         );
     }
 
@@ -823,37 +793,12 @@ fn stable_hash_for_audit(value: &str) -> String {
 /// `~/.dailyos/runtime-endpoint.json` — written on bind, removed on shutdown.
 /// Parent dir is ensured at `0700`, sentinel at `0600`.
 fn runtime_sentinel_path() -> io::Result<PathBuf> {
-    #[cfg(test)]
-    if let Some(path) = RUNTIME_SENTINEL_PATH_FOR_TESTS.lock().unwrap().clone() {
-        return Ok(path);
-    }
-
     let home = std::env::var_os("HOME")
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME unset"))?;
     let mut path = PathBuf::from(home);
     path.push(".dailyos");
     path.push("runtime-endpoint.json");
     Ok(path)
-}
-
-#[cfg(test)]
-static RUNTIME_SENTINEL_PATH_FOR_TESTS: std::sync::Mutex<Option<PathBuf>> =
-    std::sync::Mutex::new(None);
-
-#[cfg(test)]
-struct RuntimeSentinelPathGuard;
-
-#[cfg(test)]
-impl Drop for RuntimeSentinelPathGuard {
-    fn drop(&mut self) {
-        *RUNTIME_SENTINEL_PATH_FOR_TESTS.lock().unwrap() = None;
-    }
-}
-
-#[cfg(test)]
-fn set_runtime_sentinel_path_for_tests(path: PathBuf) -> RuntimeSentinelPathGuard {
-    *RUNTIME_SENTINEL_PATH_FOR_TESTS.lock().unwrap() = Some(path);
-    RuntimeSentinelPathGuard
 }
 
 /// Write the runtime sentinel after a successful bind.
@@ -943,10 +888,6 @@ fn remove_runtime_sentinel() {
         )]
         let _ = fs::remove_file(path);
     }
-}
-
-fn explicit_sentinel_cleanup() {
-    remove_runtime_sentinel();
 }
 
 async fn run_listener(
@@ -1173,9 +1114,12 @@ async fn signed_transport_response(
             // return directly.
             if let Some(action) = failure.write_action() {
                 let now = Utc::now();
-                let cleanup_reason = action.cleanup_reason();
                 let action_for_closure = action.clone();
-                let cleanup_target = app_state
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "quarantine write best-effort; rejection response is the meaningful outcome"
+                )]
+                let _ = app_state
                     .db_write(move |db| {
                         surface_pairing::apply_signed_session_write_action(
                             db,
@@ -1185,15 +1129,6 @@ async fn signed_transport_response(
                         .map_err(|e| e.to_string())
                     })
                     .await;
-                if let Ok(Some(target)) = cleanup_target {
-                    if let Some(reason) = cleanup_reason {
-                        for event in
-                            surface_pairing::cleanup_session_keychain_entries(&target, reason)
-                        {
-                            emit_pairing_audit_event(&app_state, &event);
-                        }
-                    }
-                }
                 // Quarantine write best-effort: even if the writer-mutex acquisition
                 // fails (e.g., flooding rejection attempts), the request is being
                 // rejected anyway. Rate-limit gate at surface_client_bridge.authorize
@@ -1471,9 +1406,6 @@ async fn pairing_handshake_response(
     if let Some(origin) = normalize_origin(&outcome.paired_origin) {
         runtime.paired_site_origins.write().insert(origin);
     }
-    for event in &outcome.keychain_cleanup_audits {
-        emit_pairing_audit_event(&app_state, event);
-    }
     if let Some(event) = outcome.revocation_audit.as_ref() {
         emit_pairing_audit_event(&app_state, event);
     }
@@ -1587,7 +1519,7 @@ async fn record_signed_transport_failure(
         failure_code: error.code().to_string(),
         now: Utc::now(),
     };
-    let outcome = match app_state
+    let events = match app_state
         .db_write(move |db| {
             let clock = crate::services::context::SystemClock;
             let rng = crate::services::context::SystemRng;
@@ -1612,16 +1544,10 @@ async fn record_signed_transport_failure(
             return;
         }
     };
-    if let Some(target) = outcome.cleanup_target.as_ref() {
-        for event in surface_pairing::cleanup_session_keychain_entries(target, "suspicious_replay")
-        {
-            emit_pairing_audit_event(&app_state, &event);
-        }
-    }
     if let Some(event) = direct_event {
         emit_pairing_audit_event(&app_state, &event);
     }
-    for event in outcome.events {
+    for event in events {
         if event.event_kind == "pairing_revoked" {
             if let Some(surface_client_id) = event
                 .detail
@@ -1658,15 +1584,7 @@ async fn compensate_failed_session_registration(
         })
         .await
     {
-        Ok(Ok((event, cleanup_target))) => {
-            for cleanup_event in surface_pairing::cleanup_session_keychain_entries(
-                &cleanup_target,
-                "session_registration_failed",
-            ) {
-                emit_pairing_audit_event(app_state, &cleanup_event);
-            }
-            emit_pairing_audit_event(app_state, &event);
-        }
+        Ok(Ok(event)) => emit_pairing_audit_event(app_state, &event),
         Ok(Err(error)) => {
             log::warn!(
                 "surface pairing compensation failed after session registration error: {}",
@@ -2358,6 +2276,22 @@ async fn surface_project_composition_response(
         );
     };
 
+    #[cfg(test)]
+    let registry_override = runtime.ability_registry_override.clone();
+    #[cfg(test)]
+    let registry = if let Some(registry) = registry_override.as_deref() {
+        registry
+    } else {
+        match crate::abilities::AbilityRegistry::global_checked() {
+            Ok(registry) => registry,
+            Err(_) => {
+                return error_response(
+                    SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+                );
+            }
+        }
+    };
+    #[cfg(not(test))]
     let registry = match crate::abilities::AbilityRegistry::global_checked() {
         Ok(registry) => registry,
         Err(_) => {
@@ -2367,7 +2301,7 @@ async fn surface_project_composition_response(
         }
     };
 
-    let authorization = match runtime.surface_client_bridge.authorize(
+    let authorization = match runtime.surface_client_bridge.authorize_local_render(
         registry,
         &validated,
         ability_name,
@@ -2392,12 +2326,39 @@ async fn surface_project_composition_response(
         }
     };
 
+    // The producer always advances composition_version monotonically and
+    // commits unconditionally. The surface's previously-rendered version is
+    // structurally meaningless as an OCC token because the surface has no
+    // write path — only the producer mutates compositions. Read the current
+    // substrate version before cache lookup so stale surface watermarks do
+    // not force a miss and re-run the producer.
+    let composition_id_for_lookup = request.composition_id.clone();
+    let current_db_version_for_producer = app_state
+        .db_read(move |db| {
+            let clock = crate::services::context::SystemClock;
+            let rng = crate::services::context::SystemRng;
+            let external = crate::services::context::ExternalClients::default();
+            let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external);
+            crate::services::compositions::current_composition_version_for_composition_id(
+                &ctx,
+                db,
+                &composition_id_for_lookup,
+            )
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .ok()
+        .unwrap_or(0);
+    let current_db_version = i64::try_from(current_db_version_for_producer).unwrap_or(i64::MAX);
+
     // After authorization succeeds, check the cache. Cache key includes the
-    // scopes-canonical id, so a different actor with different scopes will
-    // miss naturally; authorization above gates the allowed_actors/required_
-    // scopes/rate-limit policy that the cache key alone doesn't enforce.
+    // current DB composition version plus the scopes-canonical id, so stale
+    // client watermarks do not force misses and a different actor with
+    // different scopes will miss naturally; authorization above gates the
+    // allowed_actors/required_scopes/rate-limit policy that the cache key
+    // alone doesn't enforce.
     if let Some(cached) =
-        orchestrator.cache_lookup(&actor, &request.composition_id, request.composition_version)
+        orchestrator.cache_lookup(&actor, &request.composition_id, current_db_version)
     {
         let projection_json = match serde_json::to_value(&cached.projection) {
             Ok(value) => value,
@@ -2425,30 +2386,7 @@ async fn surface_project_composition_response(
         .live_service_context()
         .with_actor("surface_client");
 
-    // The producer always advances composition_version monotonically and
-    // commits unconditionally. The surface's previously-rendered version is
-    // structurally meaningless as an OCC token because the surface has no
-    // write path — only the producer mutates compositions. Forward the
-    // current substrate version on every render so the producer's commit
-    // step never trips its own watermark check on stale surface claims.
-    let composition_id_for_lookup = request.composition_id.clone();
-    let current_db_version = app_state
-        .db_read(move |db| {
-            let clock = crate::services::context::SystemClock;
-            let rng = crate::services::context::SystemRng;
-            let external = crate::services::context::ExternalClients::default();
-            let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external);
-            crate::services::compositions::current_composition_version_for_composition_id(
-                &ctx,
-                db,
-                &composition_id_for_lookup,
-            )
-            .map_err(|e| e.to_string())
-        })
-        .await
-        .ok()
-        .unwrap_or(0);
-    let expected_version_for_producer: u64 = current_db_version;
+    let expected_version_for_producer: u64 = current_db_version_for_producer;
     let input = json!({
         "account_id": account_id,
         "composition_id": request.composition_id,
@@ -2502,11 +2440,15 @@ async fn surface_project_composition_response(
     // substrate audit-logger drain is intentionally not wired in this
     // commit; see the v1.4.2 wave maintenance backlog for the
     // audit-emission interlock.
+    let projection_cache_version = projection
+        .composition_version
+        .unwrap_or(current_db_version_for_producer);
+    let projection_cache_version = i64::try_from(projection_cache_version).unwrap_or(i64::MAX);
     let cache_hint_token = orchestrator
         .cache_store(
             &validated.actor,
             &request.composition_id,
-            request.composition_version,
+            projection_cache_version,
             projection.clone(),
         )
         .unwrap_or_default();
@@ -3837,9 +3779,10 @@ impl PairingAttemptDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::abilities::provenance::CompositionId;
     use crate::abilities::registry::{
-        AbilityContext, AbilityDescriptor, AbilityPolicy, McpExposure, ScopeSet, SignalPolicy,
-        SurfaceClientId, SurfaceScope,
+        AbilityContext, AbilityDescriptor, AbilityPolicy, ComposesEntry, McpExposure, ScopeSet,
+        SignalPolicy, SurfaceClientId, SurfaceScope,
     };
     use crate::abilities::{AbilityCategory, AbilityError, Actor, ActorKind};
     use std::future::Future;
@@ -3849,6 +3792,12 @@ mod tests {
 
     static SURFACE_ROUTE_DISPATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
     static SURFACE_ROUTE_LIMIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static PROJECT_COMPOSITION_PRODUCER_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static GET_ACCOUNT_CONTEXT_COMPOSES: [ComposesEntry; 1] = [ComposesEntry {
+        id: CompositionId::from_static("dailyos/get-account-context"),
+        ability: "dailyos/get-account-context",
+        optional: false,
+    }];
 
     /// Tests using SURFACE_ROUTE_{DISPATCH,LIMIT}_COUNT share a
     /// process-global counter. Under parallel test execution (cargo test
@@ -3856,7 +3805,6 @@ mod tests {
     /// producing assertion failures like `left=2 right=1`. Serialize
     /// affected tests via this lock.
     static SURFACE_ROUTE_COUNTER_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    static RUNTIME_SENTINEL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     type ErasedFuture<'a> =
         Pin<Box<dyn Future<Output = Result<serde_json::Value, AbilityError>> + Send + 'a>>;
@@ -3875,6 +3823,44 @@ mod tests {
     ) -> ErasedFuture<'a> {
         SURFACE_ROUTE_LIMIT_COUNT.fetch_add(1, Ordering::SeqCst);
         surface_route_output(ctx, input, "surface_route_limited_test")
+    }
+
+    fn project_composition_erased<'a>(
+        _ctx: &'a AbilityContext<'a>,
+        input: serde_json::Value,
+    ) -> ErasedFuture<'a> {
+        PROJECT_COMPOSITION_PRODUCER_COUNT.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            let composition_id = input
+                .get("composition_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("dailyos/account-overview:account:acct-cache");
+            let projected_version = input
+                .get("expected_composition_version")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0)
+                .saturating_add(1);
+            let composition = abilities_runtime::abilities::composition::Composition::empty(
+                abilities_runtime::abilities::composition::CompositionDocId::new(composition_id),
+                abilities_runtime::abilities::composition::CompositionVersion::new(
+                    projected_version,
+                ),
+                Utc::now(),
+            );
+            Ok(json!({
+                "data": composition,
+                "provenance": {
+                    "invocation_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                    "ability_name": "dailyos/account-overview",
+                    "ability_version": { "major": 1, "minor": 0 },
+                    "ability_schema_version": 1,
+                    "actor": "surface_client",
+                    "mode": "live",
+                    "warnings": []
+                },
+                "diagnostics": { "warnings": [] }
+            }))
+        })
     }
 
     fn surface_route_output<'a>(
@@ -3903,32 +3889,6 @@ mod tests {
         })
     }
 
-    fn install_fake_running_endpoint(endpoint: &SurfaceEndpointState) {
-        let (shutdown, _shutdown_rx) = watch::channel(false);
-        let join = tokio::spawn(async {
-            std::future::pending::<()>().await;
-        });
-        let abort = join.abort_handle();
-        drop(join);
-
-        let mut inner = endpoint.inner.lock();
-        inner.availability = Some(SurfaceEndpointAvailability::Running);
-        inner.running = Some(RunningEndpoint {
-            startup_id: Uuid::new_v4(),
-            bound_port: 4411,
-            runtime_anchor_id: "anchor_test".to_string(),
-            shutdown,
-            abort,
-        });
-    }
-
-    fn install_test_sentinel_path() -> (tempfile::TempDir, PathBuf, RuntimeSentinelPathGuard) {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("runtime-endpoint.json");
-        let guard = set_runtime_sentinel_path_for_tests(path.clone());
-        (dir, path, guard)
-    }
-
     fn surface_route_schema() -> serde_json::Value {
         json!({
             "type": "object",
@@ -3936,6 +3896,20 @@ mod tests {
             "properties": {
                 "value": { "type": "number" }
             }
+        })
+    }
+
+    fn project_composition_schema() -> serde_json::Value {
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "account_id": { "type": "string" },
+                "composition_id": { "type": "string" },
+                "expected_composition_version": { "type": "number" },
+                "schema_version": { "type": "number" }
+            },
+            "required": ["account_id", "composition_id", "schema_version"]
         })
     }
 
@@ -3963,97 +3937,6 @@ mod tests {
             ability_registry_override: None,
             app_state: None,
         })
-    }
-
-    async fn app_state_with_rehydrate_rows(
-        rows: &[(&str, &str)],
-    ) -> (Arc<AppState>, tempfile::TempDir) {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let db_path = tempdir.path().join("surface-runtime-test.db");
-        let db_service = crate::db_service::DbService::open_at_unencrypted(db_path)
-            .await
-            .expect("open test db service");
-        let app_state = Arc::new(AppState::test_with_db_service(db_service));
-        let rows = rows
-            .iter()
-            .map(|(surface_client_id, session_id)| {
-                ((*surface_client_id).to_string(), (*session_id).to_string())
-            })
-            .collect::<Vec<_>>();
-        app_state
-            .db_write(move |db| {
-                let issued_at = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-                let expires_at = (Utc::now() + chrono::Duration::days(1))
-                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-                for (idx, (surface_client_id, session_id)) in rows.into_iter().enumerate() {
-                    let site_binding_digest = format!("site_digest_{idx}");
-                    let scope_digest = format!("scope_digest_{idx}");
-                    db.conn_ref()
-                        .execute(
-                            "INSERT INTO surface_client_pairings (
-                                pairing_id, surface_client_id, runtime_anchor_id, pairing_epoch,
-                                lifecycle_state, site_binding_digest, wp_install_uuid_hash,
-                                plugin_instance_uuid_hash, site_nonce, scopes_json, scope_digest,
-                                endpoint_version, ability_projection_json, created_at, activated_at,
-                                last_used_at, expires_at, audit_id
-                            ) VALUES (?1, ?2, 'runtime_test', 1, 'active', ?3, 'install_hash',
-                                'plugin_hash', 'site_nonce', '[]', ?4, 'v1', '[]', ?5, ?5, ?5, ?6, ?7)",
-                            rusqlite::params![
-                                format!("pairing_{idx}"),
-                                surface_client_id,
-                                site_binding_digest,
-                                scope_digest,
-                                issued_at,
-                                expires_at,
-                                format!("audit_{idx}")
-                            ],
-                        )
-                        .map_err(|error| error.to_string())?;
-                    db.conn_ref()
-                        .execute(
-                            "INSERT INTO surface_client_sessions (
-                                session_id, surface_client_id, pairing_epoch, hmac_key_id,
-                                issued_at, last_seen_at, inactive_expires_at, absolute_expires_at,
-                                scope_digest, site_binding_digest, wp_user_hash
-                            ) VALUES (?1, ?2, 1, ?3, ?4, ?4, ?5, ?5, ?6, ?7, 'wp_user_hash')",
-                            rusqlite::params![
-                                session_id,
-                                surface_client_id,
-                                format!("hmac_key_{idx}"),
-                                issued_at,
-                                expires_at,
-                                scope_digest,
-                                site_binding_digest
-                            ],
-                        )
-                        .map_err(|error| error.to_string())?;
-                }
-                Ok::<_, String>(())
-            })
-            .await
-            .expect("seed rehydrate rows");
-        (app_state, tempdir)
-    }
-
-    async fn session_revoked_reason(app_state: &Arc<AppState>, session_id: &str) -> Option<String> {
-        let session_id = session_id.to_string();
-        app_state
-            .db_read(move |db| {
-                db.conn_ref()
-                    .query_row(
-                        "SELECT revoked_reason FROM surface_client_sessions WHERE session_id = ?1",
-                        rusqlite::params![session_id],
-                        |row| row.get::<_, Option<String>>(0),
-                    )
-                    .map_err(|error| error.to_string())
-            })
-            .await
-            .expect("read revoked reason")
-    }
-
-    fn audit_log_text(app_state: &AppState) -> String {
-        let path = app_state.audit_log.lock().path().to_path_buf();
-        std::fs::read_to_string(path).unwrap_or_default()
     }
 
     fn surface_route_descriptor(
@@ -4157,6 +4040,158 @@ mod tests {
                     surface_route_limit_erased,
                 )],
             ),
+        )
+    }
+
+    fn project_composition_descriptor() -> AbilityDescriptor {
+        AbilityDescriptor {
+            name: "dailyos/account-overview",
+            version: "1.0.0",
+            schema_version: 1,
+            category: AbilityCategory::Read,
+            policy: AbilityPolicy {
+                allowed_actors: &[ActorKind::SurfaceClient],
+                allowed_modes: &[crate::services::context::ExecutionMode::Live],
+                requires_confirmation: false,
+                may_publish: false,
+                required_scopes: &["read.account_overview"],
+                mcp_exposure: McpExposure::None,
+                client_side_executable: false,
+                rate_limit: None,
+            },
+            composes: &GET_ACCOUNT_CONTEXT_COMPOSES,
+            mutates: &[],
+            experimental: false,
+            registered_at: None,
+            signal_policy: SignalPolicy::default(),
+            invoke_erased: project_composition_erased,
+            input_schema: project_composition_schema,
+            output_schema: project_composition_schema,
+        }
+    }
+
+    fn project_composition_registry() -> Arc<crate::abilities::AbilityRegistry> {
+        PROJECT_COMPOSITION_PRODUCER_COUNT.store(0, Ordering::SeqCst);
+        Arc::new(
+            crate::abilities::AbilityRegistry::from_descriptors_unchecked_for_runtime_validation_tests(
+                vec![project_composition_descriptor()],
+            ),
+        )
+    }
+
+    async fn runtime_for_project_composition_tests(
+        registry: Arc<crate::abilities::AbilityRegistry>,
+        bridge_config: SurfaceClientBridgeConfig,
+    ) -> Arc<EndpointRuntime> {
+        let db_path = std::env::temp_dir().join(format!(
+            "dailyos-project-composition-{}.sqlite",
+            Uuid::new_v4()
+        ));
+        let db_service = crate::db_service::DbService::open_at_unencrypted(db_path)
+            .await
+            .expect("test db service opens");
+        let app_state = Arc::new(AppState::test_with_db_service(db_service));
+        Arc::new(EndpointRuntime {
+            startup_id: Uuid::new_v4(),
+            bound_port: 49152,
+            runtime_anchor_id: "test_runtime_anchor".to_string(),
+            loopback_bucket: Mutex::new(TokenBucket::new(TokenBucketConfig {
+                capacity: 100,
+                refill_per_second: 100.0,
+            })),
+            pairing_attempts: Arc::new(Mutex::new(PairingAttemptLimiter {
+                config: PairingAttemptConfig {
+                    max_failed_attempts_per_code: 5,
+                },
+                attempts_by_code: HashMap::new(),
+            })),
+            paired_site_origins: Arc::new(RwLock::new(HashSet::new())),
+            signed_transport: hmac::SignedTransportState::default(),
+            signed_request_max_body_bytes: DEFAULT_SIGNED_REQUEST_MAX_BODY_BYTES,
+            surface_client_bridge: SurfaceClientBridge::new(bridge_config),
+            surface_nonce: SurfaceNonceService::new_from_w2b_secret([7_u8; 32])
+                .expect("nonce service"),
+            ability_registry_override: Some(registry),
+            app_state: Some(app_state),
+        })
+    }
+
+    async fn commit_composition_version_for_tests(
+        app_state: &Arc<AppState>,
+        composition_id: &str,
+        expected_version: u64,
+    ) {
+        let composition_id = composition_id.to_string();
+        app_state
+            .db_write(move |db| {
+                let clock = crate::services::context::SystemClock;
+                let rng = crate::services::context::SystemRng;
+                let external = crate::services::context::ExternalClients::default();
+                let ctx =
+                    crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+                        .with_actor("surface_runtime_test");
+                crate::services::compositions::commit_composition(
+                    &ctx,
+                    db,
+                    crate::services::compositions::CompositionProposal {
+                        composition_id:
+                            abilities_runtime::abilities::composition::CompositionDocId::new(
+                                composition_id.clone(),
+                            ),
+                        expected_composition_version: expected_version,
+                        composition: abilities_runtime::abilities::composition::Composition::empty(
+                            abilities_runtime::abilities::composition::CompositionDocId::new(
+                                composition_id,
+                            ),
+                            abilities_runtime::abilities::composition::CompositionVersion::new(
+                                expected_version,
+                            ),
+                            Utc::now(),
+                        ),
+                    },
+                )
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("composition version commits");
+    }
+
+    async fn seed_composition_version_for_tests(
+        app_state: &Arc<AppState>,
+        composition_id: &str,
+        version: u64,
+    ) {
+        for expected in 0..version {
+            commit_composition_version_for_tests(app_state, composition_id, expected).await;
+        }
+    }
+
+    fn projected_composition_for_tests(
+        composition_id: &str,
+        composition_version: u64,
+    ) -> abilities_runtime::abilities::ProjectedComposition {
+        serde_json::from_value(json!({
+            "composition_id": composition_id,
+            "composition_version": composition_version,
+            "fallback_policy_version": 1,
+            "blocks": [],
+            "diagnostics": [],
+            "unknown_block_count": 0,
+            "unknown_block_cap": 4,
+            "dropped_unknown_block_count": 0
+        }))
+        .expect("projection fixture deserializes")
+    }
+
+    fn project_composition_body(composition_id: &str, composition_version: i64) -> Bytes {
+        Bytes::from(
+            serde_json::to_vec(&json!({
+                "composition_id": composition_id,
+                "composition_version": composition_version,
+                "cache_hint_token": "stale-token"
+            }))
+            .expect("project-composition request serializes"),
         )
     }
 
@@ -4885,85 +4920,6 @@ mod tests {
         assert!(validate_origin(&headers, &endpoint.paired_site_origins.read()).is_err());
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn dos673_rehydration_revokes_only_not_found() {
-        let (app_state, _tempdir) = app_state_with_rehydrate_rows(&[
-            ("surface_found", "session_found"),
-            ("surface_missing", "session_missing"),
-            ("surface_unavailable", "session_unavailable"),
-        ])
-        .await;
-        let keychain = Arc::new(crate::services::surface_session_keychain::MockKeychain::new());
-        keychain.set_session_lookup(
-            "surface_found",
-            "session_found",
-            SessionKeyLookup::Found([7u8; 32]),
-        );
-        keychain.set_session_lookup(
-            "surface_missing",
-            "session_missing",
-            SessionKeyLookup::NotFound,
-        );
-        keychain.set_session_lookup(
-            "surface_unavailable",
-            "session_unavailable",
-            SessionKeyLookup::Unavailable {
-                reason: "keychain_locked".to_string(),
-            },
-        );
-        let _keychain_guard =
-            crate::services::surface_session_keychain::set_keychain_for_tests(keychain);
-        let signed_transport = hmac::SignedTransportState::default();
-
-        rehydrate_sessions_from_keychain(&app_state, &signed_transport)
-            .await
-            .expect("rehydrate should succeed");
-
-        assert!(signed_transport
-            .derive_active_session_key("session_found")
-            .is_some());
-        assert_eq!(
-            session_revoked_reason(&app_state, "session_missing").await,
-            Some("keychain_entry_missing".to_string())
-        );
-        assert_eq!(
-            session_revoked_reason(&app_state, "session_unavailable").await,
-            None
-        );
-        assert_eq!(
-            session_revoked_reason(&app_state, "session_found").await,
-            None
-        );
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn dos673_unavailable_emits_audit_diagnostic() {
-        let (app_state, _tempdir) =
-            app_state_with_rehydrate_rows(&[("surface_unavailable", "session_unavailable")]).await;
-        let keychain = Arc::new(crate::services::surface_session_keychain::MockKeychain::new());
-        keychain.set_session_lookup(
-            "surface_unavailable",
-            "session_unavailable",
-            SessionKeyLookup::Unavailable {
-                reason: "corrupt_payload".to_string(),
-            },
-        );
-        let _keychain_guard =
-            crate::services::surface_session_keychain::set_keychain_for_tests(keychain);
-
-        rehydrate_sessions_from_keychain(&app_state, &hmac::SignedTransportState::default())
-            .await
-            .expect("rehydrate should succeed");
-
-        assert_eq!(
-            session_revoked_reason(&app_state, "session_unavailable").await,
-            None
-        );
-        let audit = audit_log_text(&app_state);
-        assert_eq!(audit.matches("pairing.session.key_unavailable").count(), 1);
-        assert!(audit.contains("\"reason\":\"corrupt_payload\""));
-    }
-
     #[test]
     fn typed_error_envelope_supports_409_shape() {
         let response =
@@ -5216,6 +5172,347 @@ mod tests {
     }
 
     #[test]
+    fn dos671_cache_key_uses_current_db_version() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let composition_id = "dailyos/account-overview:account:acct-cache";
+        let runtime = tokio_runtime.block_on(runtime_for_project_composition_tests(
+            project_composition_registry(),
+            SurfaceClientBridgeConfig::default(),
+        ));
+        let app_state = runtime.app_state.as_ref().expect("test app state");
+        tokio_runtime.block_on(seed_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+        let session = validated_surface_session_for_tests();
+        app_state
+            .composition_render_orchestrator
+            .cache_store(
+                &session.actor,
+                composition_id,
+                5,
+                projected_composition_for_tests(composition_id, 5),
+            )
+            .expect("cache stores projection at current DB version");
+
+        let response = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session,
+            project_composition_body(composition_id, 1),
+            "req_project_cache_hit".to_string(),
+        ));
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["served_from_cache"], true);
+        assert_eq!(body["projection"]["composition_version"], 5);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn dos671_cache_hit_avoids_producer() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let composition_id = "dailyos/account-overview:account:acct-cache-hit";
+        let runtime = tokio_runtime.block_on(runtime_for_project_composition_tests(
+            project_composition_registry(),
+            SurfaceClientBridgeConfig::default(),
+        ));
+        let app_state = runtime.app_state.as_ref().expect("test app state");
+        tokio_runtime.block_on(seed_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+        let session = validated_surface_session_for_tests();
+        app_state
+            .composition_render_orchestrator
+            .cache_store(
+                &session.actor,
+                composition_id,
+                5,
+                projected_composition_for_tests(composition_id, 5),
+            )
+            .expect("cache stores projection at current DB version");
+
+        let response = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session,
+            project_composition_body(composition_id, 1),
+            "req_project_cache_hit_avoids_producer".to_string(),
+        ));
+
+        let status = response.status();
+        let body = body_json(response);
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["served_from_cache"], true);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn dos671_cache_miss_invokes_producer_and_commits() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let composition_id = "dailyos/account-overview:account:acct-store";
+        let runtime = tokio_runtime.block_on(runtime_for_project_composition_tests(
+            project_composition_registry(),
+            SurfaceClientBridgeConfig::default(),
+        ));
+        let app_state = runtime.app_state.as_ref().expect("test app state");
+        tokio_runtime.block_on(seed_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+        let session = validated_surface_session_for_tests();
+        let actor = session.actor.clone();
+
+        let response = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session,
+            project_composition_body(composition_id, 1),
+            "req_project_cache_store".to_string(),
+        ));
+
+        let status = response.status();
+        let body = body_json(response);
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{body}; count={}",
+            PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst)
+        );
+        assert_eq!(body["served_from_cache"], false);
+        assert_eq!(body["projection"]["composition_version"], 6);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 1);
+        assert!(app_state
+            .composition_render_orchestrator
+            .cache_lookup(&actor, composition_id, 1)
+            .is_none());
+        assert!(app_state
+            .composition_render_orchestrator
+            .cache_lookup(&actor, composition_id, 6)
+            .is_some());
+    }
+
+    #[test]
+    fn dos671_external_version_advance_invalidates_cache() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let composition_id = "dailyos/account-overview:account:acct-external";
+        let runtime = tokio_runtime.block_on(runtime_for_project_composition_tests(
+            project_composition_registry(),
+            SurfaceClientBridgeConfig::default(),
+        ));
+        let app_state = runtime.app_state.as_ref().expect("test app state");
+        tokio_runtime.block_on(seed_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+        let session = validated_surface_session_for_tests();
+        let actor = session.actor.clone();
+        app_state
+            .composition_render_orchestrator
+            .cache_store(
+                &actor,
+                composition_id,
+                5,
+                projected_composition_for_tests(composition_id, 5),
+            )
+            .expect("cache stores old projection");
+        tokio_runtime.block_on(commit_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+
+        let response = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session,
+            project_composition_body(composition_id, 5),
+            "req_project_external_advance".to_string(),
+        ));
+
+        let status = response.status();
+        let body = body_json(response);
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "{body}; count={}",
+            PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst)
+        );
+        assert_eq!(body["served_from_cache"], false);
+        assert_eq!(body["projection"]["composition_version"], 7);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 1);
+        assert!(app_state
+            .composition_render_orchestrator
+            .cache_lookup(&actor, composition_id, 5)
+            .is_some());
+        assert!(app_state
+            .composition_render_orchestrator
+            .cache_lookup(&actor, composition_id, 7)
+            .is_some());
+
+        // The fake producer returns the committed version in its payload; mirror
+        // the real producer's DB advancement before proving the next render hits.
+        tokio_runtime.block_on(commit_composition_version_for_tests(
+            app_state,
+            composition_id,
+            6,
+        ));
+        let response = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            validated_surface_session_for_tests(),
+            project_composition_body(composition_id, 5),
+            "req_project_external_advance_cached".to_string(),
+        ));
+
+        let status = response.status();
+        let body = body_json(response);
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["served_from_cache"], true);
+        assert_eq!(body["projection"]["composition_version"], 7);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn dos672_project_composition_local_render_decharges_ability_and_scope_buckets() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tokio_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let composition_id = "dailyos/account-overview:account:acct-local-render";
+        let mut bridge_config = SurfaceClientBridgeConfig::default();
+        let one_per_second = SurfaceClientRateLimitBudget {
+            requests_per_minute: 60,
+            burst_per_second: 1,
+        };
+        bridge_config.scope.read = one_per_second;
+        bridge_config.ability.standard_read_composition = one_per_second;
+        let runtime = tokio_runtime.block_on(runtime_for_project_composition_tests(
+            project_composition_registry(),
+            bridge_config,
+        ));
+        let app_state = runtime.app_state.as_ref().expect("test app state");
+        tokio_runtime.block_on(seed_composition_version_for_tests(
+            app_state,
+            composition_id,
+            5,
+        ));
+        let session = validated_surface_session_for_tests();
+        app_state
+            .composition_render_orchestrator
+            .cache_store(
+                &session.actor,
+                composition_id,
+                5,
+                projected_composition_for_tests(composition_id, 5),
+            )
+            .expect("cache stores projection at current DB version");
+
+        let first = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session.clone(),
+            project_composition_body(composition_id, 1),
+            "req_project_local_render_decharge_first".to_string(),
+        ));
+        let second = tokio_runtime.block_on(surface_project_composition_response(
+            runtime.as_ref(),
+            session,
+            project_composition_body(composition_id, 1),
+            "req_project_local_render_decharge_second".to_string(),
+        ));
+
+        let first_status = first.status();
+        let first_body = body_json(first);
+        assert_eq!(first_status, StatusCode::OK, "{first_body}");
+        assert_eq!(first_body["served_from_cache"], true);
+        let second_status = second.status();
+        let second_body = body_json(second);
+        assert_eq!(second_status, StatusCode::OK, "{second_body}");
+        assert_eq!(second_body["served_from_cache"], true);
+        assert_eq!(PROJECT_COMPOSITION_PRODUCER_COUNT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn dos671_project_composition_cache_lookup_current_db_version_grep_gate() {
+        let source = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/surface_runtime/mod.rs"),
+        )
+        .expect("surface runtime source is readable");
+        let production_source = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production source precedes test module");
+        let normalized = production_source.split_whitespace().collect::<String>();
+
+        assert!(
+            normalized.contains(
+                "orchestrator.cache_lookup(&actor,&request.composition_id,current_db_version)"
+            ),
+            "project_composition cache lookup must use current_db_version"
+        );
+        assert!(
+            !normalized.contains(
+                "orchestrator.cache_lookup(&actor,&request.composition_id,request.composition_version)"
+            ),
+            "project_composition cache lookup must not use request.composition_version"
+        );
+    }
+
+    #[test]
+    fn dos672_project_composition_route_uses_local_render_authorization_grep_gate() {
+        let source = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/surface_runtime/mod.rs"),
+        )
+        .expect("surface runtime source is readable");
+        let start = source
+            .find("async fn surface_project_composition_response")
+            .expect("project composition route exists");
+        let end = source[start..]
+            .find("async fn surface_nonce_verify_response")
+            .map(|offset| start + offset)
+            .expect("project composition route end exists");
+        let normalized = source[start..end].split_whitespace().collect::<String>();
+
+        assert!(
+            normalized.contains("surface_client_bridge.authorize_local_render("),
+            "project_composition route must use authorize_local_render"
+        );
+        assert!(
+            !normalized.contains("surface_client_bridge.authorize("),
+            "project_composition route must not charge standard authorize"
+        );
+    }
+
+    #[test]
     fn account_overview_success_audit_carries_composition_fields_and_writes() {
         let session = validated_surface_session_for_tests();
         let ability: AbilityResponseJson = serde_json::from_value(json!({
@@ -5386,67 +5683,6 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(body["error"]["code"], "request_body_too_large");
-    }
-
-    #[tokio::test]
-    async fn dos675_sentinel_cleaned_on_stop() {
-        let _lock = RUNTIME_SENTINEL_TEST_LOCK.lock().unwrap();
-        let (_dir, path, _guard) = install_test_sentinel_path();
-        write_runtime_sentinel(4411, "test").unwrap();
-        assert!(path.exists());
-
-        let endpoint = SurfaceEndpointState::default();
-        install_fake_running_endpoint(&endpoint);
-        endpoint.stop();
-
-        assert!(!path.exists(), "stop should remove runtime sentinel");
-    }
-
-    #[tokio::test]
-    async fn dos675_sentinel_cleaned_on_drop() {
-        let _lock = RUNTIME_SENTINEL_TEST_LOCK.lock().unwrap();
-        let (_dir, path, _guard) = install_test_sentinel_path();
-        write_runtime_sentinel(4411, "test").unwrap();
-        assert!(path.exists());
-
-        {
-            let endpoint = SurfaceEndpointState::default();
-            install_fake_running_endpoint(&endpoint);
-        }
-
-        assert!(!path.exists(), "drop should remove runtime sentinel");
-    }
-
-    #[tokio::test]
-    async fn dos675_repeated_stop_is_idempotent() {
-        let _lock = RUNTIME_SENTINEL_TEST_LOCK.lock().unwrap();
-        let (_dir, path, _guard) = install_test_sentinel_path();
-        write_runtime_sentinel(4411, "test").unwrap();
-        let endpoint = SurfaceEndpointState::default();
-        install_fake_running_endpoint(&endpoint);
-
-        endpoint.stop();
-        endpoint.stop();
-
-        assert!(!path.exists(), "repeated stop should leave sentinel absent");
-    }
-
-    #[tokio::test]
-    async fn dos675_drop_no_async_flush() {
-        let _lock = RUNTIME_SENTINEL_TEST_LOCK.lock().unwrap();
-        let (_dir, path, _guard) = install_test_sentinel_path();
-        write_runtime_sentinel(4411, "test").unwrap();
-        let started = Instant::now();
-        {
-            let endpoint = SurfaceEndpointState::default();
-            install_fake_running_endpoint(&endpoint);
-        }
-
-        assert!(started.elapsed() < Duration::from_millis(50));
-        assert!(
-            !path.exists(),
-            "drop should only perform sync sentinel cleanup"
-        );
     }
 
     #[tokio::test]

--- a/wp/dailyos/blocks/account-overview/edit.js
+++ b/wp/dailyos/blocks/account-overview/edit.js
@@ -57,6 +57,18 @@
 				},
 			} )
 				.then( ( response ) => {
+					if ( response && response.ok === false ) {
+						setError(
+							response.error && response.error.message
+								? response.error.message
+								: __(
+									"Something about this account doesn't line up. Verify before acting.",
+									'dailyos'
+								)
+						);
+						return;
+					}
+
 					setPreview( response );
 					if ( response && response.projection ) {
 						setAttributes( {
@@ -81,9 +93,13 @@
 				.finally( () => setIsLoading( false ) );
 		}, [ attributes.composition_id, attributes.composition_version, attributes.cache_hint_token, setAttributes ] );
 
+		const reloadTrigger = `${attributes.account_id || ''}|${attributes.composition_id ? '1' : '0'}`;
 		useEffect( () => {
 			reload();
-		}, [ reload ] );
+			// reload intentionally excluded: auto-refresh is keyed only by
+			// account_id and composition_id presence; manual reload keeps the full deps.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [ reloadTrigger ] );
 
 		useEffect( () => {
 			apiFetch( { path: '/dailyos/v1/account-overview/accounts' } )

--- a/wp/dailyos/blocks/account-overview/render-functions.php
+++ b/wp/dailyos/blocks/account-overview/render-functions.php
@@ -91,11 +91,14 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 			$code = isset( $response['error']['code'] ) ? (string) $response['error']['code'] : 'runtime_request_failed';
 			switch ( $code ) {
 				case 'rate_limited':
+				case 'transport_abuse_limited':
 					return dailyos_account_overview_render_throttled_notice();
+				// Session/pairing-repair-shaped codes — user reconnects from settings.
 				case 'session_requires_repair':
 				case 'session_not_found':
 				case 'session_expired':
 				case 'session_throttled':
+				case 'session_invalid':
 				case 'identity_mismatch':
 				case 'wp_user_mismatch':
 				case 'pairing_code_invalid':
@@ -105,11 +108,22 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 				case 'pairing_suspended':
 				case 'pairing_revoked':
 				case 'pairing_expired':
+				case 'pairing_authority_unavailable':
 				case 'site_binding_mismatch':
 				case 'restored_stale_pairing':
+				case 'unknown_runtime_anchor':
 				case 'scope_denied':
 				case 'auth_missing':
+				case 'signature_invalid':
+				case 'canonicalization_mismatch':
+				case 'timestamp_stale':
+				case 'timestamp_future':
+				case 'key_not_found':
+				case 'key_rotated':
+				case 'token_invalid':
+				case 'nonce_replay':
 					return dailyos_account_overview_render_session_repair_notice();
+				// Runtime-unavailable: transient infrastructure problem; retry.
 				case 'runtime_unavailable':
 				case 'runtime_request_failed':
 				case 'runtime_invalid_json':
@@ -118,20 +132,28 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 				case 'browser_origin_forbidden':
 				case 'route_not_found':
 					return dailyos_account_overview_render_runtime_unavailable_notice();
+				// Renderer-input-invalid: defensive — runtime can't process the request shape.
 				case 'request_body_too_large':
 				case 'request_body_unreadable':
 				case 'handshake_body_invalid':
 				case 'session_refresh_body_invalid':
 				case 'surface_invoke_invalid':
 				case 'event_log_id_invalid':
+				case 'project_composition_invalid':
+				case 'project_composition_unknown_producer':
+				case 'project_composition_invalid_id':
 					return dailyos_account_overview_render_invalid_request_notice();
+				// Projection-consistency failures — verification banner correct.
 				case 'projection_tampered':
 				case 'projection_version_rollback':
 				case 'stale_composition_watermark':
 				case 'missing_expected_claim_version':
 				case 'mid_flight_mutation':
+				case 'composition_version_overflow':
 					return dailyos_account_overview_render_verification_banner();
 				default:
+					// Fail-safe — unknown code → verification banner. Operator
+					// adds a typed mapping when a new code appears.
 					return dailyos_account_overview_render_verification_banner();
 			}
 		}

--- a/wp/dailyos/blocks/account-overview/render-functions.php
+++ b/wp/dailyos/blocks/account-overview/render-functions.php
@@ -22,14 +22,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 	/**
-	 * Render the account-overview block from attributes. The same function
-	 * services both the block-registration render path and the editor
-	 * preview REST route. Returns rendered HTML.
+	 * Render the account-overview block from attributes. The wrapper keeps
+	 * the block-registration render path's single runtime fetch behavior.
 	 *
 	 * @param array<string, mixed> $attributes Block attributes.
 	 * @return string
 	 */
 	function dailyos_account_overview_render( array $attributes ): string {
+		$response = dailyos_account_overview_fetch_projection( $attributes );
+		return dailyos_account_overview_render_from_projection( $response, $attributes );
+	}
+
+	/**
+	 * Fetch the projected composition for the wrapper render path.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return array<string, mixed>|\WP_Error|string Empty-state HTML when no fetch can be made.
+	 */
+	function dailyos_account_overview_fetch_projection( array $attributes ): array|\WP_Error|string {
 		$composition_id      = isset( $attributes['composition_id'] ) ? (string) $attributes['composition_id'] : '';
 		$composition_version = isset( $attributes['composition_version'] ) ? (int) $attributes['composition_version'] : 0;
 		$cache_hint_token    = isset( $attributes['cache_hint_token'] ) ? (string) $attributes['cache_hint_token'] : '';
@@ -58,8 +68,72 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 			$cache_hint_param
 		);
 
+		return $response;
+	}
+
+	/**
+	 * Render the account-overview block from an already-fetched projection.
+	 *
+	 * @param array<string, mixed>|\WP_Error|string $response Runtime projection response or transport error.
+	 * @param array<string, mixed>                  $attributes Block attributes.
+	 * @return string
+	 */
+	function dailyos_account_overview_render_from_projection( array|\WP_Error|string $response, array $attributes ): string {
+		if ( is_string( $response ) ) {
+			return $response;
+		}
+
 		if ( is_wp_error( $response ) ) {
-			return dailyos_account_overview_render_verification_banner();
+			return dailyos_account_overview_render_runtime_unavailable_notice();
+		}
+
+		if ( isset( $response['ok'] ) && false === $response['ok'] ) {
+			$code = isset( $response['error']['code'] ) ? (string) $response['error']['code'] : 'runtime_request_failed';
+			switch ( $code ) {
+				case 'rate_limited':
+					return dailyos_account_overview_render_throttled_notice();
+				case 'session_requires_repair':
+				case 'session_not_found':
+				case 'session_expired':
+				case 'session_throttled':
+				case 'identity_mismatch':
+				case 'wp_user_mismatch':
+				case 'pairing_code_invalid':
+				case 'pairing_code_expired':
+				case 'pairing_code_consumed':
+				case 'pairing_code_limited':
+				case 'pairing_suspended':
+				case 'pairing_revoked':
+				case 'pairing_expired':
+				case 'site_binding_mismatch':
+				case 'restored_stale_pairing':
+				case 'scope_denied':
+				case 'auth_missing':
+					return dailyos_account_overview_render_session_repair_notice();
+				case 'runtime_unavailable':
+				case 'runtime_request_failed':
+				case 'runtime_invalid_json':
+				case 'runtime_http_error':
+				case 'host_invalid':
+				case 'browser_origin_forbidden':
+				case 'route_not_found':
+					return dailyos_account_overview_render_runtime_unavailable_notice();
+				case 'request_body_too_large':
+				case 'request_body_unreadable':
+				case 'handshake_body_invalid':
+				case 'session_refresh_body_invalid':
+				case 'surface_invoke_invalid':
+				case 'event_log_id_invalid':
+					return dailyos_account_overview_render_invalid_request_notice();
+				case 'projection_tampered':
+				case 'projection_version_rollback':
+				case 'stale_composition_watermark':
+				case 'missing_expected_claim_version':
+				case 'mid_flight_mutation':
+					return dailyos_account_overview_render_verification_banner();
+				default:
+					return dailyos_account_overview_render_verification_banner();
+			}
 		}
 
 		$projection = isset( $response['projection'] ) && is_array( $response['projection'] )
@@ -69,6 +143,8 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 			return dailyos_account_overview_render_verification_banner();
 		}
 
+		$composition_id      = isset( $attributes['composition_id'] ) ? (string) $attributes['composition_id'] : '';
+		$composition_version = isset( $attributes['composition_version'] ) ? (int) $attributes['composition_version'] : 0;
 		$delivered_state         = function_exists( 'get_option' )
 			? get_option( 'dailyos_composition_versions', [] )
 			: [];
@@ -216,6 +292,50 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 	function dailyos_account_overview_render_stale_banner(): string {
 		return '<aside data-ds-tier="pattern" data-ds-name="StaleReportBanner" data-ds-spec="patterns/StaleReportBanner.md" class="dailyos-stale-banner">'
 			. '<p>' . esc_html__( 'Newer context has arrived. Refresh to bring this in.', 'dailyos' ) . '</p>'
+			. '</aside>';
+	}
+
+	/**
+	 * Renders a throttled runtime notice.
+	 *
+	 * @return string Rendered notice HTML.
+	 */
+	function dailyos_account_overview_render_throttled_notice(): string {
+		return '<aside data-ds-tier="pattern" data-ds-name="RuntimeThrottledNotice" data-ds-spec="patterns/RuntimeNotice.md" class="dailyos-runtime-notice dailyos-runtime-notice-throttled">'
+			. '<p>' . esc_html__( 'Runtime is throttling; retry shortly.', 'dailyos' ) . '</p>'
+			. '</aside>';
+	}
+
+	/**
+	 * Renders a session repair notice.
+	 *
+	 * @return string Rendered notice HTML.
+	 */
+	function dailyos_account_overview_render_session_repair_notice(): string {
+		return '<aside data-ds-tier="pattern" data-ds-name="SurfaceSessionRepairNotice" data-ds-spec="patterns/RuntimeNotice.md" class="dailyos-runtime-notice dailyos-runtime-notice-session-repair">'
+			. '<p>' . esc_html__( 'Surface session needs repair; reconnect from DailyOS settings.', 'dailyos' ) . '</p>'
+			. '</aside>';
+	}
+
+	/**
+	 * Renders a runtime unavailable notice.
+	 *
+	 * @return string Rendered notice HTML.
+	 */
+	function dailyos_account_overview_render_runtime_unavailable_notice(): string {
+		return '<aside data-ds-tier="pattern" data-ds-name="RuntimeUnavailableNotice" data-ds-spec="patterns/RuntimeNotice.md" class="dailyos-runtime-notice dailyos-runtime-notice-unavailable">'
+			. '<p>' . esc_html__( 'Runtime unavailable; retry.', 'dailyos' ) . '</p>'
+			. '</aside>';
+	}
+
+	/**
+	 * Renders an invalid request notice.
+	 *
+	 * @return string Rendered notice HTML.
+	 */
+	function dailyos_account_overview_render_invalid_request_notice(): string {
+		return '<aside data-ds-tier="pattern" data-ds-name="InvalidRuntimeRequestNotice" data-ds-spec="patterns/RuntimeNotice.md" class="dailyos-runtime-notice dailyos-runtime-notice-invalid-request">'
+			. '<p>' . esc_html__( "Editor sent a request the runtime couldn't process. Reload the editor.", 'dailyos' ) . '</p>'
 			. '</aside>';
 	}
 

--- a/wp/dailyos/includes/class-dailyos-plugin.php
+++ b/wp/dailyos/includes/class-dailyos-plugin.php
@@ -589,27 +589,37 @@ final class DailyOS_Plugin {
 			$composition_version,
 			$cache_hint_token
 		);
-		if ( is_wp_error( $response ) ) {
-			return $response;
+
+		if ( ! function_exists( 'dailyos_account_overview_render_from_projection' ) ) {
+			require_once DAILYOS_PLUGIN_DIR . 'blocks/account-overview/render-functions.php';
 		}
 
-		// Render the projection through the same render path to keep
-		// preview parity with front-end.
 		$attributes = [
 			'composition_id'      => $composition_id,
-			'composition_version' => isset( $response['projection']['composition_version'] )
+			'composition_version' => is_array( $response ) && isset( $response['projection']['composition_version'] )
 				? (int) $response['projection']['composition_version']
 				: $composition_version,
-			'watermarks'          => isset( $response['projection']['watermarks'] )
+			'watermarks'          => is_array( $response ) && isset( $response['projection']['watermarks'] )
 				? (array) $response['projection']['watermarks']
 				: [],
-			'cache_hint_token'    => isset( $response['cache_hint_token'] )
+			'cache_hint_token'    => is_array( $response ) && isset( $response['cache_hint_token'] )
 				? (string) $response['cache_hint_token']
 				: '',
 		];
-		// Render via the block.json render callback by calling render.php
-		// with the attributes — same code path as the front end.
-		$html = self::render_block_with_filter( $attributes, $client );
+
+		$html = dailyos_account_overview_render_from_projection( $response, $attributes );
+		if ( is_wp_error( $response ) ) {
+			return [
+				'ok'         => false,
+				'error'      => [
+					'code'    => $response->get_error_code(),
+					'message' => $response->get_error_message(),
+				],
+				'html'       => $html,
+				'attributes' => $attributes,
+			];
+		}
+
 		return array_merge(
 			$response,
 			[

--- a/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
+++ b/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
@@ -165,6 +165,50 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	}
 
 	/**
+	 * Asserts the editor reload callback keeps manual-reload inputs in its dep list.
+	 */
+	public function test_editor_reload_callback_dep_array_literal(): void {
+		$source = $this->account_overview_editor_source();
+
+		$this->assertMatchesRegularExpression(
+			'/\},\s*\[\s*attributes\.composition_id\s*,\s*attributes\.composition_version\s*,\s*attributes\.cache_hint_token\s*,\s*setAttributes\s*\]\s*\);/s',
+			$source
+		);
+	}
+
+	/**
+	 * Asserts auto-reload is keyed by account and composition presence only.
+	 */
+	public function test_editor_reload_trigger_key_literal(): void {
+		$source = $this->account_overview_editor_source();
+
+		$this->assertMatchesRegularExpression(
+			'/const\s+reloadTrigger\s*=\s*`.*attributes\.account_id\s*\|\|\s*\'\'.*attributes\.composition_id\s*\?\s*\'1\'\s*:\s*\'0\'.*`/s',
+			$source
+		);
+		$this->assertMatchesRegularExpression(
+			'/useEffect\s*\(\s*\(\s*\)\s*=>\s*\{.*reload\(\);.*\},\s*\[\s*reloadTrigger\s*\]\s*\);/s',
+			$source
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/\},\s*\[\s*reload\s*\]\s*\);/',
+			$source
+		);
+	}
+
+	/**
+	 * Asserts failed preview responses preserve last-good editor state.
+	 */
+	public function test_editor_failed_reload_preserves_last_good_preview_shape(): void {
+		$source = $this->account_overview_editor_source();
+
+		$this->assertMatchesRegularExpression(
+			'/if\s*\(\s*response\s*&&\s*response\.ok\s*===\s*false\s*\)\s*\{.*setError\(.*return;.*\}\s*setPreview\(\s*response\s*\);/s',
+			$source
+		);
+	}
+
+	/**
 	 * Asserts unknown trust bands degrade to needs verification.
 	 */
 	public function test_unknown_trust_band_degrades_to_needs_verification(): void {
@@ -468,6 +512,12 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	 * @param string $cache_hint_token Cache hint token.
 	 * @return array<string, mixed>
 	 */
+	private function account_overview_editor_source(): string {
+		$source = file_get_contents( __DIR__ . '/../../blocks/account-overview/edit.js' );
+		$this->assertIsString( $source );
+		return $source;
+	}
+
 	private function projection_response( int $version, string $cache_hint_token = '' ): array {
 		return [
 			'ok'               => true,

--- a/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
+++ b/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
@@ -24,6 +24,7 @@
 declare(strict_types=1);
 
 use DailyOS\DailyOS_Plugin;
+use DailyOS\Transport\DailyOS_Credential_Store;
 use DailyOS\Transport\DailyOS_Runtime_Client;
 use PHPUnit\Framework\TestCase;
 
@@ -75,21 +76,7 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	 */
 	public function test_render_emits_trust_band_data_attrs_per_design_system(): void {
 		$client = $this->fake_runtime_client_with_response(
-			[
-				'projection'       => [
-					'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
-					'composition_version' => 1,
-					'blocks'              => [
-						[
-							'block_type' => 'risk',
-							'trust_band' => 'likely_current',
-							'title'      => 'Risk overview',
-							'summary'    => 'Sample summary.',
-						],
-					],
-				],
-				'cache_hint_token' => 'token-abc',
-			]
+			$this->projection_response( 1, 'token-abc' )
 		);
 		$this->register_runtime_client_filter( $client );
 
@@ -104,6 +91,77 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 		$this->assertStringContainsString( 'data-ds-name="TrustBandBadge"', $html );
 		$this->assertStringContainsString( 'data-ds-trust-band="likely_current"', $html );
 		$this->assertStringContainsString( 'Likely current', $html );
+		$this->assertSame( 1, $client->calls );
+		$this->assertSame(
+			[
+				[
+					'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+					'composition_version' => 1,
+					'cache_hint_token'    => null,
+				],
+			],
+			$client->requests
+		);
+	}
+
+	/**
+	 * Asserts the wrapper still performs exactly one runtime fetch.
+	 */
+	public function test_wrapper_preserves_single_fetch_behavior(): void {
+		$client = $this->fake_runtime_client_with_response( $this->projection_response( 3, 'token-single-fetch' ) );
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_account_overview_render(
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 2,
+				'cache_hint_token'    => 'token-old',
+			]
+		);
+
+		$this->assertStringContainsString( '<article', $html );
+		$this->assertSame( 1, $client->calls );
+		$this->assertSame(
+			[
+				[
+					'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+					'composition_version' => 2,
+					'cache_hint_token'    => 'token-old',
+				],
+			],
+			$client->requests
+		);
+	}
+
+	/**
+	 * Asserts the preview route renders from its first runtime response.
+	 */
+	public function test_preview_route_uses_single_runtime_request(): void {
+		$GLOBALS['dailyos_test_current_user_id']      = 42;
+		$GLOBALS['dailyos_test_remote_post_response'] = [
+			'response' => [
+				'code' => 200,
+			],
+			'body'     => wp_json_encode( $this->projection_response( 5, 'token-preview' ) ),
+		];
+		$this->save_pairing_marker();
+		$this->add_session_key_filter();
+
+		$result = DailyOS_Plugin::instance()->account_overview_preview(
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 4,
+				'cache_hint_token'    => 'token-stale',
+			]
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertCount( 1, $GLOBALS['dailyos_test_remote_post_calls'] );
+		$this->assertSame( 'http://127.0.0.1:54321/v1/surface/project-composition', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+		$this->assertSame( 5, $result['attributes']['composition_version'] );
+		$this->assertSame( 'token-preview', $result['attributes']['cache_hint_token'] );
+		$this->assertStringContainsString( '<article', $result['html'] );
+		$this->assertStringNotContainsString( 'ConsistencyFindingBanner', $result['html'] );
 	}
 
 	/**
@@ -178,9 +236,9 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	}
 
 	/**
-	 * Asserts runtime errors render a verification banner without raw details.
+	 * Asserts transport errors render a retryable notice without raw details.
 	 */
-	public function test_runtime_wp_error_renders_verification_banner_no_raw_exception(): void {
+	public function test_runtime_wp_error_renders_runtime_unavailable_notice_no_raw_exception(): void {
 		$client = $this->fake_runtime_client_with_error(
 			new \WP_Error( 'dailyos_projection_failed', 'raw runtime exception body that must not leak' )
 		);
@@ -193,10 +251,62 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			]
 		);
 
-		$this->assertStringContainsString( 'data-ds-name="ConsistencyFindingBanner"', $html );
-		$this->assertStringContainsString( 'line up', $html );
+		$this->assertStringContainsString( 'data-ds-name="RuntimeUnavailableNotice"', $html );
+		$this->assertStringContainsString( 'Runtime unavailable; retry.', $html );
 		$this->assertStringNotContainsString( 'raw runtime exception', $html );
 		$this->assertStringNotContainsString( 'dailyos_projection_failed', $html );
+	}
+
+	/**
+	 * Asserts typed runtime error envelopes map to distinct notices.
+	 *
+	 * @dataProvider typed_error_mapping_provider
+	 *
+	 * @param string $code          Runtime error code.
+	 * @param string $expected_text Expected notice text.
+	 * @param string $expected_name Expected design-system notice name.
+	 */
+	public function test_typed_error_mapping( string $code, string $expected_text, string $expected_name ): void {
+		$html = dailyos_account_overview_render_from_projection(
+			[
+				'ok'    => false,
+				'error' => [
+					'code'    => $code,
+					'message' => 'raw runtime detail must not leak',
+				],
+			],
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 1,
+			]
+		);
+
+		$this->assertStringContainsString( 'data-ds-name="' . $expected_name . '"', $html );
+		$this->assertStringContainsString( $expected_text, $html );
+		$this->assertStringNotContainsString( 'raw runtime detail', $html );
+	}
+
+	/**
+	 * Asserts unknown typed errors fail closed to the verification banner.
+	 */
+	public function test_unknown_typed_error_fails_safe_to_verification_banner(): void {
+		$html = dailyos_account_overview_render_from_projection(
+			[
+				'ok'    => false,
+				'error' => [
+					'code'    => 'unknown_xyz',
+					'message' => 'raw runtime detail must not leak',
+				],
+			],
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 1,
+			]
+		);
+
+		$this->assertStringContainsString( 'data-ds-name="ConsistencyFindingBanner"', $html );
+		$this->assertStringContainsString( 'line up', $html );
+		$this->assertStringNotContainsString( 'raw runtime detail', $html );
 	}
 
 	/**
@@ -285,6 +395,148 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 		$this->assertStringNotContainsString( 'curl_exec', $render_fns );
 	}
 
+
+	/**
+	 * Typed error mapping provider.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string}>
+	 */
+	public static function typed_error_mapping_provider(): array {
+		$cases = [];
+		foreach ( [ 'rate_limited' ] as $code ) {
+			$cases[ $code ] = [ $code, 'Runtime is throttling; retry shortly.', 'RuntimeThrottledNotice' ];
+		}
+		foreach ( [
+			'session_requires_repair',
+			'session_not_found',
+			'session_expired',
+			'session_throttled',
+			'identity_mismatch',
+			'wp_user_mismatch',
+			'pairing_code_invalid',
+			'pairing_code_expired',
+			'pairing_code_consumed',
+			'pairing_code_limited',
+			'pairing_suspended',
+			'pairing_revoked',
+			'pairing_expired',
+			'site_binding_mismatch',
+			'restored_stale_pairing',
+			'scope_denied',
+			'auth_missing',
+		] as $code ) {
+			$cases[ $code ] = [ $code, 'Surface session needs repair; reconnect from DailyOS settings.', 'SurfaceSessionRepairNotice' ];
+		}
+		foreach ( [
+			'runtime_unavailable',
+			'runtime_request_failed',
+			'runtime_invalid_json',
+			'runtime_http_error',
+			'host_invalid',
+			'browser_origin_forbidden',
+			'route_not_found',
+		] as $code ) {
+			$cases[ $code ] = [ $code, 'Runtime unavailable; retry.', 'RuntimeUnavailableNotice' ];
+		}
+		foreach ( [
+			'request_body_too_large',
+			'request_body_unreadable',
+			'handshake_body_invalid',
+			'session_refresh_body_invalid',
+			'surface_invoke_invalid',
+			'event_log_id_invalid',
+		] as $code ) {
+			$cases[ $code ] = [ $code, "Editor sent a request the runtime couldn't process. Reload the editor.", 'InvalidRuntimeRequestNotice' ];
+		}
+		foreach ( [
+			'projection_tampered',
+			'projection_version_rollback',
+			'stale_composition_watermark',
+			'missing_expected_claim_version',
+			'mid_flight_mutation',
+		] as $code ) {
+			$cases[ $code ] = [ $code, 'line up', 'ConsistencyFindingBanner' ];
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Build a successful projection response fixture.
+	 *
+	 * @param int    $version          Composition version.
+	 * @param string $cache_hint_token Cache hint token.
+	 * @return array<string, mixed>
+	 */
+	private function projection_response( int $version, string $cache_hint_token = '' ): array {
+		return [
+			'ok'               => true,
+			'projection'       => [
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => $version,
+				'blocks'              => [
+					[
+						'selected_known_type_id' => 'dailyos/account_overview',
+						'trust_band'             => 'likely_current',
+						'payload'                => [
+							'title'   => 'Account overview',
+							'context' => [
+								[
+									'text' => 'Sample account context.',
+								],
+							],
+						],
+					],
+				],
+			],
+			'cache_hint_token' => $cache_hint_token,
+		];
+	}
+
+	/**
+	 * Save a complete test pairing marker.
+	 */
+	private function save_pairing_marker(): void {
+		( new DailyOS_Credential_Store() )->save_marker(
+			[
+				'runtime_instance_id'  => 'runtime-123',
+				'surface_client_id'    => 'surface-client-123',
+				'runtime_url'          => 'http://127.0.0.1:54321',
+				'site_nonce_hash'      => hash( 'sha256', 'siteNonceAlpha123' ),
+				'site_nonce_full'      => 'siteNonceAlpha123',
+				'site_binding_digest'  => str_repeat( 'a', 64 ),
+				'wp_site_id'           => 'install-1:1',
+				'wp_install_uuid'      => 'install-1',
+				'plugin_instance_uuid' => 'plugin-1',
+				'projection_version'   => '2026.05.13',
+				'instance_id'          => 'runtime-123',
+				'session_id'           => 'session-123',
+				'granted_scopes'       => [ 'read.account_overview' ],
+				'endpoint_version'     => 'v1',
+				'paired_at_gmt'        => '2026-05-13 00:00:00',
+				'last_use_gmt'         => '2026-05-13 00:00:00',
+				'paired_wp_user_id'    => '42',
+			]
+		);
+	}
+
+	/**
+	 * Add a valid test session key filter.
+	 */
+	private function add_session_key_filter(): void {
+		add_filter(
+			'dailyos_wp_bridge_session_key',
+			static function (): array {
+				return [
+					'hmac_key'   => str_repeat( "\x02", 32 ),
+					'session_id' => 'surface-session-id',
+				];
+			},
+			10,
+			1
+		);
+	}
+
 	/**
 	 * Build a fake runtime client that returns a canned successful response
 	 * from `project_composition_for_surface`. Wraps an anonymous class so
@@ -301,6 +553,18 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			 * @var array
 			 */
 			public array $response;
+			/**
+			 * Number of fake runtime calls.
+			 *
+			 * @var int
+			 */
+			public int $calls = 0;
+			/**
+			 * Captured fake runtime requests.
+			 *
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $requests = [];
 			/**
 			 * Initializes the fake runtime response.
 			 *
@@ -322,6 +586,12 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 				int $composition_version,
 				?string $cache_hint_token = null
 			): array {
+				++$this->calls;
+				$this->requests[] = [
+					'composition_id'      => $composition_id,
+					'composition_version' => $composition_version,
+					'cache_hint_token'    => $cache_hint_token,
+				];
 				return $this->response;
 			}
 		};
@@ -329,7 +599,7 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 
 	/**
 	 * Build a fake runtime client that returns a `WP_Error` from
-	 * `project_composition_for_surface`. Used to drive the verification-banner
+	 * `project_composition_for_surface`. Used to drive the transport-error
 	 * render path.
 	 *
 	 * @param \WP_Error $error Error to return.
@@ -343,6 +613,18 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			 * @var \WP_Error
 			 */
 			public \WP_Error $error;
+			/**
+			 * Number of fake runtime calls.
+			 *
+			 * @var int
+			 */
+			public int $calls = 0;
+			/**
+			 * Captured fake runtime requests.
+			 *
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $requests = [];
 			/**
 			 * Initializes the fake runtime error.
 			 *
@@ -364,6 +646,12 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 				int $composition_version,
 				?string $cache_hint_token = null
 			): \WP_Error {
+				++$this->calls;
+				$this->requests[] = [
+					'composition_id'      => $composition_id,
+					'composition_version' => $composition_version,
+					'cache_hint_token'    => $cache_hint_token,
+				];
 				return $this->error;
 			}
 		};

--- a/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
+++ b/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
@@ -447,14 +447,20 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	 */
 	public static function typed_error_mapping_provider(): array {
 		$cases = [];
-		foreach ( [ 'rate_limited' ] as $code ) {
+		foreach ( [ 'rate_limited', 'transport_abuse_limited' ] as $code ) {
 			$cases[ $code ] = [ $code, 'Runtime is throttling; retry shortly.', 'RuntimeThrottledNotice' ];
 		}
+		// Session/pairing-repair-shaped codes — extended in L2 cycle 2 to cover
+		// every signed-runtime / pairing / signed-transport code emittable per
+		// surface_runtime/hmac.rs, surface_pairing.rs, and surface_runtime/mod.rs
+		// constructors. Verification banner is reserved for true projection-
+		// consistency failures + unknown-code fail-safe.
 		foreach ( [
 			'session_requires_repair',
 			'session_not_found',
 			'session_expired',
 			'session_throttled',
+			'session_invalid',
 			'identity_mismatch',
 			'wp_user_mismatch',
 			'pairing_code_invalid',
@@ -464,10 +470,20 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			'pairing_suspended',
 			'pairing_revoked',
 			'pairing_expired',
+			'pairing_authority_unavailable',
 			'site_binding_mismatch',
 			'restored_stale_pairing',
+			'unknown_runtime_anchor',
 			'scope_denied',
 			'auth_missing',
+			'signature_invalid',
+			'canonicalization_mismatch',
+			'timestamp_stale',
+			'timestamp_future',
+			'key_not_found',
+			'key_rotated',
+			'token_invalid',
+			'nonce_replay',
 		] as $code ) {
 			$cases[ $code ] = [ $code, 'Surface session needs repair; reconnect from DailyOS settings.', 'SurfaceSessionRepairNotice' ];
 		}
@@ -489,6 +505,9 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			'session_refresh_body_invalid',
 			'surface_invoke_invalid',
 			'event_log_id_invalid',
+			'project_composition_invalid',
+			'project_composition_unknown_producer',
+			'project_composition_invalid_id',
 		] as $code ) {
 			$cases[ $code ] = [ $code, "Editor sent a request the runtime couldn't process. Reload the editor.", 'InvalidRuntimeRequestNotice' ];
 		}
@@ -498,6 +517,7 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 			'stale_composition_watermark',
 			'missing_expected_claim_version',
 			'mid_flight_mutation',
+			'composition_version_overflow',
 		] as $code ) {
 			$cases[ $code ] = [ $code, 'line up', 'ConsistencyFindingBanner' ];
 		}


### PR DESCRIPTION
## Summary

L0 Packet B V1.1.1 implementation for v1.4.3 W0 stabilization. Closes DOS-671 + DOS-672 — WP preview/runtime render-loop gaps surfaced by v1.4.2 W4-F L4 hands-on (PR #298).

- **DOS-671** (block content disappears ~30s after render) — root cause was the cache key keyed by stale `request.composition_version`, forcing cache miss every render, invoking producer + commit. Fix: cache key by `current_db_version` (moved upstream of cache lookup); producer rarely runs on render under stable state.
- **DOS-672** (reload-on-window-switch + second-reload verification banner) — three root causes: PHP double-fetch (preview-endpoint + nested render), editor auto-reload retrigger loop (success writes to deps), rate-budget exhaustion from the loop. Fixes: single-fetch PHP preview, `reloadTrigger` derived string for useEffect (keeps reload callback's full deps), `authorize_local_render` with `charge_ability_scope=false` (decharges ability/scope buckets; identity buckets still consumed; auth checks preserved).

## Key architectural decision (V1.1 reframe)

**Producer commit on cache miss is PRESERVED.** V1.0 §5.4 proposed removing it; codex consult cycle-1 HIGH #2 found that `commit_composition` doesn't persist a reusable projection payload, so the producer commit IS the materialization step. The user-visible fix comes from §5.3 making the cache effective, NOT from removing the producer commit. The W4-F producer contract at `surface_runtime/mod.rs:2348-2353` is unchanged.

## Commits (5)

1. `84bc4baa` Stabilize account overview preview rendering (§5.1 PHP single-fetch + §5.6 typed errors + build-tax linear/v178)
2. `5d125fee` Guard account overview editor reloads (§5.2 reloadTrigger pattern)
3. `ee1805f5` feat(DOS-671,DOS-672): runtime cache-key correction + authorize_local_render decharge (§5.3 + §5.5)
4. `97db0de2` fix(DOS-672): expand §5.6 typed-error switch to cover all emittable runtime codes (AC #14 from L2 codex challenge cycle-1)
5. `<this commit>` docs(v1.4.3): Packet B L2 review proof bundle

## L0/L2 review trail

- L0 Packet B V1.1.1 (L0-closed 2026-05-17): `.docs/plans/v1.4.3-wp-foundation/L0-packet-B-render-stabilization.md`
- L0 cycle 2 unanimous non-BLOCK (CSO APPROVE clean, codex challenge APPROVE, code-reviewer + codex consult CONDITIONAL APPROVE folded as V1.1.1)
- L2 cycle 1: codex challenge BLOCK on AC #14; code-reviewer + CSO + codex consult APPROVE
- L2 cycle 2: codex challenge re-verify APPROVE (AC #14 fix validated)

## Cross-packet interlock

Disjoint code regions on `surface_runtime/mod.rs` with Packet A PR #301 (DOS-673/674/675):
- Packet A: §327-340 + §404-421 + §468-478 + §667-740 (listener/stop/Drop/rehydrate)
- Packet B: §2280-2440 (project_composition handler)

One minor textual conflict expected on `composition_render_orchestrator.rs` (Packet A cargo-fmt cosmetic; Packet B semantic — Packet B wins on rebase).

## Path-α maintenance (filed, not blocking)

- DOS-680 — Packet B code-reviewer path-α bundle (3 items: cache-hit-rate workload test, scope grep gate, third banner call-site)
- DOS-681 — Packet B codex challenge path-α additions (3 items: cold-miss serialization, stale cache pruning, validation-gate rebase artifacts)

## Test plan

- [x] cargo clippy --workspace -- -D warnings (CLAUDE.md DoD)
- [x] cargo test --workspace (PASS on L1 self-validation)
- [x] Pre-commit gauntlet on every commit
- [x] PHP test fixture matrix (`typed_error_mapping_provider`) covers all emittable runtime codes per AC #14
- [ ] L4 hands-on (batched for `/Users/jamesgiroux/.dailyos/l4-batch/W0/`): initial render + 60s wait + 2 focus switches + 2 manual reloads — content remains visible throughout per AC #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)