### PR TITLE
feat(v1.4.7-W0): MCP foundation — Actor::McpClient + ADR amendments + mcp_v2 skeleton

### DIFF
--- a/.docs/decisions/0102-abilities-as-runtime-contract.md
+++ b/.docs/decisions/0102-abilities-as-runtime-contract.md
@@ -5,6 +5,7 @@
 **Amended:** 2026-05-10 — extended `AbilityPolicy.allowed_actors` to include `SurfaceClient` (defined in [ADR-0111](0111-surface-independent-ability-invocation.md) §8); added §7.6 specifying SurfaceClient policy and introspection semantics. Per the formal L0 panel on [DOS-546](https://linear.app/a8c/issue/DOS-546).
 **Amended (later same day):** 2026-05-10 — extended `AbilityPolicy` schema with `required_scopes: Vec<SurfaceClientScope>` and `mcp_exposure: bool` as first-class fields per the formal L0 Cycle 2 unanimous finding. Two-level SurfaceClient enforcement is now substrate-enforceable from the canonical policy, not just prose in §7.6. Default policy expanded: `required_scopes = vec![]`, `mcp_exposure = false`.
 **Amended (later same day):** 2026-05-10 — promoted `mcp_exposure` from `bool` to tri-state `McpExposure { None | MetadataOnly | Invocable }` enum per Phase 0 artifact 05 lines 383-412; retained `client_side_executable: bool` as an orthogonal separate field for the WordPress 7.0 client-side `executeAbility()` JS path. The two fields govern different trust boundaries — `mcp_exposure` controls the network-facing MCP tool surface (discovery + invocation), `client_side_executable` controls whether a trusted in-product SurfaceClient may invoke the ability after WordPress capability + runtime scope + actor checks pass. The fields are independent; either may be true while the other is false. Default policy is `mcp_exposure = McpExposure::None` + `client_side_executable = false`, opt-in per ability. This cycle-3 reversal of the cycle-2 collapse was made after re-reading artifact 05's explicit warning against the symmetric `client_side_exposure` framing.  
+**Amended:** 2026-05-19 — added `Actor::McpClient` actor variant + `ActorKind::McpClient` discriminator for MCP-originated calls; pinned MCP client authentication + session contract; froze the v1.4.7 scope namespace convention. See §"Amendment 2026-05-19 — `Actor::McpClient` + MCP client trust boundary + scope namespace" appended at end of doc. Companion ADR-0128 amendment of the same date documents the headless-head consequences (tool description as product copy, cross-conversation continuity, displacement-use-case framing applied to v1.4.7 W5 eval).
 **Target:** v1.4.0  
 **Extends:** [ADR-0101](0101-service-boundary-enforcement.md), [ADR-0091](0091-intelligence-provider-abstraction.md), [ADR-0082](0082-entity-generic-prep-pipeline.md)  
 **Related:** [ADR-0080](0080-signal-intelligence-architecture.md), [ADR-0097](0097-account-health-scoring-architecture.md), [ADR-0098](0098-data-governance-source-aware-lifecycle.md), [ADR-0100](0100-glean-first-intelligence-architecture.md), [ADR-0111](0111-surface-independent-ability-invocation.md), [ADR-0129](0129-composable-surfaces-wordpress-studio-as-primary-surface.md), [ADR-0130](0130-surface-independent-composition-contract.md) §2 (block-level `ProvenanceRef` preserves the ADR-0105 §8 lives-once invariant and avoids payload-cap blowups when ability outputs are composed into surface-rendered blocks)
@@ -572,3 +573,109 @@ Rationale: exploration needs a fast path. Discipline comes from graduation (prom
 The combined effect: an experimental ability that hasn't been graduated or removed within one cycle **breaks the build**. There's no quiet persistence. Codex adversarial review correctly flagged the original "flagged for graduation-or-removal review" language as soft — this amendment makes it hard.
 
 **Override for genuinely long-running experiments:** a `registered_at` bump (re-registering with today's date) gives another cycle. Bumping requires a PR that explicitly justifies the extension in the commit message. Audit trail exists in git.
+
+---
+
+## Amendment 2026-05-19 — `Actor::McpClient` + MCP client trust boundary + scope namespace
+
+**Origin:** v1.4.7 W0 (MCP Server v2, Abilities-First). Drafted as the substantive design output of v1.4.7's cycle-2 Class S finding ("MCP client trust boundary"). Cycles 2–5 polished the contract; this amendment lands the final shape.
+
+**Scope:** the abilities runtime contract for MCP-originated invocations. Wire-level transport, pairing handshake server impl, per-tool grant manifest format, and gateway impl are W1-A scope and not codified by this amendment — only the actor-class contract and namespace freeze are.
+
+### A. `Actor::McpClient` variant
+
+A fifth `Actor` variant joins `User`, `Agent`, `Admin`, `System`, `SurfaceClient`:
+
+```rust
+pub enum Actor {
+    Agent,
+    User,
+    Admin,
+    System,
+    SurfaceClient { instance: SurfaceClientId, scopes: ScopeSet },
+    McpClient {
+        client_id: McpClientId,
+        conversation_handle: Option<OpaqueConversationHandle>,
+    },
+}
+```
+
+`McpClientId` is a server-minted opaque handle issued during the MCP client pairing handshake (§C). Newtype lives at the abilities-runtime layer alongside `SurfaceClientId`; non-PII, non-enumerable, stable for the life of the pairing.
+
+`OpaqueConversationHandle` is a server-minted, non-PII, non-enumerable token that tracks cross-conversation continuity (§D). `Option<…>` because the handle is absent on the very first MCP call in a fresh conversation — the gateway mints one transparently per §D.
+
+The corresponding `ActorKind::McpClient` discriminator joins the existing four kinds and is the const-friendly token used in `AbilityPolicy.allowed_actors`. `Actor::kind()` gains a `McpClient { .. } => ActorKind::McpClient` arm.
+
+### B. Gateway-mediated scope enforcement (asymmetry with `SurfaceClient`)
+
+`Actor::McpClient` carries **no** scopes on the variant. This is an intentional asymmetry with `Actor::SurfaceClient { .. scopes: ScopeSet }`:
+
+- **SurfaceClient** carries `ScopeSet` on the variant because scopes are bridge-time material — the bridge (per ADR-0111 §8) reads `actor.scopes` directly to enforce `AbilityPolicy.required_scopes` before registry lookup. The scope grant rides with the invocation.
+- **McpClient** does not carry scopes because the MCP gateway (v1.4.7 `services/mcp_v2/gateway.rs`) enforces scope authorization against a **server-side per-client manifest** loaded by `services/mcp_v2/auth.rs` from the pairing record (§C). Caller-provided scope claims are rejected on principle; the gateway is the single source of truth. Once the gateway admits the call, the abilities runtime trusts the gateway's check and gates only on `AbilityPolicy.allowed_actors.contains(&ActorKind::McpClient)`.
+
+This preserves the v1.4.2 SurfaceClient bridge contract verbatim while introducing a strictly distinct trust path for MCP-originated calls — different attribution semantics, different audit shape, different rate-limit budget (§C). `AbilityPolicy.required_scopes` remains a SurfaceClient-only enforcement field; W0 ships no new field on `AbilityPolicy`.
+
+### C. MCP client authentication + session contract
+
+Every MCP-originated invocation must pass through these four gates before reaching an ability:
+
+1. **Pairing handshake.** First contact from a new MCP client issues an `McpClientId` after a server-side handshake (W1-A `auth::pair_client(handshake) -> McpClientId`). The handshake binds the client to a server-stored manifest of granted scopes + per-tool rate limits + per-tool exposure tier. Manifest content is set by the operator (DailyOS-as-product owner) at pairing time, not negotiated by the caller. Mirrors the v1.4.2 `SurfaceClient` pairing shape (`services::surface_pairing`, `services::surface_session_keychain`, `bridges::surface_client`) — the SurfaceClient pattern is the precedent and the same operator/audit ergonomics apply.
+2. **Transport signing (HMAC-SHA256).** All stdio and HTTP transports MUST present a per-message HMAC-SHA256 signature derived from the pairing-time shared key. Unsigned or invalid-signature messages are rejected at the transport layer before any `Actor::McpClient` is constructed. (Local STDIO MCP processes share the key out-of-band via the pairing record; loopback HTTP carries it as a request header.)
+3. **Scope manifest authorization.** Gateway loads the server-side scope manifest for the `McpClientId` and verifies `tool.description().scopes_required.is_subset(manifest.granted_scopes)` BEFORE handler invocation. Caller-provided scope assertions in tool params are rejected with `ToolError::BadParams`.
+4. **Per-actor × per-client × per-tool rate limits.** Gateway maintains a rate-limit registry keyed on `(ActorKind::McpClient, McpClientId, ScopedName)`. Limits are loaded from the pairing manifest; bursts exceeding them return `ToolError::RateLimited { retry_after_seconds }`. Independent of `AbilityRateLimit` (which remains a per-ability ceiling).
+
+**Revocation.** Server-side admin API (W1-A scope) can revoke an `McpClientId`. Subsequent invocations from a revoked client fail the manifest-load step and return `ToolError::PairingRevoked`. Revocation propagates within one in-flight call; in-progress invocations are not interrupted but their audit row records the revoked state if revocation happens mid-call. (`PairingRevoked` is a dedicated `ToolError` variant rather than `Unauthorized` with a sentinel `missing_scope` because the `Scope` newtype is reserved for `<namespace>.<verb>.<noun>` / substrate-shipped values per §E — auth-state revocation is not a scope-deficit case.)
+
+**Audit attribution.** Every ability invocation with `Actor::McpClient` records `(client_id, conversation_handle, tool_name, params_hash, response_hash, timestamp)` in the audit log. `params_hash` and `response_hash` are keyed HMAC-SHA256 over canonical JSON with a per-install audit key (per cycle 2 CSO MED #2) — raw param / response data never lands in audit storage.
+
+### D. `OpaqueConversationHandle` lifecycle
+
+Host-model conversations are stateless; DailyOS is not. Cross-conversation continuity (per ADR-0128 §6) is implemented via a server-minted opaque token:
+
+- **Mint trigger.** Server mints on the first MCP call from a client that does not present an existing handle. The new handle is returned in the response envelope's top-level `conversation_handle` field (separate from the tool's typed payload).
+- **Echo.** Subsequent calls in the same conversation pass the handle in the request envelope's top-level `conversation_handle` field.
+- **Expiry.** 24 hours from last touch (refreshed on every call). Post-expiry the server mints a new handle on the next call (transparent to caller). Server may proactively rotate before 24h on operator action.
+- **First-write behavior.** If a `Side::Write` tool is the first call in a conversation (no prior handle), the gateway mints a fresh handle, performs the write, and returns the handle. No `ConversationRequired` error path — first-write is transparent.
+- **Revocation.** Server-side admin API can revoke a handle; subsequent presentations return `ToolError::ConversationRevoked`. Caller must restart with a new conversation. (Dedicated variant for the same reason as `PairingRevoked` above — `Scope` does not encode auth-state sentinels.)
+- **No raw conversation IDs accepted.** Any client-asserted `conversation_id` in tool params is rejected with `ToolError::BadParams { detail: "use envelope conversation_handle" }`. Audit + signal payloads carry `conversation_handle` exclusively; raw IDs are never logged.
+
+### E. Scope namespace freeze (v1.4.7 onward)
+
+Canonical convention for new MCP tool scopes:
+
+```
+dailyos.<verb>.<noun>
+```
+
+- **Verbs.** `read` (default for queries) and `write` (system/AI-attributable creations) are core. `submit` is the verb for user-attributable corrections. For action-shaped reads, the verb-prefix vocabulary admits `search`, `list`, `get`, and `prepare` in addition to bare `read`.
+- **Examples.** `dailyos.read.account_status`, `dailyos.read.daily_briefing`, `dailyos.read.portfolio_attention`, `dailyos.search.workspace_memory`, `dailyos.write.place_document`, `dailyos.submit.note`, `dailyos.submit.action`.
+- **v1.4.5-reused scopes stay unprefixed.** Scopes shipped by v1.4.5 substrate (e.g. `write.workspace_place_document`, `read.workspace_graph`, `read.entity_names`) are kept verbatim. v1.4.7 MCP tools that reuse them present the unprefixed scope to the manifest. The manifest validation logic accepts both forms but rejects any scope outside the canonical allowlist.
+- **Encoding.** The convention is encoded both in this ADR amendment (canonical text) and in the v1.4.7 W0 `services/mcp_v2/contracts.rs` `Scope` newtype + `ScopedName` newtype, with a load-time validation pass in W1-B's `taxonomy.rs` that rejects out-of-allowlist tool names at registry boot.
+
+### F. `AbilityPolicy.allowed_actors`
+
+`AbilityPolicy.allowed_actors` may now include `ActorKind::McpClient` alongside the existing four kinds. Defaults are unchanged (`&[ActorKind::User]`, least-privilege floor); abilities opt in to MCP exposure by adding `ActorKind::McpClient` to their `allowed_actors` slice.
+
+The proc macro emitting `AbilityDescriptor` (per `abilities-macro/src/lib.rs`) gains a `McpClient` arm in the `ActorArg` parser. `inventory.rs` `AbilityActor::project(ActorKind, McpExposure)` gains the same arm.
+
+### G. `McpExposure` tri-state remains sufficient
+
+No new variants are added to `McpExposure { None | MetadataOnly | Invocable }`. The tri-state continues to govern MCP introspection behavior verbatim for v1.4.7 — `None` hides the ability from the v1.4.7 gateway's `list_tools` and `list_abilities`, `MetadataOnly` exposes name + description without invoke schema, `Invocable` exposes full schema.
+
+### H. Non-goals (v1.4.7 W0 scope discipline)
+
+This amendment **does not** ship:
+
+- The MCP gateway implementation (`services/mcp_v2/gateway.rs` body) — that is W1-A (DOS-168).
+- The pairing handshake server implementation (`services/mcp_v2/auth.rs::pair_client` body) — W1-A.
+- The per-tool grant manifest schema — W1-A defines the format; this amendment only fixes that there IS a server-side manifest.
+- HMAC-SHA256 transport-layer signing implementation — W1-A scope.
+- New `SignalType::McpToolInvoked` variant — W1-A registers it in `signals/policy_registry.rs`.
+- Tool descriptions or the YAML catalog — W1-B (DOS-478).
+- Any actual MCP tool handler logic — W2/W3/W4.
+
+W0 ships only: the actor-class contract (this amendment), the Rust enum variants + newtypes, the `services/mcp_v2/` module skeleton with shared contract types, and golden Rust/TS parity fixtures for the wire-shape types.
+
+### I. Companion ADR-0128 amendment
+
+ADR-0128 receives a same-date amendment recording the v1.4.7-specific consequences of this trust-boundary contract: tool description as product copy with eval coverage (DOS-481), cross-conversation continuity surfaced as a named affordance per ADR-0128 §6 with the wire-level shape defined here in §D, and extension of the displacement-use-case framing to v1.4.7 W5 host-selection evaluation. ADR-0128 §5 ("Feedback is the only write") narrows in v1.4.7's headless head: writes are restricted to the v1.4.7 W4 surface (note/observation, create_action, update_action_status), all routed through approved `services::*` per ADR-0101.

--- a/.docs/decisions/0128-headless-dailyos-mcp-as-product-surface.md
+++ b/.docs/decisions/0128-headless-dailyos-mcp-as-product-surface.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-03
 **Amended:** 2026-05-04 — added §7 (CLI as a third head, mediated by MCP)
+**Amended:** 2026-05-19 — same-date companion amendment to ADR-0102; codifies tool description as product copy (DOS-481 eval coverage), cross-conversation continuity wire shape (defers to ADR-0102 §D OpaqueConversationHandle lifecycle), restated v1.4.7 W4 write surface, displacement-use-case framing extended to v1.4.7 W5 host-selection eval, and Linear link refresh to the post-renumber v1.4.7 project. See section appended at end of doc.
 **Authors:** James Giroux, Claude
 **Relates to:** [ADR-0027](0027-mcp-dual-mode.md), [ADR-0083](0083-product-vocabulary.md), [ADR-0102](0102-abilities-as-runtime-contract.md), [ADR-0105](0105-provenance-as-first-class-output.md), [ADR-0111](0111-surface-independent-ability-invocation.md), [ADR-0113](0113-human-and-agent-analysis-as-first-class-claim-sources.md), [ADR-0118](0118-dailyos-as-ai-harness-principles-and-residual-gaps.md)
 **Linear:** [v1.5.0 — MCP Server v2 (Abilities-First)](https://linear.app/a8c/project/v150-mcp-server-v2-abilities-first-6e12027c36c9)
@@ -185,3 +186,45 @@ Internal:
 External:
 
 - [Anthropic — Model Context Protocol](https://modelcontextprotocol.io/) — tool description as model-facing affordance
+
+## Amendment 2026-05-19 — v1.4.7 operationalization + Linear refresh
+
+This amendment records the v1.4.7 operational consequences of the same-date [ADR-0102](0102-abilities-as-runtime-contract.md) amendment. It does not reopen the architecture. ADR-0128 remains the product-surface frame for headless DailyOS; ADR-0102 remains the runtime contract for MCP-originated ability invocation.
+
+### §A. Linear citation refresh
+
+The top-of-file `Linear:` citation still points to the historical v1.5.0 project. Per the 2026-05-17 renumber, the canonical project for this work is now v1.4.7. The historical header is left intact for traceability; the post-renumber canonical project is [v1.4.7 — MCP Server v2 (Abilities-First)](https://linear.app/a8c/project/v147-mcp-server-v2-abilities-first-6e12027c36c9).
+
+### §B. Tool description as product copy — operationalized
+
+Section 3 says "Tool descriptions are UI copy." v1.4.7 turns that posture into a versioned artifact and an eval gate. W1-A defines a typed `ToolDescription` struct in `services/mcp_v2/contracts.rs`; W1-B owns the tool-description YAML catalog at `src-tauri/resources/mcp_v2/tool_descriptions.yaml` as the version-controlled source.
+
+The host-selection eval in DOS-481, scheduled for v1.4.7 W5-A, is the product-copy acceptance test. Each tool ships with at least two positive fixtures and at least two negative fixtures: one broad-corpus negative where DailyOS should yield to enterprise or web search, and one adjacent-DailyOS-but-wrong-tool negative where another DailyOS tool is the right choice. The `when_NOT_to_call` field is mandatory and explicit because avoiding DailyOS for the wrong ask is part of the product surface, not merely an eval trick.
+
+### §C. Cross-conversation continuity — wire shape
+
+Section 6 names continuity as a headless-head affordance: host-model conversations are stateless, DailyOS is not. v1.4.7 pins the wire shape for that affordance to a server-minted `OpaqueConversationHandle`. The handle is required on writes, with the gateway minting one transparently if absent on a first write, and is optional but recommended on reads.
+
+The lifecycle is intentionally not restated here. Expiry is 24 hours from last touch, revocation is server-side, and raw caller-provided conversation IDs are rejected; the authoritative mint, echo, expiry, first-write, revocation, and "no raw IDs" contract lives in [ADR-0102](0102-abilities-as-runtime-contract.md) §D.
+
+### §D. v1.4.7 W4 write surface — narrowed
+
+Section 5 originally said "feedback is the only write." v1.4.7 preserves the consumption-first spirit while naming the W4 submit surface precisely: `dailyos.submit.note` in W4-A, `dailyos.submit.action` in W4-B, and `dailyos.submit.action_status` in W4-C.
+
+All three writes route through approved `services::*` boundaries per ADR-0101. Notes and observations flow through the claim/source services; actions and action-status updates flow through `services::actions`. The MCP head still does not expose claim creation or direct edit, file generation, calendar mutation, message composition, or external-system writes. Submit-class corrections and lightweight action tracking are the only mutations.
+
+### §E. Displacement framing extended to W5 eval
+
+The displacement use case remains the governing design check: DailyOS should win for the user's working understanding, and broad-corpus systems should win for broad enterprise or web retrieval. v1.4.7 carries that distinction into DOS-481 rather than leaving it as prose.
+
+Every v1.4.7 tool description therefore ships with positive host-selection fixtures where the model should pick DailyOS for the right personal-working-context ask, and negative fixtures where the model should avoid DailyOS for either broad-corpus questions or adjacent-DailyOS-but-wrong-tool questions. The eval is a product-strategy artifact as much as a regression test.
+
+### §F. Trust boundary — defer to ADR-0102 amendment
+
+The MCP client trust boundary is codified in the same-date [ADR-0102](0102-abilities-as-runtime-contract.md) amendment, especially §C: MCP client authentication, transport HMAC signing, server-side scope manifest authorization, per-actor × per-client × per-tool rate limits, revocation, and audit attribution with keyed HMAC parameter and response hashes. This ADR cites that contract because ADR-0128 is the product-surface frame, not the transport or authorization spec.
+
+### §G. Non-goals (v1.4.7-specific)
+
+The v1.4.7 headless head is not a Glean replacement; broad-corpus retrieval remains Glean's domain. It is not a wrapper for Claude, because DailyOS does not host the conversation. It is not a write layer beyond the W4 submit surface, and it is not a parallel feature surface beside the Tauri app.
+
+Tools are still not added for completeness. If a tool does not exercise an ability and strengthen the headless-head consumption surface, it does not belong in v1.4.7.

--- a/.docs/plans/v1.4.7-waves.md
+++ b/.docs/plans/v1.4.7-waves.md
@@ -99,6 +99,20 @@ Cycle 5 fix (one):
 
 Cycle 5 is a one-line rename; no semantic change. Final L0 cycle expected.
 
+## Cycle 6 amendment (2026-05-19) — W0 absorbs skeleton-creation scope
+
+W0 (this work, branch `v1.4.7-w0-foundation`) absorbed the `services/mcp_v2/` module-skeleton + `contracts.rs` content originally assigned to W1-A (see W1-A "Files owned" lines 333–460). The rationale is the v1.4.5-L0 lesson folded in at §"Lessons folded in from v1.4.5 L0" #2: pre-creating every cross-lane contract type and `pub mod` declaration in a single foundation PR prevents the trait-timing inversions that cost v1.4.5 cycles 3–6.
+
+**Ownership shift recorded here so W1-A's L0 reviewer reads the right boundary:**
+
+- W0 ships: top-level `mod.rs` with all submodule declarations; `contracts.rs` with full shared type set (`ToolDescription`, `ScopedName`, `Scope`, `Verb` enum + `CANONICAL_NAMESPACE` const, `ParamSpec` / `ReturnSpec` / `ToolExample` / `ParamSchema` / `Side` / `Page<T>` / `OpaqueConversationHandle` / `McpClientId` / `McpActor` / `McpToolHandler` trait / `ToolError` / `McpToolRequestEnvelope` / `McpToolResponseEnvelope` / `McpToolResult`); `gateway.rs` / `auth.rs` / `audit.rs` / `actor_policy.rs` / `taxonomy.rs` as empty doc-only placeholders; `handlers/mod.rs` + 10 per-tool handler files as empty placeholders.
+- W1-A ships: bodies of `gateway.rs` (dispatch, scope validation, audit emission, signal emission), `auth.rs` (pairing handshake, manifest loading, HMAC transport verification, conversation handle minting), `audit.rs` (HMAC-SHA256 keyed param/response hashing), `actor_policy.rs` (scope/permission matrix consumed by gateway), plus new migrations (v220–v222) and `SignalType::McpToolInvoked` registration.
+- W1-B unchanged: owns `taxonomy.rs` content + `src-tauri/resources/mcp_v2/tool_descriptions.yaml`.
+
+W0 also lands the wire-shape parity test suites for both layers (10 runtime parity tests in `abilities-runtime/src/abilities/registry.rs` + 25 wire-shape parity tests in `services/mcp_v2/contracts.rs`). W1-A's L2 will inherit these as the contract regression net.
+
+**Cycle 6 codex review surfaced four AC-bound mediums** (proc-macro `ActorArg::McpClient` parser arm; `Verb` enum + namespace const not encoded; `ToolError::Unauthorized` abusing `Scope` for auth-state sentinels; missing top-level request/response envelope types) — all four addressed in this same W0 branch before merge. Companion ADR-0102 §C / §D wording reconciled with the new `PairingRevoked` / `ConversationRevoked` `ToolError` variants.
+
 ---
 
 ## L0 prep posture (2026-05-14)

--- a/src-tauri/abilities-macro/src/lib.rs
+++ b/src-tauri/abilities-macro/src/lib.rs
@@ -913,6 +913,13 @@ enum ActorArg {
     /// at runtime; the macro records membership in `allowed_actors` here
     /// to drive the W1-B compile-error gate.
     SurfaceClient,
+    /// ADR-0102 §A–§B (2026-05-19 amendment): MCP-originated invocation.
+    /// Per the §B asymmetry, scope authorization for `McpClient` happens
+    /// at the gateway against a server-side per-client manifest, so the
+    /// `required_scopes` compile-error gate (which fires for SurfaceClient)
+    /// does NOT fire for McpClient — manifest-driven scope enforcement is
+    /// the rationale anchor.
+    McpClient,
 }
 
 impl ActorArg {
@@ -936,6 +943,9 @@ impl ActorArg {
             Self::SurfaceClient => {
                 quote! { crate::abilities::registry::ActorKind::SurfaceClient }
             }
+            Self::McpClient => {
+                quote! { crate::abilities::registry::ActorKind::McpClient }
+            }
         }
     }
 }
@@ -952,6 +962,7 @@ fn parse_actor_array(input: ParseStream<'_>) -> syn::Result<Vec<ActorArg>> {
             "Admin" => Ok(ActorArg::Admin),
             "System" => Ok(ActorArg::System),
             "SurfaceClient" => Ok(ActorArg::SurfaceClient),
+            "McpClient" => Ok(ActorArg::McpClient),
             other => Err(syn::Error::new(
                 ident.span(),
                 format!("unknown actor `{other}`"),

--- a/src-tauri/abilities-runtime/src/abilities/account_overview.rs
+++ b/src-tauri/abilities-runtime/src/abilities/account_overview.rs
@@ -1013,6 +1013,9 @@ fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Actor {
         Actor::SurfaceClient { instance, .. } => crate::abilities::provenance::Actor::External {
             source: format!("surface_client:{}", instance.as_str()),
         },
+        Actor::McpClient { client_id, .. } => crate::abilities::provenance::Actor::External {
+            source: format!("mcp_client:{}", client_id.as_str()),
+        },
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/detect_risk_shift/synthesis.rs
+++ b/src-tauri/abilities-runtime/src/abilities/detect_risk_shift/synthesis.rs
@@ -1274,6 +1274,9 @@ fn provenance_actor(actor: RegistryActor) -> crate::abilities::provenance::Actor
         RegistryActor::SurfaceClient { .. } => {
             todo!("W1-B+ wiring for Actor::SurfaceClient")
         }
+        RegistryActor::McpClient { .. } => {
+            todo!("McpClient invocation routing pending")
+        }
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
+++ b/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
@@ -949,6 +949,9 @@ fn render_actor(ctx: &FallbackProjectionContext) -> RenderActor {
         Actor::SurfaceClient { instance, .. } => {
             RenderActor::agent(format!("surface_client:{}", instance.as_str()))
         }
+        Actor::McpClient { client_id, .. } => {
+            RenderActor::agent(format!("mcp_client:{}", client_id.as_str()))
+        }
         Actor::Agent => RenderActor::agent("agent"),
         Actor::Admin => RenderActor::agent("admin"),
         Actor::System => RenderActor::agent("system"),

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_readiness/synthesis.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_readiness/synthesis.rs
@@ -2060,6 +2060,7 @@ fn render_actor_for_context(ctx: &AbilityContext<'_>) -> RenderActor {
             user_id: None,
         },
         RegistryActor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+        RegistryActor::McpClient { .. } => todo!("McpClient invocation routing pending"),
     }
 }
 
@@ -2154,6 +2155,9 @@ fn provenance_actor(actor: RegistryActor) -> crate::abilities::provenance::Actor
         },
         RegistryActor::SurfaceClient { .. } => {
             todo!("W1-B+ wiring for Actor::SurfaceClient")
+        }
+        RegistryActor::McpClient { .. } => {
+            todo!("McpClient invocation routing pending")
         }
     }
 }

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_context.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_context.rs
@@ -433,6 +433,7 @@ pub(crate) fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Ac
         // stage-1a landing only ships the actor variant; no current invocation
         // path constructs Actor::SurfaceClient.
         Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
     }
 }
 
@@ -471,6 +472,7 @@ fn render_actor_for_context(ctx: &AbilityContext<'_>) -> RenderActor {
         // TODO: W1-B+ wiring — SurfaceClient render actor mapping (per ADR-0108
         // sensitivity rules) lands with the SurfaceClientBridge plumbing.
         Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
@@ -318,6 +318,7 @@ fn render_actor_for_context(ctx: &AbilityContext<'_>) -> RenderActor {
             user_id: None,
         },
         Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
     }
 }
 
@@ -582,6 +583,7 @@ fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Actor {
             component: "dailyos".to_string(),
         },
         Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/prepare_meeting/synthesis.rs
+++ b/src-tauri/abilities-runtime/src/abilities/prepare_meeting/synthesis.rs
@@ -1849,6 +1849,9 @@ fn provenance_actor(actor: RegistryActor) -> crate::abilities::provenance::Actor
         RegistryActor::SurfaceClient { .. } => {
             todo!("W1-B+ wiring for Actor::SurfaceClient")
         }
+        RegistryActor::McpClient { .. } => {
+            todo!("McpClient invocation routing pending")
+        }
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/registry.rs
+++ b/src-tauri/abilities-runtime/src/abilities/registry.rs
@@ -103,6 +103,79 @@ impl std::fmt::Display for SurfaceScope {
     }
 }
 
+/// Stable, non-PII identifier for a paired [`Actor::McpClient`] instance.
+///
+/// Issued server-side by the MCP gateway pairing handshake per ADR-0102
+/// §C ("MCP client authentication + session contract", 2026-05-19
+/// amendment). Mirrors [`SurfaceClientId`] from ADR-0111 §8: opaque to
+/// the substrate, audit-stable across calls, rotated only via the
+/// operator-facing pairing admin path.
+///
+/// Unlike [`Actor::SurfaceClient`], the [`Actor::McpClient`] variant
+/// carries no [`ScopeSet`] — the gateway enforces scopes against a
+/// server-side per-client manifest before invocation per the ADR-0102
+/// 2026-05-19 amendment §B asymmetry note.
+///
+/// `Display` / `Debug` produce the raw inner string. Callers are
+/// expected not to embed PII in the identifier itself; the type does
+/// no scrubbing.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct McpClientId(String);
+
+impl McpClientId {
+    /// Construct a new identifier from an owned string.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Borrow the inner string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for McpClientId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Server-minted, non-PII, non-enumerable token tracking cross-
+/// conversation continuity for an [`Actor::McpClient`] invocation path.
+///
+/// Per ADR-0102 §D ("`OpaqueConversationHandle` lifecycle", 2026-05-19
+/// amendment): minted on first call (transparent to caller), echoed
+/// in subsequent requests, 24h expiry from last touch, revocable, and
+/// never derived from caller-provided conversation IDs (those are
+/// rejected at the gateway with `BadParams`).
+///
+/// The corresponding field on [`Actor::McpClient`] is `Option<_>`
+/// because the handle is absent on the very first MCP call in a fresh
+/// conversation; the gateway mints transparently per the lifecycle
+/// contract.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct OpaqueConversationHandle(String);
+
+impl OpaqueConversationHandle {
+    /// Construct a new handle from an owned string.
+    pub fn new(handle: impl Into<String>) -> Self {
+        Self(handle.into())
+    }
+
+    /// Borrow the inner string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OpaqueConversationHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
 /// Construction / deserialization errors for [`ScopeSet`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScopeSetError {
@@ -356,6 +429,25 @@ pub enum Actor {
         /// `actor_scopes` field.
         scopes: ScopeSet,
     },
+    /// MCP-originated invocation per the ADR-0102 2026-05-19 amendment §A.
+    ///
+    /// Server-issued [`McpClientId`] after a pairing handshake; per-call
+    /// continuity tracked via the optional [`OpaqueConversationHandle`].
+    /// Authorization is gateway-mediated against a server-side per-client
+    /// scope manifest (see amendment §B for the asymmetry with
+    /// [`Actor::SurfaceClient`]); this variant intentionally carries no
+    /// [`ScopeSet`] — the gateway is the source of truth for what scopes a
+    /// given `client_id` may exercise.
+    McpClient {
+        /// Stable, server-issued instance identity. Surfaces audit
+        /// emission's `actor_instance` field.
+        client_id: McpClientId,
+        /// Per-call cross-conversation continuity token. `None` on the
+        /// very first MCP call in a fresh conversation; the gateway
+        /// transparently mints a fresh handle and returns it in the
+        /// response envelope per the amendment §D lifecycle.
+        conversation_handle: Option<OpaqueConversationHandle>,
+    },
 }
 
 /// Discriminator over [`Actor`] variants — the "kind" of actor, without
@@ -385,6 +477,12 @@ pub enum ActorKind {
     /// Mirrors [`Actor::SurfaceClient`]. Per-invocation instance and scope
     /// data live on the runtime variant; only the kind appears in the policy.
     SurfaceClient,
+    /// Mirrors [`Actor::McpClient`]. Per-invocation client identity and
+    /// conversation handle live on the runtime variant; only the kind
+    /// appears in policy. Per the ADR-0102 2026-05-19 amendment §B,
+    /// scopes for `McpClient` are gateway-enforced from a server-side
+    /// per-client manifest and do not ride on the variant.
+    McpClient,
 }
 
 impl Actor {
@@ -399,6 +497,7 @@ impl Actor {
             Actor::Admin => ActorKind::Admin,
             Actor::System => ActorKind::System,
             Actor::SurfaceClient { .. } => ActorKind::SurfaceClient,
+            Actor::McpClient { .. } => ActorKind::McpClient,
         }
     }
 }
@@ -2328,6 +2427,138 @@ mod tests {
         set.insert(SurfaceScope::new("write.y"));
         set.insert(SurfaceScope::new("read.x")); // dup
         assert_eq!(set.len(), 2);
+    }
+
+    // -------------------------------------------------------------------
+    // McpClient actor class — identity / handle newtype + Actor::McpClient
+    // tests. ADR-0102 §A–§D (2026-05-19 amendment): server-issued
+    // `McpClientId` after pairing; opaque conversation handle; gateway-
+    // mediated scope enforcement (no scopes on the variant per §B).
+    // Golden Rust JSON parity fixtures for the wire shape.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn mcp_client_id_round_trip_preserves_value() {
+        let id = McpClientId::new("mcp-client-alpha");
+        assert_eq!(id.as_str(), "mcp-client-alpha");
+        assert_eq!(format!("{id}"), "mcp-client-alpha");
+        assert_eq!(format!("{id:?}"), "McpClientId(\"mcp-client-alpha\")");
+    }
+
+    #[test]
+    fn mcp_client_id_serde_round_trip_is_transparent() {
+        let id = McpClientId::new("mcp-client-alpha");
+        let encoded = serde_json::to_string(&id).expect("serializes");
+        // `#[serde(transparent)]` — the wire form is the inner string only.
+        assert_eq!(encoded, "\"mcp-client-alpha\"");
+        let decoded: McpClientId = serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn mcp_client_id_hash_eq_match_inner_string() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(McpClientId::new("alpha"));
+        set.insert(McpClientId::new("beta"));
+        set.insert(McpClientId::new("alpha")); // dup
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&McpClientId::new("alpha")));
+        assert!(set.contains(&McpClientId::new("beta")));
+        assert!(!set.contains(&McpClientId::new("gamma")));
+    }
+
+    #[test]
+    fn opaque_conversation_handle_round_trip_preserves_value() {
+        let handle = OpaqueConversationHandle::new("conv-abc-123");
+        assert_eq!(handle.as_str(), "conv-abc-123");
+        assert_eq!(format!("{handle}"), "conv-abc-123");
+        assert_eq!(
+            format!("{handle:?}"),
+            "OpaqueConversationHandle(\"conv-abc-123\")"
+        );
+    }
+
+    #[test]
+    fn opaque_conversation_handle_serde_round_trip_is_transparent() {
+        let handle = OpaqueConversationHandle::new("conv-abc-123");
+        let encoded = serde_json::to_string(&handle).expect("serializes");
+        assert_eq!(encoded, "\"conv-abc-123\"");
+        let decoded: OpaqueConversationHandle =
+            serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, handle);
+    }
+
+    #[test]
+    fn opaque_conversation_handle_hash_eq_match_inner_string() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(OpaqueConversationHandle::new("alpha"));
+        set.insert(OpaqueConversationHandle::new("beta"));
+        set.insert(OpaqueConversationHandle::new("alpha")); // dup
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn actor_mcp_client_projects_to_mcp_client_kind() {
+        let actor = Actor::McpClient {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: None,
+        };
+        assert_eq!(actor.kind(), ActorKind::McpClient);
+    }
+
+    #[test]
+    fn actor_mcp_client_with_handle_projects_to_mcp_client_kind() {
+        let actor = Actor::McpClient {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv-abc-123")),
+        };
+        assert_eq!(actor.kind(), ActorKind::McpClient);
+    }
+
+    #[test]
+    fn actor_mcp_client_serde_wire_shape_is_canonical() {
+        // Locks the JSON wire shape of `Actor::McpClient` so any future
+        // serde rename / variant reordering is caught by this test.
+        // Canonical wire: externally-tagged variant with `client_id`
+        // (transparent) + `conversation_handle` (transparent, optional).
+        let actor = Actor::McpClient {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv-abc-123")),
+        };
+        let encoded = serde_json::to_value(&actor).expect("serializes");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "McpClient": {
+                    "client_id": "mcp-client-alpha",
+                    "conversation_handle": "conv-abc-123",
+                }
+            })
+        );
+        let decoded: Actor = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, actor);
+    }
+
+    #[test]
+    fn actor_mcp_client_serde_with_absent_handle_round_trips() {
+        let actor = Actor::McpClient {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: None,
+        };
+        let encoded = serde_json::to_value(&actor).expect("serializes");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "McpClient": {
+                    "client_id": "mcp-client-alpha",
+                    "conversation_handle": null,
+                }
+            })
+        );
+        let decoded: Actor = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, actor);
     }
 
     /// Test helper: build a non-empty [`ScopeSet`] from string slices.

