### PR TITLE
docs(K-out): 3 workflow learnings from v1.4.3 merge cycle

### DIFF
--- a/docs/solutions/workflow-issues/codex-rescue-destructive-git-reset-on-529-2026-05-20.md
+++ b/docs/solutions/workflow-issues/codex-rescue-destructive-git-reset-on-529-2026-05-20.md
@@ -1,0 +1,69 @@
+---
+title: "codex-rescue agent runs `git reset --hard public/dev` mid-failure, wiping uncommitted work"
+problem_type: workflow_issue
+track: knowledge
+module: codex:codex-rescue subagent, .claude/plugins/data/codex-openai-codex/lib/codex.mjs
+tags: [codex, codex-rescue, destructive-action, git-reset, 529-overloaded, sandboxing, sub-agent-safety]
+date: 2026-05-20
+related_linear: DOS-746
+related_memories: [codex-rescue-destructive-git-reset-on-failure, codex-exec-direct-for-oneshot-reviews, dont-rm-claude-without-verify]
+---
+
+## Context
+
+While shipping DOS-746 (pairing scope refresh), the orchestrator dispatched two `codex:codex-rescue` agents back-to-back with `--write` access. Both failed with Anthropic API `529 Overloaded`. After each failure, the orchestrator found:
+
+- Original branch HEAD reset to `public/dev` (visible via `git reflog`: `HEAD@{0}: reset: moving to public/dev`)
+- ~250 LOC of uncommitted Rust + PHP work wiped from the worktree
+- Only untracked files (test files added with `Write`) survived; everything that had been staged or modified-tracked was gone
+
+Recovery required re-applying the entire diff from the conversation context (twice in one session).
+
+## Root cause
+
+The codex-rescue agent has `--write` access, which includes the ability to run arbitrary git commands. On 529 failure during execution, the agent's error path (in `.claude/plugins/data/codex-openai-codex/lib/codex.mjs` or equivalent) appears to attempt a "clean state" recovery via `git reset --hard <baseline>`. There is no inactivity timer guarding this — when codex wedges, the recovery path runs unconditionally.
+
+The system reminders about "intentional change" that appear in Claude Code after such resets point at the destination state of the reset, not at the deletion itself, so the orchestrator doesn't get a clear signal that work was lost until it checks `git status` and finds the working tree clean.
+
+## Fix
+
+Three layers of defense, in order of preference:
+
+1. **Commit before dispatching** any `--write`-capable codex agent when there is uncommitted substrate work in the worktree. Even a checkpoint commit with `L2-status: not-run-acknowledged` is fine — recoverable, doesn't destroy work.
+
+2. **Prefer `isolation: "worktree"`** when spawning codex-rescue with `--write`. The agent gets a fresh worktree it can corrupt freely; the main worktree is untouched. This is what eventually worked for DOS-575 (PR #343).
+
+3. **For one-shot reviews, switch to `codex exec` direct** via `Bash` with explicit `timeout`. Pattern that worked this session:
+
+   ```bash
+   timeout 2700 codex exec --json --full-auto --skip-git-repo-check \
+     < /tmp/prompt.txt > /tmp/codex-exec.log 2>&1
+   ```
+
+   `codex exec` runs in the current cwd, has predictable lifecycle (timeout kills it cleanly), and does NOT auto-reset on failure.
+
+## Defensive checks
+
+After any codex-rescue dispatch that returns failure (especially 529), check immediately:
+
+```bash
+git reflog | head -5
+```
+
+If you see `reset: moving to <branch>` at `HEAD@{0}`, the agent destroyed your work. Recovery is from conversation context; the staged-but-not-committed changes are gone from disk (though they may persist as dangling blobs in `git fsck --lost-found` for a short window).
+
+## Prevention checklist
+
+Before dispatching ANY codex-rescue or other `--write`-capable agent:
+
+- [ ] `git status` shows clean working tree, OR
+- [ ] Uncommitted changes are committed (checkpoint commit is fine), OR
+- [ ] Dispatch uses `isolation: "worktree"`
+
+For L2 / adversarial review work specifically, prefer `codex exec` direct over `codex-rescue` — see [codex-exec-direct-for-oneshot-reviews](../../../.../) memory.
+
+## Related
+
+- Memory `feedback_codex_rescue_destructive_git_reset_on_failure` — original capture, persists across sessions.
+- Memory `feedback_codex_exec_direct_for_oneshot_reviews` — recommended alternate path.
+- Analogous: `feedback_dont_rm_claude_without_verify` — same lesson applied to `.claude` removal.

--- a/docs/solutions/workflow-issues/gh-pr-edit-body-not-picked-up-by-run-rerun-2026-05-20.md
+++ b/docs/solutions/workflow-issues/gh-pr-edit-body-not-picked-up-by-run-rerun-2026-05-20.md
@@ -1,0 +1,60 @@
+---
+title: "`gh run rerun --failed` re-uses the original PR body snapshot — `gh pr edit --body` changes don't propagate; push an empty commit instead"
+problem_type: workflow_issue
+track: knowledge
+module: GitHub Actions pull_request event semantics, gh CLI
+tags: [gh-cli, github-actions, pr-body, ci-rerun, ci-retrigger, validate-pr-template]
+date: 2026-05-20
+related_linear: DOS-745, DOS-746
+related_memories: []
+---
+
+## Context
+
+While unblocking PR #340 (DOS-745) and PR #342 (DOS-746) on a failed `L2 / validate-pr-template` check, the orchestrator:
+
+1. Updated both PR bodies via `gh pr edit <N> --body-file new-body.md` to fix the template-validation issue.
+2. Verified the new bodies were live on GitHub via `gh pr view <N> --json body`.
+3. Re-ran the failed CI jobs via `gh run rerun <run-id> --failed`.
+4. **Same failure recurred** — the validator was still seeing the OLD body content.
+
+## Root cause
+
+`gh run rerun --failed` re-executes a job using the **original event payload snapshot** from the `pull_request` event that triggered the workflow. The PR body is captured in that snapshot at trigger time. Editing the PR body via `gh pr edit` does NOT emit a new `pull_request` event with type `edited` to the workflow (or, if it does, the workflow's `on.pull_request.types` list doesn't include `edited`, so it's ignored).
+
+Result: a rerun fetches the same snapshot as the original run. The validator job re-reads the same stale body and re-fails identically.
+
+## Fix
+
+To re-trigger CI against the **current** PR body, push an empty commit:
+
+```bash
+git commit --allow-empty --no-verify -m "ci: re-trigger L2 with updated PR body
+
+L2-status: n-a-doc-only
+"
+git push --no-verify
+```
+
+This emits a fresh `synchronize` event with a new SHA, which workflows always re-run against. The validator then sees the current body and passes.
+
+## Alternative
+
+Close + reopen the PR — fires a `reopened` event that most workflows are configured to trigger on. Heavier hammer; the empty-commit path is cleaner.
+
+## Symptom signature
+
+- A CI gate fails on the live PR.
+- You edit the PR body via `gh pr edit`.
+- `gh run rerun <run-id> --failed` produces the SAME failure with the SAME error message, despite the live body being correct.
+- `gh pr view <N> --json body` confirms the body is in the new state.
+
+If all three symptoms align, the fix is the empty-commit re-trigger.
+
+## Cost
+
+In this session: ~30 minutes lost across the DOS-745 / DOS-746 merge cycle before identifying the pattern. The fix itself takes <30 seconds once you know it.
+
+## Related
+
+- [pr-template-security-auditor-field-regex-collision-2026-05-20](./pr-template-security-auditor-field-regex-collision-2026-05-20.md) — the gate that first surfaced this gotcha.

--- a/docs/solutions/workflow-issues/pr-template-security-auditor-field-regex-collision-2026-05-20.md
+++ b/docs/solutions/workflow-issues/pr-template-security-auditor-field-regex-collision-2026-05-20.md
@@ -1,0 +1,79 @@
+---
+title: "PR template `security_auditor_invoked` regex collides with the template's own hint text — validator reports 'missing' on bodies that have the field"
+problem_type: workflow_issue
+track: knowledge
+module: .github/scripts/validate-pr-template.py, .github/pull_request_template.md
+tags: [ci, pr-template, validation, regex-gotcha, l2-gate, security-auditor]
+date: 2026-05-20
+related_linear: DOS-745, DOS-746
+related_memories: []
+---
+
+## Context
+
+While shipping DOS-745 (PR #340) and DOS-746 (PR #342), both PRs failed the `L2 / validate-pr-template` CI check with the same error:
+
+```
+🔒 PR-template validation: `security_auditor_invoked` field missing.
+```
+
+Both PR bodies explicitly had `` `security_auditor_invoked: true` `` in the §4 Security section. The field was clearly present.
+
+## Root cause
+
+`.github/scripts/validate-pr-template.py::extract_field()` uses this regex against the PR body (with fenced code blocks stripped):
+
+```python
+pattern = re.compile(
+    r"`?security_auditor_invoked`?\s*:\s*(true|false)\b",
+    re.IGNORECASE,
+)
+matches = pattern.findall(cleaned)
+if len(matches) > 1 and len(set(m.lower() for m in matches)) > 1:
+    return "ambiguous"
+```
+
+The original PR template (`.github/pull_request_template.md`) includes this literal hint line:
+
+```markdown
+**Exemption ID** (if `security_auditor_invoked: false`): `EXEMPT-DOC-ONLY` | ...
+```
+
+When an author copies the template and sets `security_auditor_invoked: true` while leaving the hint text intact, the regex matches **both** the truth-value (`true`) and the hint's literal `false`. The result is `"ambiguous"`, and the downstream validator reports it as `"missing"` (the user-visible message).
+
+## Fix
+
+Edit the §4 Security section to remove the literal `false` mention from the hint:
+
+```markdown
+**Exemption ID**: _none_
+```
+
+(Drop the `(if \`security_auditor_invoked: false\`)` parenthetical entirely.)
+
+Verify with:
+
+```bash
+gh pr view <N> --json body --jq '.body' | grep -c "security_auditor_invoked"
+# Must print 1 for the validator to pass
+```
+
+## Prevention
+
+Two paths:
+
+1. **Author-side**: when copying the PR template, strip the hint parentheticals that mention specific values (`true`/`false`) the validator regex would re-match.
+
+2. **Template-side** (recommended): rephrase the hint to avoid the literal value. For example:
+
+   ```markdown
+   **Exemption ID** (required only when invocation was skipped): ...
+   ```
+
+The downstream `gh run rerun` does NOT re-fetch the PR body — see [gh-pr-edit-body-not-picked-up-by-run-rerun-2026-05-20](./gh-pr-edit-body-not-picked-up-by-run-rerun-2026-05-20.md) for the corollary gotcha that compounds this one.
+
+## Symptom signature
+
+CI job `L2 / validate-pr-template` fails with `🔒 PR-template validation: \`security_auditor_invoked\` field missing.` even when the field is plainly visible in the rendered PR description.
+
+`gh pr view <N> --json body --jq '.body' | grep -c "security_auditor_invoked"` returning `2` is the diagnostic — should be `1`.


### PR DESCRIPTION
## Summary

K-out capture from the 2026-05-20 v1.4.3 merge cycle (PRs #340, #342, #343). Three workflow-issue solutions:

1. **codex-rescue-destructive-git-reset-on-529** — codex-rescue's failure-recovery path runs `git reset --hard public/dev`, wiping uncommitted work when Anthropic API hits 529. Mitigation: commit-before-dispatch, isolation: worktree, codex exec direct.

2. **pr-template-security-auditor-field-regex-collision** — the PR template's hint text \`(if \`security_auditor_invoked: false\`)\` collides with the validator's regex, producing an ambiguous match → "missing" error. Mitigation: strip the parenthetical hint when authoring.

3. **gh-pr-edit-body-not-picked-up-by-run-rerun** — `gh pr edit --body` does not re-emit a pull_request event that `gh run rerun` picks up. Push an empty commit to force CI re-trigger against current body.

## Test plan

- [x] Three `.md` files added under `docs/solutions/workflow-issues/`
- [x] Each entry follows YAML frontmatter convention from existing entries
- [x] Cross-links between entries where relevant

## §4 Security

\`security_auditor_invoked: false\`

**Exemption ID**: EXEMPT-DOC-ONLY

**Exemption rationale**: docs-only K-out commit; no code touched.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)