### PR TITLE
feat(recommendations): substrate scaffolding for salience subsystem (W0)

### DIFF
--- a/.docs/decisions/0125-claim-anatomy-temporal-sensitivity-typeregistry.md
+++ b/.docs/decisions/0125-claim-anatomy-temporal-sensitivity-typeregistry.md
@@ -2,7 +2,8 @@
 
 **Status:** Accepted (substrate primitives for v1.4.0 spine; downstream enforcement in v1.4.1+)
 **Date:** 2026-04-24
-**Target:** v1.4.0 (schema + enums + registry); v1.4.1 (DOS-10 freshness + DOS-214 render policy); v1.4.2/3 (per-surface enforcement)
+**Amended:** 2026-05-19 — added §5 `RecommendationClaim` variant for v1.4.6 Salience & Recommendations. Registers `ClaimType::Recommendation` in `CLAIM_TYPE_REGISTRY` (canonical persisted name `"recommendation"`) with `State` temporal scope, `Internal` sensitivity, `Medium` freshness decay, `Replace` commit policy, agent-only authorship, attaches to `Account` / `Project` / `Person` subjects. Salience factors, user-feedback state (`Accepted` / `Dismissed` / `NotUseful` / `TooNoisy` / `Converted`), conversion state, and supersession + dismissal lifecycle are declared at the substrate level; concrete DTOs land in v1.4.6 W1-A `services/recommendations/contracts.rs`. Per the v1.4.6 W0 hardening cycle in [`.docs/plans/v1.4.6-waves.md`](../plans/v1.4.6-waves.md).
+**Target:** v1.4.0 (schema + enums + registry); v1.4.1 (DOS-10 freshness + DOS-214 render policy); v1.4.2/3 (per-surface enforcement); v1.4.6 (Recommendation variant)
 **Extends:** [ADR-0113](0113-human-and-agent-analysis-as-first-class-claim-sources.md), [ADR-0105](0105-provenance-as-first-class-output.md), [ADR-0114](0114-scoring-unification.md)
 **Pattern parallel:** [ADR-0115](0115-signal-granularity-audit.md) Signal Policy Registry
 
@@ -153,11 +154,52 @@ v1.4.0 spine ships the registry mechanism + initial set covering the two pilot a
 
 ### 4. Per-dimension downstream landing
 