--- a/src-tauri/abilities-runtime/src/inventory.rs
+++ b/src-tauri/abilities-runtime/src/inventory.rs
@@ -422,6 +422,10 @@ impl AbilityActor {
         match kind {
             ActorKind::User => Self::User,
             ActorKind::SurfaceClient => Self::SurfaceClient,
+            // First-class MCP client kind (ADR-0102 §A, 2026-05-19
+            // amendment). Projects to `Self::McpClient` regardless of
+            // exposure: the actor IS an MCP client by construction.
+            ActorKind::McpClient => Self::McpClient,
             ActorKind::Agent => match exposure {
                 McpExposure::Invocable => Self::McpClient,
                 McpExposure::None | McpExposure::MetadataOnly => Self::Runtime,

--- a/src-tauri/src/audit_log.rs
+++ b/src-tauri/src/audit_log.rs
@@ -197,6 +197,7 @@ fn actor_kind_tag(actor: &Actor) -> &'static str {
         Actor::Admin => "admin",
         Actor::System => "system",
         Actor::SurfaceClient { .. } => "surface_client",
+        Actor::McpClient { .. } => "mcp_client",
     }
 }
 
@@ -323,8 +324,15 @@ impl AuditLogger {
             // Per AC line 293, `wp_user_id` is SurfaceClient-only: even if
             // the caller supplied one in `AuditFields` for a non-SurfaceClient
             // actor, we drop it so the schema cannot be misused as a generic
-            // user-id channel for non-paired actors.
-            Actor::Agent | Actor::User | Actor::Admin | Actor::System => (None, None, None),
+            // user-id channel for non-paired actors. McpClient also has no WP
+            // identity: its attribution is `client_id` + `conversation_handle`
+            // recorded via the MCP gateway's audit path, not the WP-paired
+            // user-id channel.
+            Actor::Agent
+            | Actor::User
+            | Actor::Admin
+            | Actor::System
+            | Actor::McpClient { .. } => (None, None, None),
         };
 
         self.write_record(

--- a/src-tauri/src/bridges/mcp.rs
+++ b/src-tauri/src/bridges/mcp.rs
@@ -734,6 +734,7 @@ CREATE TABLE accounts (
             // TODO: W1-B+ wiring — SurfaceClient MCP-bridge test fixture lands
             // with the SurfaceClientBridge plumbing.
             Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+            Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
         }
     }
 

--- a/src-tauri/src/bridges/tauri.rs
+++ b/src-tauri/src/bridges/tauri.rs
@@ -418,6 +418,7 @@ fn service_actor_label(actor: BridgeActor) -> &'static str {
         BridgeActor::Admin => "admin",
         BridgeActor::System => "system",
         BridgeActor::SurfaceClient => "surface_client",
+        BridgeActor::McpClient => "mcp_client",
     }
 }
 
