### PR TITLE
feat(plans): HTML-first Tier 1 — AUTHORING ruleset + engineering-ladder.html pilot

### DIFF
--- a/.docs/plans/AUTHORING.md
+++ b/.docs/plans/AUTHORING.md
@@ -1,0 +1,148 @@
+# Doc Authoring — Tier Ruleset
+
+**Status:** Canonical
+**Adopted:** 2026-05-18
+**See also:** `.docs/plans/engineering-ladder.md`, `.docs/design/product/build-foundation-html.mjs` (precedent for MD-source → HTML-render pattern)
+
+DailyOS planning docs sit in three tiers. Pick the tier by the **criteria below**, not by doc-type lists (lists drift; criteria stay).
+
+The reason this matters: planning docs are read more than they're edited, and the rendered surface affects whether they get read at all. HTML-first when layout carries information; markdown + render when it's structured prose; markdown-only when the doc is code-adjacent.
+
+---
+
+## Tier 1 — HTML-first
+
+**Author directly as `.html` against the shared design system.**
+
+Apply when **any** of these are true:
+
+- **Layout carries information that prose can't.** Status grids, timelines, reviewer matrices, gate boards, comparison cards, ladder visualizations, wave dashboards, side-by-side architecture overviews.
+- **Intended for sharing visually with people who won't edit it.** Strategy decks, PRDs you'd send to a stakeholder, vision pieces, release-narrative artifacts.
+- **Read-heavy reference doc.** Read often, edited rarely. The Engineering Ladder, the v1.4.x roadmap, the wave-W4 status board.
+
+**Examples (illustrative, not exhaustive):**
+- `.docs/plans/engineering-ladder.html` — Plan/Implement/Review/Capture matrix, K-channel diagram, rung cards
+- Wave dashboards (gate state across W0–W6)
+- PRDs with feature comparison grids
+- Strategy decks
+- Version roadmaps with milestone timelines
+- Architecture overviews with embedded diagrams
+
+**Authoring substrate:**
+- Imports from `.docs/design/reference/_shared/styles/` (design tokens, fonts, MagazinePageLayout)
+- Local `.docs/plans/plans.css` for plan-specific patterns
+- Snippet patterns at `.docs/plans/_patterns/` — copy + adapt
+- Starter templates at `.docs/plans/_templates/` — `pnpm new:plan <type> <slug>` (when wired up) clones the scaffold
+
+**Dogfooding convention:** any inline style or one-off pattern in an HTML-first doc lands with a `<!-- TODO(ds): needs pattern -->` comment naming the gap. End of each wave, the gaps roll into design-system work items. Every HTML-first doc either consumes a DS pattern or surfaces a need.
+
+---
+
+## Tier 2 — Markdown + render
+
+**Author as `.md`, render to `.html` via a build script. Commit both.**
+
+Apply when:
+
+- **Text-dominant prose with section structure.** Long-form essays where the value is the writing, not the layout.
+- **Read often, edited occasionally.** Foundational docs that evolve slowly.
+- **Content is words, not diagrams.**
+
+**Examples:**
+- `.docs/design/product/{MISSION,VISION,PHILOSOPHY,PRINCIPLES,PRODUCT-THESIS}.md` (current precedent; rendered via `build-foundation-html.mjs`)
+- Policy explainers
+- Longform strategy memos
+- Narrative status updates intended for external sharing
+
+**Authoring substrate:**
+- Markdown source as the canonical edit surface (passes through Linear sync, codex review, grep)
+- Build script per surface tier — e.g., `build-foundation-html.mjs` for product foundation. New surfaces get a new build script.
+- HTML output goes alongside the source: `MISSION.md` → `mission.html` in the same directory
+
+---
+
+## Tier 3 — Markdown-only
+
+**Author as `.md`. No HTML render.**
+
+Apply when:
+
+- **Code-adjacent.** Mixed with code blocks, file refs, line numbers, paths.
+- **Diff-reviewed.** PR-shape changes where `git diff` legibility matters more than visual layout.
+- **Linear-canonical.** Per-ticket plans where Linear's markdown view is the authoritative surface.
+- **Grep-first.** Knowledge captures meant to be retrieved by keyword.
+
+**Examples:**
+- Wave retros (`.docs/plans/wave-WN/retro.md`)
+- Proof bundles
+- `docs/solutions/` K-out captures
+- ADRs (`.docs/decisions/ADR-NNNN.md`)
+- Per-ticket Linear plans for orchestration-driven work
+- MEMORY.md and topic-file memories under `/Users/jamesgiroux/.claude/projects/.../memory/`
+- Commit messages and PR bodies
+
+---
+
+## How to pick the tier (decision flow)
+
+```
+Is the doc code-adjacent, diff-reviewed, or grep-first?
+├── YES → Tier 3 (markdown-only)
+└── NO  → continue
+
+Does the doc need layout primitives prose can't express?
+(status grids, timelines, matrices, dashboards, diagrams)
+├── YES → Tier 1 (HTML-first)
+└── NO  → continue
+
+Is the doc intended for visual sharing OR read-heavy reference?
+├── YES → Tier 1 (HTML-first)
+└── NO  → Tier 2 (markdown + render)
+```
+
+If unsure between Tier 1 and Tier 2, ask: *would I sketch this doc on a whiteboard before writing it?* If yes, Tier 1. If no, Tier 2.
+
+---
+
+## Authoring fast in Tier 1
+
+Speed in HTML-first comes from scaffolds, not from compromising the tier:
+
+- **`.docs/plans/_templates/<type>.html`** — starter HTML per doc type (`wave-plan.html`, `prd.html`, `ladder-viz.html`, `strategy-deck.html`), pre-wired to shared design-system imports. Authoring = fill in the slots.
+- **`.docs/plans/_patterns/<name>.html`** — snippet library: `gate-badge.html`, `reviewer-matrix.html`, `status-pill.html`, `ladder-rung-card.html`, `k-channel-diagram.html`, `cycle-count-chip.html`, `timeline-strip.html`, etc. Copy + adapt.
+- **`.docs/plans/_patterns/README.md`** — index of patterns with one-line descriptions of when to use each.
+
+Don't write HTML by hand from scratch — clone a template, replace tokens, compose patterns.
+
+---
+
+## What stays markdown regardless
+
+Tier 3 is non-negotiable for the following surfaces because they have tooling reasons that override visual considerations:
+
+- **Linear-canonical plans** — Linear is canonical per CLAUDE.md; converting to HTML duplicates the surface and creates sync risk.
+- **Retros + proof bundles** — wave-end review artifacts, consumed by L3 reviewers (codex challenge + architect) which expect markdown.
+- **`docs/solutions/` K-out captures** — grep-retrieved by L0/L1/L2 reviewers per the Engineering Ladder K-in obligation. HTML breaks grep.
+- **ADRs** — industry-wide markdown convention; tooling (`adr-tools`, etc.) assumes it.
+- **MEMORY.md + topic-file memories** — Claude's auto-memory reads markdown.
+
+---
+
+## What this doesn't change
+
+- Markdown remains the authoring surface for code-adjacent, diff-reviewed, and Linear-canonical docs.
+- The Engineering Ladder's L0–L6 protocol, K-in / K-out obligations, and reviewer panels are unchanged.
+- `feedback_set_and_forget_wave_protocol`, `feedback_check_substrate_before_authoring_primitives`, and other operational memories continue to apply.
+- The `docs/solutions/` knowledge store stays markdown-only — it's grep-first reference, not consumption surface.
+
+---
+
+## Surfacing patterns back to the DS
+
+When authoring an HTML-first doc surfaces a gap (inline style, ad-hoc layout, missing token):
+
+1. Annotate with `<!-- TODO(ds): needs pattern — <one-line description> -->` in the source.
+2. At wave close, sweep `grep -r 'TODO(ds):' .docs/plans/` and roll the gaps into design-system Linear issues.
+3. When the DS pattern lands, replace the inline use with the canonical class.
+
+This is the **dogfooding loop** — plan-doc authoring becomes a continuous feedback channel into the design system. Every plan that surfaces a gap either gets a new DS pattern or surfaces an over-abstraction (the gap is one-off, doesn't deserve a pattern). Both outcomes are signal.

--- a/.docs/plans/_patterns/README.md
+++ b/.docs/plans/_patterns/README.md
@@ -1,0 +1,38 @@
+# `.docs/plans/_patterns/` — Snippet library for Tier 1 HTML-first plan docs
+
+Each file in this directory is a copy-and-adapt snippet for plan-doc authoring. These are not React components or includes — they're starting points you paste into your HTML file and modify in place.
+
+## When to add a pattern here
+
+A snippet earns a place in `_patterns/` when:
+
+1. It's been used in **2+ HTML-first plan docs**, OR
+2. It's a high-confidence reusable shape (matrix tables, status pills, callouts)
+
+Single-use shapes stay inline in the source doc with a `<!-- TODO(ds): needs pattern -->` comment naming the gap. If/when the gap recurs, extract here.
+
+## When to promote a pattern OUT of here
+
+When a `_patterns/` snippet becomes useful across **multiple surface types** (product app + planning + reference), promote it to `.docs/design/reference/_shared/` (or to a new `.module.css` if it's a real component). The plan-doc snippet then becomes a `<link rel="stylesheet">` import + thin HTML.
+
+## Current patterns
+
+| Pattern | File | Purpose |
+|---|---|---|
+| Cover section | `cover-section.html` | Hero / lede / meta strip used at the top of every plan doc |
+| Section header | `section-header.html` | Eyebrow + title + lede block that introduces a section |
+| Topnav | `topnav.html` | Page topnav with brand mark + links |
+| Pass-rule badge | `pass-rule-badge.html` | Gate-state badge (REVISE / BLOCK / APPROVE / etc.) |
+| Reviewer matrix | `reviewer-matrix.html` | Two-column table mapping agent profile → domain reviewer |
+| Suite card | `suite-card.html` | Test suite card with large letter, prose, owner, pass rule |
+| K-channel diagram | `k-channel-diagram.html` | Two-zone feedback-loop visualization (store + flows) |
+| Two-column policy list | `two-column-policy.html` | Side-by-side MUST / MUST NOT lists with pills |
+| Callout strip | `callout.html` | Bordered operational-rule callout (pacing / bounding / etc.) |
+| Finis marker | `finis.html` | Close-of-document signature |
+
+## Conventions
+
+- Patterns use only design tokens from `.docs/design/reference/_shared/styles/design-tokens.css` (no hardcoded colors / sizes).
+- Patterns are presentation-only — no JavaScript, no data binding. Static HTML.
+- Class names are kebab-case with a single domain prefix (`ladder-`, `k-`, `suite-`, `l6-`, `plans-`, `callout-`). Avoid generic names like `.card`, `.title`.
+- When a snippet uses a token, reference it via `var(--color-…)` / `var(--space-…)` / `var(--font-…)` — never literal values.

--- a/.docs/plans/_patterns/callout.html
+++ b/.docs/plans/_patterns/callout.html
@@ -1,0 +1,28 @@
+<!--
+  Pattern: callout
+  Use: bordered side-strip card for operational rules, principles, or sticky guidance.
+  Used in a grid of 2-3 typically (.callout-grid wrapper).
+
+  Default left-border tone is eucalyptus. Override via inline style or a tone class
+  if a callout needs a different color (e.g., warning = saffron, danger = chili).
+-->
+<section class="plans-section plans-section-callouts" aria-label="&lt;Section label, e.g. Operational rules&gt;">
+  <div class="callout-grid">
+
+    <article class="callout">
+      <h3 class="callout-title">&lt;Callout title&gt;</h3>
+      <p class="callout-prose">&lt;The rule, principle, or guidance. Keep to 2-3 sentences max — callouts get scanned, not read.&gt;</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">&lt;Second callout&gt;</h3>
+      <p class="callout-prose">&lt;Body&gt;</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">&lt;Third callout&gt;</h3>
+      <p class="callout-prose">&lt;Body&gt;</p>
+    </article>
+
+  </div>
+</section>

--- a/.docs/plans/_patterns/cover-section.html
+++ b/.docs/plans/_patterns/cover-section.html
@@ -1,0 +1,19 @@
+<!--
+  Pattern: cover-section
+  Use: top-of-document hero. Always one per HTML-first plan doc.
+  Styled in plans.css under .plans-cover / .plans-eyebrow / .plans-title / etc.
+-->
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · &lt;Surface name&gt;</p>
+  <h1 class="plans-title">&lt;The one-sentence promise of this doc.&gt;</h1>
+  <p class="plans-kicker">&lt;The subtitle in italic serif — supports the title.&gt;</p>
+  <p class="plans-lede">
+    &lt;Two to four sentences that set context for what the doc covers and why it matters. Read once, then the reader scans the rest.&gt;
+  </p>
+  <div class="plans-meta">
+    <span>&lt;Adopted date or version&gt;</span>
+    <span>&lt;Key fact 1&gt;</span>
+    <span>&lt;Key fact 2&gt;</span>
+    <span>&lt;Key fact 3&gt;</span>
+  </div>
+</section>

--- a/.docs/plans/_patterns/finis.html
+++ b/.docs/plans/_patterns/finis.html
@@ -1,0 +1,9 @@
+<!--
+  Pattern: finis
+  Use: close marker at the end of an HTML-first plan doc. Editorial signoff.
+-->
+<div class="finis">
+  <div class="finis-mark">&lt;DOTTED · IDENTIFIER · STRIP&gt;</div>
+  <div class="finis-date">&lt;Doc name · YYYY-MM-DD&gt;</div>
+  <div class="finis-caption">&lt;One-line signature quote or principle that closes the doc.&gt;</div>
+</div>

--- a/.docs/plans/_patterns/k-channel-diagram.html
+++ b/.docs/plans/_patterns/k-channel-diagram.html
@@ -1,0 +1,53 @@
+<!--
+  Pattern: k-channel-diagram
+  Use: two-zone feedback-loop visualization. Originally for the Knowledge Channel
+  (K-in / K-out), but the shape generalizes to any "store + flows" diagram —
+  e.g., signals → handlers, claims → derived state, telemetry → dashboards.
+
+  Layout: store on left (single zone), flows on right (two stacked half-cards
+  showing inbound and outbound directions).
+-->
+<div class="k-diagram">
+
+  <!-- Left zone: the durable store -->
+  <div class="k-store">
+    <div class="k-store-header">&lt;Store name&gt;</div>
+    <ul class="k-store-items">
+      <li>
+        <code>&lt;store path 1&gt;</code>
+        <span class="k-store-detail">&lt;what lives here&gt;</span>
+      </li>
+      <li>
+        <code>&lt;store path 2&gt;</code>
+        <span class="k-store-detail">&lt;what lives here&gt;</span>
+      </li>
+    </ul>
+  </div>
+
+  <!-- Right zone: the two flows -->
+  <div class="k-flows">
+
+    <!-- Inbound flow (consume) -->
+    <div class="k-flow k-flow-in">
+      <div class="k-flow-arrow" aria-hidden="true">↑</div>
+      <div class="k-flow-label">&lt;Inbound flow name, e.g. K-in&gt;</div>
+      <p class="k-flow-prose">&lt;What triggers the inbound flow and what it does.&gt;</p>
+      <div class="k-flow-rungs">
+        <span class="k-flow-rung">&lt;primary consumer&gt;</span>
+        <span class="k-flow-rung k-flow-rung-soft">&lt;secondary consumer&gt;</span>
+      </div>
+    </div>
+
+    <!-- Outbound flow (produce) -->
+    <div class="k-flow k-flow-out">
+      <div class="k-flow-arrow" aria-hidden="true">↓</div>
+      <div class="k-flow-label">&lt;Outbound flow name, e.g. K-out&gt;</div>
+      <p class="k-flow-prose">&lt;What triggers the outbound flow and what it captures.&gt;</p>
+      <div class="k-flow-rungs">
+        <span class="k-flow-rung">&lt;primary producer&gt;</span>
+        <span class="k-flow-rung k-flow-rung-soft">&lt;secondary producer&gt;</span>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/.docs/plans/_patterns/pass-rule-badge.html
+++ b/.docs/plans/_patterns/pass-rule-badge.html
@@ -1,0 +1,36 @@
+<!--
+  Pattern: pass-rule-badge
+  Use: gate-state indicator. Inline next to a "Pass rule" label.
+  Variants:
+    pass-rule-unanimous  — green (approved / unanimous)
+    pass-rule-blockers   — saffron / terracotta (zero-blockers required)
+    pass-rule-drift      — olive (no-drift required)
+    pass-rule-escalate   — chili (escalation trigger / critical)
+
+  TODO(ds): consider promoting to .module.css if same shape is needed in
+  product surfaces (e.g., wave-dashboard cells, PR status displays).
+-->
+
+<!-- Variant: unanimous -->
+<div class="ladder-rung-pass-rule">
+  <span class="pass-rule-label">Pass rule</span>
+  <span class="pass-rule-badge pass-rule-unanimous">Unanimous required</span>
+</div>
+
+<!-- Variant: zero blockers -->
+<div class="ladder-rung-pass-rule">
+  <span class="pass-rule-label">Pass rule</span>
+  <span class="pass-rule-badge pass-rule-blockers">Zero blockers</span>
+</div>
+
+<!-- Variant: no drift -->
+<div class="ladder-rung-pass-rule">
+  <span class="pass-rule-label">Pass rule</span>
+  <span class="pass-rule-badge pass-rule-drift">No drift</span>
+</div>
+
+<!-- Variant: escalation trigger -->
+<div class="ladder-rung-pass-rule">
+  <span class="pass-rule-label">Trigger</span>
+  <span class="pass-rule-badge pass-rule-escalate">Specific structural question</span>
+</div>

--- a/.docs/plans/_patterns/reviewer-matrix.html
+++ b/.docs/plans/_patterns/reviewer-matrix.html
@@ -1,0 +1,31 @@
+<!--
+  Pattern: reviewer-matrix
+  Use: two-column table mapping agent profile / scope → domain reviewer.
+  Works for any "if X then Y" lookup where Y is a code reference.
+
+  Generic enough to use for: reviewer matrices, role assignments,
+  trigger paths → handler tables.
+-->
+<table class="reviewer-matrix">
+  <thead>
+    <tr>
+      <th>&lt;Lookup key column header&gt;</th>
+      <th>&lt;Value column header&gt;</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>&lt;Agent profile / scope description&gt;</td>
+      <td><code>&lt;domain-reviewer / handler-name&gt;</code></td>
+    </tr>
+    <tr>
+      <td>&lt;Next row&gt;</td>
+      <td><code>&lt;reviewer&gt;</code></td>
+    </tr>
+    <!-- Add rows as needed. Keep first column human-readable, second column code/identifier. -->
+  </tbody>
+</table>
+
+<p class="plans-footnote">
+  &lt;Optional footnote — clarifies edge cases, amendment triggers, when the table extends.&gt;
+</p>

--- a/.docs/plans/_patterns/section-header.html
+++ b/.docs/plans/_patterns/section-header.html
@@ -1,0 +1,11 @@
+<!--
+  Pattern: section-header
+  Use: introduces a major section. Eyebrow + title + lede.
+-->
+<header class="plans-section-header">
+  <p class="plans-section-eyebrow">&lt;Section eyebrow — short, ALL CAPS feel via CSS&gt;</p>
+  <h2 id="&lt;section-id&gt;" class="plans-section-title">&lt;Section title — one sentence&gt;</h2>
+  <p class="plans-section-lede">
+    &lt;Two-sentence lede that sets up the section's content.&gt;
+  </p>
+</header>

--- a/.docs/plans/_patterns/suite-card.html
+++ b/.docs/plans/_patterns/suite-card.html
@@ -1,0 +1,25 @@
+<!--
+  Pattern: suite-card
+  Use: test suite or named-category card with large letter mark, prose, owner, pass rule.
+  Generalizes beyond test suites — any "named category with definition + owner + pass criterion."
+
+  Variants via data-suite attribute:
+    s — chili tone (security)
+    p — turmeric tone (performance)
+    e — olive tone (edge cases)
+  Add more in plans.css if needed.
+-->
+<div class="suite-grid">
+  <article class="suite-card" data-suite="s">
+    <span class="suite-letter">S</span>
+    <h3 class="suite-name">&lt;Suite name&gt;</h3>
+    <p class="suite-prose">&lt;What the suite covers — one or two sentences.&gt;</p>
+    <p class="suite-owner">
+      <span class="suite-owner-label">Owner</span> <code>&lt;owner-agent&gt;</code>
+    </p>
+    <p class="suite-pass-rule">
+      <span class="suite-pass-label">Pass</span> &lt;pass condition&gt;
+    </p>
+  </article>
+  <!-- Add additional suite-card articles inside .suite-grid as needed. -->
+</div>

--- a/.docs/plans/_patterns/topnav.html
+++ b/.docs/plans/_patterns/topnav.html
@@ -1,0 +1,19 @@
+<!--
+  Pattern: topnav
+  Use: page chrome at the top of HTML-first plan docs.
+  Brand mark on left, doc links on right. data-active="true" marks the current page.
+-->
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="v1.4.0-waves.md">Wave Protocol</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+    <!-- Add more links as the planning surface grows. Mark current with data-active="true". -->
+  </div>
+</nav>

--- a/.docs/plans/_patterns/two-column-policy.html
+++ b/.docs/plans/_patterns/two-column-policy.html
@@ -1,0 +1,36 @@
+<!--
+  Pattern: two-column-policy
+  Use: side-by-side MUST / MUST NOT (or DO / DON'T, KEEP / DROP, INVEST / DEFER) lists
+  with header pills marking each column.
+
+  Originally for L6 escalation policy; generalizes to any binary-policy doc.
+-->
+<div class="l6-grid">
+
+  <!-- Left column: positive list -->
+  <article class="l6-list l6-list-must">
+    <header class="l6-list-header">
+      <span class="l6-list-pill l6-list-pill-must">&lt;LEFT LABEL, e.g. MUST&gt;</span>
+      <p class="l6-list-blurb">&lt;One-line description of what this column covers.&gt;</p>
+    </header>
+    <ol class="l6-list-items">
+      <li>&lt;Item 1&gt;</li>
+      <li>&lt;Item 2&gt;</li>
+      <li>&lt;Item 3&gt;</li>
+    </ol>
+  </article>
+
+  <!-- Right column: negative list -->
+  <article class="l6-list l6-list-mustnot">
+    <header class="l6-list-header">
+      <span class="l6-list-pill l6-list-pill-mustnot">&lt;RIGHT LABEL, e.g. MUST NOT&gt;</span>
+      <p class="l6-list-blurb">&lt;One-line description of what this column covers.&gt;</p>
+    </header>
+    <ol class="l6-list-items">
+      <li>&lt;Item 1&gt;</li>
+      <li>&lt;Item 2&gt;</li>
+      <li>&lt;Item 3&gt;</li>
+    </ol>
+  </article>
+
+</div>

--- a/.docs/plans/_templates/README.md
+++ b/.docs/plans/_templates/README.md
@@ -1,0 +1,38 @@
+# `.docs/plans/_templates/` — Starter scaffolds for Tier 1 HTML-first plan docs
+
+Each file here is a copyable starter for a doc type. Clone, rename, fill in.
+
+## Current templates
+
+| Template | File | When to use |
+|---|---|---|
+| Generic plan | `generic-plan.html` | Any Tier 1 plan doc — version plans, roadmaps, internal references. Includes cover, sections, callouts, finis. |
+| Wave plan | `wave-plan.html` | New wave plan (e.g., `v1.4.5-waves.html`). Includes wave-overview cards, gate states, reviewer matrix, suite cards. |
+
+## Workflow
+
+1. Copy the template to your target path:
+   ```
+   cp .docs/plans/_templates/generic-plan.html .docs/plans/my-new-doc.html
+   ```
+2. Update `<title>`, the cover section, and the topnav links to fit the new doc.
+3. Compose patterns from `.docs/plans/_patterns/` — copy snippets, paste in place, customize.
+4. Annotate any new inline style or one-off layout with `<!-- TODO(ds): needs pattern -->`.
+5. Source content stays markdown when appropriate (per the AUTHORING.md three-tier ruleset). Long-form prose sections inside an HTML doc are fine; full markdown source files are not duplicated.
+
+## What templates DON'T do
+
+- They don't auto-link the topnav — update it manually so navigation works as the planning surface grows.
+- They don't generate IDs, dates, or other metadata — fill those in.
+- They don't replace authoring judgment — the template is structure; the content is yours.
+
+## Adding new templates
+
+When 2+ docs of the same type have shipped and have a common shape, extract a new template:
+
+1. Look at the structural commonalities across the docs.
+2. Copy the cleanest version to `_templates/<doctype>.html`.
+3. Replace concrete content with placeholder text (using `&lt;angle brackets&gt;` for clarity).
+4. Add to the table above.
+
+Don't pre-emptively create templates for doc types that don't exist yet — wait for the second instance.

--- a/.docs/plans/_templates/generic-plan.html
+++ b/.docs/plans/_templates/generic-plan.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>&lt;DOC TITLE&gt; · DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body
+  data-tint="eucalyptus"
+  data-active-page="planning">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<!-- TOPNAV — see _patterns/topnav.html -->
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="&lt;CURRENT_DOC&gt;.html" data-active="true">&lt;Doc name&gt;</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<!-- COVER — see _patterns/cover-section.html -->
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · &lt;Surface name&gt;</p>
+  <h1 class="plans-title">&lt;The one-sentence promise of this doc.&gt;</h1>
+  <p class="plans-kicker">&lt;The subtitle in italic serif.&gt;</p>
+  <p class="plans-lede">
+    &lt;Two to four sentences of context.&gt;
+  </p>
+  <div class="plans-meta">
+    <span>&lt;Adopted date&gt;</span>
+    <span>&lt;Key fact 1&gt;</span>
+    <span>&lt;Key fact 2&gt;</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 1 — duplicate this block per top-level section
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="section-1">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">&lt;Section eyebrow&gt;</p>
+    <h2 id="section-1" class="plans-section-title">&lt;Section title.&gt;</h2>
+    <p class="plans-section-lede">
+      &lt;Section lede — two-sentence intro to what follows.&gt;
+    </p>
+  </header>
+
+  <!-- Section body — compose from patterns or write inline content -->
+  <p>&lt;Body content.&gt;</p>
+</section>
+
+<!-- ============================================================
+     SECTION 2 — example using callout grid
+     ============================================================ -->
+<section class="plans-section plans-section-callouts" aria-label="&lt;label&gt;">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">&lt;Callout 1&gt;</h3>
+      <p class="callout-prose">&lt;Body.&gt;</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">&lt;Callout 2&gt;</h3>
+      <p class="callout-prose">&lt;Body.&gt;</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">&lt;Callout 3&gt;</h3>
+      <p class="callout-prose">&lt;Body.&gt;</p>
+    </article>
+  </div>
+</section>
+
+<!-- ============================================================
+     RELATED / FOOTER — cross-reference other docs
+     ============================================================ -->
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">How this doc relates to others.</h2>
+  </header>
+  <ul class="plans-related">
+    <li>
+      <strong>&lt;Other doc&gt;</strong>
+      &lt;One-line description of relationship.&gt;
+    </li>
+  </ul>
+</section>
+
+<!-- FINIS — close marker -->
+<div class="finis">
+  <div class="finis-mark">&lt;IDENTIFIER STRIP&gt;</div>
+  <div class="finis-date">&lt;Doc name · YYYY-MM-DD&gt;</div>
+  <div class="finis-caption">&lt;One-line closing principle.&gt;</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/.docs/plans/_templates/wave-plan.html
+++ b/.docs/plans/_templates/wave-plan.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>&lt;VERSION&gt; Wave Plan · DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body data-tint="turmeric">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<!-- TOPNAV -->
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="&lt;VERSION&gt;-waves.html" data-active="true">&lt;Version&gt; Waves</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<!-- COVER -->
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · &lt;Version&gt; · Wave Plan</p>
+  <h1 class="plans-title">&lt;Version one-line outcome.&gt;</h1>
+  <p class="plans-kicker">&lt;Subtitle — the central promise of this version.&gt;</p>
+  <p class="plans-lede">
+    &lt;Two to four sentences setting context: what this version delivers, why the waves are shaped the way they are, what gates this version.&gt;
+  </p>
+  <div class="plans-meta">
+    <span>Target: &lt;date&gt;</span>
+    <span>Waves: &lt;N&gt;</span>
+    <span>Parallel agents: &lt;peak&gt;</span>
+    <span>Source: Linear &lt;project link&gt;</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     WAVE OVERVIEW — table or card grid showing W0..WN
+     TODO(ds): if used in 2+ wave plans, extract to _patterns/wave-overview-grid.html
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="wave-overview">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave shape</p>
+    <h2 id="wave-overview" class="plans-section-title">&lt;N&gt; waves, hard ordering across, parallel within.</h2>
+    <p class="plans-section-lede">
+      &lt;Short framing of how the waves chain. Mention the wave gate is L3 + L5.&gt;
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Wave</th>
+        <th>Issues</th>
+        <th>Parallel agents</th>
+        <th>Target</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>W0 — &lt;name&gt;</td>
+        <td>&lt;DOS-###&gt;, &lt;DOS-###&gt;</td>
+        <td>&lt;count&gt;</td>
+        <td>&lt;wall-clock target&gt;</td>
+      </tr>
+      <!-- Add rows per wave -->
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     REVIEWER MATRIX — domain reviewers per agent profile
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="reviewer-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reviewer matrix</p>
+    <h2 id="reviewer-matrix" class="plans-section-title">Domain reviewer per L0 / L2 risk profile.</h2>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Agent profile</th>
+        <th>Domain reviewer</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Substrate / schema</td>
+        <td><code>architect-reviewer</code></td>
+      </tr>
+      <tr>
+        <td>New SQL write path</td>
+        <td><code>security-auditor</code></td>
+      </tr>
+      <tr>
+        <td>Hot-path / migration</td>
+        <td><code>performance-engineer</code></td>
+      </tr>
+      <tr>
+        <td>User-facing surface</td>
+        <td><code>accessibility-tester</code></td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     SUITE CARDS — S / P / E
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="suites">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Test suites</p>
+    <h2 id="suites" class="plans-section-title">S, P, E feed into L3.</h2>
+  </header>
+
+  <div class="suite-grid">
+    <article class="suite-card" data-suite="s">
+      <span class="suite-letter">S</span>
+      <h3 class="suite-name">Security</h3>
+      <p class="suite-prose">&lt;What S covers for this version.&gt;</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>security-auditor</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> zero Critical/High</p>
+    </article>
+    <article class="suite-card" data-suite="p">
+      <span class="suite-letter">P</span>
+      <h3 class="suite-name">Performance</h3>
+      <p class="suite-prose">&lt;What P covers.&gt;</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>performance-engineer</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> no regression vs baseline</p>
+    </article>
+    <article class="suite-card" data-suite="e">
+      <span class="suite-letter">E</span>
+      <h3 class="suite-name">Edge cases</h3>
+      <p class="suite-prose">&lt;What E covers — property tests, fuzz, bundles.&gt;</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>qa-expert</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> bundles + property tests green</p>
+    </article>
+  </div>
+</section>
+
+<!-- ============================================================
+     PACING + BOUNDING CALLOUTS
+     ============================================================ -->
+<section class="plans-section plans-section-callouts">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">Pacing</h3>
+      <p class="callout-prose">No wave starts until prior wave clears L3 + L5. No agent codes before L0 clears unanimously. Two revision cycles → L6 escalation.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Bounding</h3>
+      <p class="callout-prose">L2 bounded by acceptance criteria. Path-α findings → maintenance project. Substrate PRs unblock once AC violations are closed.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Migration slots</h3>
+      <p class="callout-prose">Claim non-overlapping slot blocks per parallel agent. E.g., W4-A = v160–v169, W4-B = v170–v179.</p>
+    </article>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">Cross-references.</h2>
+  </header>
+  <ul class="plans-related">
+    <li><strong>engineering-ladder.html</strong> Engineering Ladder L0–L6 + K-channel + skill matrix per rung.</li>
+    <li><strong>Linear project</strong> &lt;link to source-of-truth project&gt;</li>
+  </ul>
+</section>
+
+<!-- FINIS -->
+<div class="finis">
+  <div class="finis-mark">W0 · W1 · W2 · W3 · W4 · W5 · W6</div>
+  <div class="finis-date">&lt;Version&gt; Wave Plan · YYYY-MM-DD</div>
+  <div class="finis-caption">Skipping a wave gate is what produces the Codex round 1+2 findings; the cost is weeks.</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/.docs/plans/engineering-ladder.html
+++ b/.docs/plans/engineering-ladder.html
@@ -1,0 +1,636 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Engineering Ladder L0–L6 · DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body
+  data-tint="eucalyptus"
+  data-active-page="planning">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<!-- ============================================================
+     TOP NAV — copies foundation-topnav pattern from product surface
+     TODO(ds): needs pattern — consider .docs/plans/_patterns/topnav.html if reused 2+ times
+     ============================================================ -->
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html" data-active="true">Engineering Ladder</a>
+    <a href="v1.4.0-waves.md">Wave Protocol</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<!-- ============================================================
+     COVER — hero / lede / meta
+     Reusing foundation-cover pattern; if it appears in 2+ plan docs, extract to _patterns/cover.html
+     ============================================================ -->
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · Engineering Ladder</p>
+  <h1 class="plans-title">From plan to merge, in seven gates.</h1>
+  <p class="plans-kicker">L0–L6 with Plan, Implement, Review, and Capture roles per rung.</p>
+  <p class="plans-lede">
+    The Engineering Ladder is how work moves from intake to merge. Each rung names the skills that apply at that phase — not just review. A continuous Knowledge Channel feeds findings into L0 and captures findings out of L3 / L5 so the same drift doesn't surface twice.
+  </p>
+  <div class="plans-meta">
+    <span>Adopted 2026-05-18</span>
+    <span>L0–L6 numbering preserved</span>
+    <span>Plan / Implement / Review / Capture per rung</span>
+    <span>K-channel: docs/solutions/ + .docs/decisions/</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     SKILL MATRIX — the heart of the ladder
+     Each rung is a card with 4 role quadrants: Plan / Implement / Review / Capture
+     TODO(ds): needs pattern — ladder-rung-card with role quadrants. First use; consider promoting to _patterns/ if used in wave dashboards.
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="skill-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Skill matrix</p>
+    <h2 id="skill-matrix" class="plans-section-title">Each rung, four roles.</h2>
+    <p class="plans-section-lede">
+      Plan, Implement, Review, and Capture skills per rung. <strong>K-in</strong> (substrate-grep at L0) and <strong>K-out</strong> (`/ce-compound` capture at L3 retro) are mandatory.
+    </p>
+  </header>
+
+  <div class="ladder-grid">
+
+    <!-- L0 Prep -->
+    <article class="ladder-rung" data-rung="l0-prep" data-tone="larkspur">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L0 Prep</span>
+        <h3 class="ladder-rung-title">Plan hardening</h3>
+        <p class="ladder-rung-blurb">Turn the Linear ticket into a reviewable plan. Not an approval gate — hardens the ticket so L0 review has something concrete.</p>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <ul class="ladder-role-skills">
+            <li><code>/plan-eng-review</code> <em>always</em></li>
+            <li><code>/plan-ceo-review</code> when product/domain</li>
+            <li><code>/plan-design-review</code> when UI/workflow</li>
+            <li><code>/plan-devex-review</code> when MCP/API/DX</li>
+            <li><code>/ce-plan</code> structure + open-question surfacing</li>
+            <li><code>/ce-strategy</code> only when no STRATEGY exists</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="capture">
+          <span class="ladder-role-label">Capture</span>
+          <ul class="ladder-role-skills">
+            <li><code>/ce-sessions</code> — pull prior-session findings into the plan</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+    <!-- L0 Plan -->
+    <article class="ladder-rung" data-rung="l0-plan" data-tone="saffron">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L0 Plan</span>
+        <h3 class="ladder-rung-title">Plan review (gate)</h3>
+        <p class="ladder-rung-blurb">Pre-code review of the hardened plan. K-in mandatory: reviewers grep <code>docs/solutions/</code> + <code>.docs/decisions/</code> before scoring.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Pass rule</span>
+          <span class="pass-rule-badge pass-rule-unanimous">Unanimous required</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <ul class="ladder-role-skills">
+            <li><code>/codex challenge</code></li>
+            <li><code>architect-reviewer</code> (default domain)</li>
+            <li><code>security-auditor</code> when paths match Amendment 3</li>
+            <li><code>/codex consult</code></li>
+            <li><code>/ce-doc-review</code> optional fifth opinion</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-kin" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kin">K-in</span></span>
+          <p class="ladder-role-prose">Each L0 reviewer greps <code>docs/solutions/</code> + <code>.docs/decisions/</code> for substrate the plan claims is net new. Cite hits in verdict. <strong>Reinvented documented substrate = BLOCKED.</strong></p>
+        </div>
+      </div>
+    </article>
+
+    <!-- L1 Self -->
+    <article class="ladder-rung" data-rung="l1-self" data-tone="turmeric">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L1 Self</span>
+        <h3 class="ladder-rung-title">Implementation + self-validation</h3>
+        <p class="ladder-rung-blurb">The implementing agent codes against the plan, runs tests, captures proof artifacts before opening the PR.</p>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <ul class="ladder-role-skills">
+            <li><code>/ce-work</code> executes against plan</li>
+            <li><code>/ce-debug</code> root-cause when stuck</li>
+            <li><code>/ce-simplify-code</code> pre-PR polish</li>
+            <li>Manual editing</li>
+          </ul>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <p class="ladder-role-prose">Self-validation: tests pass, proof artifacts captured, demo evidence captured before opening the PR.</p>
+        </div>
+        <div class="ladder-role" data-role="capture">
+          <span class="ladder-role-label">Capture</span>
+          <ul class="ladder-role-skills">
+            <li><code>/ce-sessions</code> when picking up mid-task across sessions</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
+    <!-- L2 Diff -->
+    <article class="ladder-rung" data-rung="l2-diff" data-tone="sage">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L2 Diff</span>
+        <h3 class="ladder-rung-title">PR review (gate)</h3>
+        <p class="ladder-rung-blurb">Pre-merge review of the PR. Bounded by acceptance criteria; runs locally before pushing the PR. Path-α findings → maintenance project, not cycle-N+1.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Pass rule</span>
+          <span class="pass-rule-badge pass-rule-unanimous">All three approve</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <ul class="ladder-role-skills">
+            <li><code>/review</code> (gstack pre-landing)</li>
+            <li><code>/codex review</code></li>
+            <li><code>code-reviewer</code> subagent</li>
+            <li>Domain reviewer per matrix</li>
+            <li><code>/ce-resolve-pr-feedback</code> for review-thread loop</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-kin" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kin">K-in</span></span>
+          <p class="ladder-role-prose">Domain reviewer cites matching <code>docs/solutions/</code> entries when a finding repeats a known class.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- L3 Wave -->
+    <article class="ladder-rung" data-rung="l3-wave" data-tone="eucalyptus">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L3 Wave</span>
+        <h3 class="ladder-rung-title">Integrated review (gate)</h3>
+        <p class="ladder-rung-blurb">After all wave PRs merge: codex challenge against integrated diff + ADRs, architect-reviewer on integrated state, Suites S / P / E.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Pass rule</span>
+          <span class="pass-rule-badge pass-rule-unanimous">All approve + suites green</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <ul class="ladder-role-skills">
+            <li><code>/codex challenge</code> against integrated wave + ADRs</li>
+            <li><code>architect-reviewer</code> on integrated state</li>
+            <li>Suite S / P / E</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-kout" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kout">K-out</span></span>
+          <p class="ladder-role-prose">At retro close, run <code>/ce-compound</code> for each class-pattern finding and each substrate-already-existed finding. Output committed to <code>docs/solutions/&lt;category&gt;/</code>.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- L4 Surface -->
+    <article class="ladder-rung" data-rung="l4-surface" data-tone="terracotta">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L4 Surface</span>
+        <h3 class="ladder-rung-title">User-facing QA</h3>
+        <p class="ladder-rung-blurb">User-facing change QA. L4 hands-on BEFORE L2 for UI-changing fixes — never commit a UI fix without confirming it renders.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Pass rule</span>
+          <span class="pass-rule-badge pass-rule-blockers">Zero blockers</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <ul class="ladder-role-skills">
+            <li><code>/qa-only</code> first</li>
+            <li><code>/qa</code> if remediation needed</li>
+            <li><code>accessibility-tester</code> for user-facing</li>
+            <li><code>/ce-test-browser</code> if no <code>/qa</code> config</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-kout" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kout">K-out</span></span>
+          <p class="ladder-role-prose">Capture surface bugs that recur across waves via <code>/ce-compound</code>.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- L5 Drift -->
+    <article class="ladder-rung" data-rung="l5-drift" data-tone="olive">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L5 Drift</span>
+        <h3 class="ladder-rung-title">Architecture drift</h3>
+        <p class="ladder-rung-blurb">Compare integrated state to planned end-state. Runs at checkpoints named in the wave plan and before release for multi-wave projects.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Pass rule</span>
+          <span class="pass-rule-badge pass-rule-drift">No drift</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <ul class="ladder-role-skills">
+            <li><code>/plan-eng-review</code></li>
+            <li><code>architect-reviewer</code> comparing integrated state to planned end-state</li>
+          </ul>
+        </div>
+        <div class="ladder-role ladder-role-kout" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kout">K-out</span></span>
+          <p class="ladder-role-prose">Run <code>/ce-compound-refresh</code> on stale <code>.docs/decisions/</code> and <code>docs/solutions/</code> entries the drift sweep surfaces.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- L6 Human -->
+    <article class="ladder-rung ladder-rung-human" data-rung="l6-human" data-tone="chili">
+      <div class="ladder-rung-header">
+        <span class="ladder-rung-id">L6 Human</span>
+        <h3 class="ladder-rung-title">Escalation</h3>
+        <p class="ladder-rung-blurb">James's call when the system can't resolve. Decision posted as Linear comment on the affected ticket. Used sparingly — see MUST / MUST NOT below.</p>
+        <div class="ladder-rung-pass-rule">
+          <span class="pass-rule-label">Trigger</span>
+          <span class="pass-rule-badge pass-rule-escalate">Specific structural question</span>
+        </div>
+      </div>
+      <div class="ladder-rung-roles">
+        <div class="ladder-role ladder-role-empty" data-role="plan">
+          <span class="ladder-role-label">Plan</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role ladder-role-empty" data-role="implement">
+          <span class="ladder-role-label">Implement</span>
+          <span class="ladder-role-na">n/a</span>
+        </div>
+        <div class="ladder-role" data-role="review">
+          <span class="ladder-role-label">Review</span>
+          <p class="ladder-role-prose">James — decision posted as a Linear comment on the affected ticket.</p>
+        </div>
+        <div class="ladder-role ladder-role-kout" data-role="capture">
+          <span class="ladder-role-label">Capture <span class="role-tag role-tag-kout">K-out</span></span>
+          <p class="ladder-role-prose">L6 decisions captured as Linear comments (existing); add ADR if the decision is architecturally durable.</p>
+        </div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- ============================================================
+     KNOWLEDGE CHANNEL — visual diagram
+     Two-zone: knowledge store (left) flowing both directions to ladder rungs (right)
+     TODO(ds): needs pattern — k-channel-diagram. Composed of zones + arrows + labels. Likely reusable for any "feedback loop" visualization.
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="k-channel">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Knowledge Channel</p>
+    <h2 id="k-channel" class="plans-section-title">Drift can't be prevented at the gate — it has to be prevented at authoring.</h2>
+    <p class="plans-section-lede">
+      The Knowledge Channel <strong>K</strong> is a continuous feedback loop parallel to L0–L6 — <em>not</em> a rung. Findings flow out of L3 / L5 into the knowledge store, and back into L0 / L1 / L2 as substrate-grep obligations.
+    </p>
+  </header>
+
+  <div class="k-diagram">
+    <div class="k-store">
+      <div class="k-store-header">Knowledge store</div>
+      <ul class="k-store-items">
+        <li>
+          <code>docs/solutions/</code>
+          <span class="k-store-detail">problem→fix entries + class-pattern learnings, organized by category</span>
+        </li>
+        <li>
+          <code>.docs/decisions/</code>
+          <span class="k-store-detail">ADRs — durable architectural decisions</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="k-flows">
+      <div class="k-flow k-flow-in">
+        <div class="k-flow-arrow" aria-hidden="true">↑</div>
+        <div class="k-flow-label">K-in</div>
+        <p class="k-flow-prose">L0 reviewer obligation: grep before scoring. Reinvented substrate = BLOCKED.</p>
+        <div class="k-flow-rungs">
+          <span class="k-flow-rung">L0</span>
+          <span class="k-flow-rung k-flow-rung-soft">L1</span>
+          <span class="k-flow-rung k-flow-rung-soft">L2</span>
+        </div>
+      </div>
+      <div class="k-flow k-flow-out">
+        <div class="k-flow-arrow" aria-hidden="true">↓</div>
+        <div class="k-flow-label">K-out</div>
+        <p class="k-flow-prose"><code>/ce-compound</code> captures class-pattern + substrate-already-existed findings at retro close. Output: one doc per finding to <code>docs/solutions/&lt;category&gt;/</code>.</p>
+        <div class="k-flow-rungs">
+          <span class="k-flow-rung">L3</span>
+          <span class="k-flow-rung">L5</span>
+          <span class="k-flow-rung k-flow-rung-soft">L4</span>
+          <span class="k-flow-rung k-flow-rung-soft">L6</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- K-out automation tiers — three-layer defense-in-depth -->
+  <div class="k-tiers" aria-label="K-out automation tiers">
+    <h3 class="plans-subhead">K-out automation — three tiers, defense-in-depth</h3>
+    <div class="k-tier-grid">
+      <article class="k-tier" data-tier="1">
+        <span class="k-tier-id">Tier 1</span>
+        <h4 class="k-tier-name">Autonomous</h4>
+        <p class="k-tier-prose">Claude runs <code>/ce-compound mode:headless</code> for each qualifying finding as part of L3 retro work. Same set-and-forget authorization as impl→L1→commit→L2→fix→retro→tag.</p>
+        <span class="k-tier-coverage">Handles ~90% silently</span>
+      </article>
+      <article class="k-tier" data-tier="2">
+        <span class="k-tier-id">Tier 2</span>
+        <h4 class="k-tier-name">Reminder hook</h4>
+        <p class="k-tier-prose"><code>.claude/hooks/k-out-reminder.sh</code> (Stop hook) scans the last assistant turn for trigger phrases — <em>class-pattern finding</em>, <em>same-shape twice</em>, <em>substrate already existed</em>, <em>L3 retro complete</em> — and prints a one-line nudge.</p>
+        <span class="k-tier-coverage">Catches mid-conversation surfacing</span>
+      </article>
+      <article class="k-tier" data-tier="3">
+        <span class="k-tier-id">Tier 3</span>
+        <h4 class="k-tier-name">Retro template gate</h4>
+        <p class="k-tier-prose">Proof-bundle template includes a <strong>K-out captures</strong> section that must be filled before retro-close. Blocks retro-close with the list of <code>/ce-compound</code> docs created.</p>
+        <span class="k-tier-coverage">Audit trail; can't ship without filling it</span>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     REVIEWER MATRIX — domain specialist by agent profile
+     TODO(ds): needs pattern — domain-reviewer-grid. Likely useful for wave plans too.
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="reviewer-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reviewer matrix</p>
+    <h2 id="reviewer-matrix" class="plans-section-title">Third slot at L0 / L2 is a domain specialist.</h2>
+    <p class="plans-section-lede">
+      Keyed to the agent's risk profile. Slots stack — a single agent can pull multiple domain reviewers if it touches multiple risk dimensions.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Agent profile</th>
+        <th>Domain reviewer</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Substrate / schema</td>
+        <td><code>architect-reviewer</code></td>
+      </tr>
+      <tr>
+        <td>New SQL write path or Tauri command</td>
+        <td><code>security-auditor</code></td>
+      </tr>
+      <tr>
+        <td>Migration / projection / hot-path</td>
+        <td><code>performance-engineer</code></td>
+      </tr>
+      <tr>
+        <td>User-facing surface</td>
+        <td><code>accessibility-tester</code></td>
+      </tr>
+      <tr>
+        <td>Test infrastructure</td>
+        <td><code>qa-expert</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="plans-footnote">
+    L0 panel becomes a quartet (codex challenge + architect + <code>security-auditor</code> + codex consult) when Amendment 3 paths are touched: <code>services/**</code>, <code>abilities/**</code>, <code>intelligence/**</code>, schema, prompt templates, MCP configs, gate workflows, wave-protocol docs, orchestration docs.
+  </p>
+</section>
+
+<!-- ============================================================
+     TEST SUITES S / P / E — three cards
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="suites">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Test suites</p>
+    <h2 id="suites" class="plans-section-title">S, P, E feed into L3.</h2>
+    <p class="plans-section-lede">
+      Three dedicated suites run at specified gates. Each has an owner agent separate from the implementing agent.
+    </p>
+  </header>
+
+  <div class="suite-grid">
+    <article class="suite-card" data-suite="s">
+      <span class="suite-letter">S</span>
+      <h3 class="suite-name">Security</h3>
+      <p class="suite-prose">SQL injection on new write sites, cross-tenant exposure, PII / secrets in logs, immutability-allowlist bypass.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>penetration-tester</code> + <code>security-auditor</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> zero unaddressed Critical / High</p>
+    </article>
+    <article class="suite-card" data-suite="p">
+      <span class="suite-letter">P</span>
+      <h3 class="suite-name">Performance</h3>
+      <p class="suite-prose">Migration overhead, projection latency, backfill scale, hot-path budgets. Budgets locked at end of W1 baseline.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>performance-engineer</code> + benchmarks</p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> no regression vs. baseline</p>
+    </article>
+    <article class="suite-card" data-suite="e">
+      <span class="suite-letter">E</span>
+      <h3 class="suite-name">Edge cases</h3>
+      <p class="suite-prose">Property tests on invariants; fuzz on validators; adversarial bundle coverage.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>qa-expert</code> + harness</p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> bundles + property tests green</p>
+    </article>
+  </div>
+</section>
+
+<!-- ============================================================
+     L6 ESCALATION POLICY — two-column MUST / MUST NOT
+     TODO(ds): needs pattern — must-list / must-not-list two-column layout. Useful anywhere policy is binary.
+     ============================================================ -->
+<section class="plans-section" aria-labelledby="l6-policy">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">L6 escalation policy</p>
+    <h2 id="l6-policy" class="plans-section-title">When to pull James in, and when not to.</h2>
+    <p class="plans-section-lede">
+      L6 is expensive — every escalation is a context-switch. The orchestration handles as much as possible downstream so L6 is reserved for genuine human-judgment calls.
+    </p>
+  </header>
+
+  <div class="l6-grid">
+    <article class="l6-list l6-list-must">
+      <header class="l6-list-header">
+        <span class="l6-list-pill l6-list-pill-must">MUST escalate</span>
+        <p class="l6-list-blurb">Objective triggers — agents do not get to skip these.</p>
+      </header>
+      <ol class="l6-list-items">
+        <li>Cycle cap exceeded (Amendment 1)</li>
+        <li>Reviewer flags "needs human judgment" with a specific structural question</li>
+        <li>L5 drift detected without remediation path</li>
+        <li>Suite gate failure requiring regression acceptance or budget relaxation</li>
+        <li>Reviewer infrastructure failure (codex outage after 3 retries)</li>
+        <li>Net new scope expansion (NOT scope discovery within the agreed outcome)</li>
+        <li>Contract amendment — plan needs fundamental change</li>
+      </ol>
+    </article>
+
+    <article class="l6-list l6-list-mustnot">
+      <header class="l6-list-header">
+        <span class="l6-list-pill l6-list-pill-mustnot">MUST NOT escalate</span>
+        <p class="l6-list-blurb">Handle downstream. These are the orchestrator's remit.</p>
+      </header>
+      <ol class="l6-list-items">
+        <li>Routine review iteration within cycle cap — read findings, fix, resubmit</li>
+        <li>Single flaky codex output — retry per Amendment 2</li>
+        <li>Lint, type-check, test failures — fix them</li>
+        <li>Reviewer dissent (1/3 or 2/3 against) — investigate the dissenter, don't break the tie</li>
+        <li>Same finding class repeats twice — class-level sweep, file new tickets on the wave</li>
+        <li>Scope discovery within DoD — create tickets, attach to wave, continue</li>
+        <li>Choice between equivalent implementations — pick the more complete option</li>
+        <li>"I don't know what to do" without a specific structural question</li>
+        <li>Deferral requests — "park for v1.4.x" is not a valid escape valve</li>
+        <li>Half-finished implementations — finish or escalate as net-new-scope</li>
+        <li>Asking for context already in codebase, memory, or plan</li>
+        <li>Tool choice when codebase has a convention</li>
+      </ol>
+    </article>
+  </div>
+</section>
+
+<!-- ============================================================
+     PACING + BOUNDING — small callout strip
+     ============================================================ -->
+<section class="plans-section plans-section-callouts" aria-label="Operational rules">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">Pacing</h3>
+      <p class="callout-prose">No wave starts until the prior wave clears L3 <em>and</em> L5 (where applicable). No agent codes before L0 clears unanimously. <strong>Two revision cycles</strong> on the same plan or PR without convergence → L6 escalation.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Bounding</h3>
+      <p class="callout-prose">L2 reviews are bounded by acceptance criteria. Path-α findings (theoretical hardening beyond AC) file to the <strong>maintenance project</strong>, not cycle-N+1. Substrate PRs unblock once AC violations are closed.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Wave</h3>
+      <p class="callout-prose">Wave is the project-management primitive for big version programs. Parallel agents fan out within a wave; hard ordering across waves. Smaller versions collapse to L0 → code → L2 → ship.</p>
+    </article>
+  </div>
+</section>
+
+<!-- ============================================================
+     RELATED DOCS — footer with cross-references
+     ============================================================ -->
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">How this doc relates to others.</h2>
+  </header>
+  <ul class="plans-related">
+    <li>
+      <strong>CLAUDE.md</strong> — keeps a stub section pointing here for the matrix.
+    </li>
+    <li>
+      <strong>.docs/plans/v1.4.0-waves.md</strong> — wave protocol + reviewer matrix; references this doc for the skill assignments per rung.
+    </li>
+    <li>
+      <strong>docs/solutions/README.md</strong> — knowledge store structure and K-in / K-out flow from the consumer side.
+    </li>
+    <li>
+      <strong>.docs/plans/AUTHORING.md</strong> — three-tier doc ruleset (HTML-first / markdown+render / markdown-only); this doc is the first Tier 1 pilot.
+    </li>
+    <li>
+      <strong>.docs/plans/orchestration/v1-lite.md</strong> — async orchestration design (cloud routines, claudebot, daily digest). Design archive — none of it has shipped; local invocation is the operating model.
+    </li>
+  </ul>
+</section>
+
+<!-- ============================================================
+     FINIS — close marker
+     ============================================================ -->
+<div class="finis">
+  <div class="finis-mark">L0 · L1 · L2 · L3 · L4 · L5 · L6</div>
+  <div class="finis-date">Engineering Ladder · 2026-05-18</div>
+  <div class="finis-caption">The bar is methodical, not fast. Human review is the last layer, never the first.</div>
+</div>
+
+</div><!-- /.plans-shell -->
+</main>
+</div><!-- /.MagazinePageLayout_magazinePage -->
+</body>
+</html>

--- a/.docs/plans/plans.css
+++ b/.docs/plans/plans.css
@@ -1,0 +1,1042 @@
+/* =============================================================================
+   plans.css — local stylesheet for DailyOS planning surface (Tier 1 HTML-first)
+   Consumes design tokens from ../design/reference/_shared/styles/design-tokens.css
+
+   Patterns invented here (annotated with TODO(ds) in source HTML):
+   - .ladder-grid + .ladder-rung + .ladder-role four-quadrant card
+   - .k-diagram (two-zone knowledge channel)
+   - .k-tier (three-card automation tiers)
+   - .reviewer-matrix (data-grid table)
+   - .suite-card (S / P / E)
+   - .l6-list (must / must-not two-column with pills)
+   - .pass-rule-badge (gate-state badges)
+   - .callout-grid (three-card operational rules)
+
+   When 2+ Tier 1 docs need a pattern, promote it to ../design/reference/_shared/
+   and link from this stylesheet instead of redefining.
+   ============================================================================= */
+
+/* ─────────────────────────────────────────────────────────────────────────
+   SHELL — mirrors foundation-shell from product surface
+   ───────────────────────────────────────────────────────────────────────── */
+.plans-shell {
+  position: relative;
+  z-index: var(--z-page-content);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   TOP NAV
+   ───────────────────────────────────────────────────────────────────────── */
+.plans-topnav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: calc(var(--space-5xl) + 8px) 0 var(--space-xl);
+  border-bottom: 1px solid var(--color-rule-heavy);
+}
+
+.plans-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+}
+
+.plans-mark svg {
+  color: var(--color-garden-eucalyptus);
+}
+
+.plans-topnav-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+}
+
+.plans-topnav-links a {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+}
+
+.plans-topnav-links a:hover,
+.plans-topnav-links a[data-active="true"] {
+  color: var(--color-text-primary);
+  border-bottom-color: currentColor;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   COVER
+   ───────────────────────────────────────────────────────────────────────── */
+.plans-cover {
+  padding: var(--space-5xl) 0 var(--space-4xl);
+  border-bottom: 1px solid var(--color-rule-heavy);
+}
+
+.plans-eyebrow {
+  margin: 0 0 var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-garden-eucalyptus);
+}
+
+.plans-title {
+  max-width: 920px;
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(48px, 8vw, 84px);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.04;
+  color: var(--color-text-primary);
+}
+
+.plans-kicker {
+  max-width: 720px;
+  margin: var(--space-lg) 0 0;
+  font-family: var(--font-serif);
+  font-size: clamp(20px, 2.6vw, 30px);
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1.35;
+  color: var(--color-text-secondary);
+}
+
+.plans-lede {
+  max-width: 720px;
+  margin: var(--space-lg) 0 0;
+  font-family: var(--font-serif);
+  font-size: 19px;
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.plans-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-top: var(--space-2xl);
+}
+
+.plans-meta span {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.plans-meta span + span::before {
+  content: "·";
+  margin-right: var(--space-md);
+  color: var(--color-text-tertiary);
+  opacity: 0.5;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   SECTION SHELL — eyebrow / title / lede pattern
+   ───────────────────────────────────────────────────────────────────────── */
+.plans-section {
+  padding: var(--space-4xl) 0;
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.plans-section-header {
+  margin-bottom: var(--space-2xl);
+  max-width: 760px;
+}
+
+.plans-section-eyebrow {
+  margin: 0 0 var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.plans-section-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(28px, 4vw, 40px);
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  line-height: 1.15;
+  color: var(--color-text-primary);
+}
+
+.plans-section-lede {
+  margin: var(--space-md) 0 0;
+  font-family: var(--font-serif);
+  font-size: 17px;
+  font-weight: 300;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.plans-subhead {
+  margin: var(--space-2xl) 0 var(--space-lg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.plans-footnote {
+  margin: var(--space-lg) 0 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-tertiary);
+  max-width: 720px;
+}
+
+/* =========================================================================
+   PATTERN — LADDER RUNG CARD (TODO(ds): needs pattern)
+   Each card: eyebrow ID + title + blurb + 4 role quadrants
+   tone derived from data-tone attribute (per-rung color)
+   ========================================================================= */
+.ladder-grid {
+  display: grid;
+  gap: var(--space-2xl);
+}
+
+.ladder-rung {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-xl);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Tone strip on left edge — uses data-tone */
+.ladder-rung::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  background: var(--rung-tone, var(--color-text-tertiary));
+}
+
+.ladder-rung[data-tone="larkspur"]   { --rung-tone: var(--color-garden-larkspur); }
+.ladder-rung[data-tone="saffron"]    { --rung-tone: var(--color-spice-saffron); }
+.ladder-rung[data-tone="turmeric"]   { --rung-tone: var(--color-spice-turmeric); }
+.ladder-rung[data-tone="sage"]       { --rung-tone: var(--color-garden-sage); }
+.ladder-rung[data-tone="eucalyptus"] { --rung-tone: var(--color-garden-eucalyptus); }
+.ladder-rung[data-tone="terracotta"] { --rung-tone: var(--color-spice-terracotta); }
+.ladder-rung[data-tone="olive"]      { --rung-tone: var(--color-garden-olive); }
+.ladder-rung[data-tone="chili"]      { --rung-tone: var(--color-spice-chili); }
+
+.ladder-rung-header {
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.ladder-rung-id {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rung-tone);
+  margin-bottom: var(--space-sm);
+}
+
+.ladder-rung-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+}
+
+.ladder-rung-blurb {
+  margin: var(--space-sm) 0 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  max-width: 720px;
+}
+
+.ladder-rung-pass-rule {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.pass-rule-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+/* PATTERN — pass-rule-badge (TODO(ds): needs pattern — could subsume into Pill or HealthBadge module) */
+.pass-rule-badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+
+.pass-rule-unanimous {
+  background: var(--color-garden-sage-12, rgba(126, 170, 123, 0.12));
+  color: var(--color-garden-rosemary);
+  border-color: var(--color-garden-sage-12, rgba(126, 170, 123, 0.25));
+}
+
+.pass-rule-blockers {
+  background: var(--color-spice-saffron-12, rgba(222, 184, 65, 0.12));
+  color: var(--color-spice-terracotta);
+  border-color: var(--color-spice-saffron-12, rgba(222, 184, 65, 0.25));
+}
+
+.pass-rule-drift {
+  background: var(--color-garden-olive-12, rgba(107, 124, 82, 0.12));
+  color: var(--color-garden-olive);
+  border-color: var(--color-garden-olive-12, rgba(107, 124, 82, 0.25));
+}
+
+.pass-rule-escalate {
+  background: var(--color-spice-chili-10, rgba(155, 58, 42, 0.10));
+  color: var(--color-spice-chili);
+  border-color: var(--color-spice-chili-10, rgba(155, 58, 42, 0.25));
+}
+
+/* Role quadrants */
+.ladder-rung-roles {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-lg);
+}
+
+@media (min-width: 880px) {
+  .ladder-rung-roles {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.ladder-role {
+  padding: var(--space-md) 0;
+  border-top: 2px solid var(--color-rule-light);
+}
+
+.ladder-role-empty {
+  opacity: 0.4;
+}
+
+.ladder-role-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--space-sm);
+}
+
+.ladder-role-na {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.ladder-role-skills {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.ladder-role-skills li {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.ladder-role-skills li code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--color-surface-subtle, rgba(0, 0, 0, 0.04));
+  padding: 1px 5px;
+  border-radius: 2px;
+  color: var(--color-text-primary);
+}
+
+.ladder-role-skills li em {
+  font-style: italic;
+  color: var(--color-text-tertiary);
+  font-size: 11px;
+}
+
+.ladder-role-prose {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.ladder-role-prose code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--color-surface-subtle, rgba(0, 0, 0, 0.04));
+  padding: 1px 5px;
+  border-radius: 2px;
+  color: var(--color-text-primary);
+}
+
+/* K-in / K-out role tags inline on the Capture column label */
+.role-tag {
+  display: inline-block;
+  margin-left: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+
+.role-tag-kin {
+  background: var(--color-garden-eucalyptus-12, rgba(107, 168, 164, 0.15));
+  color: var(--color-garden-eucalyptus);
+}
+
+.role-tag-kout {
+  background: var(--color-garden-sage-12, rgba(126, 170, 123, 0.15));
+  color: var(--color-garden-rosemary);
+}
+
+.ladder-role-kin {
+  background: linear-gradient(180deg, var(--color-garden-eucalyptus-5, rgba(107, 168, 164, 0.05)) 0%, transparent 100%);
+}
+
+.ladder-role-kout {
+  background: linear-gradient(180deg, var(--color-garden-sage-5, rgba(126, 170, 123, 0.05)) 0%, transparent 100%);
+}
+
+/* =========================================================================
+   PATTERN — K-CHANNEL DIAGRAM (TODO(ds): needs pattern)
+   Two zones: knowledge store (left) + flows (right)
+   ========================================================================= */
+.k-diagram {
+  display: grid;
+  gap: var(--space-2xl);
+  grid-template-columns: 1fr;
+  align-items: stretch;
+  margin-bottom: var(--space-4xl);
+}
+
+@media (min-width: 880px) {
+  .k-diagram {
+    grid-template-columns: minmax(280px, 380px) 1fr;
+  }
+}
+
+.k-store {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-xl);
+  position: relative;
+}
+
+.k-store::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  background: var(--color-garden-eucalyptus);
+}
+
+.k-store-header {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-garden-eucalyptus);
+  margin-bottom: var(--space-lg);
+}
+
+.k-store-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.k-store-items li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.k-store-items li code {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.k-store-detail {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--color-text-secondary);
+}
+
+.k-flows {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 600px) {
+  .k-flows {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.k-flow {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  position: relative;
+}
+
+.k-flow-arrow {
+  font-size: 32px;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  font-family: var(--font-sans);
+}
+
+.k-flow-in .k-flow-arrow { color: var(--color-garden-eucalyptus); }
+.k-flow-out .k-flow-arrow { color: var(--color-garden-rosemary); }
+
+.k-flow-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.k-flow-in .k-flow-label { color: var(--color-garden-eucalyptus); }
+.k-flow-out .k-flow-label { color: var(--color-garden-rosemary); }
+
+.k-flow-prose {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.k-flow-prose code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--color-surface-subtle, rgba(0, 0, 0, 0.04));
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
+.k-flow-rungs {
+  display: flex;
+  gap: 6px;
+  margin-top: var(--space-sm);
+}
+
+.k-flow-rung {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 8px;
+  border-radius: 3px;
+  background: var(--color-text-primary);
+  color: var(--color-paper-cream);
+}
+
+.k-flow-rung-soft {
+  background: transparent;
+  color: var(--color-text-tertiary);
+  border: 1px dashed var(--color-rule-heavy);
+}
+
+/* =========================================================================
+   K-OUT AUTOMATION TIERS — three cards
+   ========================================================================= */
+.k-tier-grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 800px) {
+  .k-tier-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.k-tier {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.k-tier-id {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-garden-rosemary);
+}
+
+.k-tier-name {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+}
+
+.k-tier-prose {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  flex: 1;
+}
+
+.k-tier-prose code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--color-surface-subtle, rgba(0, 0, 0, 0.04));
+  padding: 1px 5px;
+  border-radius: 2px;
+}
+
+.k-tier-coverage {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-rule-light);
+}
+
+/* =========================================================================
+   PATTERN — REVIEWER MATRIX TABLE (TODO(ds): needs pattern)
+   ========================================================================= */
+.reviewer-matrix {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.reviewer-matrix thead th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-paper-linen);
+  border-bottom: 1px solid var(--color-rule-heavy);
+}
+
+.reviewer-matrix tbody td {
+  padding: var(--space-md) var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-rule-light);
+  vertical-align: top;
+}
+
+.reviewer-matrix tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.reviewer-matrix tbody td:first-child {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.reviewer-matrix tbody td code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--color-surface-subtle, rgba(0, 0, 0, 0.04));
+  padding: 2px 8px;
+  border-radius: 3px;
+  color: var(--color-text-primary);
+}
+
+/* =========================================================================
+   PATTERN — SUITE CARD (S / P / E)
+   ========================================================================= */
+.suite-grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 800px) {
+  .suite-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.suite-card {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  position: relative;
+}
+
+.suite-letter {
+  font-family: var(--font-serif);
+  font-size: 72px;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--color-spice-turmeric);
+  opacity: 0.18;
+  position: absolute;
+  top: var(--space-md);
+  right: var(--space-lg);
+  pointer-events: none;
+}
+
+.suite-card[data-suite="s"] .suite-letter { color: var(--color-spice-chili); }
+.suite-card[data-suite="p"] .suite-letter { color: var(--color-spice-turmeric); }
+.suite-card[data-suite="e"] .suite-letter { color: var(--color-garden-olive); }
+
+.suite-name {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+}
+
+.suite-prose {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  flex: 1;
+}
+
+.suite-owner,
+.suite-pass-rule {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.suite-owner-label,
+.suite-pass-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  margin-right: var(--space-sm);
+}
+
+.suite-owner code,
+.suite-pass-rule code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-primary);
+}
+
+/* =========================================================================
+   PATTERN — L6 MUST / MUST-NOT TWO-COLUMN
+   ========================================================================= */
+.l6-grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 880px) {
+  .l6-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.l6-list {
+  background: var(--color-paper-warm-white);
+  border: 1px solid var(--color-rule-heavy);
+  border-radius: 6px;
+  padding: var(--space-xl);
+}
+
+.l6-list-header {
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.l6-list-pill {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 3px;
+  margin-bottom: var(--space-sm);
+}
+
+.l6-list-pill-must {
+  background: var(--color-spice-chili-10, rgba(155, 58, 42, 0.10));
+  color: var(--color-spice-chili);
+}
+
+.l6-list-pill-mustnot {
+  background: var(--color-garden-sage-12, rgba(126, 170, 123, 0.12));
+  color: var(--color-garden-rosemary);
+}
+
+.l6-list-blurb {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.l6-list-items {
+  list-style: none;
+  counter-reset: l6-item;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.l6-list-items li {
+  counter-increment: l6-item;
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: var(--space-sm);
+  align-items: start;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  padding: var(--space-xs, 4px) 0;
+}
+
+.l6-list-items li::before {
+  content: counter(l6-item);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  text-align: right;
+  padding-top: 2px;
+}
+
+/* =========================================================================
+   CALLOUT GRID — operational rules (pacing / bounding / wave)
+   ========================================================================= */
+.plans-section-callouts {
+  padding: var(--space-3xl) 0;
+}
+
+.callout-grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 800px) {
+  .callout-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.callout {
+  background: var(--color-paper-linen);
+  border-left: 3px solid var(--color-garden-eucalyptus);
+  padding: var(--space-lg) var(--space-xl);
+  border-radius: 0 6px 6px 0;
+}
+
+.callout-title {
+  margin: 0 0 var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
+.callout-prose {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+/* =========================================================================
+   RELATED / FOOTER
+   ========================================================================= */
+.plans-section-footer {
+  border-bottom: none;
+}
+
+.plans-related {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-md);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 700px) {
+  .plans-related {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.plans-related li {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  padding: var(--space-md) 0;
+  border-top: 1px solid var(--color-rule-light);
+}
+
+.plans-related li strong {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-xs, 4px);
+}
+
+/* =========================================================================
+   FINIS (reusing chrome.css base classes if loaded, plus local accent)
+   ========================================================================= */
+.finis {
+  text-align: center;
+  padding: var(--space-4xl) 0 var(--space-2xl);
+  color: var(--color-text-tertiary);
+}
+
+.finis-mark {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  color: var(--color-garden-eucalyptus);
+  opacity: 0.5;
+  letter-spacing: 0.4em;
+}
+
+.finis-date {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: var(--space-sm);
+  color: var(--color-text-tertiary);
+}
+
+.finis-caption {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 14px;
+  color: var(--color-text-tertiary);
+  margin: var(--space-sm) auto 0;
+  max-width: 380px;
+}


### PR DESCRIPTION
## Summary

- **`.docs/plans/AUTHORING.md`** — canonical three-tier doc ruleset (criteria not lists). HTML-first when layout carries information, markdown+render when text-dominant prose, markdown-only when code-adjacent / diff-reviewed / grep-first.
- **`.docs/plans/engineering-ladder.html`** — first Tier 1 pilot. Full L0–L6 skill matrix with Plan/Implement/Review/Capture quadrants per rung, K-channel diagram, reviewer matrix, suite cards (S/P/E), L6 MUST/MUST-NOT two-column policy, callout strip.
- **`.docs/plans/plans.css`** — local stylesheet built on shared design tokens. Patterns invented here annotated for promotion to `.docs/design/reference/_shared/` once they hit 2+ uses across surfaces.
- **`.docs/plans/_patterns/`** — 10 copy-and-adapt snippets: `cover-section`, `section-header`, `topnav`, `pass-rule-badge`, `reviewer-matrix`, `suite-card`, `k-channel-diagram`, `two-column-policy`, `callout`, `finis`.
- **`.docs/plans/_templates/`** — `generic-plan.html` and `wave-plan.html` starter scaffolds.

## Local-only (gitignored, not in this PR)

- CLAUDE.md gets a stub `## Doc Authoring — Tier Ruleset` section pointing at AUTHORING.md. Already applied locally.

## Dogfooding loop

Inline styles and one-off patterns in HTML-first docs land with `<!-- TODO(ds): needs pattern -->` comments. At wave close, `grep -r 'TODO(ds):' .docs/plans/` rolls into design-system Linear issues. The engineering-ladder pilot surfaces ~7 candidate patterns (ladder-rung-card, k-channel-diagram, suite-card, two-column-policy, pass-rule-badge, reviewer-matrix-table, callout-grid) that may earn promotion to `.docs/design/reference/_shared/` if they appear in future plan docs.

## How to view

```
open .docs/plans/engineering-ladder.html
```

Renders against the shared `_shared/styles/design-tokens.css` + `MagazinePageLayout.module.css` so it inherits the magazine-shell typography and layout conventions used by the product foundation pages.

## What stays markdown

- `.docs/plans/engineering-ladder.md` remains the codex / Linear-reviewable source-of-text. The `.html` version is the human-consumption surface for this Tier 1 doc.
- All retros, proof bundles, `docs/solutions/` K-out captures, ADRs, per-ticket Linear plans stay markdown per Tier 3.

## Test plan

- [ ] Open `engineering-ladder.html` in a browser and verify all 8 rung cards render with correct tones, quadrant grid wraps responsively, K-channel diagram lays out, reviewer matrix table styles, L6 two-column reads, callout strip looks right
- [ ] Verify all `var(--…)` token references resolve (no missing tokens warnings in DevTools)
- [ ] Clone `_templates/generic-plan.html` to a scratch path, open in browser, confirm it renders with placeholder content

🤖 Generated with [Claude Code](https://claude.com/claude-code)