### PR TITLE
feat(theme): restore editorial colophon below FinisMarker

### DIFF
--- a/wp/dailyos/theme/assets/chrome/wp-overlay-colophon.css
+++ b/wp/dailyos/theme/assets/chrome/wp-overlay-colophon.css
@@ -1,0 +1,29 @@
+/* =============================================================================
+   WP-only chrome overlay: editorial colophon below the FinisMarker
+   -----------------------------------------------------------------------------
+   The FinisMarker pattern (three turmeric brand-mark asterisks) is the
+   canonical end-of-page signal. Below it, the WP layer adds a quiet
+   colophon line — "DailyOS · memory + judgment" — as a small editorial
+   sign-off. Visually it mirrors the .FinisMarker_timestamp style:
+   font-mono, 10px, uppercase-ish letter-spacing, text-tertiary color,
+   margin-top: 16px (matching the timestamp slot in the canonical
+   FinisMarker.module.css).
+
+   The colophon is a WP-specific addition — the canonical Tauri-side
+   surfaces don't carry one because the macOS title bar handles
+   sign-off via the app chrome. WP has no equivalent, so the editorial
+   sign-off lives below the FinisMarker.
+
+   Per L0 packet §10 WP-only deviation exception; not synced from canonical.
+   ============================================================================= */
+
+.dailyos-colophon {
+	margin-top: 16px;
+	text-align: center;
+	font-family: var(--font-mono);
+	font-size: 10px;
+	font-weight: 500;
+	letter-spacing: 0.06em;
+	color: var(--color-text-tertiary);
+	text-transform: uppercase;
+}

--- a/wp/dailyos/theme/functions.php
+++ b/wp/dailyos/theme/functions.php
@@ -89,6 +89,16 @@ function enqueue_chrome_assets(): void {
 		VERSION
 	);
 
+	// 4b-iii. Editorial colophon below the FinisMarker. WP-specific sign-off
+	// the canonical Tauri surfaces don't need (macOS title bar handles it).
+	// Styled like the FinisMarker_timestamp slot: mono uppercase tertiary.
+	wp_enqueue_style(
+		'dailyos-chrome-wp-overlay-colophon',
+		$base . '/wp-overlay-colophon.css',
+		array( 'dailyos-pattern-finismarker' ),
+		VERSION
+	);
+
 	// 4b-ii. DayStrip-aware pageContainer offset overlay. Briefing surfaces
 	// add a fixed DayStrip below the FolioBar; the page container below
 	// needs `+ 72px` margin-top to clear both bars. Mirrors the canonical

--- a/wp/dailyos/theme/parts/footer.html
+++ b/wp/dailyos/theme/parts/footer.html
@@ -6,6 +6,7 @@
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="18" height="18"><path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/></svg>
 	</div>
+	<p class="dailyos-colophon">DailyOS &middot; memory + judgment</p>
 	<!-- /wp:html -->
 </footer>
 <!-- /wp:group -->


### PR DESCRIPTION
## Summary

Brings back the \`DailyOS · memory + judgment\` colophon as a quiet sign-off **below** the FinisMarker dots, not instead of them. User liked it from before #339 swapped to pure FinisMarker.

## What changed

- \`parts/footer.html\` — adds \`<p class="dailyos-colophon">DailyOS · memory + judgment</p>\` inside the FinisMarker_root footer, below the three brand-mark asterisks.
- New \`wp/dailyos/theme/assets/chrome/wp-overlay-colophon.css\` — styles the colophon to mirror the canonical \`FinisMarker_timestamp\` slot: mono, 10px, weight 500, uppercase, letter-spacing 0.06em, text-tertiary, margin-top 16px.
- \`functions.php\` enqueues the overlay after \`dailyos-pattern-finismarker\` so the FinisMarker base styles cascade first.

## Why WP-only

Canonical Tauri surfaces don't carry a colophon — the macOS title bar handles app sign-off. WP has no equivalent, so the colophon lives in a WP-only overlay per L0 packet §10 deviation exception.

## §4 Security

\`security_auditor_invoked: false\`

**Exemption ID**: \`EXEMPT-STYLE\`

**Rationale**: Single \`<p>\` add to footer template + 1 CSS file + 1 enqueue line. No trust boundary, no claim substrate, no privileged action.

- [ ] All blocklist checks — no

## Test plan

- [x] PHPCS clean
- [x] PHP syntax clean
- [x] Pre-commit gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)