@@ -635,6 +636,7 @@ mod tests {
             // TODO: W1-B+ wiring — SurfaceClient provenance fixture lands
             // with the SurfaceClientBridge plumbing.
             Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
+            Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
         }
     }
 

--- a/src-tauri/src/bridges/types.rs
+++ b/src-tauri/src/bridges/types.rs
@@ -41,6 +41,7 @@ pub enum BridgeActor {
     Admin,
     System,
     SurfaceClient,
+    McpClient,
 }
 
 impl BridgeActor {
@@ -53,6 +54,9 @@ impl BridgeActor {
             Self::SurfaceClient => {
                 panic!("BridgeActor::SurfaceClient requires request-scoped Actor::SurfaceClient")
             }
+            Self::McpClient => {
+                panic!("BridgeActor::McpClient requires request-scoped Actor::McpClient")
+            }
         }
     }
 
@@ -63,6 +67,7 @@ impl BridgeActor {
             Actor::Admin => Self::Admin,
             Actor::System => Self::System,
             Actor::SurfaceClient { .. } => Self::SurfaceClient,
+            Actor::McpClient { .. } => Self::McpClient,
         }
     }
 }
@@ -829,6 +834,7 @@ fn bridge_actor_label(actor: BridgeActor) -> &'static str {
         BridgeActor::Admin => "admin",
         BridgeActor::System => "system",
         BridgeActor::SurfaceClient => "surface_client",
