### PR TITLE
feat(provenance): WorkspaceFile DataSource variant per ADR-0107 amendment (v1.4.5 W0)

### DIFF
--- a/.docs/decisions/0107-source-taxonomy-alignment.md
+++ b/.docs/decisions/0107-source-taxonomy-alignment.md
@@ -251,3 +251,74 @@ pub enum DataSource {
 - DOS-299 — backfill writes `LegacyUnattributed` for legacy items; preserves trust band parity.
 - DOS-300 — `CLAIM_TYPE_REGISTRY` does NOT include `legacy_unattributed`; that was a category error in the earlier writeup.
 - DOS-7 — backfill migration depends on this variant existing.
+
+---
+
+## Amendment — 2026-05-19 — WorkspaceFile DataSource variant
+
+### Why
+
+v1.4.5 Workspace Memory introduces ingestion of local workspace files into the claim store. Per ADR-0107 §1, adding a new `DataSource` variant requires an amendment, not the `Other` escape hatch. This amendment defines the typed variant plus its scoring/lifecycle posture so v1.4.5 W1+ lanes can freeze their lifecycle records and W4-C MCP placement can build against a stable contract. Triggered by v1.4.5 W0 close gate per `.docs/plans/v1.4.5-waves.md` §'Cycle 2 amendments' #4 and §'W0 close gate'.
+
+### What
+
+Add to the `DataSource` enum:
+
+```rust
+DataSource::WorkspaceFile { kind: WorkspaceFileKind }
+
+pub enum WorkspaceFileKind {
+    Inbox,
+    EntityDoc,
+    DriveSync,
+    UserAttachment,
+    GranolaTranscript,
+    QuillTranscript,
+    McpPlacement,
+}
+```
+
+Per-kind semantics:
+
+| Kind | Meaning |
+|------|---------|
+| `Inbox` | user-placed files in the workspace inbox awaiting categorization |
+| `EntityDoc` | files already linked to a specific entity in the workspace |
+| `DriveSync` | files synced from a connected drive source under workspace ownership |
+| `UserAttachment` | files attached directly by the user via the Tauri or WordPress surfaces |
+| `GranolaTranscript` | meeting transcripts ingested from Granola |
+| `QuillTranscript` | meeting transcripts ingested from Quill |
+| `McpPlacement` | files placed by an AI agent via the MCP `workspace_place_document` ability |
+
+### Properties
+
+- **`ScoringClass`:** `Reference` (conservative default per ADR-0107 §Risks; file-derived facts cite, they do not score directly).
+- **`LifecycleBehavior`:** `Purge` (workspace files are local storage; removing the source file removes derived claims).
+- **Default `confidence`:** not pinned by this amendment — `abilities-runtime` computes per-claim confidence from freshness + corroboration.
+
+The §4 scoring class table extension is:
+
+| DataSource | ScoringClass | Reasoning |
+|------------|--------------|-----------|
+| `WorkspaceFile { kind: Inbox }` | Reference | user-staged; awaiting categorization, no scoring weight until linked |
+| `WorkspaceFile { kind: EntityDoc }` | Reference | derived from linked file; cites the entity context |
+| `WorkspaceFile { kind: DriveSync }` | Reference | derived from drive file; same cite-only posture |
+| `WorkspaceFile { kind: UserAttachment }` | Reference | user-supplied evidence; trust set by user attestation, not by the file alone |
+| `WorkspaceFile { kind: GranolaTranscript }` | Reference | meeting transcript; cites speakers and topics, doesn't score |
+| `WorkspaceFile { kind: QuillTranscript }` | Reference | meeting transcript; same as Granola |
+| `WorkspaceFile { kind: McpPlacement }` | Reference | AI-placed evidence; reference until corroborated by a scoring source |
+
+### Lifecycle
+
+The §5 lifecycle table extension is:
+
+| DataSource | LifecycleBehavior |
+|------------|-------------------|
+| `WorkspaceFile { kind }` | Purge (file removal triggers cascade) |
+
+### Consumer issues affected
+
+- v1.4.5 W1-A DOS-463: lifecycle record's `data_source` field types as `WorkspaceFile { kind }`.
+- v1.4.5 W4-C DOS-474: MCP `place_document` ability writes claims with `kind=McpPlacement`.
+- Trust freshness decay: per-kind half-life rules added in `services::trust::freshness_decay` cascade (separate code change, not this ADR).
+- Known follow-up: a separate DB-level `DataSource` enum exists at `src-tauri/src/db/data_lifecycle.rs:315`. Dual-enum reconciliation is filed as a path-α maintenance ticket.

--- a/src-tauri/abilities-runtime/src/abilities/provenance/render.rs
+++ b/src-tauri/abilities-runtime/src/abilities/provenance/render.rs
@@ -2221,6 +2221,7 @@ fn canonical_data_source_class(data_source: &DataSource) -> String {
         DataSource::Ai => "ai".to_string(),
         DataSource::CoAttendance => "co_attendance".to_string(),
         DataSource::LocalEnrichment => "local_enrichment".to_string(),
+        DataSource::WorkspaceFile { .. } => "workspace_file".to_string(),
         DataSource::Other(_) => "extracted".to_string(),
         DataSource::LegacyUnattributed => "legacy_unattributed".to_string(),
     }

--- a/src-tauri/abilities-runtime/src/abilities/provenance/source.rs
+++ b/src-tauri/abilities-runtime/src/abilities/provenance/source.rs
@@ -78,6 +78,7 @@ pub enum DataSource {
     Ai,
     CoAttendance,
     LocalEnrichment,
+    WorkspaceFile { kind: WorkspaceFileKind },
     Other(SourceName),
     LegacyUnattributed,
 }
@@ -102,6 +103,7 @@ impl DataSource {
             } => ScoringClass::Context,
             DataSource::Glean { .. }
             | DataSource::Ai
+            | DataSource::WorkspaceFile { .. }
             | DataSource::Other(_)
             | DataSource::LegacyUnattributed => ScoringClass::Reference,
         }
