### PR TITLE
docs(design-system): WordPress block consumption counts as integrated status

### DIFF
--- a/.docs/design/patterns/README.md
+++ b/.docs/design/patterns/README.md
@@ -6,8 +6,8 @@ A pattern knows about a domain concept (a claim, a trust state, a briefing, a me
 
 ## Status vocabulary
 
-- **proposed** — WIP, prototype, roadmap, reference-only, or source-only work that is not yet used by routed app UI.
-- **integrated** — real app code exists and is used in the product, including shared components, page-local classes, or extracted components.
+- **proposed** — WIP, prototype, roadmap, reference-only, or source-only work that is not yet used by one of DailyOS's primary surfaces.
+- **integrated** — real app code exists and is consumed by at least one of DailyOS's primary surfaces. Per ADR-0129 the primary surfaces are **WordPress Studio** (the leading primary surface as of 2026-05-15) and the Tauri React app (in stasis per the reorientation but still primary until WP parity ships). A WordPress block under `wp/dailyos/blocks/<name>/` consuming this pattern counts as integrated. Likewise a Tauri React surface consumer counts as integrated regardless of WordPress block status. The bar is: a primary surface routes or renders this pattern against real substrate data.
 - **production** — integrated and included in a tagged release. Move a pattern here only after the release tag exists.
 
 ## Index

--- a/.docs/design/primitives/README.md
+++ b/.docs/design/primitives/README.md
@@ -6,8 +6,8 @@ A primitive is *not* a primitive if it knows about claims, trust, briefings, or 
 
 ## Status vocabulary
 
-- **proposed** — WIP, prototype, roadmap, or source-only work that is not yet integrated into routed app UI.
-- **integrated** — real app code exists and is used in the product, including shared components, page-local classes, or extracted modules.
+- **proposed** — WIP, prototype, roadmap, or source-only work that is not yet integrated into one of DailyOS's primary surfaces.
+- **integrated** — real app code exists and is consumed by at least one of DailyOS's primary surfaces. Per ADR-0129 the primary surfaces are **WordPress Studio** (the leading primary surface as of 2026-05-15) and the Tauri React app (in stasis per the reorientation but still primary until WP parity ships). A WordPress block under `wp/dailyos/blocks/<name>/` counts as integrated consumption of the underlying primitive — it does not also need a Tauri React surface consumer. Likewise a Tauri React surface consumer is integrated regardless of WordPress block status. The bar is: a primary surface routes or renders this primitive against real substrate data.
 - **production** — integrated and included in a tagged release.
 
 ## Index


### PR DESCRIPTION
## Summary

Per ADR-0129 reorientation (2026-05-15), WordPress Studio is the leading primary surface. The primitives + patterns status vocabularies were still phrased as 'routed app UI' which implied Tauri-only consumption. Both READMEs now state explicitly: a WordPress block consuming a primitive/pattern counts as integrated.

## Why

Surfaced during v1.4.3 W2 L0 cycle 1: TrustBandBadge is 'proposed' and W2 plans to promote it via its WP block. The design-reviewer flagged this as premature under the old vocabulary (WP block existence ≠ routed app UI consumption). Per ADR-0129 it IS consumption, so the vocabulary needed to catch up.

## Test plan

- [ ] README diffs read cleanly (no broken links / formatting)
- [ ] Vocabulary now matches the 2026-05-15 anchored decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)