+        BridgeActor::McpClient => "mcp_client",
     }
 }
 
@@ -940,6 +946,9 @@ fn provenance_actor_for_bridge(actor: BridgeActor) -> ProvenanceActor {
         },
         BridgeActor::SurfaceClient => ProvenanceActor::External {
             source: "surface_client".to_string(),
+        },
+        BridgeActor::McpClient => ProvenanceActor::External {
+            source: "mcp_client".to_string(),
         },
     }
 }

--- a/src-tauri/src/services/mcp_v2/actor_policy.rs
+++ b/src-tauri/src/services/mcp_v2/actor_policy.rs
@@ -1,0 +1,6 @@
+//! Scope/permission matrix for Actor::McpClient.
+//!
+//! Consumed by gateway after auth resolves the per-client scope manifest.
+//! Per ADR-0102 §B — 2026-05-19 amendment — scope authorization for
+//! McpClient invocations is gateway-mediated; the runtime variant carries
+//! no scopes. Implementation pending.

--- a/src-tauri/src/services/mcp_v2/audit.rs
+++ b/src-tauri/src/services/mcp_v2/audit.rs
@@ -1,0 +1,7 @@
+//! MCP v2 audit log writer.
+//!
+//! Records client_id, conversation_handle, tool_name, params_hash,
+//! response_hash, timestamp for every gateway dispatch. Hashes are
+//! keyed HMAC-SHA256 over canonical JSON with a per-install audit key —
+//! raw param/response data never lands in audit storage.
+//! Implementation pending.

