### PR TITLE
feat(theme): document Pill primitive duality + collision gate (DOS-722)

### DIFF
--- a/.docs/decisions/0132-pill-primitive-dual-existence.md
+++ b/.docs/decisions/0132-pill-primitive-dual-existence.md
@@ -1,0 +1,68 @@
+# ADR 0132 — Pill primitive dual-existence (chrome + block)
+
+**Status**: Accepted
+**Date**: 2026-05-19
+**Decision drivers**: v1.4.4 W3 chrome lane (DOS-722)
+
+## Context
+
+After the v1.4.4 W3 chrome lane lands, the `Pill` primitive exists in two places in the WordPress layer:
+
+- **Chrome version** at `wp/dailyos/theme/assets/chrome/styles/Pill.module.css` (selectors `.Pill_pill`, `.Pill_pillDot`, etc.). Runtime-injected via `chrome.js` as a child primitive inside FloatingNavIsland tooltips, FolioBar status indicators, AtmosphereLayer watermark labels. Chrome consumers cannot use Gutenberg block markup because chrome injects after WP renders the page.
+- **Block version** at `wp/dailyos/blocks/pill/` (selectors `.dailyos-pill`, `.dailyos-pill__dot`, etc.). Ships with `block.json`, `render.php`, `edit.js`. Authorable via Site Editor — users can drop a Pill into post/page body content.
+
+Same conceptual primitive, two universes. Selector prefixes differ (`.Pill_*` vs `.dailyos-pill*`), so there is no CSS collision today. But without an explicit invariant, the next primitive that goes dual (Pill, Badge, Chip…) drifts in the same direction with no signal to anyone.
+
+## Decision
+
+**Accept Pill's dual existence as a documented pattern.** Do not consolidate.
+
+Pill is special because it serves two genuinely different roles:
+
+- **As a content-authoring primitive** — users want to drop Pills into body content via Site Editor. Block path is the right fit.
+- **As a chrome-internal primitive** — chrome.js needs to render Pills client-side inside DOM it has already injected (status dots, watermark labels, etc.). Block markup cannot survive that path; CSS-class instantiation is the only option.
+
+The cost of forcing a single source-of-truth here is much higher than the cost of maintaining duality:
+
+- **Option A** (block-only): chrome.js would have to construct Gutenberg block markup at runtime, which is novel and fragile, and it cancels the chrome.js architecture's main advantage (sync from canonical Tauri reference).
+- **Option B** (chrome-only): drops Site Editor authoring of Pills entirely, contradicting [`project_wp_block_custom_vs_core_strategy`](../../tools/dailyos-mcp/note) (many small blocks → editable content).
+
+Both A and B trade a small ongoing maintenance cost (keeping two Pill CSS files token-aligned) for a much larger structural cost. Option C trades nothing.
+
+## Invariant
+
+Pill is the only primitive permitted to live in both `wp/dailyos/theme/assets/chrome/styles/` AND `wp/dailyos/blocks/`. New primitives must pick one universe.
+
+This is enforced by `wp/dailyos/scripts/check-chrome-block-collision.sh` (the allowlist gate). The script fails if any primitive name other than `pill` appears in both directories. The allowlist starts at `pill` only and is amended only by a follow-on ADR.
+
+## Consequences
+
+**Positive:**
+
+- Chrome.js stays canonical-synced; no special-cased block construction at runtime.
+- Site Editor authoring of Pills works unchanged.
+- Future primitives get a clear, automated signal when they try to go dual: pick one universe or write an ADR.
+
+**Negative:**
+
+- Two CSS files must stay token-aligned for the Pill. Both consume the same `--color-spice-*`, `--color-garden-*` palette tokens via `var(--*)` references, so theme.json updates flow into both without code edits — but new Pill states (e.g., a `disabled` variant) have to land in both files.
+- L0 reviewers must check that any new primitive proposal explicitly states which universe it belongs to.
+
+## Allowlist gate operational notes
+
+`wp/dailyos/scripts/check-chrome-block-collision.sh`:
+
+- Scans `wp/dailyos/theme/assets/chrome/styles/` for module CSS files.
+- Scans `wp/dailyos/blocks/` for block directories.
+- Lowercases module basenames (`Pill.module.css` → `pill`) and compares against block directory names.
+- Exits 0 if every collision is on the allowlist (`pill`).
+- Exits 1 with a per-collision diagnostic otherwise.
+
+The script ships in this same PR. Wire it into CI alongside the existing `wp/dailyos/scripts/run-grep-gates.sh` invocations (one-line addition to the existing lint job).
+
+## References
+
+- L0 packet `.docs/plans/v1.4.4-wp-surface-migration/L0-packet-W3-chrome-lane-pulled-forward.md` V1.3 §5.2 AC #6 + §10 invariants + AC #28
+- Linear DOS-722 (this ticket)
+- Memory: many-small-blocks strategy
+- [ADR 0130](0130-surface-independent-composition-contract.md) — surface-independent composition contract