@@ -130,7 +132,8 @@ impl DataSource {
             DataSource::Google
             | DataSource::Clay
             | DataSource::CoAttendance
-            | DataSource::LocalEnrichment => LifecycleBehavior::Purge,
+            | DataSource::LocalEnrichment
+            | DataSource::WorkspaceFile { .. } => LifecycleBehavior::Purge,
             DataSource::Glean { .. } | DataSource::Other(_) => LifecycleBehavior::Mask,
             DataSource::Ai | DataSource::LegacyUnattributed => {
                 LifecycleBehavior::FlagForReEnrichment
@@ -147,6 +150,7 @@ impl DataSource {
             DataSource::Ai => "AI".to_string(),
             DataSource::CoAttendance => "Co-attendance".to_string(),
             DataSource::LocalEnrichment => "Local enrichment".to_string(),
+            DataSource::WorkspaceFile { kind } => format!("Workspace file ({})", kind.display_name()),
             DataSource::Other(name) => name.as_str().to_string(),
             DataSource::LegacyUnattributed => "Legacy unattributed".to_string(),
         }
@@ -179,6 +183,37 @@ impl GleanDownstream {
             GleanDownstream::OrgDirectory => "org directory",
             GleanDownstream::Documents => "documents",
             GleanDownstream::Unknown => "unknown",
+        }
+    }
+}
+
+/// Kind of workspace file source for `DataSource::WorkspaceFile`.
+///
+/// Lifecycle and trust treatment are identical across kinds (Reference scoring,
+/// Purge lifecycle), but the kind carries provenance for downstream rendering
+/// and per-kind freshness decay rules in `services::trust::freshness_decay`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceFileKind {
+    Inbox,
+    EntityDoc,
+    DriveSync,
+    UserAttachment,
+    GranolaTranscript,
+    QuillTranscript,
+    McpPlacement,
+}
+
+impl WorkspaceFileKind {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            WorkspaceFileKind::Inbox => "inbox",
+            WorkspaceFileKind::EntityDoc => "entity document",
+            WorkspaceFileKind::DriveSync => "drive sync",
+            WorkspaceFileKind::UserAttachment => "user attachment",
+            WorkspaceFileKind::GranolaTranscript => "Granola transcript",
+            WorkspaceFileKind::QuillTranscript => "Quill transcript",
+            WorkspaceFileKind::McpPlacement => "MCP placement",
         }
     }
 }