--- a/src-tauri/src/services/mcp_v2/auth.rs
+++ b/src-tauri/src/services/mcp_v2/auth.rs
@@ -1,0 +1,6 @@
+//! MCP client authentication + session.
+//!
+//! Per ADR-0102 §C — 2026-05-19 amendment — pairing handshake issues
+//! McpClientId; loads server-side scope manifest per client; revocation
+//! path; per-message HMAC-SHA256 transport verification; opaque
+//! conversation handle minting per §D lifecycle. Implementation pending.

--- a/src-tauri/src/services/mcp_v2/contracts.rs
+++ b/src-tauri/src/services/mcp_v2/contracts.rs
@@ -1,0 +1,732 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolDescription {
+    pub name: ScopedName,
+    pub summary: String,
+    pub when_to_call: String,
+    #[serde(rename = "when_NOT_to_call")]
+    pub when_not_to_call: String,
+    pub side: Side,
+    pub parameters: Vec<ParamSpec>,
+    pub returns: ReturnSpec,
+    pub examples: Vec<ToolExample>,
+    pub scopes_required: Vec<Scope>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Side {
+    Read,
+    SubmitCorrection,
+    Write,
+}
+
+/// Canonical namespace prefix for all MCP v2 tools and new-since-amendment
+/// scopes per ADR-0102 §E (2026-05-19 amendment). The form is
+/// `<NAMESPACE>.<verb>.<noun>` — for example `dailyos.read.account_status`.
+pub const CANONICAL_NAMESPACE: &str = "dailyos";
+
+/// Canonical verb vocabulary for MCP v2 tool names and new scopes per
+/// ADR-0102 §E (2026-05-19 amendment).
+///
+/// - `Read`, `Write`, `Submit` are the three core verb classes.
+/// - `Search`, `List`, `Get`, `Prepare` are read-class subtypes allowed
+///   when the action shape is more specific than generic `read`.
+///
+/// The enum is the typed encoding of the namespace freeze; runtime
+/// validation against the per-client manifest is the gateway's
+/// responsibility (`auth.rs`), and the validator may also accept
+/// pre-amendment substrate-shipped scopes (e.g. `read.workspace_graph`,
+/// `write.workspace_place_document`, `read.entity_names`) verbatim per
+/// §E. [`Scope`] itself stays a permissive newtype to keep that
+/// substrate-shipped form expressible.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verb {
+    Read,
+    Write,
+    Submit,
+    Search,
+    List,
+    Get,
+    Prepare,
+}
+
+impl Verb {
+    /// Wire-canonical lowercase token for this verb (`"read"`, `"write"`,
+    /// `"submit"`, `"search"`, `"list"`, `"get"`, `"prepare"`). Stable
+    /// across releases; used by the gateway's manifest validator and by
+    /// tool-name composition helpers.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Submit => "submit",
+            Self::Search => "search",
+            Self::List => "list",
+            Self::Get => "get",
+            Self::Prepare => "prepare",
+        }
+    }
+
+    /// The full ordered set of allowed verbs. Stable surface for the
+    /// manifest allowlist + W1-B taxonomy validation pass.
+    pub const ALL: &'static [Verb] = &[
+        Verb::Read,
+        Verb::Write,
+        Verb::Submit,
+        Verb::Search,
+        Verb::List,
+        Verb::Get,
+        Verb::Prepare,
+    ];
+}
+
+impl std::fmt::Display for Verb {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Compose a canonical [`ScopedName`] from the namespace prefix, a verb,
+/// and a noun per ADR-0102 §E. Equivalent to `format!("{}.{}.{}", ...)`.
+pub fn compose_scoped_name(verb: Verb, noun: &str) -> ScopedName {
+    ScopedName::new(format!("{}.{}.{}", CANONICAL_NAMESPACE, verb.as_str(), noun))
+}
+
+/// Compose a canonical [`Scope`] from the namespace prefix, a verb,
+/// and a noun per ADR-0102 §E. Equivalent to `format!("{}.{}.{}", ...)`.
+pub fn compose_scope(verb: Verb, noun: &str) -> Scope {
+    Scope::new(format!("{}.{}.{}", CANONICAL_NAMESPACE, verb.as_str(), noun))
+}
+
+/// canonical form dailyos.<verb>.<noun> per ADR-0102 amendment §E.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScopedName(pub String);
+
+impl ScopedName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ScopedName {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// canonical form dailyos.<verb>.<noun> for new tools; pre-2026-05-19 substrate-shipped scopes — read.workspace_graph, write.workspace_place_document, read.entity_names — stay unprefixed verbatim per ADR-0102 amendment §E; manifest validation rejects out-of-allowlist.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Scope(pub String);
+
+impl Scope {
+    pub fn new(scope: impl Into<String>) -> Self {
+        Self(scope.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Scope {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParamSpec {
+    pub name: String,
+    pub schema: ParamSchema,
+    pub required: bool,
+    pub description: String,
+}
+
+/// valid JSON Schema fragment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ParamSchema(pub serde_json::Value);
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReturnSpec {
+    pub schema: ParamSchema,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolExample {
+    pub prompt: String,
+    pub invocation: serde_json::Value,
+    pub expected_response_shape: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+    pub page_size: u32,
+}
+
+/// wire envelope mirror of the runtime type defined in abilities_runtime::abilities::registry::OpaqueConversationHandle.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OpaqueConversationHandle(pub String);
+
+impl OpaqueConversationHandle {
+    pub fn new(handle: impl Into<String>) -> Self {
+        Self(handle.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OpaqueConversationHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// wire envelope mirror of the runtime type.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct McpClientId(pub String);
+
+impl McpClientId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for McpClientId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// resolved/hydrated gateway-side envelope; carries granted_scopes because the gateway loads them from the server-side manifest before dispatching. Distinct from the abilities-runtime Actor::McpClient variant which carries no scopes per ADR-0102 amendment §B asymmetry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all_fields = "camelCase")]
+pub enum McpActor {
+    Client {
+        client_id: McpClientId,
+        conversation_handle: Option<OpaqueConversationHandle>,
+        tool_name: ScopedName,
+        granted_scopes: Vec<Scope>,
+    },
+}
+
+/// Top-level MCP request envelope per ADR-0102 §D (2026-05-19 amendment).
+///
+/// The `conversation_handle` rides at the envelope level, separate from
+/// the tool's typed `params` payload. `None` on the first call in a
+/// fresh conversation; the gateway mints a new handle and returns it on
+/// the response envelope.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolRequestEnvelope {
+    /// Server-minted opaque token from a prior response, echoed by the
+    /// caller. Absent on the very first call in a conversation.
+    pub conversation_handle: Option<OpaqueConversationHandle>,
+    /// Canonical tool name being invoked. Manifest-validated at the
+    /// gateway.
+    pub tool_name: ScopedName,
+    /// Tool-specific parameters. Validated against the tool's typed
+    /// `ParamSpec` schema before handler invocation.
+    pub params: serde_json::Value,
+}
+
+/// Top-level MCP response envelope per ADR-0102 §D (2026-05-19
+/// amendment).
+///
+/// The `conversation_handle` is always present on the response: the
+/// gateway either echoes the caller-presented handle or returns a
+/// freshly minted one on the first call (transparent mint per §D
+/// lifecycle). The tool result is carried in `result`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolResponseEnvelope {
+    /// Server-minted opaque token. Caller persists for follow-up
+    /// invocations in the same conversation.
+    pub conversation_handle: OpaqueConversationHandle,
+    /// Tool result. `Ok` carries the handler's typed JSON return value;
+    /// `Err` carries a [`ToolError`].
+    pub result: McpToolResult,
+}
+
+/// Tool outcome carried by [`McpToolResponseEnvelope`].
+///
+/// Externally tagged on the wire: `{"kind":"ok","value":...}` or
+/// `{"kind":"error","error":...}`. Splitting success / error at the
+/// envelope layer (rather than `Result<Value, ToolError>`) keeps the
+/// wire shape stable under serde's default `Result` representation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum McpToolResult {
+    /// Handler succeeded; `value` is the typed JSON return payload.
+    Ok { value: serde_json::Value },
+    /// Handler or gateway returned a typed error.
+    Error { error: ToolError },
+}
+
+pub trait McpToolHandler: Send + Sync {
+    fn description(&self) -> &ToolDescription;
+
+    fn invoke(
+        &self,
+        actor: &McpActor,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolError>;
+}
+
+/// Typed errors propagated to the MCP wire.
+///
+/// `ConversationRequired` is intentionally absent — the gateway mints
+/// handles transparently on first write per ADR-0102 §D (2026-05-19
+/// amendment). Auth-state-revocation cases (`PairingRevoked`,
+/// `ConversationRevoked`) live as their own variants rather than abusing
+/// `Unauthorized::missing_scope` with sentinel strings: the [`Scope`]
+/// type is reserved for `<namespace>.<verb>.<noun>` (or pre-amendment
+/// substrate) values per §E, so auth-state sentinels do not belong on
+/// that field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ToolError {
+    BadParams { detail: String },
+    /// Scope-deficit authorization failure — the caller's manifest grant
+    /// did not include a required scope. The named `missing_scope` is a
+    /// canonical or substrate-shipped [`Scope`] per ADR-0102 §E.
+    Unauthorized { missing_scope: Scope },
+    /// MCP client pairing was revoked (per ADR-0102 §C). The caller must
+    /// re-pair before further invocations succeed.
+    PairingRevoked,
+    /// `OpaqueConversationHandle` was revoked (per ADR-0102 §D). The
+    /// caller must restart with a fresh conversation (the gateway will
+    /// mint a new handle on the next call).
+    ConversationRevoked,
+    NotFound { resource: String },
+    RateLimited { retry_after_seconds: u32 },
+    UpstreamFailure { detail: String },
+    Internal { trace_id: String },
+}
+
+#[cfg(test)]
+mod tests {
+    //! Golden Rust JSON parity fixtures for the MCP v2 wire-shape types.
+    //!
+    //! These tests lock the canonical JSON wire shape so any future
+    //! serde rename / variant reordering is caught at the contract
+    //! layer rather than downstream. TS clients (handlers, frontends,
+    //! tooling) consume these shapes exactly.
+
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn mcp_client_id_wire_is_transparent_string() {
+        let id = McpClientId::new("mcp-client-alpha");
+        let encoded = serde_json::to_string(&id).expect("serializes");
+        assert_eq!(encoded, "\"mcp-client-alpha\"");
+        let decoded: McpClientId = serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn opaque_conversation_handle_wire_is_transparent_string() {
+        let handle = OpaqueConversationHandle::new("conv-abc-123");
+        let encoded = serde_json::to_string(&handle).expect("serializes");
+        assert_eq!(encoded, "\"conv-abc-123\"");
+        let decoded: OpaqueConversationHandle =
+            serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, handle);
+    }
+
+    #[test]
+    fn scope_wire_is_transparent_string() {
+        let scope = Scope::new("dailyos.read.account_status");
+        let encoded = serde_json::to_string(&scope).expect("serializes");
+        assert_eq!(encoded, "\"dailyos.read.account_status\"");
+        let decoded: Scope = serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, scope);
+    }
+
+    #[test]
+    fn scope_accepts_pre_amendment_unprefixed_substrate_form() {
+        // Per ADR-0102 amendment §E: scopes shipped by pre-2026-05-19
+        // substrate (e.g. `write.workspace_place_document`,
+        // `read.workspace_graph`) stay unprefixed verbatim. The `Scope`
+        // newtype is intentionally permissive at the type layer; the
+        // manifest validation in `auth` rejects out-of-allowlist values.
+        let legacy = Scope::new("write.workspace_place_document");
+        let encoded = serde_json::to_string(&legacy).expect("serializes");
+        assert_eq!(encoded, "\"write.workspace_place_document\"");
+    }
+
+    #[test]
+    fn scoped_name_wire_is_transparent_string() {
+        let name = ScopedName::new("dailyos.read.account_status");
+        let encoded = serde_json::to_string(&name).expect("serializes");
+        assert_eq!(encoded, "\"dailyos.read.account_status\"");
+        let decoded: ScopedName = serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, name);
+    }
+
+    #[test]
+    fn mcp_actor_client_wire_uses_camel_case_fields() {
+        // Wire shape MUST match: snake_case Rust fields → camelCase JSON
+        // keys, per the substrate's wire-side parity rule for MCP v2
+        // contracts. `tool_name` / `client_id` / `conversation_handle`
+        // / `granted_scopes` all rename.
+        let actor = McpActor::Client {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv-abc-123")),
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+            granted_scopes: vec![
+                Scope::new("dailyos.read.account_status"),
+                Scope::new("read.entity_names"),
+            ],
+        };
+        let encoded = serde_json::to_value(&actor).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "Client": {
+                    "clientId": "mcp-client-alpha",
+                    "conversationHandle": "conv-abc-123",
+                    "toolName": "dailyos.read.account_status",
+                    "grantedScopes": ["dailyos.read.account_status", "read.entity_names"],
+                }
+            })
+        );
+        let decoded: McpActor = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, actor);
+    }
+
+    #[test]
+    fn mcp_actor_client_wire_with_absent_conversation_handle() {
+        let actor = McpActor::Client {
+            client_id: McpClientId::new("mcp-client-alpha"),
+            conversation_handle: None,
+            tool_name: ScopedName::new("dailyos.submit.note"),
+            granted_scopes: vec![Scope::new("dailyos.submit.note")],
+        };
+        let encoded = serde_json::to_value(&actor).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "Client": {
+                    "clientId": "mcp-client-alpha",
+                    "conversationHandle": null,
+                    "toolName": "dailyos.submit.note",
+                    "grantedScopes": ["dailyos.submit.note"],
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn tool_error_wire_is_tagged_snake_case_with_camel_case_fields() {
+        // `BadParams` → `bad_params` tag with `detail` field unchanged.
+        let err = ToolError::BadParams {
+            detail: "missing parameter".to_string(),
+        };
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({ "kind": "bad_params", "detail": "missing parameter" })
+        );
+        let decoded: ToolError = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, err);
+    }
+
+    #[test]
+    fn tool_error_unauthorized_carries_scope() {
+        let err = ToolError::Unauthorized {
+            missing_scope: Scope::new("dailyos.write.place_document"),
+        };
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "kind": "unauthorized",
+                "missingScope": "dailyos.write.place_document",
+            })
+        );
+    }
+
+    #[test]
+    fn tool_error_rate_limited_camel_cases_retry_after() {
+        let err = ToolError::RateLimited {
+            retry_after_seconds: 30,
+        };
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({ "kind": "rate_limited", "retryAfterSeconds": 30 })
+        );
+    }
+
+    #[test]
+    fn tool_error_internal_carries_trace_id() {
+        let err = ToolError::Internal {
+            trace_id: "trace-abc".to_string(),
+        };
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({ "kind": "internal", "traceId": "trace-abc" })
+        );
+    }
+
+    #[test]
+    fn page_t_wire_camel_cases_next_cursor_and_page_size() {
+        let page: Page<String> = Page {
+            items: vec!["a".to_string(), "b".to_string()],
+            next_cursor: Some("cursor-1".to_string()),
+            page_size: 50,
+        };
+        let encoded = serde_json::to_value(&page).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "items": ["a", "b"],
+                "nextCursor": "cursor-1",
+                "pageSize": 50,
+            })
+        );
+    }
+
+    #[test]
+    fn tool_description_wire_when_not_to_call_keeps_uppercase_alias() {
+        // `when_NOT_to_call` deliberately preserves the uppercase NOT
+        // on the wire — host models read the field name itself as a
+        // signal of attention. Locked here so a future serde rename
+        // can't silently downcase it.
+        let desc = ToolDescription {
+            name: ScopedName::new("dailyos.read.account_status"),
+            summary: "Returns current account status.".to_string(),
+            when_to_call: "When the user asks about an account they work with.".to_string(),
+            when_not_to_call: "Do NOT call for broad enterprise search.".to_string(),
+            side: Side::Read,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: "Account status payload.".to_string(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("dailyos.read.account_status")],
+        };
+        let encoded = serde_json::to_value(&desc).expect("serializes");
+        // The field is renamed to the literal `when_NOT_to_call` token.
+        assert!(encoded.get("when_NOT_to_call").is_some());
+        // Other fields use camelCase from the struct-level rename_all.
+        assert!(encoded.get("whenToCall").is_some());
+        assert!(encoded.get("scopesRequired").is_some());
+    }
+
+    #[test]
+    fn side_wire_uses_pascal_case_variants() {
+        // `Side` is an externally-tagged unit enum; default serde
+        // serialization keeps the Rust PascalCase variant names.
+        let read = Side::Read;
+        let encoded = serde_json::to_value(read).expect("serializes");
+        assert_eq!(encoded, json!("Read"));
+
+        let submit = Side::SubmitCorrection;
+        let encoded = serde_json::to_value(submit).expect("serializes");
+        assert_eq!(encoded, json!("SubmitCorrection"));
+
+        let write = Side::Write;
+        let encoded = serde_json::to_value(write).expect("serializes");
+        assert_eq!(encoded, json!("Write"));
+    }
+
+    #[test]
+    fn param_spec_and_return_spec_use_camel_case_fields() {
+        let param = ParamSpec {
+            name: "subject".to_string(),
+            schema: ParamSchema(json!({ "type": "string" })),
+            required: true,
+            description: "Entity to query".to_string(),
+        };
+        let encoded = serde_json::to_value(&param).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "name": "subject",
+                "schema": { "type": "string" },
+                "required": true,
+                "description": "Entity to query",
+            })
+        );
+
+        let ret = ReturnSpec {
+            schema: ParamSchema(json!({})),
+            description: "payload".to_string(),
+        };
+        let encoded = serde_json::to_value(&ret).expect("serializes");
+        assert!(encoded.get("schema").is_some());
+        assert!(encoded.get("description").is_some());
+    }
+
+    #[test]
+    fn tool_example_camel_cases_expected_response_shape() {
+        let example = ToolExample {
+            prompt: "What's going on with Acme?".to_string(),
+            invocation: json!({ "name": "dailyos.read.account_status" }),
+            expected_response_shape: json!({}),
+        };
+        let encoded = serde_json::to_value(&example).expect("serializes");
+        assert!(encoded.get("prompt").is_some());
+        assert!(encoded.get("invocation").is_some());
+        assert!(encoded.get("expectedResponseShape").is_some());
+    }
+
+    #[test]
+    fn verb_serializes_lowercase_and_round_trips() {
+        for verb in Verb::ALL {
+            let encoded = serde_json::to_value(verb).expect("serializes");
+            assert_eq!(encoded, json!(verb.as_str()));
+            let decoded: Verb = serde_json::from_value(encoded).expect("deserializes");
+            assert_eq!(decoded, *verb);
+        }
+    }
+
+    #[test]
+    fn verb_as_str_matches_canonical_tokens() {
+        assert_eq!(Verb::Read.as_str(), "read");
+        assert_eq!(Verb::Write.as_str(), "write");
+        assert_eq!(Verb::Submit.as_str(), "submit");
+        assert_eq!(Verb::Search.as_str(), "search");
+        assert_eq!(Verb::List.as_str(), "list");
+        assert_eq!(Verb::Get.as_str(), "get");
+        assert_eq!(Verb::Prepare.as_str(), "prepare");
+    }
+
+    #[test]
+    fn compose_helpers_produce_canonical_dotted_form() {
+        let name = compose_scoped_name(Verb::Read, "account_status");
+        assert_eq!(name.as_str(), "dailyos.read.account_status");
+        let scope = compose_scope(Verb::Submit, "note");
+        assert_eq!(scope.as_str(), "dailyos.submit.note");
+    }
+
+    #[test]
+    fn tool_error_pairing_revoked_wire_shape() {
+        let err = ToolError::PairingRevoked;
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(encoded, json!({ "kind": "pairing_revoked" }));
+        let decoded: ToolError = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, err);
+    }
+
+    #[test]
+    fn tool_error_conversation_revoked_wire_shape() {
+        let err = ToolError::ConversationRevoked;
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(encoded, json!({ "kind": "conversation_revoked" }));
+        let decoded: ToolError = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, err);
+    }
+
+    #[test]
+    fn mcp_tool_request_envelope_wire_shape() {
+        let envelope = McpToolRequestEnvelope {
+            conversation_handle: Some(OpaqueConversationHandle::new("conv-abc-123")),
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+            params: json!({ "subject": "acme" }),
+        };
+        let encoded = serde_json::to_value(&envelope).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "conversationHandle": "conv-abc-123",
+                "toolName": "dailyos.read.account_status",
+                "params": { "subject": "acme" },
+            })
+        );
+        let decoded: McpToolRequestEnvelope =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn mcp_tool_request_envelope_first_call_omits_handle() {
+        let envelope = McpToolRequestEnvelope {
+            conversation_handle: None,
+            tool_name: ScopedName::new("dailyos.submit.note"),
+            params: json!({ "body": "kickoff" }),
+        };
+        let encoded = serde_json::to_value(&envelope).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "conversationHandle": null,
+                "toolName": "dailyos.submit.note",
+                "params": { "body": "kickoff" },
+            })
+        );
+    }
+
+    #[test]
+    fn mcp_tool_response_envelope_ok_wire_shape() {
+        let envelope = McpToolResponseEnvelope {
+            conversation_handle: OpaqueConversationHandle::new("conv-abc-123"),
+            result: McpToolResult::Ok {
+                value: json!({ "status": "ok" }),
+            },
+        };
+        let encoded = serde_json::to_value(&envelope).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "conversationHandle": "conv-abc-123",
+                "result": { "kind": "ok", "value": { "status": "ok" } },
+            })
+        );
+        let decoded: McpToolResponseEnvelope =
+            serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, envelope);
+    }
+
+    #[test]
+    fn mcp_tool_response_envelope_error_wire_shape() {
+        let envelope = McpToolResponseEnvelope {
+            conversation_handle: OpaqueConversationHandle::new("conv-abc-123"),
+            result: McpToolResult::Error {
+                error: ToolError::RateLimited {
+                    retry_after_seconds: 30,
+                },
+            },
+        };
+        let encoded = serde_json::to_value(&envelope).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "conversationHandle": "conv-abc-123",
+                "result": {
+                    "kind": "error",
+                    "error": { "kind": "rate_limited", "retryAfterSeconds": 30 },
+                },
+            })
+        );
+    }
+}