-| Dimension | v1.4.0 spine | v1.4.1 | v1.4.2 | v1.4.3 |
-|---|---|---|---|---|
-| Temporal scope | column + enum + serde | DOS-10 freshness consults it; supersession semantics | — | — |
-| Sensitivity | column + enum + serde | DOS-214 render layer enforces | entity surfaces enforce ceiling | briefing surfaces enforce ceiling |
-| Claim type registry | mechanism + initial set + CI lint | extensions as new abilities ship | extensions | extensions |
+| Dimension | v1.4.0 spine | v1.4.1 | v1.4.2 | v1.4.3 | v1.4.6 |
+|---|---|---|---|---|---|
+| Temporal scope | column + enum + serde | DOS-10 freshness consults it; supersession semantics | — | — | `Recommendation` uses `State` |
+| Sensitivity | column + enum + serde | DOS-214 render layer enforces | entity surfaces enforce ceiling | briefing surfaces enforce ceiling | `Recommendation` defaults `Internal` |
+| Claim type registry | mechanism + initial set + CI lint | extensions as new abilities ship | extensions | extensions | `Recommendation` variant added (W0) |
+
+### 5. RecommendationClaim variant (v1.4.6 amendment)
+
+**Decision (2026-05-19, W0 of v1.4.6 Salience & Recommendations).** Recommendations are first-class claims, not a parallel substrate. They register in `CLAIM_TYPE_REGISTRY` and ride the same provenance, trust, supersession, and sensitivity primitives every other claim type already inherits from this ADR. The W0 amendment fixes the substrate-level shape; concrete DTOs land in v1.4.6 W1-A `services/recommendations/contracts.rs`.
+
+**Why a claim-type, not a separate table.** A recommendation says *"this action is recommended for this subject as of this moment, with this evidence and this expected impact"* — that is a claim. Trust band, freshness decay, contradiction handling, and the existing claim lifecycle (assert → corroborate → contradict → supersede → retract) already apply. Making it a claim means every existing intelligence-loop surface (entity context, briefing prep, surface render) consumes recommendations through the same render path as every other claim, with the same provenance receipt and the same trust signaling. A parallel `recommendation_claims` table would have re-invented all of that.
+
+**Registry entry.** `ClaimType::Recommendation` is added with canonical persisted name `"recommendation"`. Metadata:
+
+| Field | Value | Rationale |
+|---|---|---|
+| `default_temporal_scope` | `State` | A recommendation persists as the *current* recommendation for its subject until accepted, dismissed, or superseded. Not a `PointInTime` event; not a `Trend`. |
+| `default_sensitivity` | `Internal` | Recommendations are derived intelligence. They reference upstream evidence whose own sensitivity may be higher; render-time masking still consults the upstream evidence's sensitivity (per §2). |
+| `freshness_decay_class` | `Medium` | Weeks-scale half-life. The recommendation's evidence ages out on its own freshness clock; the recommendation itself decays alongside. W1-B salience re-scoring rebuilds candidacy continuously on signal arrival, so the freshness class governs how long a *quiet* recommendation remains valid before W4-B deviation detection re-evaluates. |
+| `commit_policy_class` | `Replace` | A newer same-subject recommendation supersedes the older one. Recommendations are uniquely identified by `(subject, recommended_action_kind)`; corroboration semantics (`Reinforce`) don't apply because two distinct agent runs producing the same recommendation should *replace* (newer evidence wins), not stack confidence. Contradiction (`Fork`) is handled at the salience layer (W1-B): mutually-contradictory recommendations on the same subject lower each other's salience score and surface as a triage decision, not as parallel claim rows. |
+| `allowed_actor_classes` | `[Agent]` | Recommendations are agent-generated. User feedback (Accepted / Dismissed / NotUseful / TooNoisy / Converted) flows through `services::claims::record_claim_feedback` and emits `ClaimFeedbackRecorded` signals — it does *not* write a separate user-authored Recommendation claim. |
+| `canonical_subject_types` | `[Account, Project, Person]` | Recommendations attach to entities. Meeting-scoped recommendations attach to the meeting's containing entity (per the v1.4.6 W3 cross-surface render contract); they don't get their own meeting subject. Email subjects are excluded — the email is evidence, not the recommendation target. |
+
+**Lifecycle additions beyond the base claim envelope.** Recommendations carry three substrate fields above what other claim types use, declared at the ADR level here and frozen as wire format in W1-A `contracts.rs`:
+
+- **Salience factors.** Inspectable per-factor scoring (trust, novelty, freshness, urgency, similarity, fit). One row per factor at write time; the salience score is the deterministic combination, not an LLM judgment. ADR-0115 Signal Policy Registry exhaustiveness pattern applies: factor kinds are a closed enum. See [ADR-0114](0114-scoring-unification.md) for the underlying scoring composition.
+- **User-feedback state.** Closed enum `{ Accepted | Dismissed | NotUseful | TooNoisy | Converted }`. Default `None` (no feedback yet). State transitions are append-only at the `claim_feedback` level (per existing v1.4.0 substrate); the denormalized current-state field on the recommendation claim row is rebuilt from the feedback log by the W4-A feedback loop on each `ClaimFeedbackRecorded` signal.
+- **Conversion state.** Closed enum `{ NotConverted | InProgress | Converted | Abandoned }`. Default `NotConverted`. Updated when a downstream action (commitment, meeting outcome, account event) is causally linked back to the recommendation. v1.4.6 W4-A wires the link; v1.5.x causal-lineage substrate (deferred per §"Non-goals", anatomy review §14) makes the link first-class.
+
+**Supersession + dismissal.** Standard claim lifecycle applies:
+- *Supersession*: a newer recommendation on the same `(subject, recommended_action_kind)` writes a `supersedes` reference to the older claim's id and the older claim's `verification_state` transitions to `Superseded`.
+- *Dismissal*: `record_claim_feedback` with action `Dismissed` flips the user-feedback state to `Dismissed` and emits `ClaimFeedbackRecorded`. The W2-A surfacing policy treats `Dismissed` as a hard suppression for the recommendation's lifetime (with a configurable cooldown); W4-A feedback weights downgrade the source factors that contributed to the dismissed recommendation, so future similar candidates score lower.
+- *Retraction*: agents may retract their own recommendations (e.g. when upstream evidence is contradicted). Standard `ClaimRetracted` flow applies; W2-A removes from surface immediately on signal receipt.
+
+**Surface render contract (v1.4.6 W3 consumers).** The `Recommendation` claim's render output goes through the same Shared Receipt DTO (`services::claim_receipt::contracts::ClaimReceipt`) every other claim uses. Per the v1.4.6 W0 close gate cross-version row, this ADR amendment is unblocked only after v1.4.4 W1-A ships the `ClaimReceipt` substrate.
+
+**Out of scope at the ADR level.** Per `.docs/plans/v1.4.6-waves.md` line 213 owner table:
+- `RecommendationClaim` DTO struct + serde encoding → W1-A (`services/recommendations/contracts.rs`)
+- `recommendation_claims` table vs `intelligence_claims` extension → W1-A migration choice (slot range v260–v279)
+- Salience scoring engine → W1-B (`services/recommendations/salience.rs`)
+- Surfacing policy → W2-A (`services/recommendations/surfacing.rs`)
+- Trigger policy → W2-B (`services/recommendations/triggers.rs`)
+- Feedback wiring → W4-A (`services/recommendations/feedback.rs`)
+- Cross-surface rendering → W3 (consumes `claim_receipt::contracts::ClaimReceipt`)
+
+**ADR-0102 (abilities runtime) assessment.** v1.4.6's `recommend_for_entity` ability targets the existing `mcp_exposure: McpExposure::MetadataOnly` tri-state value (added in the 2026-05-10 amendment). No further ADR-0102 amendment needed for v1.4.6 W0. v1.4.7 may amend ADR-0102 to flip `mcp_exposure` to `Invocable` once the MCP `dailyos.read.portfolio_attention` consumer ships.
 
 ## Non-goals for spine
 