@@ -370,6 +405,38 @@ mod tests {
             DataSource::Ai.lifecycle_behavior(),
             LifecycleBehavior::FlagForReEnrichment
         );
+    }
+
+    #[test]
+    fn workspace_file_variant_serializes_with_kind_and_taxonomy_holds() {
+        let source = DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::McpPlacement,
+        };
+
+        let encoded = serde_json::to_string(&source).unwrap();
+        let decoded: DataSource = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded, source);
+        assert_eq!(decoded.scoring_class(), ScoringClass::Reference);
+        assert_eq!(decoded.lifecycle_behavior(), LifecycleBehavior::Purge);
+        assert_eq!(decoded.display_name(), "Workspace file (MCP placement)");
+        assert!(!decoded.is_structured_trusted_source());
+
+        for kind in [
+            WorkspaceFileKind::Inbox,
+            WorkspaceFileKind::EntityDoc,
+            WorkspaceFileKind::DriveSync,
+            WorkspaceFileKind::UserAttachment,
+            WorkspaceFileKind::GranolaTranscript,
+            WorkspaceFileKind::QuillTranscript,
+            WorkspaceFileKind::McpPlacement,
+        ] {
+            let ds = DataSource::WorkspaceFile { kind: kind.clone() };
+            assert_eq!(ds.scoring_class(), ScoringClass::Reference);
+            assert_eq!(ds.lifecycle_behavior(), LifecycleBehavior::Purge);
+            assert!(!ds.is_structured_trusted_source());
+            assert!(ds.display_name().starts_with("Workspace file ("));
+        }
     }
 
     #[test]

--- a/src-tauri/abilities-runtime/src/abilities/trust/freshness_decay.rs
+++ b/src-tauri/abilities-runtime/src/abilities/trust/freshness_decay.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::abilities::provenance::{DataSource, GleanDownstream, SourceName};
+use crate::abilities::provenance::{DataSource, GleanDownstream, SourceName, WorkspaceFileKind};
 use crate::services::context::Clock;
 use crate::types::{ClaimState, TemporalScope};
 
@@ -40,6 +40,7 @@ const CLAY_ENRICHMENT: &str = "clay_enrichment";
 const AI: &str = "ai";
 const CO_ATTENDANCE: &str = "co_attendance";
 const LOCAL_ENRICHMENT: &str = "local_enrichment";
+const WORKSPACE_FILE: &str = "workspace_file";
 const LEGACY_UNATTRIBUTED: &str = "legacy_unattributed";
 const USER_CORRECTION: &str = "user_correction";
 const RENEWAL_NOTES: &str = "renewal_notes";
@@ -66,6 +67,7 @@ const REQUIRED_CONFIG_KEYS: &[&str] = &[
     AI,
     CO_ATTENDANCE,
     LOCAL_ENRICHMENT,
+    WORKSPACE_FILE,
     LEGACY_UNATTRIBUTED,
     USER_CORRECTION,
     RENEWAL_NOTES_IMMINENT,
@@ -436,6 +438,27 @@ fn representative_data_sources() -> Vec<DataSource> {
         DataSource::Ai,
         DataSource::CoAttendance,
         DataSource::LocalEnrichment,
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::Inbox,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::EntityDoc,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::DriveSync,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::UserAttachment,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::GranolaTranscript,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::QuillTranscript,
+        },
+        DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::McpPlacement,
+        },
         DataSource::Other(SourceName::new(LINEAR_ISSUE)),
         DataSource::Other(SourceName::new(RENEWAL_NOTES)),
         DataSource::LegacyUnattributed,
