### PR TITLE
DOS-685 path-α: token-mapping manifest emission (pre-W2 gate)

### DIFF
--- a/.github/workflows/block-kit-integration.yml
+++ b/.github/workflows/block-kit-integration.yml
@@ -9,7 +9,7 @@ on:
       - 'wp/dailyos/blocks/**'
       - 'wp/dailyos/scripts/**'
       - 'wp/dailyos/theme/**'
-      - 'wp/dailyos/tests/blocks/StarterKitIntegrationTest.php'
+      - 'wp/dailyos/tests/**'
       - 'src-tauri/abilities-runtime/**'
       - 'src/styles/design-tokens.css'
       - '.docs/design/tokens/**'
@@ -146,6 +146,12 @@ jobs:
             echo "FAIL: translator accepted NotSupported primitive 'Switch'" >&2
             exit 1
           fi
+
+      - name: Token-mapping manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash wp/dailyos/tests/token-mapping-manifest-gate.sh
 
       # §9 invariant #4 — token-to-theme.json generator MUST run cleanly via --check.
       # Fails CI on drift between canonical CSS sources and committed wp/dailyos/theme/theme.json.

--- a/wp/dailyos/scripts/translate-tauri.mjs
+++ b/wp/dailyos/scripts/translate-tauri.mjs
@@ -11,7 +11,7 @@
 // supported primitives scaffold cleanly; their JSX-to-PHP body translation
 // is filed per-primitive in W2 (the Wave 1 primitive translation batch).
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { dirname, resolve as resolvePath, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -21,6 +21,15 @@ const REPO_ROOT = resolvePath(SCRIPT_DIR, '..', '..', '..');
 const PRIMITIVES_README = resolvePath(REPO_ROOT, '.docs', 'design', 'primitives', 'README.md');
 const BLOCKS_DIR = resolvePath(REPO_ROOT, 'wp', 'dailyos', 'blocks');
 const NEW_BLOCK = resolvePath(SCRIPT_DIR, 'new-block.mjs');
+const TOKEN_ALIAS_MAP = new Map([
+	['--color-text', '--color-text-primary'],
+	['--color-text-muted', '--color-text-tertiary'],
+	['--color-warning', '--color-trust-use-with-caution'],
+	['--color-error', '--color-trust-needs-verification'],
+	['--color-border', '--color-rule-heavy'],
+	['--color-surface-muted', '--color-surface-subtle'],
+	['--radius-md', '--radius-editorial-md'],
+]);
 
 // Authoritative scope matrix from packet §5.7. Categories drive scaffold
 // behavior; new primitives must be added here before translation succeeds.
@@ -425,6 +434,127 @@ function applyBodyTranslation(primitive, slug) {
 	);
 }
 