--- a/src-tauri/abilities-runtime/src/abilities/account_overview.rs
+++ b/src-tauri/abilities-runtime/src/abilities/account_overview.rs
@@ -313,7 +313,8 @@ fn placement_for_claim_type(kind: ClaimType) -> ClaimPlacement {
         | ClaimType::MeetingEventNote
         | ClaimType::AttendeeContext
         | ClaimType::MeetingChangeMarker
-        | ClaimType::SuggestedOutcome => ClaimPlacement::Ignored,
+        | ClaimType::SuggestedOutcome
+        | ClaimType::Recommendation => ClaimPlacement::Ignored,
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/claims.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claims.rs
@@ -169,6 +169,13 @@ pub enum ClaimType {
     MeetingChangeMarker,
     SuggestedOutcome,
     UserNote,
+    // --- Recommendations (salience subsystem) -----------------------
+    /// Agent-generated recommendation for an action against an entity
+    /// subject. Carries salience-factor evidence, user-feedback state
+    /// (accepted / dismissed / not-useful / too-noisy / converted) and
+    /// conversion lifecycle. Subject is the entity the recommendation
+    /// targets. See ADR-0125 §5.
+    Recommendation,
 }
 
 impl ClaimType {
@@ -265,6 +272,7 @@ pub const fn metadata_for_claim_type(kind: ClaimType) -> &'static ClaimTypeMetad
         ClaimType::MeetingChangeMarker => &MEETING_CHANGE_MARKER_META,
         ClaimType::SuggestedOutcome => &SUGGESTED_OUTCOME_META,
         ClaimType::UserNote => &USER_NOTE_META,
+        ClaimType::Recommendation => &RECOMMENDATION_META,
     }
 }
 
@@ -684,6 +692,17 @@ claim_meta!(
     SUBJECTS_ANY_ENTITY,
     ACTORS_USER_OR_SYSTEM
 );
+claim_meta!(
+    RECOMMENDATION_META,
+    Recommendation,
+    "recommendation",
+    State,
+    Internal,
+    Medium,
+    Replace,
+    SUBJECTS_ANY_ENTITY,
+    ACTORS_AGENT
+);
 
 /// Closed registry of claim types for name-based traversal paths.
 /// `metadata_for_claim_type` is independently exhaustive; this slice