--- a/.github/workflows/wp-plugin.yml
+++ b/.github/workflows/wp-plugin.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Grep gates (secret-persistence + L0 invariants)
         run: bash scripts/run-grep-gates.sh
 
+      - name: Chrome/block collision gate (ADR 0132 — Pill duality invariant)
+        run: bash scripts/check-chrome-block-collision.sh
+
   phpunit:
     name: PHPUnit (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest

--- a/wp/dailyos/scripts/check-chrome-block-collision.sh
+++ b/wp/dailyos/scripts/check-chrome-block-collision.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check-chrome-block-collision.sh — enforce the Pill duality invariant from ADR 0132.
+#
+# A primitive may live in EITHER the chrome layer (runtime-injected via
+# chrome.js, CSS at wp/dailyos/theme/assets/chrome/styles/<Name>.module.css)
+# OR the block layer (Gutenberg block at wp/dailyos/blocks/<name>/), but
+# not both — with the explicit allowlist below as the only exception.
+#
+# Pill is grandfathered because it serves two genuinely different roles
+# (content-authoring primitive + chrome-internal primitive). Future
+# dual-existence requests must amend the allowlist via a follow-on ADR.
+#
+# Exits 0 when every collision is on the allowlist; exits 1 with a
+# per-collision diagnostic otherwise.
+#
+# Anchored in:
+#   - ADR 0132 (Pill primitive dual-existence)
+#   - L0 packet v1.4.4-wp-surface-migration §5.2 AC #6 + §10 invariants + AC #28
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CHROME_STYLES="$REPO_ROOT/wp/dailyos/theme/assets/chrome/styles"
+BLOCKS_DIR="$REPO_ROOT/wp/dailyos/blocks"
+
+# Allowlist — keep in sync with ADR 0132. Lowercase primitive names only.
+ALLOWLIST=(
+  "pill"
+)
+
+is_allowed() {
+  local name="$1"
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$name" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ ! -d "$CHROME_STYLES" ]]; then
+  echo "chrome-block collision check skipped: $CHROME_STYLES not found"
+  exit 0
+fi
+
+if [[ ! -d "$BLOCKS_DIR" ]]; then
+  echo "chrome-block collision check skipped: $BLOCKS_DIR not found"
+  exit 0
+fi
+
+violations=0
+
+for chrome_module in "$CHROME_STYLES"/*.module.css; do
+  [[ -e "$chrome_module" ]] || continue
+  module_name="$(basename "$chrome_module" .module.css)"
+  primitive="$(echo "$module_name" | tr '[:upper:]' '[:lower:]')"
+  block_dir="$BLOCKS_DIR/$primitive"
+  if [[ -d "$block_dir" ]]; then
+    if is_allowed "$primitive"; then
+      continue
+    fi
+    echo "chrome-block collision: $primitive exists in BOTH" >&2
+    echo "  chrome CSS:  ${chrome_module#$REPO_ROOT/}" >&2
+    echo "  block dir:   ${block_dir#$REPO_ROOT/}" >&2
+    echo "  Resolve by removing one side, or amend ADR 0132 + the ALLOWLIST in this script." >&2
+    violations=$((violations + 1))
+  fi
+done
+
+if (( violations > 0 )); then
+  echo "" >&2
+  echo "chrome-block collision check FAILED: $violations primitive(s) violate the dual-existence invariant." >&2
+  exit 1
+fi
+
+echo "chrome-block collision check passed (allowlist: ${ALLOWLIST[*]})"


### PR DESCRIPTION
## Linear ticket

[DOS-722](https://linear.app/a8c/issue/DOS-722) — Reconcile Pill primitive dual-existence (chrome `.Pill_*` vs block `.dailyos-pill*`)

## Summary

Accepts Pill's dual existence as documented (Option C per the ticket recommendation) and adds a CI gate so future primitives can't silently drift into the same dual-existence shape. Pill earns its duality because it serves two genuinely different roles; future primitives must pick one universe or amend the allowlist via a follow-on ADR.

## What changed

- **`.docs/decisions/0132-pill-primitive-dual-existence.md`** (new ADR) — records why Pill lives in both `wp/dailyos/theme/assets/chrome/styles/Pill.module.css` (chrome-internal primitive, runtime-injected via chrome.js) AND `wp/dailyos/blocks/pill/` (content-authoring Gutenberg block). Examines Options A (consolidate to block; novel runtime construction), B (consolidate to chrome; drops Site Editor authoring), and C (accept duality + lint gate). Picks C.
- **`wp/dailyos/scripts/check-chrome-block-collision.sh`** — new lint gate. Scans `wp/dailyos/theme/assets/chrome/styles/*.module.css` and `wp/dailyos/blocks/*/`. For any primitive that appears in both, exits 1 unless the lowercase primitive name is on the in-script `ALLOWLIST`. Currently allowlist = `pill` only.
- **`.github/workflows/wp-plugin.yml`** — wires the new gate into the existing `Lint, static analysis, audit, grep-gates` job, immediately after `run-grep-gates.sh`.

## L2 self-review

- Gate runs clean locally: `chrome-block collision check passed (allowlist: pill)`
- ADR follows the existing `.docs/decisions/` template (Context / Decision / Consequences / References)
- No PII; no claim-substrate or trust-boundary touches; pure architectural invariant + CI gate

## Test plan

- [x] L2-status declared `passed`
- [x] Pre-commit gate clean
- [x] Manual: `bash wp/dailyos/scripts/check-chrome-block-collision.sh` passes
- [x] Manual: gate would fail if I added e.g. `wp/dailyos/theme/assets/chrome/styles/Badge.module.css` while `wp/dailyos/blocks/badge/` exists (tested by mock — error message names the primitive + both paths + remediation)

## Definition of Done

- [x] Acceptance criteria validated (ADR documented; allowlist gate grandfathers Pill)
- [x] End-to-end flow: CI gate fires on PR, fails closed for unauthorized dual-existence
- [x] No stubs/TODOs/deferrals
- [x] Tests pass

## §4 Security

\`security_auditor_invoked: true\`

**Exemption ID** (if false): n/a

**Rationale**: Auditor invoked because `.github/workflows/wp-plugin.yml` is on the security-trigger path list. The actual change is a one-line addition of a non-destructive bash gate that scans local repo files (no network egress, no secret access, no merge/publish authority, no privileged action). Path-prefix detection per Amendment 3 — true declared as required.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`? — No
- [x] Modifies `.sql` migrations? — No
- [x] Touches a claim-substrate table? — No
- [x] Changes a prompt template? — No
- [x] Modifies sensitivity/rendering/allowlist/actor-filter logic? — The "allowlist" here is a CI-gate primitive-name list, not a sensitivity/rendering/actor allowlist
- [x] Modifies MCP/tool registry/skill definitions? — No
- [x] Adds new trust boundary? — No (the gate enforces an architectural invariant, not a security boundary)
- [x] Defines privileged action? — No
- [x] Adds/modifies `.github/workflows/*` — Yes (one-line CI step addition)
- [x] Adds new dependency? — No

## Follow-ups

None — closes DOS-722.

## Notes for review

Per the ticket: "Recommend Option C unless reconciliation work pays for itself in shipped value." Option C is the cheapest path that prevents drift. Future primitives proposed for dual-existence must amend `ALLOWLIST` in the script AND ship a follow-on ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)