--- a/src-tauri/src/services/mcp_v2/gateway.rs
+++ b/src-tauri/src/services/mcp_v2/gateway.rs
@@ -1,0 +1,10 @@
+//! MCP v2 gateway: the single entry point that receives MCP tool calls.
+//!
+//! Validates Actor::McpClient policy against the server-side scope
+//! manifest loaded by auth; dispatches through registered McpToolHandler
+//! implementations; records audit attribution; emits McpToolInvoked
+//! signals — signal type registration happens in signals/policy_registry.rs
+//! when the first handler lands.
+//!
+//! Implementation pending — see ADR-0102 amendment §C for the contract
+//! and ADR-0128 for the product-surface frame.

--- a/src-tauri/src/services/mcp_v2/handlers/mod.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/mod.rs
@@ -1,0 +1,13 @@
+//! Per-tool MCP handler modules. Each handler implements McpToolHandler.
+//! Module names match the canonical scoped names declared in taxonomy.
+
+pub mod tool_briefing;
+pub mod tool_portfolio;
+pub mod tool_pagination;
+pub mod tool_resources;
+pub mod tool_workspace_search;
+pub mod tool_workspace_source_provenance;
+pub mod tool_placement;
+pub mod tool_note;
+pub mod tool_create_action;
+pub mod tool_update_action_status;

