### PR TITLE
feat(workspace_ingestion): add IngestionMode::EntitySeeded + Realtime (W1-extension; v1.4.5 W2 L1 precondition)

### DIFF
--- a/src-tauri/src/services/workspace_ingestion/runs.rs
+++ b/src-tauri/src/services/workspace_ingestion/runs.rs
@@ -26,7 +26,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct IngestionRunId(pub String);
 
-/// Ingestion mode per L0 V1.3 §4.
+/// Ingestion mode per L0 V1.3 §4. `EntitySeeded` and `Realtime` added by the
+/// v1.4.5 W1-extension PR (cycle-13 §13.1) as preconditions for W2-A/C/D L1:
+/// W2-C entity-intake ability requests `EntitySeeded`; W2-D inbox immediate-
+/// ingest path requests `Realtime`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IngestionMode {
@@ -34,6 +37,8 @@ pub enum IngestionMode {
     Incremental,
     Forced,
     Backfill,
+    EntitySeeded,
+    Realtime,
 }
 
 impl IngestionMode {
@@ -43,6 +48,8 @@ impl IngestionMode {
             Self::Incremental => "incremental",
             Self::Forced => "forced",
             Self::Backfill => "backfill",
+            Self::EntitySeeded => "entity_seeded",
+            Self::Realtime => "realtime",
         }
     }
 
@@ -52,6 +59,8 @@ impl IngestionMode {
             "incremental" => Some(Self::Incremental),
             "forced" => Some(Self::Forced),
             "backfill" => Some(Self::Backfill),
+            "entity_seeded" => Some(Self::EntitySeeded),
+            "realtime" => Some(Self::Realtime),
             _ => None,
         }
     }
@@ -731,5 +740,46 @@ mod tests {
             )
             .expect("count");
         assert_eq!(success_count, 1, "single success row preserved");
+    }
+
+    #[test]
+    fn ingestion_mode_storage_roundtrip_covers_all_variants() {
+        // W1-extension PR (cycle-13 §13.1): every IngestionMode variant must
+        // round-trip through as_storage_str/from_storage_str. Catches missed
+        // arms in either direction when variants are added.
+        for variant in [
+            IngestionMode::Initial,
+            IngestionMode::Incremental,
+            IngestionMode::Forced,
+            IngestionMode::Backfill,
+            IngestionMode::EntitySeeded,
+            IngestionMode::Realtime,
+        ] {
+            let s = variant.as_storage_str();
+            let back = IngestionMode::from_storage_str(s);
+            assert_eq!(
+                back,
+                Some(variant),
+                "round-trip mismatch for {variant:?} via {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ingestion_mode_storage_slugs_are_distinct() {
+        // Slug-collision guard: a future variant must not collide with an
+        // existing storage slug.
+        let slugs = [
+            IngestionMode::Initial.as_storage_str(),
+            IngestionMode::Incremental.as_storage_str(),
+            IngestionMode::Forced.as_storage_str(),
+            IngestionMode::Backfill.as_storage_str(),
+            IngestionMode::EntitySeeded.as_storage_str(),
+            IngestionMode::Realtime.as_storage_str(),
+        ];
+        let mut sorted = slugs.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(slugs.len(), sorted.len(), "storage slug collision");
     }
 }


### PR DESCRIPTION
## Summary

Mechanical additive change adding two `IngestionMode` variants to `src-tauri/src/services/workspace_ingestion/runs.rs`. Hard precondition for v1.4.5 W2-A/C/D L1 per cycle-13 wave amendment §13.1.

## Why

The v1.4.5 W2 L0 packets (merged at PR #349) name two ingestion modes that W1 didn't ship:

- **`EntitySeeded`** — W2-C entity-intake ability requests this when a Gutenberg block user submits a workspace document with a known entity binding (`abilities-runtime/src/abilities/entity_intake.rs` → `WorkspaceIntakeService::ingest`).
- **`Realtime`** — W2-D inbox immediate-ingest path requests this when a file drops into `_inbox/` and processing fires before the next watcher tick (`src-tauri/src/commands/workspace.rs::process_inbox_file`).

Without these variants the W2 L1 stubs don't compile. This PR ships them as a bounded mechanical change so W2-A/C/D L1 can start.

## What changes

```diff
 pub enum IngestionMode {
     Initial,
     Incremental,
     Forced,
     Backfill,
+    EntitySeeded,
+    Realtime,
 }
```

Plus exhaustive match-arm updates in `IngestionMode::as_storage_str` (storage slugs `entity_seeded` and `realtime`) and `IngestionMode::from_storage_str`. Plus two unit tests: round-trip across all 6 variants, and storage-slug collision distinctness.

No schema changes, no behavior changes, no migration.

## §4 Security

security_auditor_invoked: true

**Verdict:** APPROVE — security-lens review confirms no new attack surface.

Findings (full review at L2 below):
1. **No untrusted-input ingress:** new variants enter the system via `StartRunSeed.mode` (internal callers) or `from_storage_str` (local SQLite, single-user loopback). No external principal supplies a raw mode string via network endpoint or IPC.
2. **No slug collision:** `entity_seeded` and `realtime` are lexically distinct from existing slugs; collision-distinctness CI test added.
3. **No privileged-variant branch:** new variants fall through to the standard non-Forced path; the two narrow `matches!(_, IngestionMode::Forced)` checks at lines 166 + 214 remain Forced-only (retry-lineage), which is correct.
4. **No prompt-channel reach (ADR-0093):** mode is pure run-tracking metadata; never reaches prompt construction.
5. **No rendering reach (ADR-0108):** mode is storage label only; never emitted to a rendering surface.

Trust topology: local-to-local single-user per engineering-ladder L0 framing (PR #348). The Amendment-3 path-prefix gate fires because `runs.rs` is in the workspace-ingestion service tree, but the actual review found zero security surface impact.

## Verification

- ✅ `cargo clippy --lib -- -D warnings` — clean
- ✅ `cargo test --lib services::workspace_ingestion::runs::tests::ingestion_mode` — both new tests pass
- ✅ No exhaustive-match call sites outside `runs.rs` (`rg 'match.*IngestionMode\b'` returns only the two `matches!(_, IngestionMode::Forced)` checks at lines 157 + 205, both narrow-pattern not exhaustive)
- ✅ /cso review APPROVE (above)

## L2-status

passed

## Test plan

- [x] cargo clippy + targeted cargo test green locally
- [x] /cso security review APPROVE
- [ ] CI cargo + clippy + tsc green on PR check
- [ ] After merge: v1.4.5 W2 L1 implementer can start W2-A (substrate + bridge), then W2-B/C/D in parallel after W2-A merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)