@@ -494,6 +517,7 @@ fn rule_for_freshness_data_source(
         DataSource::Ai => configured_rule(AI),
         DataSource::CoAttendance => configured_rule(CO_ATTENDANCE),
         DataSource::LocalEnrichment => configured_rule(LOCAL_ENRICHMENT),
+        DataSource::WorkspaceFile { .. } => configured_rule(WORKSPACE_FILE),
         DataSource::LegacyUnattributed => configured_rule(LEGACY_UNATTRIBUTED),
     }
 }

--- a/src-tauri/src/abilities/trust/config/trust_compiler.toml
+++ b/src-tauri/src/abilities/trust/config/trust_compiler.toml
@@ -17,6 +17,7 @@ clay_enrichment = 90
 ai = 21
 co_attendance = 21
 local_enrichment = 21
+workspace_file = 21
 legacy_unattributed = 21
 user_correction = 365
 renewal_notes_with_imminent_renewal = 400

--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -310,6 +310,13 @@ pub fn db_file_size_bytes() -> u64 {
 }
 
 /// Provenance source for persisted data with purge semantics.
+///
+/// This is the DB-level mirror used by `purge_source`. The authoritative,
+/// richer `DataSource` enum lives in `abilities-runtime` provenance and carries
+/// nested variants (e.g. `Glean { downstream }`, `WorkspaceFile { kind }`).
+/// The DB enum collapses those to flat category markers for the purge SQL
+/// `WHERE data_source = ?` paths. Reconciliation of the two enums is tracked
+/// as a maintenance follow-up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DataSource {
@@ -319,6 +326,7 @@ pub enum DataSource {
     Gravatar,
     Google,
     Ai,
+    WorkspaceFile,
 }
 
 impl DataSource {
@@ -330,6 +338,7 @@ impl DataSource {
             DataSource::Gravatar => "gravatar",
             DataSource::Google => "google",
             DataSource::Ai => "ai",
+            DataSource::WorkspaceFile => "workspace_file",
         }
     }
 }


### PR DESCRIPTION
## Linear ticket

v1.4.5 W0 — Workspace Memory W0 close gate (ADR-0107 amendment). No standalone Linear ticket; tracked under the v1.4.5 wave plan + W0 reuse-audit packet.

## Summary

W0 close-gate substrate for v1.4.5 Workspace Memory. Per [ADR-0107 §1](.docs/decisions/0107-source-taxonomy-alignment.md), adding a new `DataSource` variant requires an amendment, not the `Other` escape hatch. The amendment defines a typed `WorkspaceFile { kind: WorkspaceFileKind }` variant plus its scoring/lifecycle posture so downstream W1+ lanes can freeze their lifecycle records and the W4 MCP placement ability can build against a stable contract.

## What changed

- **ADR-0107 amendment appended** at `.docs/decisions/0107-source-taxonomy-alignment.md` (LegacyUnattributed-style block)
- **`DataSource::WorkspaceFile { kind: WorkspaceFileKind }` variant** added at `src-tauri/abilities-runtime/src/abilities/provenance/source.rs`
- **`WorkspaceFileKind`** with 7 kinds: `Inbox`, `EntityDoc`, `DriveSync`, `UserAttachment`, `GranolaTranscript`, `QuillTranscript`, `McpPlacement`
- **All `match DataSource` sites updated:** `scoring_class`, `lifecycle_behavior`, `display_name` (source.rs), `canonical_data_source_class` (render.rs), `rule_for_freshness_data_source` + `representative_data_sources` (freshness_decay.rs)
- **Half-life entry** `workspace_file = 21` in `trust_compiler.toml` + `REQUIRED_CONFIG_KEYS`
- **DB-level mirror** at `src-tauri/src/db/data_lifecycle.rs` extended with flat `WorkspaceFile` variant (kind intentionally collapsed for the SQL purge path; reconciliation tracked as DOS-703)

