### PR TITLE
fix(wp): forward claim_ref field_path over inferred path (DOS-745)

### DIFF
--- a/wp/dailyos/blocks/account-overview/render-functions.php
+++ b/wp/dailyos/blocks/account-overview/render-functions.php
@@ -367,11 +367,17 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 			// V4-W4 binding tuple: the runtime's IssueNonceRequest::parse
 			// requires field_path + claim_version + composition_id +
 			// composition_version on every nonce mint. claim_ref carries
-			// per-claim values; composition_* comes from render_context.
+			// substrate-authoritative values (the projection normalizes
+			// the claim's stored field_path via claim_field_path() in
+			// abilities-runtime); $row['field_path'] is inferred from
+			// payload shape and is a fallback when no claim_ref matches.
+			// Sending the inferred path when the projection normalized
+			// to a different one causes runtime to reject the nonce
+			// with reason: wrong_field (DOS-745).
 			$claim_version       = isset( $claim_ref['claim_version'] ) ? (int) $claim_ref['claim_version'] : 0;
-			$field_path          = isset( $row['field_path'] ) && is_string( $row['field_path'] )
-				? (string) $row['field_path']
-				: ( isset( $claim_ref['field_path'] ) && is_string( $claim_ref['field_path'] ) ? (string) $claim_ref['field_path'] : '' );
+			$field_path          = isset( $claim_ref['field_path'] ) && is_string( $claim_ref['field_path'] ) && '' !== $claim_ref['field_path']
+				? (string) $claim_ref['field_path']
+				: ( isset( $row['field_path'] ) && is_string( $row['field_path'] ) ? (string) $row['field_path'] : '' );
 			$composition_id      = isset( $render_context['composition_id'] ) && is_string( $render_context['composition_id'] )
 				? (string) $render_context['composition_id']
 				: '';