--- a/src-tauri/src/services/mcp_v2/handlers/tool_briefing.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_briefing.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_note.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_note.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_pagination.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_pagination.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_placement.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_placement.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_portfolio.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_portfolio.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_resources.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_resources.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_workspace_search.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_workspace_search.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/handlers/tool_workspace_source_provenance.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_workspace_source_provenance.rs
@@ -1,0 +1,1 @@
+//! Placeholder. Handler implementation pending.

--- a/src-tauri/src/services/mcp_v2/mod.rs
+++ b/src-tauri/src/services/mcp_v2/mod.rs
@@ -1,0 +1,29 @@
+//! MCP v2 gateway: headless MCP head over the DailyOS abilities runtime.
+//!
+//! Per ADR-0128 — MCP as co-equal product surface — and the 2026-05-19
+//! amendment to ADR-0102 — Actor::McpClient actor variant + MCP client
+//! authentication + session contract — this module is the single ingress
+//! for MCP-originated invocations. Tool handlers never read the DB directly;
+//! every call flows through the gateway into services::* or the abilities
+//! runtime.
+//!
+//! Submodules:
+//! - contracts — shared wire-shape types — ToolDescription, ScopedName,
+//!   Scope, McpActor, ToolError, Page, OpaqueConversationHandle envelope,
+//!   McpClientId envelope.
+//! - gateway — single entry-point dispatcher; loads scope manifest;
+//!   validates Actor::McpClient policy; emits audit + signals.
+//! - handlers — per-tool handler implementations — placeholder.
+//! - taxonomy — tool catalog and host-selection contract — placeholder.
+//! - actor_policy — scope/permission matrix for Actor::McpClient.
+//! - auth — pairing handshake; server-side scope manifest loading;
+//!   transport HMAC verification; conversation handle minting.
+//! - audit — audit log writer with keyed HMAC parameter/response hashes.
+
+pub mod contracts;
+pub mod gateway;
+pub mod handlers;
+pub mod taxonomy;
+pub mod actor_policy;
+pub mod auth;
+pub mod audit;

--- a/src-tauri/src/services/mcp_v2/taxonomy.rs
+++ b/src-tauri/src/services/mcp_v2/taxonomy.rs
@@ -1,0 +1,5 @@
+//! MCP tool taxonomy + host-selection contract.
+//!
+//! The catalog of tool descriptions — the version-controlled product
+//! copy per ADR-0128 §3 — loads from a YAML file at runtime; this
+//! module defines the load + validation surface. Implementation pending.

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -28,6 +28,7 @@ pub mod intelligence;
 pub mod invalidation_jobs;
 pub mod linear;
 pub mod linear_issue_signals;