## Posture (uniform across all kinds)

| Property | Value | Rationale |
|---|---|---|
| `ScoringClass` | `Reference` | Cite, do not score — conservative per ADR-0107 §Risks |
| `LifecycleBehavior` | `Purge` | File deletion is source revocation |
| `is_structured_trusted_source` | `false` | Workspace files cannot self-attest; trust comes from corroboration |
| Half-life (decay) | 21 days | Matches `ai`, `co_attendance`, `local_enrichment`, `legacy_unattributed` reference cohort |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p abilities-runtime --lib` passes (17 source tests including new roundtrip)
- [x] `pnpm tsc --noEmit` clean
- [x] `cargo check --workspace` clean
- [x] Manual verification: walked through enum addition + cascade arms; compiler caught all non-exhaustive matches in `render.rs` and `freshness_decay.rs`

## Definition of Done

- [x] Acceptance criteria from the brief validated with real data (compiler-verified exhaustive matches, test roundtrip across all 7 kinds)
- [x] End-to-end flow works through the Intelligence Loop: `DataSource::WorkspaceFile { kind }` builds a SourceAttribution → ScoringClass::Reference, LifecycleBehavior::Purge, freshness rule resolves, canonical class label renders
- [x] No stubs, TODOs, or "Phase 2" deferrals (per-kind freshness decay is explicitly future scope per wave plan §283, not stubbed)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption rationale**: N/A — security reviewer was invoked.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`? Yes — `abilities-runtime/src/abilities/provenance/` and `src-tauri/src/db/data_lifecycle.rs`
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table? No — claim schema unchanged; this PR is enum-level only
- [ ] Changes a prompt template? No
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic? Yes — extends ScoringClass + LifecycleBehavior + freshness decay posture for the new variant
- [ ] Modifies MCP configs, tool registry, or skill definitions?

`/cso` (`ce-security-sentinel`) verdict: **APPROVE**. All 6 trust-boundary + lifecycle invariants traced clean; one path-α downstream obligation belongs to v1.4.5 W1-A DOS-463 (writer-side serialization conformance test).

## L2 reviewer verdicts

Bounded by the W0 acceptance criteria above; theoretical hardening filed as path-α maintenance notes.

| Reviewer | Verdict | Notes |
|---|---|---|
| ce-correctness-reviewer | APPROVE | 2 path-α residuals (35% / 30% conf.): DB kind-loss → DOS-703; render-layer arm not separately unit-tested (compiler-verified) |
| ce-security-sentinel (`/cso` role) | APPROVE | Writer-side conformance test is a downstream v1.4.5 W1-A DOS-463 obligation |
| ce-architecture-strategist | APPROVE | Optional refinements for follow-up: `WorkspaceFileKind::all()` constructor + DOS-703 should weigh per-kind purge column |
| codex review | APPROVE | No findings, no path-α follow-ups |

## Maintenance ticket

[DOS-703](https://linear.app/a8c/issue/DOS-703) — Reconcile dual DataSource enum (abilities-runtime vs db). Filed in Codebase Maintenance project. Path-α.

## Out of scope (downstream waves)

- Per-kind freshness decay differentiation (wave plan §283 — future refinement)
- DB-level kind preservation (DOS-703)
- Writer-side serialization conformance test (v1.4.5 W1-A DOS-463)

## Authority

- L0 audit packet: `.docs/plans/v1.4.5-w0-reuse-audit-2026-05-19.md` §"W0 close gate items" #1
- Wave plan: `.docs/plans/v1.4.5-waves.md` §"Cycle 2 amendments" #4 + §"W0 close gate"
- ADR-0107 amendment rules (LegacyUnattributed amendment as format precedent)

L2-status: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)