### PR TITLE
fix(repo): untrack node_modules — self-referential symlink pattern

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jamesgiroux/Documents/dailyos-repo/node_modules


### PR DESCRIPTION
## Summary

Untracks `node_modules` from the index. It was committed as a symlink whose blob target is the repo root's own `node_modules` path — same self-referential pattern fixed for `.claude` in PR #318. Both were accidentally introduced at the same commit (`8b4e8cf5`, v1.4.3 W2 PR-D2).

## Why merge

CI's frontend + lint-and-checks jobs currently fail on every PR with `ENOTDIR: not a directory, mkdir '/home/runner/work/daily-operating-system/daily-operating-system/node_modules'` because pnpm tries to create the directory after the symlink has been checked out. This is broken-master.

## Class sweep

After this lands, `git ls-tree -r HEAD | awk '$1 == "120000" {print $4}'` returns empty — no remaining tracked symlinks.

## Test plan

- [ ] CI passes on this branch's diff (1-byte index-only deletion)
- [ ] After merge, `gh pr checks` on PR #319 shows frontend + lint-and-checks recovered
- [ ] `.gitignore` line 73 (`node_modules/`) keeps the working-tree state ignored

L2-status: n-a-doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)