+pub mod mcp_v2;
 pub mod meetings;
 pub mod mutations;
 pub mod people;

--- a/src-tauri/src/services/version_dispatcher.rs
+++ b/src-tauri/src/services/version_dispatcher.rs
@@ -285,6 +285,7 @@ fn actor_kind_str(actor: &Actor) -> &'static str {
         Actor::Admin => "admin",
         Actor::System => "system",
         Actor::SurfaceClient { .. } => "surface_client",
+        Actor::McpClient { .. } => "mcp_client",
     }
 }
 

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -1933,7 +1933,11 @@ fn surface_client_can_read_keyring(actor: &Actor) -> bool {
             .iter()
             .any(|scope| scope.as_str().starts_with("read.") || scope.as_str() == "manage.pairing"),
         Actor::Admin | Actor::System => true,
-        Actor::Agent | Actor::User => false,
+        // McpClient invocations never read the SurfaceClient pairing
+        // keyring. The MCP head has its own pairing path (per ADR-0102
+        // §C, 2026-05-19 amendment) — surface keyring access is the
+        // bridge-side concern.
+        Actor::Agent | Actor::User | Actor::McpClient { .. } => false,
     }
 }
 


### PR DESCRIPTION
## Linear ticket

Plan: `tasks/session-3-v1.4.7-w0-mcp-foundation.md` (parallel substrate fan-out off `dev`). Path-α residuals: [DOS-710](https://linear.app/a8c/issue/DOS-710).

## Summary

v1.4.7 W0 (MCP Server v2 foundation). Ships the plan-side + skeleton-side foundation that subsequent waves implement against. Two ADR amendments dated 2026-05-19, the `Actor::McpClient` runtime variant + companion newtypes with match-arm propagation across 13 files, and the full `services/mcp_v2/` skeleton with the wire-shape contract surface and 35 parity tests.

## What changed

- **ADR-0102 §A–§I amendment** — codifies the `Actor::McpClient` actor variant; pins MCP client authentication + session contract (pairing handshake, HMAC-SHA256 transport signing, server-side scope manifest, revocation, per-actor × per-client × per-tool rate limits, audit attribution with keyed HMAC hashes); defines the `OpaqueConversationHandle` lifecycle (24h expiry, transparent first-write mint, no caller-provided IDs); freezes the `dailyos.<verb>.<noun>` scope namespace with the substrate-shipped legacy exception; documents the gateway-mediated scope-enforcement asymmetry vs the bridge-time `SurfaceClient` pattern.
- **ADR-0128 §A–§G amendment** — companion product-surface amendment recording v1.4.7 operationalization: tool description as product copy with eval coverage, cross-conversation continuity wire shape, the W4 submit-class write surface, displacement-use-case framing applied to host-selection eval, Linear citation refresh.
- **Wave plan cycle-6 amendment** — records that W0 absorbs the `services/mcp_v2/` skeleton-creation scope originally assigned to W1-A.
- **`abilities-runtime`** — `Actor::McpClient { client_id, conversation_handle }` runtime variant + `McpClientId` + `OpaqueConversationHandle` newtypes + `ActorKind::McpClient` discriminator + `Actor::kind()` projection + `AbilityActor::project` arm + match propagation across 7 ability synthesis files + `abilities-macro` `ActorArg` parser support. 10 runtime parity tests.
- **`dailyos` lib** — match-arm propagation in `audit_log` (drops WP-paired fields for McpClient), `bridges/types::BridgeActor` (gains McpClient discriminator + provenance + label arms), `bridges/{tauri,mcp}` (service label + test-fixture arms), `services/version_dispatcher::actor_kind_str`, `surface_runtime::surface_client_can_read_keyring` (returns false).
- **`services/mcp_v2/` skeleton** pre-created — `mod.rs` declares all submodules; `gateway.rs` / `auth.rs` / `audit.rs` / `actor_policy.rs` / `taxonomy.rs` + 10 handler placeholders are doc-only.
- **`services/mcp_v2/contracts.rs`** — full wire-shape type surface (`ToolDescription` with `when_NOT_to_call` alias, `Side`, `ScopedName`, `Scope`, `Verb` enum + `CANONICAL_NAMESPACE` const + `compose_*` helpers, `ParamSpec`/`ReturnSpec`/`ToolExample`/`ParamSchema`, `Page<T>` camelCase wire, `McpActor::Client` gateway envelope, `McpToolHandler` trait, `ToolError` tagged enum with first-class `PairingRevoked`/`ConversationRevoked` variants, `McpToolRequestEnvelope`/`McpToolResponseEnvelope`/`McpToolResult` envelopes pinning the ADR §D top-level `conversation_handle` wire shape). 25 wire-shape parity tests.

## Test plan

- [x] `cargo clippy -- -D warnings` clean on lib code I touched (workspace `--lib --features mcp` is clean; pre-existing test-file clippy debt in unrelated `tests/dos567*`, `tests/dos568*`, `db/core.rs`, `intel_queue.rs`, `mcp/main.rs` filed as path-α in [DOS-710](https://linear.app/a8c/issue/DOS-710))
- [x] `cargo test --lib --features mcp` passes (10 new runtime parity tests + 25 new wire-shape parity tests + 350+ existing)
- [x] `pnpm tsc --noEmit` clean
- [x] `git diff --check dev` clean (no trailing whitespace)
- [x] L2 unanimous APPROVE across codex review + correctness-reviewer + architecture-strategist + security-reviewer (CSO) + api-contract-reviewer (devex), bounded by W0 acceptance criteria
- [x] Manual verification: walked through the diff against the brief AC; ADR text and Rust encoding stay in sync; the wire-vs-runtime asymmetry on `Actor::McpClient` is documented in code + tests + ADR §B.

## Definition of Done

- [x] Acceptance criteria from `tasks/session-3-v1.4.7-w0-mcp-foundation.md` validated (ADR amendments landed; `Actor::McpClient` variant + newtypes; match arms propagated; scope namespace encoded as `Verb` enum + const + ADR §E; `services/mcp_v2/` skeleton compiles; golden parity fixtures for `McpActor`, `McpClientId`, `OpaqueConversationHandle`, `Scope`)
- [x] End-to-end: cargo workspace + tests + clippy + tsc clean; CI gates pending merge
- [x] No new stubs / TODOs / Phase-2 deferrals (placeholders in `gateway.rs` / `auth.rs` / `audit.rs` / handler files are intentional W1+ scope per ADR §H non-goals; tracked as the next wave, not deferrals)
- [x] Tests pass

## §4 Security

`security_auditor_invoked: true`

CSO (`compound-engineering:ce-security-reviewer`) was one of the 5 mandatory L2 reviewers for this PR. Verdict: APPROVE — 0 findings, 4 residual risks explicitly deferred to W1-A CSO review (gateway dispatch / `auth.rs` body / `audit.rs` body / pairing-handshake server are all W1-A scope and were intentionally NOT shipped here per ADR §H non-goals).

**Exemption ID** (if invoked = false): _none_ — auditor was invoked

**Exemption rationale**: N/A

Trust-boundary changes in this PR:

- [x] Touches `src-tauri/src/services/` (new `services/mcp_v2/` module + minor `services/version_dispatcher.rs` arm), `abilities/` (new `Actor::McpClient` variant in `abilities-runtime/src/abilities/registry.rs` + match arm propagation across 7 ability files), `bridges/` (new `BridgeActor::McpClient` variant + match arms), `commands/`: no
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`: no (W1+ scope)
- [ ] Touches a claim-substrate table: no
- [ ] Changes a prompt template (`.claude/**`): no
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic: yes — `surface_runtime::surface_client_can_read_keyring` gains an `Actor::McpClient => false` arm; `audit_log::append_with_actor` drops WP-paired fields for McpClient
- [x] Modifies MCP configs, tool registry, or skill definitions: yes — `services/mcp_v2/` introduces the (skeleton) MCP v2 gateway and tool registry surface
- [x] Adds a new trust boundary (auth, scope, sensitivity tier): yes — `Actor::McpClient` is a new first-class actor class; MCP client trust boundary codified in ADR-0102 §C
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity): no — all write code paths are W1-A `gateway.rs` body
- [ ] Adds or modifies `.github/workflows/*`: no
- [ ] Adds a new dependency: no

## Follow-ups

- [DOS-710](https://linear.app/a8c/issue/DOS-710) — v1.4.7 W0 L2 path-α findings: MCP foundation hardening (13 items grouped by reviewer; deferred to W1-A or maintenance per the path-α policy).
- W1-A (DOS-168) — gateway dispatch body, `auth.rs` (pairing handshake + manifest + HMAC transport + handle minting), `audit.rs` (keyed HMAC-SHA256 hashes), `actor_policy.rs` body, `SignalType::McpToolInvoked` registration, migrations v220–v222.
- W1-B (DOS-478) — tool description YAML catalog at `src-tauri/resources/mcp_v2/tool_descriptions.yaml` + `taxonomy.rs` body.
- DOS-624 (coordination) — v1.4.7 W2-A briefing tools require CSO-approved L0 amendment coordinating with v1.4.2 W3-C WP-mediated MCP path. Separate gate at W2 kickoff.

## Notes for review

- This PR is doc + skeleton + type-system foundation only. Implementation bodies are W1+ scope per ADR-0102 §H non-goals. Reviewers should verify the contracts match the ADR text and that match-arm propagation doesn't silently grant McpClient any authority that wasn't explicitly intended.
- The wire-vs-runtime asymmetry on `Actor::McpClient` is intentional and locked by separate parity tests:
  - Runtime `abilities_runtime::Actor::McpClient { client_id, conversation_handle }` — substrate-internal, externally-tagged JSON, no scopes on the variant.
  - Wire `services::mcp_v2::contracts::McpActor::Client { client_id, conversation_handle, tool_name, granted_scopes }` — gateway-resolved envelope, camelCase JSON, includes scopes hydrated server-side from the per-client manifest.
- Per the parallel-session protocol in `tasks/README.md`, Session 2 (`v1.4.4-w1-receipt`) and Session 4 (`v1.4.6-w0-adr-0125`) also edit `src-tauri/src/services/mod.rs`. First merger is conflict-free; subsequent sessions resolve a trivial one-line conflict by rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