@@ -720,6 +739,7 @@ pub const CLAIM_TYPE_REGISTRY: &[&ClaimTypeMetadata] = &[
     &MEETING_CHANGE_MARKER_META,
     &SUGGESTED_OUTCOME_META,
     &USER_NOTE_META,
+    &RECOMMENDATION_META,
 ];
 
 /// Look up a metadata row by canonical persisted name. Returns `None`
@@ -768,7 +788,8 @@ mod tests {
             | ClaimType::StakeholderEngagement
             | ClaimType::StakeholderAssessment
             | ClaimType::Commitment
-            | ClaimType::OpenLoop => FreshnessDecayClass::Medium,
+            | ClaimType::OpenLoop
+            | ClaimType::Recommendation => FreshnessDecayClass::Medium,
             ClaimType::MeetingReadiness => FreshnessDecayClass::Fast,
             ClaimType::TriageSnooze
             | ClaimType::MeetingTopic
@@ -788,7 +809,8 @@ mod tests {
             | ClaimType::EntitySummary
             | ClaimType::EntityCurrentState
             | ClaimType::MeetingReadiness
-            | ClaimType::SuggestedOutcome => CommitPolicyClass::Replace,
+            | ClaimType::SuggestedOutcome
+            | ClaimType::Recommendation => CommitPolicyClass::Replace,
             ClaimType::Win
             | ClaimType::LinkingDismissed
             | ClaimType::EmailDismissed
@@ -879,6 +901,7 @@ mod tests {
             (ClaimType::MeetingChangeMarker, "meeting_change_marker"),
             (ClaimType::SuggestedOutcome, "suggested_outcome"),
             (ClaimType::UserNote, "user_note"),
+            (ClaimType::Recommendation, "recommendation"),
         ];
         for (idx, (kind, expected)) in cases.iter().copied().enumerate() {
             let m = &CLAIM_TYPE_REGISTRY[idx];
@@ -994,6 +1017,7 @@ mod tests {
             ClaimType::AttendeeContext,
             ClaimType::MeetingChangeMarker,
             ClaimType::SuggestedOutcome,
+            ClaimType::Recommendation,
         ];
         for kind in agent_only {
             let actors = metadata_for_claim_type(kind).allowed_actor_classes;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -34,6 +34,7 @@ pub mod mutations;
 pub mod people;
 pub mod projection_signing;
 pub mod projects;
+pub mod recommendations;
 pub mod reports;
 pub mod sensitivity;
 pub mod settings;

--- a/src-tauri/src/services/recommendations/contracts.rs
+++ b/src-tauri/src/services/recommendations/contracts.rs
@@ -1,0 +1,7 @@
+//! Frozen cross-lane contracts for the recommendations subsystem.
+//!
+//! Owns the `RecommendationClaim` DTO, salience-factor types,
+//! `SurfacingDecision` shape, `EngagementSignal`, `FeedbackAction`,
+//! and every other type consumed by more than one lane. Wire format
+//! is camelCase JSON via serde; Rust/TS golden parity fixtures
+//! belong here.

--- a/src-tauri/src/services/recommendations/deviation.rs
+++ b/src-tauri/src/services/recommendations/deviation.rs
@@ -1,0 +1,6 @@
+//! Deviation detection.
+//!
+//! Compares current recommendation candidates against learned
+//! baselines on the same subject and surfaces deviations as
+//! ranking input. May require a `deviation_baselines` table —
+//! migration choice belongs to the lane that owns this file.

--- a/src-tauri/src/services/recommendations/engagement.rs
+++ b/src-tauri/src/services/recommendations/engagement.rs
@@ -1,0 +1,6 @@
+//! Engagement telemetry.
+//!
+//! Privacy-bounded telemetry capturing recommendation-render and
+//! recommendation-acceptance engagement signals that feed ranking
+//! (not trust). May require an `engagement_telemetry` table —
+//! migration choice belongs to the lane that owns this file.

--- a/src-tauri/src/services/recommendations/eval.rs
+++ b/src-tauri/src/services/recommendations/eval.rs
@@ -1,0 +1,6 @@
+//! Evaluation harness for the salience subsystem.
+//!
+//! Fixture-driven assertions over the high-signal, low-signal,
+//! stale, noisy, missed-important, and user-corrected cases. The
+//! release gate for the salience subsystem is this harness passing
+//! against the canonical fixture set.

--- a/src-tauri/src/services/recommendations/feedback.rs
+++ b/src-tauri/src/services/recommendations/feedback.rs
@@ -1,0 +1,7 @@
+//! Feedback loop.
+//!
+//! Wires user feedback (accepted / dismissed / not-useful /
+//! too-noisy / converted) on a `Recommendation` claim into the
+//! salience-factor weight table, adjusting future ranking on the
+//! same fixture entity. Extends the existing semantic feedback
+//! substrate; does not introduce a parallel feedback path.

--- a/src-tauri/src/services/recommendations/mod.rs
+++ b/src-tauri/src/services/recommendations/mod.rs
@@ -1,0 +1,23 @@
+//! Recommendations and salience subsystem.
+//!
+//! Recommendations ride the existing claim substrate as
+//! `ClaimType::Recommendation`. This module owns the recommendation
+//! contracts, salience scoring engine, surfacing + trigger policies,
+//! feedback wiring, cross-surface render, and the evaluation harness.
+//!
+//! Skeleton-only on landing; per-file ownership follows the salience
+//! wave plan. The shape of `RecommendationClaim`, salience factors,
+//! user-feedback state, and conversion state is pinned at the ADR
+//! level (see ADR-0125 §5).
+
+pub mod contracts;
+pub mod deviation;
+pub mod engagement;
+pub mod eval;
+pub mod feedback;
+pub mod recommendation;
+pub mod render;
+pub mod salience;
+pub mod surfacing;
+pub mod triggers;
+pub mod why_this_now;

--- a/src-tauri/src/services/recommendations/recommendation.rs
+++ b/src-tauri/src/services/recommendations/recommendation.rs
@@ -1,0 +1,4 @@
+//! `RecommendationClaim` implementation surface — write helpers,
+//! supersession logic, and the typed bridge from the salience
+//! engine's scored candidate to a committable claim payload for
+//! `services::claims::commit_claim`.

--- a/src-tauri/src/services/recommendations/render.rs
+++ b/src-tauri/src/services/recommendations/render.rs
@@ -1,0 +1,6 @@
+//! Cross-surface render contract.
+//!
+//! Returns the recommendation's render payload through the Shared
+//! Receipt DTO (`services::claim_receipt::contracts::ClaimReceipt`),
+//! the same shape every other claim type uses. No parallel render
+//! contract for recommendations.

--- a/src-tauri/src/services/recommendations/salience.rs
+++ b/src-tauri/src/services/recommendations/salience.rs
@@ -1,0 +1,8 @@
+//! Salience scoring engine.
+//!
+//! Computes a salience score from explicit inspectable factors
+//! (trust, novelty, freshness, urgency, similarity, fit). No
+//! provider / LLM call from this module — factor rationale is
+//! constructed from typed `FactorRationale` values, never assembled
+//! from raw strings. The CI invariant for this file is the absence
+//! of any LLM client import.

--- a/src-tauri/src/services/recommendations/surfacing.rs
+++ b/src-tauri/src/services/recommendations/surfacing.rs
@@ -1,0 +1,7 @@
+//! Surfacing policy.
+//!
+//! Decides which scored candidates surface to the user (tiered),
+//! which defer, which suppress, and emits the
+//! `SurfacingDecisionMade` audit signal for each decision. Enforces
+//! the daily surfacing budget. No provider / LLM call from this
+//! module.

--- a/src-tauri/src/services/recommendations/triggers.rs
+++ b/src-tauri/src/services/recommendations/triggers.rs
@@ -1,0 +1,6 @@
+//! Trigger policy.
+//!
+//! Consumes upstream signals (claim changes, signal-bus events) and
+//! emits `SalienceCandidateRefreshTriggered` when a candidate's
+//! salience must be re-scored. Deterministic — no provider / LLM
+//! call from this module.

--- a/src-tauri/src/services/recommendations/why_this_now.rs
+++ b/src-tauri/src/services/recommendations/why_this_now.rs
@@ -1,0 +1,6 @@
+//! Deterministic `why this now` rationale construction.
+//!
+//! Given a scored candidate, returns a typed `WhyThisNow` payload
+//! built from the primary factor and a closed set of triggers. The
+//! render layer formats this for display; no string templating
+//! happens here. No provider / LLM call from this module.

--- a/src-tauri/src/signals/policy_registry.rs
+++ b/src-tauri/src/signals/policy_registry.rs
@@ -97,6 +97,10 @@ pub enum SignalType {
     RenewalProximity,
     RenewalRiskEscalation,
     RenewalStageUpdated,
+    /// Trigger policy event: upstream change indicates a recommendation
+    /// candidate needs re-scoring. Emitted from the recommendations
+    /// trigger module; coalesced invalidation policy.
+    SalienceCandidateRefreshTriggered,
     SourceRestricted,
     SourceRevoked,
     SourceWithdrawn,
@@ -107,6 +111,10 @@ pub enum SignalType {
     StakeholdersChanged,
     StakeholdersUpdated,
     SupportHealthUpdated,
+    /// Surfacing policy event: audit row written for every recommendation
+    /// surface / defer / suppress decision. Emitted from the recommendations
+    /// surfacing module; coalesced invalidation policy.
+    SurfacingDecisionMade,
     TechnicalFootprintUpdated,
     ThreadPosition,
     TitleChange,
@@ -215,6 +223,7 @@ impl SignalType {
             "renewal_proximity" => Self::RenewalProximity,
             "renewal_risk_escalation" => Self::RenewalRiskEscalation,
             "renewal_stage_updated" => Self::RenewalStageUpdated,
+            "salience_candidate_refresh_triggered" => Self::SalienceCandidateRefreshTriggered,
             "source_restricted" => Self::SourceRestricted,
             "source_revoked" => Self::SourceRevoked,
             "source_withdrawn" => Self::SourceWithdrawn,
@@ -225,6 +234,7 @@ impl SignalType {
             "stakeholders_changed" => Self::StakeholdersChanged,
             "stakeholders_updated" => Self::StakeholdersUpdated,
             "support_health_updated" => Self::SupportHealthUpdated,
+            "surfacing_decision_made" => Self::SurfacingDecisionMade,
             "technical_footprint_updated" => Self::TechnicalFootprintUpdated,
             "thread_position" => Self::ThreadPosition,
             "title_change" => Self::TitleChange,
@@ -330,6 +340,7 @@ impl SignalType {
             Self::RenewalProximity => "renewal_proximity",
             Self::RenewalRiskEscalation => "renewal_risk_escalation",
             Self::RenewalStageUpdated => "renewal_stage_updated",
+            Self::SalienceCandidateRefreshTriggered => "salience_candidate_refresh_triggered",
             Self::SourceRestricted => "source_restricted",
             Self::SourceRevoked => "source_revoked",
             Self::SourceWithdrawn => "source_withdrawn",
@@ -340,6 +351,7 @@ impl SignalType {
             Self::StakeholdersChanged => "stakeholders_changed",
             Self::StakeholdersUpdated => "stakeholders_updated",
             Self::SupportHealthUpdated => "support_health_updated",
+            Self::SurfacingDecisionMade => "surfacing_decision_made",
             Self::TechnicalFootprintUpdated => "technical_footprint_updated",
             Self::ThreadPosition => "thread_position",
             Self::TitleChange => "title_change",
@@ -459,6 +471,7 @@ pub fn known_signal_type_names() -> &'static [&'static str] {
         "renewal_proximity",
         "renewal_risk_escalation",
         "renewal_stage_updated",
+        "salience_candidate_refresh_triggered",
         "source_restricted",
         "source_revoked",
         "source_withdrawn",
@@ -469,6 +482,7 @@ pub fn known_signal_type_names() -> &'static [&'static str] {
         "stakeholders_changed",
         "stakeholders_updated",
         "support_health_updated",
+        "surfacing_decision_made",
         "technical_footprint_updated",
         "thread_position",
         "title_change",
@@ -695,6 +709,7 @@ pub fn policy_for(signal: &SignalType) -> SignalPolicy {
         | RenewalProximity
         | RenewalRiskEscalation
         | RenewalStageUpdated
+        | SalienceCandidateRefreshTriggered
         | StakeholderChange
         | StakeholderDisengagement
         | StakeholderUnverified
@@ -702,6 +717,7 @@ pub fn policy_for(signal: &SignalType) -> SignalPolicy {
         | StakeholdersChanged
         | StakeholdersUpdated
         | SupportHealthUpdated
+        | SurfacingDecisionMade
         | TechnicalFootprintUpdated
         | ThreadPosition
         | TitleChange


### PR DESCRIPTION
## Summary

W0 substrate scaffolding for the salience & recommendations subsystem. Per session 4 of the v1.4.x parallel fan-out and the W0 close gate in `.docs/plans/v1.4.6-waves.md`.

- **ADR-0125 §5 amendment** — Recommendation claim variant. Subject / recommended action / evidence / salience factors / user-feedback state (accepted / dismissed / not-useful / too-noisy / converted) / conversion state / supersession + dismissal lifecycle pinned at the ADR level. Default metadata: `State` temporal scope, `Internal` sensitivity, `Medium` freshness decay, `Replace` commit policy, `[Account, Project, Person]` subjects, agent-only authorship.
- **`ClaimType::Recommendation` variant** + `RECOMMENDATION_META` + `CLAIM_TYPE_REGISTRY` entry land in `abilities-runtime`. Exhaustive partitions (`expected_freshness_decay_class`, `expected_commit_policy_class`, `allowed_actor_classes_partition_substrate_correctly`, `claim_type_registry_indices_align_with_enum`) + `placement_for_claim_type` in `account_overview.rs` updated.
- **SignalType pre-declarations** — `SurfacingDecisionMade` + `SalienceCandidateRefreshTriggered` added to `signals/policy_registry.rs` (enum / `from_name` / `canonical_name` / `known_signal_type_names` / `policy_for`). Both route to the coalesced invalidation policy. Owned by W0 (coordination role) per cycle 4 fix C — shared infrastructure outside the recommendations module tree.
- **`services/recommendations/` module skeleton** — 12 files (`mod.rs` + 11 stubs: contracts, recommendation, salience, surfacing, triggers, why_this_now, feedback, deviation, engagement, render, eval). Per-file ownership lives in the salience wave plan; implementations land per-lane.
- **ADR-0102 assessment** — no amendment needed at this scope. The existing `McpExposure::MetadataOnly` tri-state (2026-05-10 amendment) covers the `recommend_for_entity` ability surface. An `Invocable` promotion belongs with the future MCP consumer work.

## L2 review

Unanimous APPROVE — bounded by W0 close-gate acceptance criteria, path-α policy active.

- **codex review** (`--base dev`, `model_reasoning_effort=high`): clean, no [P1] / [P2] findings. "The diff cleanly adds the Recommendation claim registry entry, recommendations module skeleton, and signal pre-declarations without breaking compilation."
- **ce-correctness-reviewer**: APPROVE. Verified exhaustive-match coverage across the workspace, round-trip on the new persisted strings, test-partition consistency, slice-alignment invariant, policy routing defensibility against neighboring arms, and module skeleton hygiene. Two path-α residuals filed as Maintenance (test for new SignalType policy routing; `known_signal_type_names` drift gate — pre-existing fragility).
- **ce-architecture-strategist**: APPROVE. Verified ADR-0125 §5 ↔ Rust code parity, ADR-0115 exhaustiveness pattern compliance, registry-order invariant, policy registry conventions, alphabetical ordering. Two path-α observations filed as Maintenance (tighter `SUBJECTS_RECOMMENDATION` constant; CI gate for the "no LLM client import" invariant promised in salience/surfacing/triggers/why_this_now stub doc-comments).

## Gates

- `cargo clippy --workspace -- -D warnings` — passed
- `pnpm tsc --noEmit` — passed
- `cargo test --lib` on affected modules (`claim_type`, `signals::policy_registry`) — 19/19 passed
- pre-push hook tree-SHA cache hit (already passed pre-commit gauntlet)

## Test plan

- [ ] Verify the new `ClaimType::Recommendation` variant survives a round-trip through `try_from_db_str` against a real `intelligence_claims` row (W1-A acceptance — after this skeleton lands)
- [ ] Verify W2-A / W2-B downstream lanes can emit `SurfacingDecisionMade` / `SalienceCandidateRefreshTriggered` without re-touching `policy_registry.rs`
- [ ] Verify W1-A picks up the `services/recommendations/contracts.rs` stub and fills the cross-lane DTO set as planned