### PR TITLE
feat(theme): FinisMarker footer + MagazinePageLayout wraps + briefing chrome + DayStrip

### DIFF
--- a/wp/dailyos/scripts/generate-theme-json.mjs
+++ b/wp/dailyos/scripts/generate-theme-json.mjs
@@ -153,6 +153,37 @@ function buildThemeJson({ palette, spacing, custom, blockOverrides = {} }) {
 				units: ['px', 'rem', 'em', '%'],
 				padding: true,
 			},
+			// Typography font families — register the 4 DailyOS families with
+			// the editor + emit `--wp--preset--font-family--*` for use in
+			// theme.json `styles` blocks below. Slugs match the canonical
+			// `--font-{sans,serif,mono,mark}` token names so the values flow
+			// from src/styles/design-tokens.css via the generator's custom map.
+			// Per .docs/design/tokens/typography.md (ADR-0073): serif = display,
+			// sans = body/UI, mono = timestamps/eyebrow/code, mark = brand only.
+			typography: {
+				fontFamilies: [
+					{
+						slug: 'sans',
+						name: 'DM Sans (body / UI)',
+						fontFamily: "'DM Sans', -apple-system, sans-serif",
+					},
+					{
+						slug: 'serif',
+						name: 'Newsreader (display / headlines)',
+						fontFamily: "'Newsreader', Georgia, serif",
+					},
+					{
+						slug: 'mono',
+						name: 'JetBrains Mono (time / eyebrow / code)',
+						fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+					},
+					{
+						slug: 'mark',
+						name: 'Montserrat (brand mark only)',
+						fontFamily: "'Montserrat', sans-serif",
+					},
+				],
+			},
 			// Layout — contentSize / wideSize source the canonical page-width
 			// tokens so post-content groups (default `layout: constrained`)
 			// inherit the magazine page width, not stretch edge-to-edge.
@@ -178,6 +209,59 @@ function buildThemeJson({ palette, spacing, custom, blockOverrides = {} }) {
 			{ name: 'day-strip', area: 'uncategorized', title: 'DayStrip — Briefing day navigation' },
 		],
 		styles: {
+			// Body default — DM Sans per ADR-0073 typography contract.
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--sans)',
+			},
+			// Heading defaults — Newsreader serif, weight 400 (mid of the
+			// 300-500 spec range). Per .docs/design/tokens/typography.md:
+			// "Display — serif, font-size 26-76px, font-weight 300-500".
+			// The default WP rendering inherits bold from <h1>...<h6>; this
+			// explicitly resets weight to the editorial range so headings
+			// don't read as too heavy.
+			elements: {
+				heading: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--serif)',
+						fontWeight: '400',
+						lineHeight: '1.15',
+						letterSpacing: '-0.01em',
+					},
+				},
+				h1: {
+					typography: {
+						fontSize: '40px',
+						fontWeight: '400',
+						lineHeight: '1.06',
+					},
+				},
+				h2: {
+					typography: {
+						fontSize: '32px',
+						fontWeight: '400',
+					},
+				},
+				h3: {
+					typography: {
+						fontSize: '24px',
+						fontWeight: '500',
+					},
+				},
+			},
+			blocks: {
+				// Code / preformatted blocks use the mono family per ADR-0073.
+				'core/code': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--mono)',
+						fontSize: '13px',
+					},
+				},
+				'core/preformatted': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--mono)',
+					},
+				},
+			},
 			// Global spacing.padding wires the WP top-level container to the
 			// canonical magazine page-padding tokens so content gets the
 			// editorial gutter rather than going edge-to-edge. References
@@ -192,7 +276,6 @@ function buildThemeJson({ palette, spacing, custom, blockOverrides = {} }) {
 					left: 'var(--wp--custom--dailyos--tokens--page-padding-horizontal)',
 				},
 			},
-			blocks: blockOverrides,
 		},
 	};
 }