+function normalizeSourceToken(sourceToken) {
+	return TOKEN_ALIAS_MAP.get(sourceToken) || sourceToken;
+}
+
+function wpTokenForSourceToken(sourceToken) {
+	const normalized = normalizeSourceToken(sourceToken);
+	if (normalized.startsWith('--color-')) {
+		return {
+			sourceToken: normalized,
+			targetToken: `wp--preset--color--${normalized.slice('--color-'.length)}`,
+		};
+	}
+	if (normalized.startsWith('--space-')) {
+		return {
+			sourceToken: normalized,
+			targetToken: `wp--preset--spacing--${normalized.slice('--space-'.length)}`,
+		};
+	}
+	if (
+		normalized.startsWith('--font-') ||
+		normalized.startsWith('--radius-') ||
+		normalized.startsWith('--shadow-') ||
+		normalized.startsWith('--transition-') ||
+		normalized.startsWith('--border-') ||
+		normalized.startsWith('--backdrop-') ||
+		normalized.startsWith('--frosted-')
+	) {
+		return {
+			sourceToken: normalized,
+			targetToken: `wp--custom--dailyos--tokens--${normalized.slice(2)}`,
+		};
+	}
+	return null;
+}
+
+function splitVarArgs(inner) {
+	let depth = 0;
+	for (let i = 0; i < inner.length; i++) {
+		const ch = inner[i];
+		if (ch === '(') depth++;
+		else if (ch === ')') depth = Math.max(0, depth - 1);
+		else if (ch === ',' && depth === 0) {
+			return [inner.slice(0, i).trim(), inner.slice(i + 1).trim()];
+		}
+	}
+	return [inner.trim(), ''];
+}
+
+function replaceTokenVars(css) {
+	const mappings = new Map();
+	let out = '';
+	let cursor = 0;
+	while (cursor < css.length) {
+		const start = css.indexOf('var(', cursor);
+		if (start === -1) {
+			out += css.slice(cursor);
+			break;
+		}
+		out += css.slice(cursor, start);
+		let depth = 0;
+		let end = start;
+		for (; end < css.length; end++) {
+			const ch = css[end];
+			if (ch === '(') depth++;
+			else if (ch === ')') {
+				depth--;
+				if (depth === 0) {
+					end++;
+					break;
+				}
+			}
+		}
+		if (depth !== 0) {
+			out += css.slice(start);
+			break;
+		}
+		const original = css.slice(start, end);
+		const inner = css.slice(start + 'var('.length, end - 1);
+		const [rawToken] = splitVarArgs(inner);
+		const mapped = wpTokenForSourceToken(rawToken);
+		if (!mapped) {
+			out += original;
+			cursor = end;
+			continue;
+		}
+		mappings.set(`${mapped.sourceToken}→${mapped.targetToken}`, mapped);
+		out += `var(--${mapped.targetToken})`;
+		cursor = end;
+	}
+	return { css: out, mappings: [...mappings.values()] };
+}
+
+function sortManifestEntries(entries) {
+	return entries
+		.map((entry) => ({
+			source_token: entry.sourceToken,
+			target_token: entry.targetToken,
+		}))
+		.sort((a, b) => a.target_token.localeCompare(b.target_token) || a.source_token.localeCompare(b.source_token));
+}
+
+function emitTokenMappingManifest(primitive, slug, cssPath) {
+	const blockDir = resolvePath(BLOCKS_DIR, slug);
+	const styleCssPath = resolvePath(blockDir, 'style.css');
+	const manifestPath = resolvePath(blockDir, '.token-mapping.json');
+	if (!existsSync(styleCssPath)) {
+		writeFileSync(manifestPath, '[]\n');
+		process.stdout.write(`[translate-tauri] ${primitive}: wrote empty token manifest (style.css missing)\n`);
+		return;
+	}
+	const styleCss = readFileSync(styleCssPath, 'utf8');
+	const translated = replaceTokenVars(styleCss);
+	writeFileSync(styleCssPath, translated.css);
+	const manifest = sortManifestEntries(translated.mappings);
+	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
+	process.stdout.write(
+		`[translate-tauri] ${primitive}: token mapping manifest written\n` +
+		`  - ${manifestPath} (${manifest.length} mapped token${manifest.length === 1 ? '' : 's'} from ${cssPath || 'scaffold style.css'})\n`
+	);
+}
+
 function emitFollowups(primitive, slug, category) {
 	const blockDir = resolvePath(BLOCKS_DIR, slug);
 	process.stdout.write(`
@@ -486,6 +616,7 @@ function main() {
 
 	runScaffold(flags.primitive, entry.shape, slug);
 	applyBodyTranslation(flags.primitive, slug);
+	emitTokenMappingManifest(flags.primitive, slug, cssPath);
 	emitFollowups(flags.primitive, slug, entry.category);
 }
 

--- a/wp/dailyos/tests/blocks/TokenMappingManifestTest.php
+++ b/wp/dailyos/tests/blocks/TokenMappingManifestTest.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Token-mapping manifest translator and gate tests.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers DOS-685 token-mapping manifest emission and CI gate failure modes.
+ */
+final class DailyOS_TokenMappingManifestTest extends TestCase {
+	/**
+	 * Paths created by the test and removed in tearDown.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $created_paths = [];
+
+	/**
+	 * Cleanup generated fixture files.
+	 */
+	protected function tearDown(): void {
+		foreach ( array_reverse( $this->created_paths ) as $path ) {
+			$this->remove_path( $path );
+		}
+		$this->created_paths = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * The real translator emits a token manifest beside generated style.css.
+	 */
+	public function test_translate_tauri_emits_token_mapping_manifest_for_pill(): void {
+		$this->require_command( 'node' );
+
+		$repo_root = $this->repo_root();
+		$block_dir = $repo_root . '/wp/dailyos/blocks/pill';
+		if ( is_dir( $block_dir ) ) {
+			$this->markTestSkipped( 'Pill block already exists; translator overwrite guard is working.' );
+		}
+
+		$this->created_paths[] = $block_dir;
+		$result = $this->run_command(
+			[
+				'node',
+				'wp/dailyos/scripts/translate-tauri.mjs',
+				'--primitive',
+				'Pill',
+			],
+			$repo_root
+		);
+
+		$this->assertSame(
+			0,
+			$result['code'],
+			"translator failed\nstdout:\n{$result['stdout']}\nstderr:\n{$result['stderr']}"
+		);
+
+		$manifest_path = $block_dir . '/.token-mapping.json';
+		$style_path    = $block_dir . '/style.css';
+		$this->assertFileExists( $manifest_path );
+		$this->assertFileExists( $style_path );
+
+		$manifest = json_decode( (string) file_get_contents( $manifest_path ), true );
+		$this->assertIsArray( $manifest );
+		$this->assertContains(
+			[
+				'source_token' => '--color-spice-turmeric',
+				'target_token' => 'wp--preset--color--spice-turmeric',
+			],
+			$manifest
+		);
+		$this->assertContains(
+			[
+				'source_token' => '--space-xs',
+				'target_token' => 'wp--preset--spacing--xs',
+			],
+			$manifest
+		);
+
+		$style = (string) file_get_contents( $style_path );
+		$this->assertStringContainsString( 'var(--wp--preset--color--spice-turmeric)', $style );
+		$this->assertStringNotContainsString( 'var(--color-', $style );
+		$this->assertDoesNotMatchRegularExpression( '/#[0-9a-f]{3,8}\b|rgba?\(|hsla?\(/i', $style );
+	}
+
+	/**
+	 * The gate passes when style.css, manifest, and theme.json agree.
+	 */
+	public function test_token_mapping_gate_passes_valid_fixture(): void {
+		$style = '.wp-block-dailyos-token-fixture { '
+			. 'color: var(--wp--preset--color--spice-turmeric); '
+			. 'gap: var(--wp--preset--spacing--sm); '
+			. '}';
+		$root = $this->create_gate_fixture(
+			[
+				[
+					'source_token' => '--color-spice-turmeric',
+					'target_token' => 'wp--preset--color--spice-turmeric',
+				],
+				[
+					'source_token' => '--space-sm',
+					'target_token' => 'wp--preset--spacing--sm',
+				],
+			],
+			$style,
+			[ 'spice-turmeric' ]
+		);
+
+		$result = $this->run_gate( $root );
+		$this->assertSame(
+			0,
+			$result['code'],
+			"gate failed\nstdout:\n{$result['stdout']}\nstderr:\n{$result['stderr']}"
+		);
+	}
+
+	/**
+	 * The gate fails when a manifest color target is absent from theme.json.
+	 */
+	public function test_token_mapping_gate_rejects_undefined_palette_target(): void {
+		$style = '.wp-block-dailyos-token-fixture { '
+			. 'color: var(--wp--preset--color--missing); '
+			. '}';
+		$root = $this->create_gate_fixture(
+			[
+				[
+					'source_token' => '--color-spice-turmeric',
+					'target_token' => 'wp--preset--color--missing',
+				],
+			],
+			$style,
+			[ 'spice-turmeric' ]
+		);
+
+		$result = $this->run_gate( $root );
+		$this->assertNotSame( 0, $result['code'] );
+		$this->assertStringContainsString( 'not defined in theme.json settings.color.palette', $result['stderr'] );
+	}
+
+	/**
+	 * The gate fails when style.css uses a WordPress var missing from manifest.
+	 */
+	public function test_token_mapping_gate_rejects_style_var_missing_from_manifest(): void {
+		$style = '.wp-block-dailyos-token-fixture { '
+			. 'color: var(--wp--preset--color--spice-turmeric); '
+			. 'background: var(--wp--preset--color--garden-larkspur); '
+			. '}';
+		$root = $this->create_gate_fixture(
+			[
+				[
+					'source_token' => '--color-spice-turmeric',
+					'target_token' => 'wp--preset--color--spice-turmeric',
+				],
+			],
+			$style,
+			[ 'spice-turmeric', 'garden-larkspur' ]
+		);
+
+		$result = $this->run_gate( $root );
+		$this->assertNotSame( 0, $result['code'] );
+		$this->assertStringContainsString( 'missing from .token-mapping.json', $result['stderr'] );
+	}
+
+	/**
+	 * The gate fails on raw hex/rgb/hsl color literals outside the escape list.
+	 */
+	public function test_token_mapping_gate_rejects_raw_color_literals(): void {
+		$style = '.wp-block-dailyos-token-fixture { '
+			. 'color: var(--wp--preset--color--spice-turmeric); '
+			. 'border-color: #ffffff; '
+			. '}';
+		$root = $this->create_gate_fixture(
+			[
+				[
+					'source_token' => '--color-spice-turmeric',
+					'target_token' => 'wp--preset--color--spice-turmeric',
+				],
+			],
+			$style,
+			[ 'spice-turmeric' ]
+		);
+
+		$result = $this->run_gate( $root );
+		$this->assertNotSame( 0, $result['code'] );
+		$this->assertStringContainsString( 'raw color literal', $result['stderr'] );
+	}
+
+	/**
+	 * Creates a temporary repo-shaped fixture for the bash gate.
+	 *
+	 * @param array<int, array{source_token: string, target_token: string}> $manifest Manifest entries.
+	 * @param string                                                       $style    style.css contents.
+	 * @param array<int, string>                                           $palette  Theme color slugs.
+	 */
+	private function create_gate_fixture( array $manifest, string $style, array $palette ): string {
+		$this->require_command( 'bash' );
+		$this->require_command( 'jq' );
+		$root = sys_get_temp_dir() . '/dailyos-token-map-' . bin2hex( random_bytes( 6 ) );
+		$this->created_paths[] = $root;
+
+		$block_dir = $root . '/wp/dailyos/blocks/token-fixture';
+		$theme_dir = $root . '/wp/dailyos/theme';
+		mkdir( $block_dir, 0777, true );
+		mkdir( $theme_dir, 0777, true );
+
+		file_put_contents( $block_dir . '/style.css', $style . "\n" );
+		file_put_contents(
+			$block_dir . '/.token-mapping.json',
+			json_encode( $manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n"
+		);
+		file_put_contents(
+			$theme_dir . '/theme.json',
+			json_encode(
+				[
+					'version'  => 3,
+					'settings' => [
+						'color' => [
+							'palette' => array_map(
+								static fn ( string $slug ): array => [
+									'slug'  => $slug,
+									'name'  => ucwords( str_replace( '-', ' ', $slug ) ),
+									'color' => '#000000',
+								],
+								$palette
+							),
+						],
+					],
+				],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			) . "\n"
+		);
+
+		return $root;
+	}
+
+	/**
+	 * Runs the token-mapping gate against a fixture repo root.
+	 *
+	 * @return array{code: int, stdout: string, stderr: string}
+	 */
+	private function run_gate( string $fixture_root ): array {
+		return $this->run_command(
+			[
+				'bash',
+				'wp/dailyos/tests/token-mapping-manifest-gate.sh',
+			],
+			$this->repo_root(),
+			[
+				'DAILYOS_TOKEN_MAPPING_ROOT' => $fixture_root,
+			]
+		);
+	}
+
+	/**
+	 * Returns the repository root.
+	 */
+	private function repo_root(): string {
+		return dirname( __DIR__, 4 );
+	}
+
+	/**
+	 * Skips the test when a required command is unavailable.
+	 */
+	private function require_command( string $command ): void {
+		$result = $this->run_command(
+			[ 'bash', '-lc', 'command -v ' . escapeshellarg( $command ) ],
+			$this->repo_root()
+		);
+		if ( 0 !== $result['code'] ) {
+			$this->markTestSkipped( "Required command '{$command}' is unavailable." );
+		}
+	}
+
+	/**
+	 * Runs a command and captures stdout/stderr.
+	 *
+	 * @param array<int, string>       $command Command argv.
+	 * @param array<string, string>    $env     Extra environment.
+	 * @return array{code: int, stdout: string, stderr: string}
+	 */
+	private function run_command( array $command, string $cwd, array $env = [] ): array {
+		$descriptor_spec = [
+			1 => [ 'pipe', 'w' ],
+			2 => [ 'pipe', 'w' ],
+		];
+		$base_env        = $_ENV;
+		foreach ( [ 'PATH', 'HOME', 'TMPDIR' ] as $key ) {
+			if ( isset( $_SERVER[ $key ] ) && ! isset( $base_env[ $key ] ) ) {
+				$base_env[ $key ] = (string) $_SERVER[ $key ];
+			}
+		}
+
+		$process = proc_open(
+			implode( ' ', array_map( 'escapeshellarg', $command ) ),
+			$descriptor_spec,
+			$pipes,
+			$cwd,
+			array_merge( $base_env, $env )
+		);
+		if ( ! is_resource( $process ) ) {
+			$this->fail( 'Failed to start process: ' . implode( ' ', $command ) );
+		}
+
+		$stdout = stream_get_contents( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+
+		return [
+			'code'   => proc_close( $process ),
+			'stdout' => false === $stdout ? '' : $stdout,
+			'stderr' => false === $stderr ? '' : $stderr,
+		];
+	}
+
+	/**
+	 * Recursively removes a test-created path.
+	 */
+	private function remove_path( string $path ): void {
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+		if ( is_file( $path ) || is_link( $path ) ) {
+			unlink( $path );
+			return;
+		}
+		$entries = scandir( $path );
+		if ( false === $entries ) {
+			return;
+		}
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$this->remove_path( $path . DIRECTORY_SEPARATOR . $entry );
+		}
+		rmdir( $path );
+	}
+}

--- a/wp/dailyos/tests/token-mapping-manifest-gate.sh
+++ b/wp/dailyos/tests/token-mapping-manifest-gate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${DAILYOS_TOKEN_MAPPING_ROOT:-$(pwd)}"
+blocks_dir="${repo_root}/wp/dailyos/blocks"
+theme_json="${repo_root}/wp/dailyos/theme/theme.json"
+
+if [ ! -d "$blocks_dir" ]; then
+	echo "No WordPress block directory found at ${blocks_dir}; token-mapping manifest gate skipped."
+	exit 0
+fi
+
+block_dirs=()
+while IFS= read -r block_dir; do
+	block_dirs+=("$block_dir")
+done < <(find "$blocks_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+if [ "${#block_dirs[@]}" -eq 0 ]; then
+	echo "No WordPress block subdirectories found; token-mapping manifest gate skipped."
+	exit 0
+fi
+
+if [ ! -f "$theme_json" ]; then
+	echo "FAIL: theme.json missing at ${theme_json}" >&2
+	exit 1
+fi
+
+palette_file="$(mktemp)"
+cleanup() {
+	rm -f "$palette_file"
+}
+trap cleanup EXIT
+
+jq -r '.settings.color.palette[]?.slug // empty' "$theme_json" | sort -u > "$palette_file"
+
+raw_color_escape_files=(
+	"wp/dailyos/blocks/account-overview/style.css"
+)
+
+is_raw_color_escape_file() {
+	local rel_path="$1"
+	local allowed
+	for allowed in "${raw_color_escape_files[@]}"; do
+		if [ "$rel_path" = "$allowed" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+relative_path() {
+	local abs_path="$1"
+	printf '%s\n' "${abs_path#"$repo_root"/}"
+}
+
+for block_dir in "${block_dirs[@]}"; do
+	style_file="${block_dir}/style.css"
+	manifest_file="${block_dir}/.token-mapping.json"
+	rel_style="$(relative_path "$style_file")"
+
+	if [ ! -f "$style_file" ]; then
+		continue
+	fi
+
+	style_tokens=()
+	while IFS= read -r style_token; do
+		style_tokens+=("${style_token#--}")
+	done < <(grep -Eho -- '--wp--[a-z0-9-]+' "$style_file" | sort -u || true)
+	if [ "${#style_tokens[@]}" -gt 0 ] && [ ! -f "$manifest_file" ]; then
+		echo "FAIL: ${rel_style} uses WordPress token vars but ${manifest_file} is missing" >&2
+		exit 1
+	fi
+
+	if [ -f "$manifest_file" ]; then
+		jq -e '
+			type == "array"
+			and all(.[]; (.source_token | type == "string") and (.target_token | type == "string"))
+		' "$manifest_file" >/dev/null
+
+		manifest_tokens=()
+		while IFS= read -r manifest_token; do
+			manifest_tokens+=("$manifest_token")
+		done < <(jq -r '.[].target_token' "$manifest_file" | sort -u)
+		for style_token in "${style_tokens[@]}"; do
+			if ! printf '%s\n' "${manifest_tokens[@]}" | grep -Fxq "$style_token"; then
+				echo "FAIL: ${rel_style} uses ${style_token}, missing from .token-mapping.json" >&2
+				exit 1
+			fi
+		done
+
+		while IFS= read -r target_token; do
+			[ -n "$target_token" ] || continue
+			slug="${target_token#wp--preset--color--}"
+			if ! grep -Fxq "$slug" "$palette_file"; then
+				echo "FAIL: ${manifest_file} references ${target_token}, but ${slug} is not defined in theme.json settings.color.palette" >&2
+				exit 1
+			fi
+		done < <(jq -r '.[] | select(.target_token | startswith("wp--preset--color--")) | .target_token' "$manifest_file")
+	fi
+
+	raw_color_output="$(mktemp)"
+	if grep -Eni '#[0-9a-f]{3,8}\b|rgba?\(|hsla?\(' "$style_file" >"$raw_color_output" 2>/dev/null; then
+		if ! is_raw_color_escape_file "$rel_style"; then
+			echo "FAIL: ${rel_style} contains raw color literal(s):" >&2
+			cat "$raw_color_output" >&2
+			rm -f "$raw_color_output"
+			exit 1
+		fi
+	fi
+	rm -f "$raw_color_output"
+done
+
+echo "Token-mapping manifest gate passed (${#block_dirs[@]} block director$( [ "${#block_dirs[@]}" -eq 1 ] && printf 'y' || printf 'ies' ) scanned)."


### PR DESCRIPTION
## Summary

- v1.4.3 W2 pre-W2 gate per L0 Packet D V1.4 §5.9 + AC #14. Codex consult cycle-2 confirmed `wp/dailyos/scripts/translate-tauri.mjs:414-419 + 487-489` does NOT currently emit `.token-mapping.json` — required by §5.9 CI gates that will run on every PR-D2/D3/D4 once W2 starts.
- This PR MUST land on `dev` before PR-D1 (v1.4.3 W2 foundation) opens. Per Packet D AC #8 it is the only allowed W1-side edit during the W2 cycle.

## Files

- `wp/dailyos/scripts/translate-tauri.mjs` — per-primitive `.token-mapping.json` emission. Translator now rewrites generated `style.css` token vars (`--color-*` / `--space-*` / `--font-*` / `--radius-*` / `--shadow-*` / etc.) to their WP-preset counterparts (`var(--wp--preset--color--*)`, `var(--wp--custom--dailyos--tokens--*)`, etc.) and writes a sorted manifest pairing each source token with its target.
- `.github/workflows/block-kit-integration.yml` — new "Token-mapping manifest" step after the translator parity gate, runs `wp/dailyos/tests/token-mapping-manifest-gate.sh` (scoped to existing block dirs only; does not fail PR-D1 when `wp/dailyos/blocks/<slug>/` directories are absent).
- `wp/dailyos/tests/token-mapping-manifest-gate.sh` — bash gate that fails on: manifest references a `wp--preset--color--X` not defined in `wp/dailyos/theme/theme.json` `settings.color.palette`; OR `style.css` uses a WP-preset var missing from `.token-mapping.json`; OR raw color literal (`#hex` / `rgb()` / `hsl()`) in `style.css` outside an allowlist (currently just the v1.4.2 reference `account-overview` block).
- `wp/dailyos/tests/blocks/TokenMappingManifestTest.php` — PHPUnit coverage for emission + all three gate failure modes.

## Test plan

- [x] `pnpm dailyos:translate-tauri --primitive Pill` emits `.token-mapping.json` with 13 entries
- [x] `bash wp/dailyos/tests/token-mapping-manifest-gate.sh` passes on dev
- [x] Manual negative fixture: missing manifest mapping triggers expected failure
- [x] `pnpm dailyos:generate-theme-json --check` green
- [x] `pnpm tsc --noEmit` green
- [x] `node --check` + `bash -n` + `php -l` + `git diff --check` green
- [ ] L2: codex challenge + code-reviewer dispatching in parallel before merge
- [ ] CI block-kit-integration workflow runs on this PR

## Cross-references

- Parent: DOS-685 (v1.4.3 W1 starter kit path-α maintenance; comment added describing this scope).
- Consumer: DOS-682 (v1.4.3 W2 — Wave 1 primitive blocks) — PR-D1 cannot open until this lands.
- Spec: `.docs/plans/v1.4.3-wp-foundation/L0-packet-D-wave-1-primitives.md` V1.4 §5.9 + §10 + AC #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