--- a/wp/dailyos/blocks/account-overview/render-functions.php
+++ b/wp/dailyos/blocks/account-overview/render-functions.php
@@ -373,7 +373,7 @@ if ( ! function_exists( 'dailyos_account_overview_render' ) ) {
 			// payload shape and is a fallback when no claim_ref matches.
 			// Sending the inferred path when the projection normalized
 			// to a different one causes runtime to reject the nonce
-			// with reason: wrong_field (DOS-745).
+			// with reason: wrong_field.
 			$claim_version       = isset( $claim_ref['claim_version'] ) ? (int) $claim_ref['claim_version'] : 0;
 			$field_path          = isset( $claim_ref['field_path'] ) && is_string( $claim_ref['field_path'] ) && '' !== $claim_ref['field_path']
 				? (string) $claim_ref['field_path']

--- a/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
+++ b/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
@@ -431,7 +431,7 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	 * Asserts the feedback affordance emits the substrate-authoritative
 	 * field_path from claim_refs, not the payload-inferred path.
 	 *
-	 * Regression coverage for DOS-745: when the runtime's claim projection
+	 * Regression coverage: when the runtime's claim projection
 	 * normalizes claim.field_path (see claim_field_path() in
 	 * abilities-runtime/src/abilities/account_overview.rs) to a value that
 	 * differs from the WP-side inference (`/text` for top-level, `/items/N/text`

--- a/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
+++ b/wp/dailyos/tests/blocks/AccountOverviewBlockTest.php
@@ -428,6 +428,116 @@ final class DailyOS_AccountOverviewBlockTest extends TestCase {
 	}
 
 	/**
+	 * Asserts the feedback affordance emits the substrate-authoritative
+	 * field_path from claim_refs, not the payload-inferred path.
+	 *
+	 * Regression coverage for DOS-745: when the runtime's claim projection
+	 * normalizes claim.field_path (see claim_field_path() in
+	 * abilities-runtime/src/abilities/account_overview.rs) to a value that
+	 * differs from the WP-side inference (`/text` for top-level, `/items/N/text`
+	 * for collections), the rendered feedback props MUST forward the
+	 * projection's value so IssueNonceRequest::parse does not reject with
+	 * reason: wrong_field / rejection_class: binding.
+	 */
+	public function test_feedback_props_use_claim_ref_field_path_over_inferred_payload_path(): void {
+		$client = $this->fake_runtime_client_with_response(
+			[
+				'projection' => [
+					'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+					'composition_version' => 9,
+					'blocks'              => [
+						[
+							'block_type' => 'account_overview',
+							'trust_band' => 'likely_current',
+							'payload'    => [
+								'title'    => 'Account overview',
+								'text'     => 'Substrate-authoritative summary.',
+								'claim_id' => 'claim-divergent-001',
+							],
+							'claim_refs' => [
+								[
+									'claim_id'      => 'claim-divergent-001',
+									'claim_version' => 4,
+									'field_path'    => '/answer',
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_account_overview_render(
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 9,
+			]
+		);
+
+		$this->assertStringContainsString( 'data-dailyos-feedback-affordance', $html );
+		$this->assertMatchesRegularExpression(
+			'/data-dailyos-feedback-props="([^"]+)"/',
+			$html,
+			'rendered HTML must carry the feedback mount with serialized props'
+		);
+
+		preg_match( '/data-dailyos-feedback-props="([^"]+)"/', $html, $matches );
+		$props = json_decode( html_entity_decode( $matches[1], ENT_QUOTES | ENT_HTML5 ), true );
+
+		$this->assertIsArray( $props );
+		$this->assertSame(
+			'/answer',
+			$props['fieldPath'] ?? null,
+			'feedback affordance MUST forward claim_ref.field_path (substrate truth), not the payload-shape inferred path (/text)'
+		);
+		$this->assertSame( 'claim-divergent-001', $props['claimId'] ?? null );
+		$this->assertSame( 4, $props['claimVersion'] ?? null );
+	}
+
+	/**
+	 * Asserts the inferred payload path is used as a fallback when no
+	 * claim_ref is present — only the substrate-truth supersedes inference,
+	 * never replaces fallback behavior.
+	 */
+	public function test_feedback_props_fall_back_to_inferred_payload_path_when_claim_ref_absent(): void {
+		$client = $this->fake_runtime_client_with_response(
+			[
+				'projection' => [
+					'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+					'composition_version' => 9,
+					'blocks'              => [
+						[
+							'block_type' => 'account_overview',
+							'trust_band' => 'likely_current',
+							'payload'    => [
+								'title'    => 'Account overview',
+								'text'     => 'Inferred path renders when no claim_ref attached.',
+								'claim_id' => 'claim-no-ref-001',
+							],
+							'claim_refs' => [],
+						],
+					],
+				],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_account_overview_render(
+			[
+				'composition_id'      => 'dailyos/account-overview:account:acct-test-001',
+				'composition_version' => 9,
+			]
+		);
+
+		preg_match( '/data-dailyos-feedback-props="([^"]+)"/', $html, $matches );
+		$this->assertNotEmpty( $matches, 'feedback mount must still render when claim_ref is absent' );
+		$props = json_decode( html_entity_decode( $matches[1], ENT_QUOTES | ENT_HTML5 ), true );
+
+		$this->assertSame( '/text', $props['fieldPath'] ?? null );
+	}
+
+	/**
 	 * Asserts render PHP never calls the W4-D projector directly.
 	 */
 	public function test_render_php_never_calls_w4d_projector_directly(): void {


### PR DESCRIPTION
<!-- protocol-doc: dailyos-pr-template -->

## Linear ticket

https://linear.app/a8c/issue/DOS-745

## Summary

Production-blocking bug: feedback affordance on a real Tauri-paired `dailyos/account-overview` block failed with `presence_nonce_rejected` (`reason: wrong_field, rejection_class: binding`) because the WP render reused a payload-shape-inferred `/text` path instead of the substrate-authoritative `field_path` already projected onto the claim_ref. One-line priority flip fixes it; the inferred path remains the fallback when no claim_ref matches.

## What changed

- `wp/dailyos/blocks/account-overview/render-functions.php` — `field_path` priority flipped so `claim_ref['field_path']` wins over the inferred `$row['field_path']`. Substrate-authoritative path is the source of truth; payload-shape inference is the fallback.
- `wp/dailyos/tests/blocks/AccountOverviewBlockTest.php` — two new tests: divergence case (`claim_ref` says `/answer`, payload shape infers `/text`, must forward `/answer`) and fallback case (no claim_ref, inferred path used).

## Test plan

- [x] `cargo clippy -- -D warnings` clean (not touched by this diff but verified)
- [x] `cargo test --lib` passes
- [x] `cd wp/dailyos && vendor/bin/phpunit` passes (271/271 + 2 new)
- [x] PHPCS lint clean on touched files
- [x] Class-wide audit across `wp/dailyos/blocks/` — account-overview is the only block with this inference pattern (codex L2 reviewer confirmed)
- [ ] Manual verification: L4 hands-on with paired Tauri + WP page, click feedback affordance, confirm presence nonce mints successfully

## Definition of Done

- [x] Acceptance criterion from the Linear ticket validated by new PHPUnit tests covering the actual divergence shape
- [x] End-to-end flow exercised via `dailyos_account_overview_render` integration test
- [x] No stubs, TODOs, or "Phase 2" deferrals
- [x] Tests pass per the test plan above

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: N/A — codex L2 review ran and returned APPROVE with no blockers. The diff is a one-line WP-side priority flip + 2 PHPUnit tests touching only `wp/dailyos/blocks/account-overview/` (not the security-trigger Rust services paths). Codex L2 confirmed the claim_ref-over-inferred priority is the right defense for the `wrong_field` rejection class.

- [ ] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs, tool registry, or skill definitions?
- [ ] Adds a new trust boundary?
- [ ] Defines a privileged action?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency?

## Follow-ups

- L4 hands-on validation on a paired Tauri + WP install — required before close per ticket AC.
- Consider a contract-layer assertion in `FeedbackRuntimeContractTest.php` that exercises field_path drift specifically (codex L2 said the new block-render test is sufficient; revisit if drift recurs elsewhere).

## Notes for review

`L2-status: passed` on the implementation commit. Codex L2 review verdict: APPROVE. Class-wide grep confirmed account-overview is the only WP block with this inference pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