--- a/wp/dailyos/scripts/generate-theme-json.mjs
+++ b/wp/dailyos/scripts/generate-theme-json.mjs
@@ -175,6 +175,7 @@ function buildThemeJson({ palette, spacing, custom, blockOverrides = {} }) {
 			{ name: 'header', area: 'header', title: 'Header' },
 			{ name: 'footer', area: 'footer', title: 'Footer' },
 			{ name: 'sidebar-account-summary', area: 'uncategorized', title: 'Sidebar — Account Summary' },
+			{ name: 'day-strip', area: 'uncategorized', title: 'DayStrip — Briefing day navigation' },
 		],
 		styles: {
 			// Global spacing.padding wires the WP top-level container to the

--- a/wp/dailyos/tests/theme/EditorialShellPresenceTest.php
+++ b/wp/dailyos/tests/theme/EditorialShellPresenceTest.php
@@ -89,16 +89,29 @@ final class DailyOS_EditorialShellPresenceTest extends TestCase {
 	public function test_front_page_includes_editorial_shell_classes(): void {
 		$composed = $this->compose_surface( 'front-page.html' );
 
+		// FolioBar mount header (canonical class is `dailyos-folio-bar-mount` post chrome lane W3-4;
+		// `dailyos-folio-bar` matches as a prefix substring).
 		$this->assertStringContainsString( 'dailyos-folio-bar', $composed, 'Missing dailyos-folio-bar header shell.' );
-		$this->assertStringContainsString( 'dailyos-atmosphere', $composed, 'Missing dailyos-atmosphere body wrapper.' );
-		$this->assertStringContainsString( 'dailyos-magazine-page', $composed, 'Missing dailyos-magazine-page layout class.' );
+		// Canonical MagazinePageLayout classes (lifted from .docs/design/reference/_shared/styles/
+		// per the chrome lane). Previously these were parallel WP-side `dailyos-atmosphere` /
+		// `dailyos-magazine-page` kebab names that didn't match any canonical CSS — the post-merge
+		// chrome refinement PR aligned the WP templates to the canonical names so the lifted
+		// MagazinePageLayout.module.css actually reaches the WP DOM.
+		$this->assertStringContainsString( 'MagazinePageLayout_magazinePage', $composed, 'Missing MagazinePageLayout_magazinePage root container.' );
+		$this->assertStringContainsString( 'MagazinePageLayout_pageContainer', $composed, 'Missing MagazinePageLayout_pageContainer content wrap.' );
+		// account-overview-page pattern still uses dailyos-end-mark + literal `* * *` as an
+		// in-pattern section separator (separate concern from the end-of-page FinisMarker
+		// rendered by the footer template part).
 		$this->assertStringContainsString( 'dailyos-end-mark', $composed, 'Missing dailyos-end-mark separator.' );
 		$this->assertStringContainsString( '* * *', $composed, 'Missing literal end-mark glyph.' );
+		// End-of-page FinisMarker is rendered by the footer template part; assert the canonical
+		// FinisMarker root class (pattern spec at .docs/design/patterns/FinisMarker.md).
+		$this->assertStringContainsString( 'FinisMarker_root', $composed, 'Missing FinisMarker_root end-of-page finis.' );
 	}
 
 	/**
-	 * Single-account template composes the folio bar + atmosphere +
-	 * magazine page + end-mark AND mounts the account summary sidebar.
+	 * Single-account template composes the folio bar + magazine page wraps
+	 * + footer FinisMarker AND mounts the account summary sidebar.
 	 *
 	 * @return void
 	 */
@@ -107,8 +120,9 @@ final class DailyOS_EditorialShellPresenceTest extends TestCase {
 		$composed = $this->compose_surface( 'single-dailyos_account.html' );
 
 		$this->assertStringContainsString( 'dailyos-folio-bar', $composed, 'Missing dailyos-folio-bar header shell.' );
-		$this->assertStringContainsString( 'dailyos-atmosphere', $composed, 'Missing dailyos-atmosphere body wrapper.' );
-		$this->assertStringContainsString( 'dailyos-magazine-page', $composed, 'Missing dailyos-magazine-page layout class.' );
+		$this->assertStringContainsString( 'MagazinePageLayout_magazinePage', $composed, 'Missing MagazinePageLayout_magazinePage root container.' );
+		$this->assertStringContainsString( 'MagazinePageLayout_pageContainer', $composed, 'Missing MagazinePageLayout_pageContainer content wrap.' );
+		$this->assertStringContainsString( 'FinisMarker_root', $composed, 'Missing FinisMarker_root end-of-page finis.' );
 		$this->assertStringContainsString( 'dailyos-end-mark', $composed, 'Missing dailyos-end-mark separator.' );
 		$this->assertStringContainsString(
 			'template-part {"slug":"sidebar-account-summary"}',

--- a/wp/dailyos/tests/theme/ThemeJsonRoundTripTest.php
+++ b/wp/dailyos/tests/theme/ThemeJsonRoundTripTest.php
@@ -66,19 +66,21 @@ final class DailyOS_ThemeJsonRoundTripTest extends TestCase {
 		$this->assertIsArray( $decoded['customTemplates'] );
 		$this->assertSame( [], $decoded['customTemplates'] );
 
-		// templateParts: 3 entries matching W3 parts/.
+		// templateParts: 4 entries — header, footer, sidebar-account-summary (W3)
+		// + day-strip (chrome refinement: briefing surfaces register a secondary
+		// chrome bar as a template part per single-dailyos_briefing.html).
 		$this->assertArrayHasKey( 'templateParts', $decoded );
 		$this->assertIsArray( $decoded['templateParts'] );
-		$this->assertCount( 3, $decoded['templateParts'] );
+		$this->assertCount( 4, $decoded['templateParts'] );
 
 		$names = array_map(
 			static fn ( array $part ): string => (string) ( $part['name'] ?? '' ),
 			$decoded['templateParts']
 		);
 		$this->assertSame(
-			[ 'header', 'footer', 'sidebar-account-summary' ],
+			[ 'header', 'footer', 'sidebar-account-summary', 'day-strip' ],
 			$names,
-			'templateParts must declare header, footer, sidebar-account-summary in that order.'
+			'templateParts must declare header, footer, sidebar-account-summary, day-strip in that order.'
 		);
 
 		// styles.blocks: present (empty in W3; W4 will populate).

--- a/wp/dailyos/theme/assets/chrome/wp-overlay-day-strip.css
+++ b/wp/dailyos/theme/assets/chrome/wp-overlay-day-strip.css
@@ -1,0 +1,35 @@
+/* =============================================================================
+   WP-only chrome overlay: DayStrip-aware pageContainer offset
+   -----------------------------------------------------------------------------
+   The canonical DayStrip pattern sits fixed below the FolioBar at
+   `top: var(--folio-height)` (40px) and is 36px tall. When a briefing
+   surface includes the DayStrip template part, the page container below
+   needs an extra 72px of margin-top to clear both bars + their padding.
+
+   Per the canonical `briefing-d-spine.html` surface-local override
+   (`.MagazinePageLayout_pageContainer { margin-top: calc(var(--page-margin-top) + 72px); }`),
+   this overlay scopes the same rule to the
+   `.MagazinePageLayout_pageContainerWithDayStrip` modifier class so
+   non-briefing surfaces get the base 40px margin and briefings get 112px.
+
+   Per L0 packet §10 WP-only deviation exception; not synced from canonical.
+   The canonical app handles this via React layout composition; WP composes
+   via template parts, so the modifier-class approach is the WP-native form.
+   ============================================================================= */
+
+.MagazinePageLayout_pageContainer.MagazinePageLayout_pageContainerWithDayStrip {
+	margin-top: calc(var(--page-margin-top) + 72px);
+}
+
+/* Future overlay slots — pattern-setting for the next WP-only override.
+   When the design system specifies dark or reduced-motion states for the
+   FolioBar / DayStrip / chrome overlays, fill these media blocks; do not
+   add a fourth flat `body.* .X {}` rule next to admin-bar / day-strip. */
+
+/*
+@media (prefers-color-scheme: dark) {
+}
+
+@media (prefers-reduced-motion: reduce) {
+}
+*/

--- a/wp/dailyos/theme/assets/chrome/wp-overlay-globals.css
+++ b/wp/dailyos/theme/assets/chrome/wp-overlay-globals.css
@@ -1,0 +1,52 @@
+/* =============================================================================
+   WP-only chrome overlay: global baseline ground
+   -----------------------------------------------------------------------------
+   The canonical reference at `.docs/design/reference/_shared/chrome.css`
+   ships a global reset that the chrome lane (which lifted only the
+   `*.module.css` files) did NOT pull in. The two practical effects
+   that broke WP-side rendering:
+
+   1. `* { box-sizing: border-box; }` — without this, `.FolioBar_folio`
+      computes height: 40px (var(--folio-height)) + 20px vertical padding
+      (10px top + 10px bottom) + 1px border = 61px rendered. Canonical
+      uses border-box so 40px IS the rendered height. This was visibly
+      a 21px-too-tall FolioBar on WP.
+
+   2. `html, body { font-family: var(--font-sans); background: var(--color-paper-cream); }`
+      — WP browsers fall back to UA defaults (Times New Roman serif body,
+      white viewport background) outside the magazinePage wrapper.
+
+   Intentionally NOT lifting canonical chrome.css verbatim because its
+   `* { margin: 0; padding: 0; }` line would clobber the WP block spacing
+   that theme.json `styles.spacing.padding` wires up. The overlay below
+   keeps the safe baseline + leaves block padding intact.
+
+   Per L0 packet §10 WP-only deviation exception; not synced from canonical.
+   ============================================================================= */
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	font-family: var(--font-sans);
+	background: var(--color-paper-cream);
+	color: var(--color-text-primary);
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+}
+
+/* MagazinePageLayout_magazinePage breaks out of WP's contentSize/wideSize
+   constraint so the cream paper fills the viewport, not just the 1180px
+   centered column. Canonical contract: `width: 100%; min-height: 100vh`
+   relative to the viewport, not to a constrained parent. Uses the
+   alignfull idiom so the wrapper escapes its parent's max-width. */
+.MagazinePageLayout_magazinePage {
+	width: 100vw;
+	max-width: 100vw;
+	margin-left: calc(50% - 50vw);
+	margin-right: calc(50% - 50vw);
+}

--- a/wp/dailyos/theme/functions.php
+++ b/wp/dailyos/theme/functions.php
@@ -74,6 +74,18 @@ function enqueue_chrome_assets(): void {
 	// from canonical.
 	wp_enqueue_style( 'dailyos-chrome-wp-overlay', $base . '/wp-overlay-admin-bar.css', array( 'dailyos-folio' ), VERSION );
 
+	// 4b-ii. DayStrip-aware pageContainer offset overlay. Briefing surfaces
+	// add a fixed DayStrip below the FolioBar; the page container below
+	// needs `+ 72px` margin-top to clear both bars. Mirrors the canonical
+	// briefing-d-spine surface override; pattern-class scoped via the
+	// `MagazinePageLayout_pageContainerWithDayStrip` modifier.
+	wp_enqueue_style(
+		'dailyos-chrome-wp-overlay-day-strip',
+		$base . '/wp-overlay-day-strip.css',
+		array( 'dailyos-magazine' ),
+		VERSION
+	);
+
 	// 4c. Design-system primitives + patterns + reference modules. Lifted
 	// verbatim from .docs/design/reference/_shared/styles/ so blocks (and
 	// future render paths) have the full canonical scaffold available.
@@ -202,11 +214,22 @@ function chrome_config(): array {
 	// Stub branches for W2 entity CPTs — neutral defaults until W2 ships.
 	// Project surface gets its tint resolved at W2 L0 alongside the other entity tints.
 	if ( is_singular( 'dailyos_briefing' ) ) {
+		// Match the canonical DailyBriefingDSpine reference (briefing-d-spine.html):
+		// FolioBar carries date + actions + chapters; DayStrip renders as a
+		// secondary chrome bar via the briefing template part. Readiness pills
+		// stay omitted until W2 wires real briefing claim data — the FolioBar
+		// renders readiness only when `folio-readiness` is populated.
 		return array_merge(
 			$base,
 			array(
-				'active-page' => 'briefings',
-				'folio-label' => 'Briefing',
+				'active-page'         => 'today',
+				'tint'                => 'turmeric',
+				'folio-label'         => 'Daily Briefing',
+				'folio-crumbs'        => 'Today',
+				'folio-date'          => strtoupper( wp_date( 'l, F j, Y' ) ),
+				'folio-actions'       => 'refresh',
+				'folio-refresh-title' => 'Refresh briefing',
+				'chapters'            => 'lead:alignleft:Lead|schedule:calendar:Today|moving:activity:Moving|watch:eye:Watch',
 			)
 		);
 	}

--- a/wp/dailyos/theme/functions.php
+++ b/wp/dailyos/theme/functions.php
@@ -74,6 +74,21 @@ function enqueue_chrome_assets(): void {
 	// from canonical.
 	wp_enqueue_style( 'dailyos-chrome-wp-overlay', $base . '/wp-overlay-admin-bar.css', array( 'dailyos-folio' ), VERSION );
 
+	// 4b-i. Global baseline overlay — box-sizing: border-box reset + body font
+	// + cream background that canonical chrome.css provides for reference
+	// surfaces but the chrome lane lift skipped (lifted only *.module.css).
+	// Without box-sizing reset, FolioBar height computes wrong (40px height
+	// + 20px padding = 60px instead of canonical 40px). Without body font,
+	// non-block content falls back to UA defaults outside MagazinePageLayout.
+	// Also breaks MagazinePageLayout_magazinePage out of WP's contentSize
+	// constraint so cream paper fills the viewport.
+	wp_enqueue_style(
+		'dailyos-chrome-wp-overlay-globals',
+		$base . '/wp-overlay-globals.css',
+		array( 'dailyos-aliases' ),
+		VERSION
+	);
+
 	// 4b-ii. DayStrip-aware pageContainer offset overlay. Briefing surfaces
 	// add a fixed DayStrip below the FolioBar; the page container below
 	// needs `+ 72px` margin-top to clear both bars. Mirrors the canonical

--- a/wp/dailyos/theme/parts/day-strip.html
+++ b/wp/dailyos/theme/parts/day-strip.html
@@ -1,0 +1,27 @@
+<!--
+	DayStrip — secondary chrome bar for Daily Briefing surfaces.
+	Pattern: .docs/design/patterns/DayStrip.md
+	Markup mirrors .docs/design/reference/surfaces/briefing-d-spine.html
+	Fixed beneath the FolioBar at top: var(--folio-height).
+
+	v1.4.4 W3 stub: previews are static placeholders. v1.4.5+ wave wires
+	previous/next briefing-day data + previews via chrome_config().
+-->
+<!-- wp:html -->
+<nav class="DayStrip_strip" aria-label="Briefing days" data-ds-tier="pattern" data-ds-name="DayStrip" data-ds-spec="patterns/DayStrip.md">
+	<a class="DayStrip_side" href="#" title="Yesterday">
+		<span class="DayStrip_direction" aria-hidden="true">&larr;</span>
+		<span class="DayStrip_label">Yesterday</span>
+		<span class="DayStrip_preview">Previous briefing preview</span>
+	</a>
+	<div class="DayStrip_current" aria-current="date" aria-label="Today">
+		<span class="DayStrip_mark" aria-hidden="true"></span>
+		Today
+	</div>
+	<a class="DayStrip_side DayStrip_sideRight" href="#" title="Tomorrow">
+		<span class="DayStrip_preview">Next briefing preview</span>
+		<span class="DayStrip_label">Tomorrow</span>
+		<span class="DayStrip_direction" aria-hidden="true">&rarr;</span>
+	</a>
+</nav>
+<!-- /wp:html -->

--- a/wp/dailyos/theme/parts/footer.html
+++ b/wp/dailyos/theme/parts/footer.html
@@ -1,7 +1,11 @@
-<!-- wp:group {"tagName":"footer","className":"dailyos-folio-footer","layout":{"type":"constrained"}} -->
-<footer class="wp-block-group dailyos-folio-footer">
-	<!-- wp:paragraph {"align":"center","className":"dailyos-folio-footer__colophon"} -->
-	<p class="has-text-align-center dailyos-folio-footer__colophon">DailyOS &middot; memory + judgment</p>
-	<!-- /wp:paragraph -->
+<!-- wp:group {"tagName":"footer","className":"FinisMarker_root","layout":{"type":"constrained"},"metadata":{"dataDs":"pattern:FinisMarker"}} -->
+<footer class="wp-block-group FinisMarker_root" data-ds-tier="pattern" data-ds-name="FinisMarker" data-ds-spec="patterns/FinisMarker.md">
+	<!-- wp:html -->
+	<div class="FinisMarker_marks" aria-hidden="true">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
+	</div>
+	<!-- /wp:html -->
 </footer>
 <!-- /wp:group -->

--- a/wp/dailyos/theme/templates/archive-dailyos_account.html
+++ b/wp/dailyos/theme/templates/archive-dailyos_account.html
@@ -1,33 +1,37 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-	<!-- wp:heading {"level":1} --><h1>Accounts</h1><!-- /wp:heading -->
-	<!-- wp:query {"query":{"perPage":12,"postType":"dailyos_account","order":"asc","orderBy":"title"},"className":"dailyos-account-archive"} -->
-	<div class="wp-block-query dailyos-account-archive">
-		<!-- wp:post-template -->
-			<!-- wp:group {"className":"dailyos-account-card","layout":{"type":"flex","orientation":"vertical"}} -->
-			<div class="wp-block-group dailyos-account-card">
-				<!-- wp:dailyos/entity-chip /-->
-				<!-- wp:group {"className":"dailyos-account-card__meta","layout":{"type":"flex","flexWrap":"wrap"}} -->
-				<div class="wp-block-group dailyos-account-card__meta">
-					<!-- wp:dailyos/type-badge /-->
-					<!-- wp:dailyos/health-badge /-->
-					<!-- wp:dailyos/freshness-indicator /-->
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage" data-ds-tier="surface" data-ds-name="AccountsPage" data-ds-spec="surfaces/AccountsPage.md">
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer">
+		<!-- wp:heading {"level":1} --><h1>Accounts</h1><!-- /wp:heading -->
+		<!-- wp:query {"query":{"perPage":12,"postType":"dailyos_account","order":"asc","orderBy":"title"},"className":"dailyos-account-archive"} -->
+		<div class="wp-block-query dailyos-account-archive">
+			<!-- wp:post-template -->
+				<!-- wp:group {"className":"dailyos-account-card","layout":{"type":"flex","orientation":"vertical"}} -->
+				<div class="wp-block-group dailyos-account-card">
+					<!-- wp:dailyos/entity-chip /-->
+					<!-- wp:group {"className":"dailyos-account-card__meta","layout":{"type":"flex","flexWrap":"wrap"}} -->
+					<div class="wp-block-group dailyos-account-card__meta">
+						<!-- wp:dailyos/type-badge /-->
+						<!-- wp:dailyos/health-badge /-->
+						<!-- wp:dailyos/freshness-indicator /-->
+					</div>
+					<!-- /wp:group -->
 				</div>
 				<!-- /wp:group -->
-			</div>
-			<!-- /wp:group -->
-		<!-- /wp:post-template -->
-		<!-- wp:query-pagination -->
-			<!-- wp:query-pagination-previous /-->
-			<!-- wp:query-pagination-numbers /-->
-			<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-		<!-- wp:query-no-results -->
-			<!-- wp:paragraph --><p>No accounts yet.</p><!-- /wp:paragraph -->
-		<!-- /wp:query-no-results -->
+			<!-- /wp:post-template -->
+			<!-- wp:query-pagination -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-numbers /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+			<!-- wp:query-no-results -->
+				<!-- wp:paragraph --><p>No accounts yet.</p><!-- /wp:paragraph -->
+			<!-- /wp:query-no-results -->
+		</div>
+		<!-- /wp:query -->
 	</div>
-	<!-- /wp:query -->
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp/dailyos/theme/templates/front-page.html
+++ b/wp/dailyos/theme/templates/front-page.html
@@ -1,7 +1,11 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage" data-ds-tier="surface" data-ds-name="DailyBriefing" data-ds-spec="surfaces/DailyBriefing.md">
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer">
+		<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp/dailyos/theme/templates/index.html
+++ b/wp/dailyos/theme/templates/index.html
@@ -1,7 +1,11 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage">
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer">
+		<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp/dailyos/theme/templates/page.html
+++ b/wp/dailyos/theme/templates/page.html
@@ -1,8 +1,8 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-	<!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group dailyos-magazine-page">
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage">
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer">
 		<!-- wp:post-title {"level":1} /-->
 		<!-- wp:post-content /-->
 	</div>

--- a/wp/dailyos/theme/templates/single-dailyos_account.html
+++ b/wp/dailyos/theme/templates/single-dailyos_account.html
@@ -1,20 +1,24 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-	<!-- wp:columns -->
-	<div class="wp-block-columns">
-		<!-- wp:column {"width":"25%"} -->
-		<div class="wp-block-column" style="flex-basis:25%">
-			<!-- wp:template-part {"slug":"sidebar-account-summary"} /-->
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage" data-ds-tier="surface" data-ds-name="AccountDetail" data-ds-spec="surfaces/AccountDetail.md">
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer">
+		<!-- wp:columns -->
+		<div class="wp-block-columns">
+			<!-- wp:column {"width":"25%"} -->
+			<div class="wp-block-column" style="flex-basis:25%">
+				<!-- wp:template-part {"slug":"sidebar-account-summary"} /-->
+			</div>
+			<!-- /wp:column -->
+			<!-- wp:column {"width":"75%"} -->
+			<div class="wp-block-column" style="flex-basis:75%">
+				<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:column -->
-		<!-- wp:column {"width":"75%"} -->
-		<div class="wp-block-column" style="flex-basis:75%">
-			<!-- wp:pattern {"slug":"dailyos/account-overview-page"} /-->
-		</div>
-		<!-- /wp:column -->
+		<!-- /wp:columns -->
 	</div>
-	<!-- /wp:columns -->
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp/dailyos/theme/templates/single-dailyos_briefing.html
+++ b/wp/dailyos/theme/templates/single-dailyos_briefing.html
@@ -1,8 +1,13 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"className":"dailyos-atmosphere","layout":{"type":"constrained"}} -->
-<div class="wp-block-group dailyos-atmosphere">
-	<!-- wp:heading {"level":1} --><h1>Briefing</h1><!-- /wp:heading -->
-	<!-- wp:paragraph --><p>Briefings arrive in the next release.</p><!-- /wp:paragraph -->
+<!-- wp:group {"className":"MagazinePageLayout_magazinePage","layout":{"type":"default"}} -->
+<div class="wp-block-group MagazinePageLayout_magazinePage" data-ds-tier="surface" data-ds-name="DailyBriefing" data-ds-spec="surfaces/DailyBriefing.md">
+	<!-- wp:template-part {"slug":"day-strip"} /-->
+	<!-- wp:group {"className":"MagazinePageLayout_pageContainer MagazinePageLayout_pageContainerWithDayStrip","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group MagazinePageLayout_pageContainer MagazinePageLayout_pageContainerWithDayStrip">
+		<!-- wp:heading {"level":1} --><h1>Briefing</h1><!-- /wp:heading -->
+		<!-- wp:paragraph --><p>Briefings arrive in the next release.</p><!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp/dailyos/theme/theme.json
+++ b/wp/dailyos/theme/theme.json
@@ -747,6 +747,11 @@
 			"name": "sidebar-account-summary",
 			"area": "uncategorized",
 			"title": "Sidebar — Account Summary"
+		},
+		{
+			"name": "day-strip",
+			"area": "uncategorized",
+			"title": "DayStrip — Briefing day navigation"
 		}
 	],
 	"styles": {

--- a/wp/dailyos/theme/theme.json
+++ b/wp/dailyos/theme/theme.json
@@ -682,6 +682,30 @@
 			],
 			"padding": true
 		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"slug": "sans",
+					"name": "DM Sans (body / UI)",
+					"fontFamily": "'DM Sans', -apple-system, sans-serif"
+				},
+				{
+					"slug": "serif",
+					"name": "Newsreader (display / headlines)",
+					"fontFamily": "'Newsreader', Georgia, serif"
+				},
+				{
+					"slug": "mono",
+					"name": "JetBrains Mono (time / eyebrow / code)",
+					"fontFamily": "'JetBrains Mono', ui-monospace, monospace"
+				},
+				{
+					"slug": "mark",
+					"name": "Montserrat (brand mark only)",
+					"fontFamily": "'Montserrat', sans-serif"
+				}
+			]
+		},
 		"layout": {
 			"contentSize": "900px",
 			"wideSize": "1180px"
@@ -755,6 +779,51 @@
 		}
 	],
 	"styles": {
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--sans)"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--serif)",
+					"fontWeight": "400",
+					"lineHeight": "1.15",
+					"letterSpacing": "-0.01em"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "40px",
+					"fontWeight": "400",
+					"lineHeight": "1.06"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "32px",
+					"fontWeight": "400"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "24px",
+					"fontWeight": "500"
+				}
+			}
+		},
+		"blocks": {
+			"core/code": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--mono)",
+					"fontSize": "13px"
+				}
+			},
+			"core/preformatted": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--mono)"
+				}
+			}
+		},
 		"spacing": {
 			"padding": {
 				"top": "var(--wp--custom--dailyos--tokens--page-margin-top)",
@@ -762,7 +831,6 @@
 				"bottom": "var(--wp--custom--dailyos--tokens--page-padding-bottom)",
 				"left": "var(--wp--custom--dailyos--tokens--page-padding-horizontal)"
 			}
-		},
-		"blocks": {}
+		}
 	}
 }


