### PR TITLE
feat(theme): chrome lane Tier 1 — tokens + alias layer (DOS-729)

### DIFF
--- a/wp/dailyos/theme/assets/chrome/styles/.synced-from
+++ b/wp/dailyos/theme/assets/chrome/styles/.synced-from
@@ -1,0 +1,7 @@
+# Source-of-truth pin for chrome module lift.
+# Format: <repo-relative path>: <git rev-parse HEAD:path> @ <UTC ISO 8601>
+
+source_root: .docs/design/reference/_shared/styles/
+synced_at: 2026-05-19T23:37:22Z
+
+design-tokens.css: 490230aa8a0b93ba332cb933924081d6c425ff47

--- a/wp/dailyos/theme/assets/chrome/styles/design-tokens.css
+++ b/wp/dailyos/theme/assets/chrome/styles/design-tokens.css
@@ -1,0 +1,298 @@
+/* =============================================================================
+   DESIGN TOKENS — ADR-0076 Brand Identity + ADR-0073 Typography & Spacing
+
+   Single source of truth for all design values across the magazine-layout
+   editorial redesign. Use these CSS custom properties throughout all components.
+   ============================================================================= */
+
+:root {
+  /* ─────────────────────────────────────────────────────────────────────────
+     PAPER PALETTE — Grounds & Backgrounds
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-paper-cream: #f5f2ef;
+  --color-paper-linen: #e8e2d9;
+  --color-paper-warm-white: #faf8f6;
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     DESK PALETTE — Frame & Primary Text
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-desk-charcoal: #1e2530;
+  --color-desk-ink: #2a2b3d;
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     SURFACE ALIASES — Semantic Backgrounds (DOS-62)
+     Ghost tokens consumed by ActionRow/Emails/DatabaseRecovery/ContextSource.
+     Map to paper palette so backgrounds render opaque instead of transparent.
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-surface: var(--color-paper-cream); /* Page ground, base surface */
+  --color-surface-primary: var(--color-paper-warm-white); /* Primary card surface */
+  --color-surface-secondary: var(--color-paper-linen); /* Recessed / secondary panels */
+  --color-surface-inset: var(--color-desk-charcoal-4); /* Inset config panels, subtle recess on cream */
+  --color-surface-subtle: var(--color-black-4); /* Subtle chip/badge tint */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     SPICE PALETTE — Warm Accents (Accounts, Active States, Urgency)
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-spice-turmeric: #c9a227; /* Primary accent, accounts, warm emphasis */
+  --color-spice-saffron: #deb841; /* Secondary warm accent */
+  --color-spice-terracotta: #c4654a; /* Urgency, errors, overdue items */
+  --color-spice-chili: #9b3a2a; /* Deep red, critical states */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     GARDEN PALETTE — Cool Accents (People, Success, Forward-Looking)
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-garden-sage: #7eaa7b; /* Success, healthy, prepped */
+  --color-garden-olive: #6b7c52; /* Projects, muted secondary */
+  --color-garden-rosemary: #4a6741; /* Deep green, success variant */
+  --color-garden-larkspur: #8fa3c4; /* People, calm, expansive, forward-looking */
+  --color-garden-eucalyptus: #6ba8a4; /* User entity (/me), professional context, self-knowledge */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     SEMANTIC TEXT COLORS
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-text-primary: var(--color-desk-charcoal); /* Primary text, headlines */
+  --color-text-secondary: #5a6370; /* Body text, secondary content */
+  --color-text-tertiary: #6b7280; /* Labels, hints, tertiary content (WCAG AA compliant) */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     RULE COLORS — Dividers, Borders, Grid Lines
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-rule-heavy: rgba(30, 37, 48, 0.12); /* Primary dividers, section rules */
+  --color-rule-light: rgba(30, 37, 48, 0.06); /* Secondary dividers, soft separators */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     ENTITY COLOR ALIASES — Semantic layer
+     ADR-0076 entity color semantics. These tokens provide one canonical
+     vocabulary for entity identity.
+
+     Use these when the rendered element represents an entity in context
+     (an account hero, a person card, the user's own surface, etc.).
+     Direct uses of underlying paint tokens (--color-spice-turmeric, etc.)
+     remain valid where the meaning is "the turmeric paint color" rather
+     than "the account entity color" — e.g., warm-emphasis prose styling,
+     prep-state indicators, status warnings.
+
+     Migration of existing direct entity-color references happens gradually
+     as surface specs land.
+     ───────────────────────────────────────────────────────────────────────── */
+  /* Named tokens — use these when the color carries surface semantics
+     (an account hero, a project badge, a person card, the user's /me surface).
+     Use the underlying spice/garden paint tokens only when the color is pure
+     decoration (a turmeric divider that's just nice-looking).
+
+     Renamed from --color-entity-* (2026-05-03): "entity" was internal jargon;
+     surface authors think "account, project, person." `user` → `self` to match
+     the /me surface name. */
+  --color-account: var(--color-spice-turmeric);
+  --color-project: var(--color-garden-olive);
+  --color-person:  var(--color-garden-larkspur);
+  --color-action:  var(--color-spice-terracotta);
+  --color-self:    var(--color-garden-eucalyptus);
+
+  /* Alpha variants for the named tokens — point to the same alpha values as
+     the underlying paint tokens so tints stay in lockstep. */
+  --color-account-4:  var(--color-spice-turmeric-4);
+  --color-account-5:  var(--color-spice-turmeric-5);
+  --color-account-6:  var(--color-spice-turmeric-6);
+  --color-account-7:  var(--color-spice-turmeric-7);
+  --color-account-8:  var(--color-spice-turmeric-8);
+  --color-account-10: var(--color-spice-turmeric-10);
+  --color-account-12: var(--color-spice-turmeric-12);
+  --color-account-15: var(--color-spice-turmeric-15);
+  --color-account-18: var(--color-spice-turmeric-18);
+  --color-account-30: var(--color-spice-turmeric-30);
+  --color-account-60: var(--color-spice-turmeric-60);
+
+  --color-project-6:  var(--color-garden-olive-6);
+  --color-project-8:  var(--color-garden-olive-8);
+  --color-project-10: var(--color-garden-olive-10);
+
+  --color-person-8:  var(--color-garden-larkspur-8);
+  --color-person-10: var(--color-garden-larkspur-10);
+  --color-person-12: var(--color-garden-larkspur-12);
+  --color-person-14: var(--color-garden-larkspur-14);
+  --color-person-15: var(--color-garden-larkspur-15);
+
+  --color-action-8:  var(--color-spice-terracotta-8);
+  --color-action-10: var(--color-spice-terracotta-10);
+  --color-action-12: var(--color-spice-terracotta-12);
+  --color-action-15: var(--color-spice-terracotta-15);
+  --color-action-20: var(--color-spice-terracotta-20);
+
+  --color-self-6:  var(--color-garden-eucalyptus-6);
+  --color-self-10: var(--color-garden-eucalyptus-10);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     TRUST BAND ALIASES — v1.4.0 user-facing trust render bands
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-trust-likely-current: var(--color-garden-sage);
+  --color-trust-use-with-caution: var(--color-spice-saffron);
+  --color-trust-needs-verification: var(--color-spice-terracotta);
+
+  --color-trust-likely-current-8: var(--color-garden-sage-8);
+  --color-trust-likely-current-10: var(--color-garden-sage-10);
+  --color-trust-likely-current-12: var(--color-garden-sage-12);
+  --color-trust-likely-current-15: var(--color-garden-sage-15);
+
+  --color-trust-use-with-caution-8: var(--color-spice-saffron-8);
+  --color-trust-use-with-caution-10: var(--color-spice-saffron-10);
+  --color-trust-use-with-caution-12: var(--color-spice-saffron-12);
+  --color-trust-use-with-caution-15: var(--color-spice-saffron-15);
+
+  --color-trust-needs-verification-8: var(--color-spice-terracotta-8);
+  --color-trust-needs-verification-10: var(--color-spice-terracotta-10);
+  --color-trust-needs-verification-12: var(--color-spice-terracotta-12);
+  --color-trust-needs-verification-15: var(--color-spice-terracotta-15);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     OPACITY VARIANTS — Tinted backgrounds, borders, hover states
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-spice-turmeric-8: rgba(201, 162, 39, 0.08);
+  --color-spice-turmeric-12: rgba(201, 162, 39, 0.12);
+  --color-spice-turmeric-30: rgba(201, 162, 39, 0.30);
+  --color-spice-saffron-8: rgba(222, 184, 65, 0.08);
+  --color-spice-saffron-12: rgba(222, 184, 65, 0.12);
+  --color-spice-terracotta-8: rgba(196, 101, 74, 0.08);
+  --color-spice-terracotta-12: rgba(196, 101, 74, 0.12);
+  --color-garden-sage-12: rgba(126, 170, 123, 0.12);
+  --color-garden-larkspur-8: rgba(143, 163, 196, 0.08);
+  --color-garden-larkspur-12: rgba(143, 163, 196, 0.12);
+  --color-garden-larkspur-15: rgba(143, 163, 196, 0.15);
+  --color-garden-eucalyptus-6: rgba(107, 168, 164, 0.06);
+  --color-garden-eucalyptus-10: rgba(107, 168, 164, 0.10);
+  --color-garden-olive-6: rgba(107, 124, 82, 0.06);
+  --color-garden-olive-8: rgba(107, 124, 82, 0.08);
+  --color-garden-olive-10: rgba(107, 124, 82, 0.10);
+  --color-garden-sage-8: rgba(126, 170, 123, 0.08);
+  --color-garden-sage-10: rgba(126, 170, 123, 0.10);
+  --color-garden-sage-14: rgba(126, 170, 123, 0.14);
+  --color-garden-sage-15: rgba(126, 170, 123, 0.15);
+  --color-garden-sage-20: rgba(126, 170, 123, 0.20);
+  --color-garden-larkspur-10: rgba(143, 163, 196, 0.10);
+  --color-garden-larkspur-14: rgba(143, 163, 196, 0.14);
+  --color-garden-rosemary-12: rgba(74, 103, 65, 0.12);
+  --color-garden-rosemary-14: rgba(74, 103, 65, 0.14);
+  --color-spice-turmeric-4: rgba(201, 162, 39, 0.04);
+  --color-spice-turmeric-5: rgba(201, 162, 39, 0.05);
+  --color-spice-turmeric-6: rgba(201, 162, 39, 0.06);
+  --color-spice-turmeric-7: rgba(201, 162, 39, 0.07);
+  --color-spice-turmeric-10: rgba(201, 162, 39, 0.10);
+  --color-spice-turmeric-15: rgba(201, 162, 39, 0.15);
+  --color-spice-turmeric-18: rgba(201, 162, 39, 0.18);
+  --color-spice-turmeric-60: rgba(201, 162, 39, 0.60);
+  --color-spice-terracotta-10: rgba(196, 101, 74, 0.10);
+  --color-spice-terracotta-15: rgba(196, 101, 74, 0.15);
+  --color-spice-terracotta-20: rgba(196, 101, 74, 0.20);
+  --color-spice-saffron-10: rgba(222, 184, 65, 0.10);
+  --color-spice-saffron-15: rgba(222, 184, 65, 0.15);
+  --color-desk-charcoal-15: rgba(30, 37, 48, 0.015);
+  --color-desk-charcoal-4: rgba(30, 37, 48, 0.04);
+  --color-desk-charcoal-5: rgba(30, 37, 48, 0.05);
+  --color-desk-charcoal-8: rgba(30, 37, 48, 0.08);
+  --color-desk-charcoal-25: rgba(30, 37, 48, 0.25);
+  --color-desk-charcoal-40: rgba(30, 37, 48, 0.40);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     OVERLAY COLORS — Modal backdrops, scrim layers
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-overlay-light: rgba(0, 0, 0, 0.4);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     BLACK OPACITY VARIANTS — Neutral shadows, subtle backgrounds
+     ───────────────────────────────────────────────────────────────────────── */
+  --color-black-2: rgba(0, 0, 0, 0.02);
+  --color-black-3: rgba(0, 0, 0, 0.03);
+  --color-black-4: rgba(0, 0, 0, 0.04);
+  --color-black-8: rgba(0, 0, 0, 0.08);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     TYPOGRAPHY — Font Families (ADR-0073)
+     ───────────────────────────────────────────────────────────────────────── */
+  --font-serif: 'Newsreader', Georgia, serif; /* Display, headlines, narrative */
+  --font-sans: 'DM Sans', -apple-system, sans-serif; /* Body, UI text, labels */
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace; /* Time, dates, code */
+  --font-mark: 'Montserrat', sans-serif; /* Brand mark asterisk (must be 800) */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     SPACING SCALE (ADR-0073) — Base 4px grid
+     ───────────────────────────────────────────────────────────────────────── */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+  --space-3xl: 56px;
+  --space-4xl: 72px;
+  --space-5xl: 80px;
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     LAYOUT — Fixed Dimensions for App Shell
+     ───────────────────────────────────────────────────────────────────────── */
+  --folio-height: 40px; /* FolioBar fixed height */
+  --folio-padding-top: 10px;
+  --folio-padding-bottom: 10px;
+  --folio-padding-left: 80px;
+  --folio-padding-right: 48px;
+  --page-padding-horizontal: 120px; /* Left/right padding for page container */
+  --page-padding-bottom: 160px; /* Bottom padding for page container */
+  --page-margin-top: 40px; /* Clearance for fixed folio bar */
+  --page-max-width: 1180px; /* Maximum content width */
+  --page-content-width-standard: 900px; /* Standard editorial page width */
+  --page-content-width-reading: 760px; /* Narrower prose/report width */
+  --nav-island-right: 28px; /* Distance from right edge */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     BORDER RADIUS
+     ───────────────────────────────────────────────────────────────────────── */
+  --radius-editorial-sm: 4px; /* Search button, small elements */
+  --radius-editorial-md: 10px; /* Nav island items */
+  --radius-editorial-lg: 12px; /* Featured actions box */
+  --radius-editorial-xl: 16px; /* Nav island container */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     SHADOWS
+     ───────────────────────────────────────────────────────────────────────── */
+  --shadow-sm: 0 2px 8px rgba(30, 37, 48, 0.1);
+  --shadow-md: 0 2px 12px rgba(30, 37, 48, 0.06), 0 0 0 1px rgba(30, 37, 48, 0.04);
+  --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-xl: 0 4px 16px rgba(0, 0, 0, 0.12);
+  --shadow-2xl: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --shadow-modal: 0 20px 60px rgba(30, 37, 48, 0.15);
+  --shadow-dropdown: 0 4px 24px rgba(0, 0, 0, 0.08);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     TRANSITIONS & ANIMATIONS
+     ───────────────────────────────────────────────────────────────────────── */
+  --transition-fast: 0.12s ease;
+  --transition-normal: 0.15s ease;
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     BACKDROP & GLASS EFFECTS (macOS Native)
+     ───────────────────────────────────────────────────────────────────────── */
+  --backdrop-blur: blur(12px);
+  --frosted-glass-background: rgba(245, 242, 239, 0.85); /* Folio bar background */
+  --frosted-glass-nav: rgba(250, 248, 246, 0.8); /* Nav island background */
+
+  /* ─────────────────────────────────────────────────────────────────────────
+     Z-INDEX STACK
+     ───────────────────────────────────────────────────────────────────────── */
+  --z-atmosphere: 0; /* Background layer */
+  --z-page-content: 1; /* Main content, above atmosphere */
+  --z-app-shell: 100; /* Folio bar, nav island, top-level UI */
+  --z-lock: 1000; /* App lock overlay — above everything */
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   KEYFRAME ANIMATIONS
+   (Global reset lives in index.css via Tailwind — not here)
+   ───────────────────────────────────────────────────────────────────────── */
+@keyframes atmosphere-breathe {
+  0% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/wp/dailyos/theme/assets/chrome/styles/token-aliases.css
+++ b/wp/dailyos/theme/assets/chrome/styles/token-aliases.css
@@ -1,0 +1,124 @@
+/* =============================================================================
+   DailyOS chrome token aliases — Option C bridge layer
+   -----------------------------------------------------------------------------
+   Chrome CSS modules (FolioBar / FloatingNavIsland / AtmosphereLayer /
+   MagazinePageLayout / Pill) consume raw `--color-*`, `--folio-*`, `--space-*`
+   etc. design-token names. theme.json emits the same values as
+   `--wp--preset--*` and `--wp--custom--dailyos--tokens--*`. This file bridges
+   the two so the modules render correctly under WP cascade.
+
+   Cascade contract:
+     baseline-tokens.css (plugin, priority 9)
+        → design-tokens.css (raw values as fallback)
+        → token-aliases.css (THIS FILE — bridges raw → WP preset/custom)
+        → chrome modules
+   Aliases live in `:root` last-declaration-wins; enqueue order enforced via
+   `wp_enqueue_style` dependency graph in functions.php (AC #15).
+
+   Per L0 Packet W3 §5.1 + AC #2 + AC #3 + AC #30. Names extracted via
+   `grep -hoE 'var\(--[A-Za-z0-9_-]+(,[^)]+)?\)' <chrome modules>` and
+   classified as alias-required (cross-module) vs module-local (skipped here).
+   ============================================================================= */
+
+:root {
+	/* ─────────────────────────────────────────────────────────────────────
+	   COLOR TOKENS — bridge to --wp--preset--color--*
+	   ───────────────────────────────────────────────────────────────────── */
+
+	/* Paper neutrals */
+	--color-paper-cream: var(--wp--preset--color--paper-cream);
+	--color-paper-warm-white: var(--wp--preset--color--paper-warm-white);
+
+	/* Desk inks */
+	--color-desk-charcoal-4: var(--wp--preset--color--desk-charcoal-4);
+	--color-desk-charcoal-8: var(--wp--preset--color--desk-charcoal-8);
+	--color-desk-charcoal-25: var(--wp--preset--color--desk-charcoal-25);
+
+	/* Rule lines */
+	--color-rule-heavy: var(--wp--preset--color--rule-heavy);
+	--color-rule-light: var(--wp--preset--color--rule-light);
+
+	/* Text inks */
+	--color-text-primary: var(--wp--preset--color--text-primary);
+	--color-text-secondary: var(--wp--preset--color--text-secondary);
+	--color-text-tertiary: var(--wp--preset--color--text-tertiary);
+
+	/* Spice palette */
+	--color-spice-chili: var(--wp--preset--color--spice-chili);
+	--color-spice-saffron: var(--wp--preset--color--spice-saffron);
+	--color-spice-terracotta: var(--wp--preset--color--spice-terracotta);
+	--color-spice-terracotta-10: var(--wp--preset--color--spice-terracotta-10);
+	--color-spice-terracotta-15: var(--wp--preset--color--spice-terracotta-15);
+	--color-spice-turmeric: var(--wp--preset--color--spice-turmeric);
+	--color-spice-turmeric-10: var(--wp--preset--color--spice-turmeric-10);
+	--color-spice-turmeric-15: var(--wp--preset--color--spice-turmeric-15);
+
+	/* Garden palette */
+	--color-garden-eucalyptus: var(--wp--preset--color--garden-eucalyptus);
+	--color-garden-eucalyptus-10: var(--wp--preset--color--garden-eucalyptus-10);
+	--color-garden-larkspur: var(--wp--preset--color--garden-larkspur);
+	--color-garden-larkspur-10: var(--wp--preset--color--garden-larkspur-10);
+	--color-garden-larkspur-15: var(--wp--preset--color--garden-larkspur-15);
+	--color-garden-olive: var(--wp--preset--color--garden-olive);
+	--color-garden-olive-10: var(--wp--preset--color--garden-olive-10);
+	--color-garden-rosemary: var(--wp--preset--color--garden-rosemary);
+	--color-garden-sage: var(--wp--preset--color--garden-sage);
+	--color-garden-sage-15: var(--wp--preset--color--garden-sage-15);
+
+	/* AC #30 V1.3 special case: --color-alert-red maps to spice-chili
+	   (alert-red is NOT in design-tokens.css; chili is the semantic
+	   substitute. Canonical fallback `#dc2626` in module CSS is a
+	   non-load-bearing safety net for stock-theme contexts.) */
+	--color-alert-red: var(--wp--preset--color--spice-chili);
+
+	/* ─────────────────────────────────────────────────────────────────────
+	   SPACING — bridge to --wp--preset--spacing--*
+	   ───────────────────────────────────────────────────────────────────── */
+	--space-lg: var(--wp--preset--spacing--lg);
+
+	/* ─────────────────────────────────────────────────────────────────────
+	   CUSTOM DAILYOS TOKENS — bridge to --wp--custom--dailyos--tokens--*
+	   ───────────────────────────────────────────────────────────────────── */
+
+	/* Typography */
+	--font-sans: var(--wp--custom--dailyos--tokens--font-sans);
+	--font-mono: var(--wp--custom--dailyos--tokens--font-mono);
+
+	/* Folio bar geometry */
+	--folio-height: var(--wp--custom--dailyos--tokens--folio-height);
+	--folio-padding-top: var(--wp--custom--dailyos--tokens--folio-padding-top);
+	--folio-padding-right: var(--wp--custom--dailyos--tokens--folio-padding-right);
+	--folio-padding-bottom: var(--wp--custom--dailyos--tokens--folio-padding-bottom);
+	--folio-padding-left: var(--wp--custom--dailyos--tokens--folio-padding-left);
+
+	/* Floating nav island geometry */
+	--nav-island-right: var(--wp--custom--dailyos--tokens--nav-island-right);
+
+	/* Page layout geometry */
+	--page-margin-top: var(--wp--custom--dailyos--tokens--page-margin-top);
+	--page-max-width: var(--wp--custom--dailyos--tokens--page-max-width);
+	--page-padding-bottom: var(--wp--custom--dailyos--tokens--page-padding-bottom);
+	--page-padding-horizontal: var(--wp--custom--dailyos--tokens--page-padding-horizontal);
+
+	/* Editorial radii */
+	--radius-editorial-sm: var(--wp--custom--dailyos--tokens--radius-editorial-sm);
+	--radius-editorial-md: var(--wp--custom--dailyos--tokens--radius-editorial-md);
+	--radius-editorial-xl: var(--wp--custom--dailyos--tokens--radius-editorial-xl);
+
+	/* Editorial shadows */
+	--shadow-sm: var(--wp--custom--dailyos--tokens--shadow-sm);
+	--shadow-md: var(--wp--custom--dailyos--tokens--shadow-md);
+
+	/* Transitions */
+	--transition-normal: var(--wp--custom--dailyos--tokens--transition-normal);
+
+	/* Backdrop + frosted glass */
+	--backdrop-blur: var(--wp--custom--dailyos--tokens--backdrop-blur);
+	--frosted-glass-background: var(--wp--custom--dailyos--tokens--frosted-glass-background);
+	--frosted-glass-nav: var(--wp--custom--dailyos--tokens--frosted-glass-nav);
+
+	/* Z-index ladder */
+	--z-app-shell: var(--wp--custom--dailyos--tokens--z-app-shell);
+	--z-atmosphere: var(--wp--custom--dailyos--tokens--z-atmosphere);
+	--z-page-content: var(--wp--custom--dailyos--tokens--z-page-content);
+}


### PR DESCRIPTION
## Linear ticket

[DOS-729](https://linear.app/a8c/issue/DOS-729) — Chrome lane Tier 1 (pulled forward from v1.4.4 W3 to parallel v1.4.3 W4)

## Summary

Lifts the canonical `design-tokens.css` into the theme + adds an Option C `token-aliases.css` bridge so chrome CSS modules can consume raw `--color-*`, `--folio-*`, `--space-*` names that resolve to `--wp--preset--*` / `--wp--custom--dailyos--tokens--*` under WP cascade.

## What changed

- `wp/dailyos/theme/assets/chrome/styles/design-tokens.css` — synced verbatim from `.docs/design/reference/_shared/styles/design-tokens.css` (sha `490230aa`)
- `wp/dailyos/theme/assets/chrome/styles/token-aliases.css` — 124 LOC, **54 alias declarations** covering every non-module-local `var(--*)` consumed by the 5 chrome modules
- `wp/dailyos/theme/assets/chrome/styles/.synced-from` — source/sha/timestamp pin

## L2 self-review (codex CLI hit OAuth glitch — verified manually against bounded ACs)

- **AC #1 byte-equivalence**: `diff` against canonical empty ✓
- **AC #2 alias coverage**: 54/54 alias-required refs declared (verified via `grep -hoE 'var\(--[A-Za-z0-9_-]+'` extraction across all 5 modules; 5 module-local names `--pill-*`/`--local-pill-top` correctly skipped)
- **AC #3 RHS validity**: every alias RHS verified to exist in `wp/dailyos/theme/theme.json` palette or `settings.custom.dailyos.tokens` (28 colors → `--wp--preset--color--*`, 24 custom tokens → `--wp--custom--dailyos--tokens--*`, 1 spacing → `--wp--preset--spacing--lg`, 1 special: `--color-alert-red` → `--wp--preset--color--spice-chili` per V1.3 mapping fix)
- **AC #30 alias-discipline**: `--color-alert-red` correctly mapped to `spice-chili`

## Test plan

- [x] L2-status declared `passed`
- [x] Pre-commit gate clean (no PII, blocklist clean; tsc N/A — pure CSS)
- [x] Manual: alias coverage verified via grep extraction
- [x] Manual: every RHS verified against theme.json palette + custom tokens

## Definition of Done

- [x] Acceptance criteria validated
- [x] End-to-end flow: aliases consume canonical theme.json output; chrome modules will resolve under WP cascade once functions.php (W3-4) wires enqueue
- [x] No stubs/TODOs/deferrals
- [x] Tests pass

## §4 Security

\`security_auditor_invoked: false\`

**Exemption ID**: \`EXEMPT-STYLE\`

**Exemption rationale**: Pure presentation-layer additions to the WP theme. New CSS files only. No code, no migrations, no claim substrate, no prompt templates, no trust boundary, no MCP/skill config, no deps.

- [ ] Touches src-tauri/, abilities/, bridges/, commands/, intelligence/?
- [ ] Modifies migrations?
- [ ] Touches claim-substrate table?
- [ ] Changes prompt template (.claude/, prompts/)?
- [ ] Modifies sensitivity/rendering/allowlist/actor-filter logic?
- [ ] Modifies MCP/tool registry/skill definitions?
- [ ] Adds new trust boundary?
- [ ] Defines privileged action?
- [ ] Adds/modifies .github/workflows/* with egress/secret/merge authority?
- [ ] Adds new dependency?

All no.

## Follow-ups

DOS-730 (W3-2 modules+fonts), DOS-731 (W3-3 chrome.js+sync), DOS-732 (W3-4 functions.php+templates) ship sibling slices of the chrome lane.

## Notes for review

Gated on DOS-721 (already merged dev \`b9bb252d\`). Sibling PRs land in parallel: DOS-730 (modules+fonts), DOS-731 (chrome.js+sync). W3-4 functions.php enqueue lands last (depends on all three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)