### PR TITLE
fix(repo): untrack .claude — recurring self-referential symlink

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,1 +1,0 @@
-/Users/jamesgiroux/Documents/dailyos-repo/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Claude Code
+.claude
 .claude/
 CLAUDE.md
 AGENTS.md


### PR DESCRIPTION
## Summary

- `git rm --cached .claude` — drop the tracked self-referential symlink from the index (working trees preserve on-disk content)
- `.gitignore` hardened: add a slash-less `.claude` line so future symlinks named .claude can't sneak past the existing `.claude/` directory-only rule

## Why

`.claude` was committed as a symlink at `8b4e8cf5` (PR #308 squash). The blob content of that symlink is the absolute path to the repo's own `.claude` — a self-reference. Anything that tries to follow it gets ELOOP. New worktrees materialize the symlink and inherit the breakage.

This is the **third** time the same accident has happened on this repo:

| Commit | Event |
|---|---|
| `f1b958cc` | First accidental symlink commit |
| `0e1e74f0` | "remove accidental .claude symlink" — fixed |
| `821f3c0b` | Re-introduced as part of W5-A |
| `0ab1a213` | "untrack .claude" — fixed (commit msg: "recurring ELOOP source") |
| `8b4e8cf5` | Re-introduced again as part of PR #308 squash |

The prior `.gitignore` rule was `.claude/` (trailing slash → matches directories only). Symlinks slipped through. Adding a slash-less `.claude` line in front of the existing rule prevents the same accident from re-landing without an explicit `git add -f`.

## Effect

- New `git worktree add` invocations no longer materialize a broken self-referential symlink.
- Existing worktrees (4 already cut for parallel sessions): pull this branch → on-disk `.claude` symlink becomes untracked + ignored. Each session can replace its symlink with a real copy without touching a tracked file.

## Test plan

- [ ] CI passes (no code touched; .gitignore + index deletion only)
- [ ] `git ls-tree HEAD .claude` returns empty after merge
- [ ] Fresh worktree from updated dev has no `.claude` in working tree

L2-status: n-a-doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)