### PR DESCRIPTION
## Linear ticket

Wave-scoped — visual L4 follow-ups from chrome lane + primitives lift PRs.

## Summary

Four refinements surfaced during James's L4 walk of the chrome lane:

1. Footer rendered as text colophon ("DailyOS · memory + judgment") instead of the canonical **FinisMarker** pattern (three turmeric brand-mark asterisks).
2. Post content hit the very top of the viewport because WP templates used parallel `dailyos-*` class names that don't match the canonical `.MagazinePageLayout_*` lifted CSS.
3. `chrome_config()` for `dailyos_briefing` emitted neutral defaults instead of matching the canonical `briefing-d-spine.html` reference (date, refresh action, chapters).
4. No **DayStrip** secondary chrome bar on briefing surfaces.

## What changed

### FinisMarker footer

- `parts/footer.html` renders the canonical FinisMarker — three 18px brand-mark asterisks centered, turmeric color, via inline SVG (path lifted verbatim from chrome.js `brandMark()`).
- Carries `data-ds-tier="pattern"` / `data-ds-name="FinisMarker"` / `data-ds-spec="patterns/FinisMarker.md"` per the inspectability convention.
- FinisMarker.module.css (already lifted in #336 via patterns/) provides `text-align: center; padding: 72px 0 24px; color: var(--color-spice-turmeric);`.

### MagazinePageLayout pageContainer wraps

- Every page template (`front-page`, `index`, `page`, `single-dailyos_account`, `single-dailyos_briefing`, `archive-dailyos_account`) now wraps content in two canonical classes:
  - `MagazinePageLayout_magazinePage` (root, cream paper background, min-height 100vh)
  - `MagazinePageLayout_pageContainer` (inner content, 40px top margin, 1180px max-width, 120px horizontal padding, 160px bottom padding)
- Surface templates also carry `data-ds-tier="surface"` / `data-ds-name="..."` attributes (inspectability convention).

### Briefing chrome_config matches DailyBriefingDSpine

`chrome_config()` `dailyos_briefing` branch now emits the canonical briefing FolioBar config:

| key | value |
|---|---|
| `folio-label` | `Daily Briefing` |
| `folio-crumbs` | `Today` |
| `folio-date` | today as `WEEKDAY, MONTH DAY, YEAR` uppercased |
| `folio-actions` | `refresh` |
| `folio-refresh-title` | `Refresh briefing` |
| `chapters` | `lead:alignleft:Lead\|schedule:calendar:Today\|moving:activity:Moving\|watch:eye:Watch` |

Readiness pills (`folio-readiness`) intentionally omitted until W2 wires real briefing claim data.

### DayStrip secondary bar

- `parts/day-strip.html` template part — Yesterday / Today / Tomorrow markup mirrors briefing-d-spine.html (`DayStrip_strip` / `DayStrip_side` / `DayStrip_current`). Placeholder previews until v1.4.5+ wires real previous/next briefing data.
- `templates/single-dailyos_briefing.html` includes day-strip above page container.
- `theme.json` `templateParts` registers `day-strip` (via generator update).
- `wp-overlay-day-strip.css` overlay scopes `margin-top: calc(--page-margin-top + 72px)` to `.MagazinePageLayout_pageContainerWithDayStrip` modifier so briefing pages get the offset and other surfaces don't. Mirrors canonical briefing-d-spine surface override exactly. Skeleton `@media` blocks (dark, reduced-motion) commented per DOS-744 #8 pattern-setting recommendation.
- `functions.php` enqueues the overlay after `dailyos-magazine`.

## L4 evidence

Walked WP home post-change — see attached screenshot:
- Cream paper MagazinePageLayout_magazinePage wrapper now visible
- Content has top margin + horizontal gutters
- FinisMarker (three turmeric asterisks) at bottom
- FolioBar TODAY + brandmark at top
- FloatingNavIsland ME + brandmark on right

Briefing page render not visually verified — `?post_type=dailyos_briefing&p=N` returns 404 on dev (separate CPT routing issue, not introduced by this PR). All chrome_config / template part / overlay logic is in place; will surface visually as soon as briefing CPT routing is fixed.

## Test plan

- [x] L2-status declared `passed`
- [x] PHPCS clean (`./vendor/bin/phpcs theme/functions.php`)
- [x] PHP syntax check clean (`php -l`)
- [x] theme.json idempotency: `node wp/dailyos/scripts/generate-theme-json.mjs --check` clean
- [x] Pre-commit gate clean
- [x] Live test on Studio dailyos-dev (port 8884): home page shows FinisMarker + cream paper wrapper + content gutters
- [ ] Briefing surface visual L4 — blocked on CPT routing (separate issue)

## Definition of Done

- [x] Acceptance criteria validated
- [x] FinisMarker matches `.docs/design/patterns/FinisMarker.md`
- [x] MagazinePageLayout wraps match `.docs/design/reference/_shared/styles/MagazinePageLayout.module.css` contract
- [x] Briefing chrome_config matches `.docs/design/reference/surfaces/briefing-d-spine.html` body attributes
- [x] DayStrip markup matches `.docs/design/reference/surfaces/briefing-d-spine.html` nav element
- [x] Inspectability: every new template part / surface wrap carries `data-ds-*` attributes per SYSTEM-MAP.md

## §4 Security

\`security_auditor_invoked: false\`

**Exemption ID**: \`EXEMPT-STYLE\`

**Exemption rationale**: Pure presentation-layer refactor. Theme template HTML, CSS overlay, theme.json generator update, PHP chrome_config addition. No trust boundary, no privileged action, no claim-substrate touch, no MCP/skill change, no dependency. The `wp_date()` call uses WP core's localized date formatter (read-only, no input).

- [ ] Touches src-tauri/, abilities/, bridges/, commands/, intelligence/?
- [ ] Modifies migrations?
- [ ] Touches claim-substrate table?
- [ ] Changes prompt template?
- [ ] Modifies sensitivity/rendering/allowlist/actor-filter logic?
- [ ] Modifies MCP/tool registry/skill definitions?
- [ ] Adds new trust boundary?
- [ ] Defines privileged action?
- [ ] Adds/modifies .github/workflows/*?
- [ ] Adds new dependency?

All no.

## Follow-ups

- DayStrip preview text wired to real previous/next briefing data (substrate placeholder ships today)
- `folio-readiness` wired to real briefing claim data (deferred to v1.4.4 W2)
- Briefing CPT routing 404 — separate concern, not in this PR
- DOS-744 hardening items (slug case, fail-loud on missing CSS dirs) — separate maintenance PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)