### PR TITLE
docs(engineering-ladder): L0 threat-topology framing for reviewer scoping

### DIFF
--- a/.docs/plans/engineering-ladder.md
+++ b/.docs/plans/engineering-ladder.md
@@ -34,6 +34,8 @@ Used in chat: "L2 looks good." Used in docs/headings: "L2 (Diff) review verdict:
 
 **Bounding.** L2 reviews are bounded by acceptance criteria (memory `feedback_l2_must_review_against_acceptance_criteria`). Path-α findings (theoretical hardening beyond AC) → file in the maintenance project, not cycle-N+1.
 
+**Threat-topology framing (L0 reviewer scoping).** Every L0 packet declares its trust topology in §1 header: `local-to-local single-user | local-to-local multi-user | remote-to-local | remote-to-remote`. `/cso`, `security-auditor`, and codex challenge scope their threat model to that topology — they do **not** enforce multi-actor gates on single-actor surfaces. DailyOS's WP block → loopback Tauri runtime is local-to-local single-user; most multi-actor gates (confirmation tokens, principal differentiation, cross-actor poisoning, scope-gated redaction of data the user already has filesystem access to) collapse to non-issues. What still applies regardless of topology: compile bugs, crate-boundary rules, slug/path validation for data hygiene, indirect prompt injection from untrusted document content (ADR-0093), and sensitivity redaction in logs/screenshots (ADR-0108). Reviewers who flag multi-actor gates on a single-actor surface waste a cycle; reviewer prompts must cite the topology and constrain accordingly. See memory entry on local-to-local security overreach for the full pattern.
+
 ## The Knowledge Channel (K)
 
 `K` is a continuous feedback channel parallel to L0–L6, not a rung.


### PR DESCRIPTION
## Summary

Adds a single paragraph to `engineering-ladder.md`'s Pass rules section: every L0 packet declares its trust topology in §1 header (`local-to-local single-user | local-to-local multi-user | remote-to-local | remote-to-remote`). `/cso`, `security-auditor`, and codex challenge scope their threat model to that topology — they do **not** enforce multi-actor gates on single-actor surfaces.

## Why

2026-05-21 v1.4.5 W2 L0 cycle 3 stalled because the reviewer panel applied multi-actor security gates (confirmation tokens, principal differentiation, scope-gated redaction, cross-actor poisoning prevention) to a local-to-local single-user surface where those gates collapse to non-issues. Memory `feedback_local_to_local_security_overreach_primary_concern` already captures the pattern at the user-feedback level; this doc edit makes the framing structural at the L0 protocol layer so future cycles don't repeat the stall.

## What still applies regardless of topology

Compile bugs, crate-boundary rules, slug/path validation for data hygiene, ADR-0093 indirect prompt injection from untrusted document content, ADR-0108 sensitivity redaction in logs/screenshots.

## Test plan

- [x] Doc-only change; no code paths touched
- [x] Diff is 2 lines (one paragraph inserted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)