### PR TITLE
v1.4.5 W2-A: workspace_ingestion IngestPipeline + bridge (DOS-466)

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-A-DOS-466.md
+++ b/.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-A-DOS-466.md
@@ -1,6 +1,6 @@
 # L0 Packet — v1.4.5 W2-A — DOS-466 Staged Ingestion Service: Pipeline Shell + Quarantine + auto_detect_category
 
-**Current revision:** V1.4 (cycle-4 cross-lane reconciliation + mechanical bug fold, 2026-05-21). See §2 Changelog.
+**Current revision:** V1.5 (L1 kickoff precondition resolutions, 2026-05-21). See §2 Changelog.
 
 ## 1. Header
 
@@ -20,6 +20,10 @@
 
 ## 2. Changelog
 
+- **V1.5 — 2026-05-21 (L1 kickoff):** Resolves three L1-preconditions from `L1-residuals-from-L0-cycle-5.md` against live substrate.
+  1. **`entity_name` IS a path segment.** Live `registry.rs:448` (`PathBuf::from(entity_dir).join(entity_name)`) confirms. REVERTS V1.4 §7 / §9 wording marking it "display-only". The bridge (`workspace_intake_impl.rs`) MUST slug-validate `entity_name` via `is_valid_slug_shape` (registry.rs:464 pattern) before constructing `IngestRequest`; invalid → `WorkspaceIntakeError::InvalidEntityName(String)` (new variant added to §0 V1.4).
+  2. **`workspace_root` threaded via constructor.** `IngestPipeline` holds `workspace_root: PathBuf` as a field; `pub fn build_pipeline(workspace_root: PathBuf) -> IngestPipeline` (still infallible). `pipeline.run()` revalidates `request.file_id == file_id_from_identity(&request.identity, &self.workspace_root)`. Also resolves W2-B residual #2 — W2-B call sites become `wiring::build_pipeline(workspace_root)`, no `?`.
+  3. **§0 typed-DTO duplicate removed.** `W2-shared-contract.md` §4's stale typed-field `WorkspaceIntakeRequest` mirror (V1.2 leftover) deleted; canonical V1.3 raw-slug form is the only authority.
 - **V1.4 — 2026-05-21:** Folds §0 V1.3 and cycle-4 mechanical findings without changing architecture.
   1. Absorbs §0 V1.3: `WorkspaceIntakeService` trait DTOs use raw slugs at the crate boundary; `LifecycleRepo` adds `set_entity` + `get` helpers.
   2. Makes `workspace_intake_impl.rs` the SLUG→TYPED translator: parse `WorkspaceIntakeRequest` raw slugs into `WorkspaceFileKind` / `IngestionMode` / `WorkspaceCategory`, parse entity type via `EntityType::from_str_lossy`, validate categories through `WorkspaceCategoryRegistry::validate`, then construct the internal typed `IngestRequest`.
@@ -193,7 +197,7 @@ DOS-466 is security-annotated. Untrusted file content enters the service. Requir
 - No shell command invocation from the pipeline (no `std::process::Command` for content extraction).
 - Pipeline reads from the `(File, FileIdentity)` returned by `WorkspaceSourceRegistry::open_validated` only — never re-opens by path.
 - Caller-provided `IngestRequest.file_id` MUST match `file_id_from_identity(&request.identity, workspace_root)` per §0 V1.2 §2.1 and §2.4. Mismatch returns typed `IngestError::FileIdMismatch { expected, found }`; L1 must not downgrade this to `DbError`, `Io`, `RejectionReason`, or an untyped string. §10 requires the negative test.
-- `EntityRef.entity_name` is display-only per §0 V1.3 §2.1 and must not be used as a routing/path segment. Do not add a slug-validation gate to `entity_name`; path resolution uses typed `entity_type` plus validated category only.
+- **V1.5 fold:** `EntityRef.entity_name` IS a path segment per live `registry.rs:448` (`PathBuf::from(entity_dir).join(entity_name)`). The bridge MUST slug-validate via `is_valid_slug_shape` before constructing `IngestRequest`; invalid → `WorkspaceIntakeError::InvalidEntityName(String)`. Inside `pipeline.run()` we trust the type (validation happens at the bridge boundary).
 - CI grep gate covers ALL path-opening APIs from §0 §8, verbatim:
 
 ```text
@@ -273,8 +277,9 @@ impl IngestPipeline {
         // L1 fills:
         // 1. Re-derive file_id via file_id_from_identity(&request.identity, workspace_root).
         // 2. Reject caller-provided file_id mismatch with IngestError::FileIdMismatch { expected, found }.
-        // 3. Resolve path through WorkspaceCategoryRegistry using category + entity_type only.
-        //    EntityRef.entity_name is display-only; never treat it as a path segment.
+        // 3. Resolve path through WorkspaceCategoryRegistry::resolve_path using
+        //    entity_type + entity_name + category. V1.5: entity_name IS a path
+        //    segment (registry.rs:448); bridge has already slug-validated it.
         // 4. Read from request.file only, enforcing max bytes and 4KB content_head.
         // 5. Seek back to start before calling Extractor::extract(&File, ...).
         // 6. Populate resolved_path in the receipt; no scope redaction in this topology.
@@ -360,7 +365,7 @@ pub trait WorkspaceIntakeService: Send + Sync {
 }
 ```
 
-The required DTO fields are `file_ref`, `source_type_slug`, `entity: Option<EntityRefDto>`, `mode_slug`, and `category_slug: Option<String>`. `EntityRefDto` carries `entity_type_slug`, `entity_id`, and display-only `entity_name`.
+The required DTO fields are `file_ref`, `source_type_slug`, `entity: Option<EntityRefDto>`, `mode_slug`, and `category_slug: Option<String>`. `EntityRefDto` carries `entity_type_slug`, `entity_id`, and `entity_name` (path-segment per V1.5; bridge slug-validates via `is_valid_slug_shape`).
 
 `src-tauri/abilities-runtime/src/services/context.rs` grows the service accessor behind `AbilityContext::services()`; ability functions still receive `AbilityContext`, not `ServiceContext`, per §0 V1.2 §13:
 
@@ -486,7 +491,7 @@ service_context_builder.workspace_intake(&ingest_pipeline_workspace_intake);
 - Sniff only the first 4KB for frontmatter category detection, and prove this at the pipeline read boundary rather than only by unit-testing `auto_detect_category_pure`.
 - Treat caller-provided `category_hint` as already registry-valid by contract.
 - Treat auto-detected category output as provisional until registry validation passes.
-- Treat `EntityRef.entity_name` as display-only lifecycle data. Do not slug-validate it, and do not use it for path resolution; route using `entity_type` plus category only.
+- V1.5: `EntityRef.entity_name` IS the path segment between `{Accounts|People|Projects}/` and the category dir (live `registry.rs:448`). The bridge slug-validates via `is_valid_slug_shape` before `IngestRequest` is constructed; `pipeline.run()` trusts the typed field. Routing uses `entity_type` + `entity_name` + category, not entity_type + category alone.
 - Pre-hash rejection paths (for example file too large before read allocation) do not create a `document_ingestion_runs` row because W1-C requires non-null `content_sha256`; they transition lifecycle to `Rejected` and emit a typed rejection. Post-hash handled failures complete the run as `Failed`.
 - Preserve the no-claim W2 behavior even if `Extractor::extract` is swapped early in a local workspace.
 - Complete failed runs with typed error detail; never leave a fresh run permanently `in_progress` on handled rejection paths.

--- a/.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-A-DOS-466.md
+++ b/.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-A-DOS-466.md
@@ -1,6 +1,6 @@
 # L0 Packet — v1.4.5 W2-A — DOS-466 Staged Ingestion Service: Pipeline Shell + Quarantine + auto_detect_category
 
-**Current revision:** V1.5 (L1 kickoff precondition resolutions, 2026-05-21). See §2 Changelog.
+**Current revision:** V1.6 (L2 cycle-1 codex BLOCK fold, 2026-05-21). See §2 Changelog.
 
 ## 1. Header
 
@@ -20,6 +20,9 @@
 
 ## 2. Changelog
 
+- **V1.6 — 2026-05-21 (L2 cycle-1 fold):** Codex L2 challenge returned BLOCK at 18:30Z with two findings. Architect / correctness / security reviewers returned APPROVE. Folds per `feedback_reviewer_dissent_is_signal`:
+  1. **Finding 2 (§3 + §7 AC violation) — FIXED in cycle 2.** Frontmatter `doc_type` priority 1 was not terminal: a present-but-shape-invalid `doc_type` (e.g. `Bad`) fell through to filename-glob, letting filename intent override user-supplied invalid intent. Fix at `pipeline.rs::auto_detect_category_pure` — new internal helper `frontmatter_doctype_detection(content_head) -> Option<Option<WorkspaceCategory>>` distinguishes "priority 1 didn't fire" from "priority 1 fired with no match". Regression test at `tests/workspace_ingestion_w2a_auto_detect_category.rs::invalid_frontmatter_doctype_is_terminal_none_even_with_filename_match` (2 assertions covering shape-invalid + leading-digit cases).
+  2. **Finding 1 (ServiceContext field shape) — PATH-α, NOT BLOCK.** Codex flagged that §9 stub specifies `workspace_intake: &'a dyn WorkspaceIntakeService` (non-Option borrowed ref) but impl uses `Option<Arc<dyn WorkspaceIntakeService>>`. Per `feedback_l2_path_alpha_to_maintenance_project`: this is code-stub drift, not an AC violation (§11 says "ServiceContext extended with workspace_intake; bootstrap registers IngestPipelineWorkspaceIntake" — satisfied), not an ADR-named contract violation, not a PR-introduced regression. Architect reviewer correctly noted the impl shape matches the established convention for builder-populated handles (`entity_context_reader`, `composition_commit`, `claim_receipt_reader` are all `Option<Arc<dyn ...>>`). Non-Option borrowed refs in ServiceContext (`Clock`, `SeededRng`, `ExternalClients`) are constructor params; handles need builder pattern. File under DOS-751 to revisit when W2-C's consumer pattern stabilizes — if `workspace_intake().expect(...)` proliferates, lift the field to non-Option.
 - **V1.5 — 2026-05-21 (L1 kickoff):** Resolves three L1-preconditions from `L1-residuals-from-L0-cycle-5.md` against live substrate.
   1. **`entity_name` IS a path segment.** Live `registry.rs:448` (`PathBuf::from(entity_dir).join(entity_name)`) confirms. REVERTS V1.4 §7 / §9 wording marking it "display-only". The bridge (`workspace_intake_impl.rs`) MUST slug-validate `entity_name` via `is_valid_slug_shape` (registry.rs:464 pattern) before constructing `IngestRequest`; invalid → `WorkspaceIntakeError::InvalidEntityName(String)` (new variant added to §0 V1.4).
   2. **`workspace_root` threaded via constructor.** `IngestPipeline` holds `workspace_root: PathBuf` as a field; `pub fn build_pipeline(workspace_root: PathBuf) -> IngestPipeline` (still infallible). `pipeline.run()` revalidates `request.file_id == file_id_from_identity(&request.identity, &self.workspace_root)`. Also resolves W2-B residual #2 — W2-B call sites become `wiring::build_pipeline(workspace_root)`, no `?`.

--- a/.docs/plans/v1.4.5-workspace-memory/W2-shared-contract.md
+++ b/.docs/plans/v1.4.5-workspace-memory/W2-shared-contract.md
@@ -310,7 +310,7 @@ pub struct WorkspaceIntakeRequest {
 pub struct EntityRefDto {
     pub entity_type_slug: String,   // bridge parses to EntityType via from_str_lossy
     pub entity_id: String,
-    pub entity_name: Option<String>, // display only; NOT a path segment
+    pub entity_name: Option<String>, // V1.4: IS a path segment per live registry.rs:448. Bridge MUST slug-validate via is_valid_slug_shape before construction; None or invalid → reject with InvalidEntityName (bridge error).
 }
 
 pub struct WorkspaceIntakeReceipt {
@@ -328,6 +328,7 @@ pub enum WorkspaceIntakeError {
     CategoryNotAllowed { allowed: Vec<String> },
     InvalidEntityTypeSlug(String),
     InvalidEntityId,
+    InvalidEntityName(String), // V1.4: entity_name is a path segment; must pass is_valid_slug_shape.
     EntityNotFound,
     FileNotFound,
     PathTraversalAttempt,
@@ -339,18 +340,9 @@ pub enum WorkspaceIntakeError {
     Io(String),
     DbError(String),
 }
-
-/// Mirror of IngestRequest but flattened for crate-boundary stability. The
-/// dailyos_lib impl converts WorkspaceIntakeRequest into IngestRequest using
-/// internal helpers (registry::open_validated, file_id_from_identity).
-pub struct WorkspaceIntakeRequest {
-    pub file_ref: String,              // workspace-relative path
-    pub source_type: WorkspaceFileKind,
-    pub entity: Option<EntityRefDto>,
-    pub mode: IngestionMode,
-    pub category_hint: Option<WorkspaceCategory>,
-}
 ```
+
+**V1.4 dedup (W2-A L1 kickoff, 2026-05-21):** A stale typed-DTO mirror of `WorkspaceIntakeRequest` (with `source_type: WorkspaceFileKind`, `mode: IngestionMode`, `category_hint: Option<WorkspaceCategory>`) was removed from this section. The canonical V1.3 raw-slug form at lines 302–308 is the only authority; the bridge in `workspace_intake_impl.rs` parses raw slugs to typed enums per §4 paragraph 1.
 
 `ServiceContext` gets a new accessor: `ctx.services().workspace_intake() -> &dyn WorkspaceIntakeService`. The dailyos_lib `Bootstrap` registers an `IngestPipelineWorkspaceIntake` impl during app startup.
 

--- a/src-tauri/abilities-runtime/src/lib.rs
+++ b/src-tauri/abilities-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod services {
     pub mod sensitivity {
         pub use crate::sensitivity::*;
     }
+    pub mod workspace_intake;
 }
 pub mod structured_claim;
 pub mod types;

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -53,6 +53,7 @@ use crate::services::external_replay::{
     AuthScopeId, ExternalReplayFixture, ExternalReplayFixtureMissing, JsonExternalReplayFixture,
     ReplayResponse, RequestKey,
 };
+use crate::services::workspace_intake::WorkspaceIntakeService;
 use crate::types::{
     subject_ref_from_json, ClaimSubjectRef, EntityContextEntry, EntityContextText,
     IntelligenceClaim,
@@ -849,6 +850,7 @@ pub struct ServiceContext<'a> {
     account_list_reader: Option<Arc<dyn AccountListReadHandle>>,
     person_list_reader: Option<Arc<dyn PersonListReadHandle>>,
     project_list_reader: Option<Arc<dyn ProjectListReadHandle>>,
+    workspace_intake: Option<Arc<dyn WorkspaceIntakeService>>,
 }
 
 pub type EntityContextReadFuture<'a> =
@@ -1599,9 +1601,8 @@ pub enum ClaimReceiptReadError {
     ReadFailed(String),
 }
 
-pub type ClaimReceiptReadFuture<'a> = Pin<
-    Box<dyn Future<Output = Result<ClaimReceiptSnapshot, ClaimReceiptReadError>> + Send + 'a>,
->;
+pub type ClaimReceiptReadFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ClaimReceiptSnapshot, ClaimReceiptReadError>> + Send + 'a>>;
 
 /// Narrow read handle that the app crate attaches so the `claim_receipt`
 /// ability can dispatch through `services::claim_receipt::render::
@@ -1678,6 +1679,7 @@ impl<'a> ServiceContext<'a> {
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
+            workspace_intake: None,
         }
     }
 
@@ -1710,6 +1712,7 @@ impl<'a> ServiceContext<'a> {
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
+            workspace_intake: None,
         }
     }
 
@@ -1753,6 +1756,7 @@ impl<'a> ServiceContext<'a> {
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
+            workspace_intake: None,
         }
     }
 
@@ -1847,10 +1851,7 @@ impl<'a> ServiceContext<'a> {
         self
     }
 
-    pub fn with_claim_receipt_reader(
-        mut self,
-        reader: Arc<dyn ClaimReceiptReadHandle>,
-    ) -> Self {
+    pub fn with_claim_receipt_reader(mut self, reader: Arc<dyn ClaimReceiptReadHandle>) -> Self {
         self.claim_receipt_reader = Some(reader);
         self
     }
@@ -1868,6 +1869,15 @@ impl<'a> ServiceContext<'a> {
     pub fn with_project_list_reader(mut self, reader: Arc<dyn ProjectListReadHandle>) -> Self {
         self.project_list_reader = Some(reader);
         self
+    }
+
+    pub fn with_workspace_intake(mut self, service: Arc<dyn WorkspaceIntakeService>) -> Self {
+        self.workspace_intake = Some(service);
+        self
+    }
+
+    pub fn workspace_intake(&self) -> Option<&dyn WorkspaceIntakeService> {
+        self.workspace_intake.as_deref()
     }
 
     /// Reader-backed touchpoint composition. When no reader is

--- a/src-tauri/abilities-runtime/src/services/workspace_intake.rs
+++ b/src-tauri/abilities-runtime/src/services/workspace_intake.rs
@@ -1,0 +1,66 @@
+use async_trait::async_trait;
+
+use crate::abilities::registry::AbilityContext;
+
+#[async_trait]
+pub trait WorkspaceIntakeService: Send + Sync {
+    async fn ingest(
+        &self,
+        ctx: &AbilityContext<'_>,
+        request: WorkspaceIntakeRequest,
+    ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceIntakeRequest {
+    pub file_ref: String,
+    pub source_type_slug: String,
+    pub entity: Option<EntityRefDto>,
+    pub mode_slug: String,
+    pub category_slug: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityRefDto {
+    pub entity_type_slug: String,
+    pub entity_id: String,
+    pub entity_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceIntakeReceipt {
+    pub run_id: String,
+    pub file_id: String,
+    pub content_sha256: String,
+    pub lifecycle_state_after_slug: String,
+    pub resolved_path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceIntakeError {
+    InvalidSourceTypeSlug(String),
+    InvalidModeSlug(String),
+    InvalidCategorySlug(String),
+    CategoryNotAllowed { allowed: Vec<String> },
+    InvalidEntityTypeSlug(String),
+    InvalidEntityId,
+    InvalidEntityName(String),
+    EntityNotFound,
+    FileNotFound,
+    PathTraversalAttempt,
+    OutsideWorkspace,
+    SymlinkRaced,
+    FileTooLarge,
+    UnsupportedFormat,
+    AlreadyProcessed { existing_run_id: String },
+    Io(String),
+    DbError(String),
+}
+
+impl std::fmt::Display for WorkspaceIntakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for WorkspaceIntakeError {}

--- a/src-tauri/scripts/check_workspace_mutation_allowlist.sh
+++ b/src-tauri/scripts/check_workspace_mutation_allowlist.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Workspace-ingestion mutation lint.
+#
+# Runtime writes to workspace lifecycle/run/link tables and direct workspace-file
+# filesystem mutation must stay inside services/workspace_ingestion/.
+
+set -euo pipefail
+
+if [[ -d "src-tauri" ]]; then
+  roots=("src-tauri/src" "src-tauri/tests")
+else
+  roots=("src" "tests")
+fi
+
+allowed_regex='services/workspace_ingestion/|tests/workspace_ingestion_|tests/workspace_mutation_allowlist_test\.rs|src/accounts\.rs|src/processor/|src/projects\.rs|src/commands/app_support\.rs|src/commands/workspace\.rs|src/db_backup\.rs|src/services/accounts\.rs'
+table_pattern='(INSERT([[:space:]]+OR[[:space:]]+(IGNORE|REPLACE))?[[:space:]]+INTO|REPLACE[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(workspace_file_lifecycle|document_ingestion_runs|document_entity_links)\b'
+fs_pattern='(std::fs::(write|rename|copy|remove_file|remove_dir|remove_dir_all|create_dir|create_dir_all)|tokio::fs::(write|rename|copy|remove_file|remove_dir|remove_dir_all|create_dir|create_dir_all))'
+
+table_matches="$(
+  grep -rEni --include='*.rs' --include='*.sql' "$table_pattern" "${roots[@]}" 2>/dev/null \
+    | grep -Ev '^[^:]+:[0-9]+:[[:space:]]*(//|--)' \
+    | grep -Ev "($allowed_regex)" \
+    || true
+)"
+
+fs_matches="$(
+  grep -rEn --include='*.rs' "$fs_pattern" "${roots[@]}" 2>/dev/null \
+    | grep -Ev "($allowed_regex)" \
+    | grep -Ei 'workspace|Workspace|workspace_root|workspace_path|canonical_path|file_ref' \
+    || true
+)"
+
+if [[ -n "$table_matches" || -n "$fs_matches" ]]; then
+  echo "Workspace lifecycle/run/link table writes and workspace-file filesystem writes must route through services/workspace_ingestion."
+  echo
+  if [[ -n "$table_matches" ]]; then
+    echo "Table write violations:"
+    echo "$table_matches"
+    echo
+  fi
+  if [[ -n "$fs_matches" ]]; then
+    echo "Filesystem write violations:"
+    echo "$fs_matches"
+    echo
+  fi
+  exit 1
+fi
+
+echo "Workspace mutation allowlist clean."

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -70,6 +70,9 @@ pub fn attach_live_workspace_readers(ctx: ServiceContext<'_>) -> ServiceContext<
         ))
         .with_meeting_prep_status_reader(Arc::new(LiveMeetingPrepStatusReader))
         .with_claim_receipt_reader(Arc::new(LiveClaimReceiptReader))
+        .with_workspace_intake(Arc::new(
+            crate::services::workspace_ingestion::workspace_intake_impl::IngestPipelineWorkspaceIntake::from_config_or_empty(),
+        ))
 }
 
 impl EntityContextReadHandle for LiveEntityContextReader {
@@ -298,9 +301,7 @@ fn prep_status_to_str(status: crate::services::meeting_prep_status::PrepStatus) 
     }
 }
 
-fn blocking_reason_to_str(
-    reason: crate::services::meeting_prep_status::BlockingReason,
-) -> String {
+fn blocking_reason_to_str(reason: crate::services::meeting_prep_status::BlockingReason) -> String {
     use crate::services::meeting_prep_status::BlockingReason::*;
     match reason {
         NoLinkedEntity => "no_linked_entity",
@@ -415,15 +416,13 @@ impl ClaimReceiptReadHandle for LiveClaimReceiptReader {
         surface: ClaimReceiptSurfaceContext,
     ) -> ClaimReceiptReadFuture<'a> {
         Box::pin(async move {
-            tokio::task::spawn_blocking(move || {
-                live_render_claim_receipt(target, surface)
-            })
-            .await
-            .map_err(|error| {
-                ClaimReceiptReadError::ReadFailed(format!(
-                    "claim_receipt blocking task failed: {error}"
-                ))
-            })?
+            tokio::task::spawn_blocking(move || live_render_claim_receipt(target, surface))
+                .await
+                .map_err(|error| {
+                    ClaimReceiptReadError::ReadFailed(format!(
+                        "claim_receipt blocking task failed: {error}"
+                    ))
+                })?
         })
     }
 }
@@ -492,13 +491,9 @@ fn live_render_claim_receipt(
         crate::services::claim_receipt::privacy::Audience::UserTauri
     ) {
         if let app::ReceiptTarget::Claim { claim_id, .. } = &app_target {
-            let claim_opt =
-                crate::services::claims::load_claim_by_id(db.conn_ref(), claim_id)
-                    .map_err(|error| {
-                        ClaimReceiptReadError::ReadFailed(error.to_string())
-                    })?;
-            let claim =
-                claim_opt.ok_or(ClaimReceiptReadError::TargetNotFound)?;
+            let claim_opt = crate::services::claims::load_claim_by_id(db.conn_ref(), claim_id)
+                .map_err(|error| ClaimReceiptReadError::ReadFailed(error.to_string()))?;
+            let claim = claim_opt.ok_or(ClaimReceiptReadError::TargetNotFound)?;
             let render_surface = match app_surface {
                 app::SurfaceContext::ActionsWork => RenderSurface::Action,
                 app::SurfaceContext::EntityDetail => RenderSurface::TauriEntityDetail,

--- a/src-tauri/src/services/workspace_ingestion/lifecycle.rs
+++ b/src-tauri/src/services/workspace_ingestion/lifecycle.rs
@@ -9,9 +9,13 @@
 
 use abilities_runtime::abilities::provenance::source::DataSource;
 use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
-use super::contracts::{WorkspaceCategory, WorkspaceFileKind};
+use crate::entity::EntityType;
+
+use super::contracts::{FileIdentity, WorkspaceCategory, WorkspaceFileKind};
+use super::pipeline::EntityRef;
 
 /// Seven-state lifecycle per wave plan §Goal + cycle 2 amendment
 /// (`pending_entity_assignment`).
@@ -101,10 +105,9 @@ impl std::fmt::Display for LifecycleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::FileNotFound => write!(f, "workspace file not found"),
-            Self::InvalidStateTransition { from, to } => write!(
-                f,
-                "invalid lifecycle transition: {from:?} → {to:?}"
-            ),
+            Self::InvalidStateTransition { from, to } => {
+                write!(f, "invalid lifecycle transition: {from:?} → {to:?}")
+            }
             Self::DbError(msg) => write!(f, "lifecycle db error: {msg}"),
         }
     }
@@ -125,4 +128,301 @@ pub fn escalate_to_pending(_file_id: &str, _actor: &str) -> Result<(), Lifecycle
     Err(LifecycleError::DbError(
         "escalate_to_pending: W1-A stub; W4-A wires the real DB update".to_string(),
     ))
+}
+
+pub struct LifecycleRepo;
+
+impl LifecycleRepo {
+    pub fn insert_pending(
+        conn: &Connection,
+        file_id: &str,
+        identity: &FileIdentity,
+        source_type: &WorkspaceFileKind,
+        source_asof: DateTime<Utc>,
+        entity: Option<&EntityRef>,
+    ) -> Result<(), LifecycleError> {
+        let data_source = DataSource::WorkspaceFile {
+            kind: source_type.clone(),
+        };
+        let data_source_json = serde_json::to_string(&data_source)
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        let canonical_path = identity.canonical_path.to_string_lossy().to_string();
+        let entity_id = entity.map(|e| e.entity_id.0.as_str());
+        let entity_type = entity.map(|e| e.entity_type.as_str());
+
+        conn.execute(
+            "INSERT OR IGNORE INTO workspace_file_lifecycle \
+             (file_id, canonical_path, device, inode, source_type, data_source, \
+              lifecycle_state, source_asof, entity_id, entity_type) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?8, ?9)",
+            params![
+                file_id,
+                canonical_path,
+                identity.device as i64,
+                identity.inode as i64,
+                workspace_file_kind_slug(source_type),
+                data_source_json,
+                source_asof.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                entity_id,
+                entity_type,
+            ],
+        )
+        .map(|_| ())
+        .map_err(|e| LifecycleError::DbError(e.to_string()))
+    }
+
+    pub fn transition(
+        conn: &Connection,
+        file_id: &str,
+        from: LifecycleState,
+        to: LifecycleState,
+    ) -> Result<(), LifecycleError> {
+        if !is_valid_transition(from, to) {
+            return Err(LifecycleError::InvalidStateTransition { from, to });
+        }
+        let rows = conn
+            .execute(
+                "UPDATE workspace_file_lifecycle SET lifecycle_state = ?1, \
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+                 WHERE file_id = ?2 AND lifecycle_state = ?3",
+                params![
+                    lifecycle_state_slug(to),
+                    file_id,
+                    lifecycle_state_slug(from)
+                ],
+            )
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        if rows > 0 {
+            return Ok(());
+        }
+        let current = Self::get(conn, file_id)?.ok_or(LifecycleError::FileNotFound)?;
+        if current.lifecycle_state == to {
+            Ok(())
+        } else {
+            Err(LifecycleError::InvalidStateTransition {
+                from: current.lifecycle_state,
+                to,
+            })
+        }
+    }
+
+    pub fn record_user_override(
+        conn: &Connection,
+        file_id: &str,
+        actor: &str,
+    ) -> Result<(), LifecycleError> {
+        let rows = conn
+            .execute(
+                "UPDATE workspace_file_lifecycle SET user_override_actor = ?1, \
+                 user_override_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'), \
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+                 WHERE file_id = ?2",
+                params![actor, file_id],
+            )
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        if rows == 0 {
+            Err(LifecycleError::FileNotFound)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn update_category(
+        conn: &Connection,
+        file_id: &str,
+        category: Option<&WorkspaceCategory>,
+    ) -> Result<(), LifecycleError> {
+        let rows = conn
+            .execute(
+                "UPDATE workspace_file_lifecycle SET category = ?1, \
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+                 WHERE file_id = ?2",
+                params![category.map(WorkspaceCategory::as_slug), file_id],
+            )
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        if rows == 0 {
+            Err(LifecycleError::FileNotFound)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn update_content_sha256(
+        conn: &Connection,
+        file_id: &str,
+        content_sha256: &str,
+    ) -> Result<(), LifecycleError> {
+        let rows = conn
+            .execute(
+                "UPDATE workspace_file_lifecycle SET content_sha256 = ?1, \
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+                 WHERE file_id = ?2",
+                params![content_sha256, file_id],
+            )
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        if rows == 0 {
+            Err(LifecycleError::FileNotFound)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn get(
+        conn: &Connection,
+        file_id: &str,
+    ) -> Result<Option<WorkspaceFileLifecycle>, LifecycleError> {
+        conn.query_row(
+            "SELECT file_id, canonical_path, device, inode, source_type, data_source, \
+             lifecycle_state, source_asof, entity_id, entity_type, content_sha256, category, \
+             user_override_actor, user_override_at, created_at, updated_at \
+             FROM workspace_file_lifecycle WHERE file_id = ?1",
+            params![file_id],
+            row_to_lifecycle,
+        )
+        .optional()
+        .map_err(|e| LifecycleError::DbError(e.to_string()))
+    }
+
+    pub fn set_entity(
+        conn: &Connection,
+        file_id: &str,
+        entity_type: EntityType,
+        entity_id: &str,
+        entity_name: Option<&str>,
+    ) -> Result<(), LifecycleError> {
+        let rows = conn
+            .execute(
+                "UPDATE workspace_file_lifecycle SET entity_type = ?1, entity_id = ?2, \
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+                 WHERE file_id = ?3",
+                params![entity_type.as_str(), entity_id, file_id],
+            )
+            .map_err(|e| LifecycleError::DbError(e.to_string()))?;
+        let _path_segment = entity_name;
+        if rows == 0 {
+            Err(LifecycleError::FileNotFound)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn row_to_lifecycle(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkspaceFileLifecycle> {
+    let source_type_raw: String = row.get(4)?;
+    let data_source_raw: String = row.get(5)?;
+    let lifecycle_state_raw: String = row.get(6)?;
+    let source_asof_raw: String = row.get(7)?;
+    let category_raw: Option<String> = row.get(11)?;
+    let override_actor: Option<String> = row.get(12)?;
+    let override_at_raw: Option<String> = row.get(13)?;
+    let created_at_raw: String = row.get(14)?;
+    let updated_at_raw: String = row.get(15)?;
+
+    Ok(WorkspaceFileLifecycle {
+        file_id: row.get(0)?,
+        canonical_path: row.get(1)?,
+        device: row.get::<_, i64>(2)? as u64,
+        inode: row.get::<_, i64>(3)? as u64,
+        source_type: workspace_file_kind_from_slug(&source_type_raw)
+            .unwrap_or(WorkspaceFileKind::Inbox),
+        data_source: serde_json::from_str(&data_source_raw).unwrap_or(DataSource::WorkspaceFile {
+            kind: WorkspaceFileKind::Inbox,
+        }),
+        lifecycle_state: lifecycle_state_from_slug(&lifecycle_state_raw)
+            .unwrap_or(LifecycleState::Pending),
+        source_asof: parse_dt(&source_asof_raw),
+        entity_id: row.get(8)?,
+        entity_type: row.get(9)?,
+        content_sha256: row.get(10)?,
+        category: category_raw
+            .as_deref()
+            .and_then(WorkspaceCategory::from_slug),
+        user_override: match (override_actor, override_at_raw.as_deref().map(parse_dt)) {
+            (Some(actor_id), Some(at)) => Some(UserOverride { actor_id, at }),
+            _ => None,
+        },
+        created_at: parse_dt(&created_at_raw),
+        updated_at: parse_dt(&updated_at_raw),
+    })
+}
+
+fn parse_dt(raw: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now())
+}
+
+fn is_valid_transition(from: LifecycleState, to: LifecycleState) -> bool {
+    if from == to {
+        return true;
+    }
+    matches!(
+        (from, to),
+        (LifecycleState::Pending, LifecycleState::Ingesting)
+            | (LifecycleState::Pending, LifecycleState::Ingested)
+            | (LifecycleState::Pending, LifecycleState::Rejected)
+            | (
+                LifecycleState::Pending,
+                LifecycleState::PendingEntityAssignment
+            )
+            | (LifecycleState::Ingesting, LifecycleState::Ingested)
+            | (LifecycleState::Ingesting, LifecycleState::Rejected)
+            | (
+                LifecycleState::Ingesting,
+                LifecycleState::PendingEntityAssignment
+            )
+            | (LifecycleState::Ingested, LifecycleState::Superseded)
+            | (_, LifecycleState::Quarantined)
+            | (LifecycleState::Rejected, LifecycleState::Pending)
+    )
+}
+
+pub fn lifecycle_state_slug(state: LifecycleState) -> &'static str {
+    match state {
+        LifecycleState::Pending => "pending",
+        LifecycleState::PendingEntityAssignment => "pending_entity_assignment",
+        LifecycleState::Ingesting => "ingesting",
+        LifecycleState::Ingested => "ingested",
+        LifecycleState::Superseded => "superseded",
+        LifecycleState::Rejected => "rejected",
+        LifecycleState::Quarantined => "quarantined",
+    }
+}
+
+fn lifecycle_state_from_slug(slug: &str) -> Option<LifecycleState> {
+    match slug {
+        "pending" => Some(LifecycleState::Pending),
+        "pending_entity_assignment" => Some(LifecycleState::PendingEntityAssignment),
+        "ingesting" => Some(LifecycleState::Ingesting),
+        "ingested" => Some(LifecycleState::Ingested),
+        "superseded" => Some(LifecycleState::Superseded),
+        "rejected" => Some(LifecycleState::Rejected),
+        "quarantined" => Some(LifecycleState::Quarantined),
+        _ => None,
+    }
+}
+
+pub fn workspace_file_kind_slug(kind: &WorkspaceFileKind) -> &'static str {
+    match kind {
+        WorkspaceFileKind::Inbox => "inbox",
+        WorkspaceFileKind::EntityDoc => "entity_doc",
+        WorkspaceFileKind::DriveSync => "drive_sync",
+        WorkspaceFileKind::UserAttachment => "user_attachment",
+        WorkspaceFileKind::GranolaTranscript => "granola_transcript",
+        WorkspaceFileKind::QuillTranscript => "quill_transcript",
+        WorkspaceFileKind::McpPlacement => "mcp_placement",
+    }
+}
+
+pub fn workspace_file_kind_from_slug(slug: &str) -> Option<WorkspaceFileKind> {
+    match slug {
+        "inbox" => Some(WorkspaceFileKind::Inbox),
+        "entity_doc" => Some(WorkspaceFileKind::EntityDoc),
+        "drive_sync" => Some(WorkspaceFileKind::DriveSync),
+        "user_attachment" => Some(WorkspaceFileKind::UserAttachment),
+        "granola_transcript" => Some(WorkspaceFileKind::GranolaTranscript),
+        "quill_transcript" => Some(WorkspaceFileKind::QuillTranscript),
+        "mcp_placement" => Some(WorkspaceFileKind::McpPlacement),
+        _ => None,
+    }
 }

--- a/src-tauri/src/services/workspace_ingestion/mod.rs
+++ b/src-tauri/src/services/workspace_ingestion/mod.rs
@@ -16,3 +16,4 @@ pub mod registry;
 pub mod runs;
 pub mod signals;
 pub mod wiring;
+pub mod workspace_intake_impl;

--- a/src-tauri/src/services/workspace_ingestion/pipeline.rs
+++ b/src-tauri/src/services/workspace_ingestion/pipeline.rs
@@ -1,6 +1,513 @@
-//! Staged ingestion pipeline — W2-A fills this with the
-//! `IngestPipeline::run(IngestRequest)` + `quarantine_source` +
-//! `auto_detect_category` implementations.
+//! Staged workspace ingestion pipeline.
 //!
-//! W1-A pre-creates this placeholder so no later lane needs to create a new
-//! file or edit `mod.rs`.
+//! W2-A owns the shell: validated file handle in, lifecycle/run bookkeeping,
+//! category sniffing, quarantine mutation, and zero claim production.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use abilities_runtime::abilities::provenance::source::{EntityId, WorkspaceFileKind};
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+use sha2::{Digest, Sha256};
+
+use crate::entity::EntityType;
+
+use super::contracts::{
+    Extractor, FileIdentity, RejectionReason, SignalEmitter, WorkspaceCategory,
+    WorkspaceClaimProposal,
+};
+use super::lifecycle::{LifecycleError, LifecycleRepo, LifecycleState};
+use super::registry::{ResolvePathError, WorkspaceCategoryRegistry};
+use super::runs::{
+    IngestionMode, IngestionRunId, IngestionRunStatus, RunsError, RunsRepo, StartRunSeed,
+};
+
+const DEFAULT_MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
+const CONTENT_HEAD_BYTES: usize = 4 * 1024;
+
+pub struct IngestPipeline {
+    pub extractor: Box<dyn Extractor>,
+    pub signal_emitter: Box<dyn SignalEmitter>,
+    pub max_file_bytes: u64,
+    pub extractor_version: String,
+    pub workspace_root: PathBuf,
+}
+
+pub struct IngestRequest {
+    pub file: File,
+    pub identity: FileIdentity,
+    pub file_id: String,
+    pub source_asof: DateTime<Utc>,
+    pub source_type: WorkspaceFileKind,
+    pub entity: Option<EntityRef>,
+    pub mode: IngestionMode,
+    pub category_hint: Option<WorkspaceCategory>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityRef {
+    pub entity_type: EntityType,
+    pub entity_id: EntityId,
+    pub entity_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IngestReceipt {
+    pub ingestion_run_id: IngestionRunId,
+    pub file_id: String,
+    pub content_sha256: String,
+    pub lifecycle_state_after: LifecycleState,
+    pub claim_proposals: Vec<WorkspaceClaimProposal>,
+    pub resolved_category: Option<WorkspaceCategory>,
+    pub resolved_path: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum IngestError {
+    FileIdMismatch { expected: String, found: String },
+    Rejected(RejectionReason),
+    AlreadyProcessed { existing_run_id: IngestionRunId },
+    Io(std::io::Error),
+    DbError(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectionMetadata {
+    pub limit_bytes: Option<u64>,
+    pub found_bytes: Option<u64>,
+    pub detected_format: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileIdError {
+    OutsideWorkspace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuarantineActor {
+    User { user_id: String },
+}
+
+impl IngestPipeline {
+    pub fn new(
+        extractor: Box<dyn Extractor>,
+        signal_emitter: Box<dyn SignalEmitter>,
+        max_file_bytes: u64,
+        extractor_version: impl Into<String>,
+        workspace_root: PathBuf,
+    ) -> Self {
+        Self {
+            extractor,
+            signal_emitter,
+            max_file_bytes,
+            extractor_version: extractor_version.into(),
+            workspace_root,
+        }
+    }
+
+    pub fn default_with(
+        extractor: Box<dyn Extractor>,
+        signal_emitter: Box<dyn SignalEmitter>,
+        workspace_root: PathBuf,
+    ) -> Self {
+        Self::new(
+            extractor,
+            signal_emitter,
+            DEFAULT_MAX_FILE_BYTES,
+            "workspace-null-extractor-v1",
+            workspace_root,
+        )
+    }
+
+    pub fn run(
+        &self,
+        conn: &Connection,
+        mut request: IngestRequest,
+    ) -> Result<IngestReceipt, IngestError> {
+        let expected = file_id_from_identity(&request.identity, &self.workspace_root)
+            .map_err(|e| IngestError::DbError(format!("file id derivation failed: {e:?}")))?;
+        if expected != request.file_id {
+            return Err(IngestError::FileIdMismatch {
+                expected,
+                found: request.file_id,
+            });
+        }
+
+        LifecycleRepo::insert_pending(
+            conn,
+            &request.file_id,
+            &request.identity,
+            &request.source_type,
+            request.source_asof,
+            request.entity.as_ref(),
+        )?;
+
+        let file_size = request.file.metadata().map_err(IngestError::Io)?.len();
+        if file_size > self.max_file_bytes {
+            self.reject_before_run(
+                conn,
+                &request.file_id,
+                RejectionReason::FileTooLarge,
+                LifecycleState::Pending,
+            )?;
+            return Err(IngestError::Rejected(RejectionReason::FileTooLarge));
+        }
+
+        let mut bytes = Vec::with_capacity(file_size as usize);
+        request
+            .file
+            .read_to_end(&mut bytes)
+            .map_err(IngestError::Io)?;
+        if bytes.contains(&0) || std::str::from_utf8(&bytes).is_err() {
+            self.reject_before_run(
+                conn,
+                &request.file_id,
+                RejectionReason::UnsupportedFormat,
+                LifecycleState::Pending,
+            )?;
+            return Err(IngestError::Rejected(RejectionReason::UnsupportedFormat));
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let content_sha256 = hex::encode(hasher.finalize());
+
+        let content = std::str::from_utf8(&bytes)
+            .map_err(|_| IngestError::Rejected(RejectionReason::UnsupportedFormat))?;
+        let head_end = if content.len() <= CONTENT_HEAD_BYTES {
+            content.len()
+        } else {
+            content
+                .char_indices()
+                .map(|(idx, _)| idx)
+                .take_while(|idx| *idx <= CONTENT_HEAD_BYTES)
+                .last()
+                .unwrap_or(0)
+        };
+        let content_head = &content[..head_end];
+
+        let filename = request
+            .identity
+            .canonical_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("workspace-file");
+
+        let resolved_category = if let Some(category) = request.category_hint.clone() {
+            Some(category)
+        } else if let Some(entity) = request.entity.as_ref() {
+            Self::validate_detected_category(
+                conn,
+                Self::auto_detect_category_pure(filename, content_head),
+                entity.entity_type,
+            )?
+        } else {
+            None
+        };
+        LifecycleRepo::update_category(conn, &request.file_id, resolved_category.as_ref())?;
+        LifecycleRepo::update_content_sha256(conn, &request.file_id, &content_sha256)?;
+
+        let run_id = RunsRepo::start_run(
+            conn,
+            StartRunSeed {
+                file_id: request.file_id.clone(),
+                mode: request.mode,
+                content_sha256: content_sha256.clone(),
+                file_size_bytes: file_size,
+                extractor_version: self.extractor_version.clone(),
+                retry_of_run_id: None,
+            },
+        )?;
+
+        LifecycleRepo::transition(
+            conn,
+            &request.file_id,
+            LifecycleState::Pending,
+            LifecycleState::Ingesting,
+        )?;
+
+        request
+            .file
+            .seek(SeekFrom::Start(0))
+            .map_err(IngestError::Io)?;
+        let _discarded_proposals = self.extractor.extract(
+            &request.file,
+            &request.identity,
+            request.source_type.clone(),
+        );
+        let claim_proposals = Vec::new();
+
+        RunsRepo::complete_run(conn, &run_id, IngestionRunStatus::Success, 0, None)?;
+
+        let lifecycle_state_after = if request.entity.is_some() {
+            LifecycleState::Ingested
+        } else {
+            LifecycleState::PendingEntityAssignment
+        };
+        LifecycleRepo::transition(
+            conn,
+            &request.file_id,
+            LifecycleState::Ingesting,
+            lifecycle_state_after,
+        )?;
+
+        let entity_id_for_signal = request.entity.as_ref().map(|e| e.entity_id.0.as_str());
+        match lifecycle_state_after {
+            LifecycleState::Ingested => self.signal_emitter.emit_file_ingested(
+                &request.file_id,
+                &content_sha256,
+                &run_id.0,
+                entity_id_for_signal,
+            ),
+            LifecycleState::PendingEntityAssignment => self
+                .signal_emitter
+                .emit_file_pending_entity_assignment(&request.file_id, &run_id.0),
+            _ => {}
+        }
+
+        let resolved_path =
+            resolve_receipt_path(conn, &request, resolved_category.as_ref(), filename)?;
+
+        Ok(IngestReceipt {
+            ingestion_run_id: run_id,
+            file_id: request.file_id,
+            content_sha256,
+            lifecycle_state_after,
+            claim_proposals,
+            resolved_category,
+            resolved_path,
+        })
+    }
+
+    pub fn validate_detected_category(
+        conn: &Connection,
+        candidate: Option<WorkspaceCategory>,
+        entity_type: EntityType,
+    ) -> Result<Option<WorkspaceCategory>, IngestError> {
+        let Some(category) = candidate else {
+            return Ok(None);
+        };
+        match WorkspaceCategoryRegistry::validate(conn, &category, entity_type) {
+            Ok(()) => Ok(Some(category)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn auto_detect_category_pure(
+        filename: &str,
+        content_head: &str,
+    ) -> Option<WorkspaceCategory> {
+        if let Some(category) = category_from_frontmatter(content_head) {
+            return Some(category);
+        }
+        if content_head.trim_start().starts_with("---") && frontmatter_block(content_head).is_none()
+        {
+            return None;
+        }
+
+        let lower = filename.to_ascii_lowercase();
+        if lower.contains("-transcript-") {
+            return Some(WorkspaceCategory::Transcripts);
+        }
+        if lower.contains("-deck-")
+            || lower.ends_with(".pptx")
+            || lower.ends_with(".key")
+            || lower.contains("-slides-")
+        {
+            return Some(WorkspaceCategory::Presentations);
+        }
+        if lower.contains("meeting") || lower.contains("-1on1-") {
+            return Some(WorkspaceCategory::Meetings);
+        }
+        if lower.contains("contract") || lower.contains("msa") || lower.contains("sow") {
+            return Some(WorkspaceCategory::Contracts);
+        }
+        if lower.ends_with(".pdf") {
+            return Some(WorkspaceCategory::Attachments);
+        }
+        if lower.ends_with(".md") || lower.ends_with(".txt") {
+            return Some(WorkspaceCategory::Notes);
+        }
+        None
+    }
+
+    fn reject_before_run(
+        &self,
+        conn: &Connection,
+        file_id: &str,
+        reason: RejectionReason,
+        from: LifecycleState,
+    ) -> Result<(), IngestError> {
+        let _metadata = RejectionMetadata {
+            limit_bytes: Some(self.max_file_bytes),
+            found_bytes: None,
+            detected_format: None,
+        };
+        LifecycleRepo::transition(conn, file_id, from, LifecycleState::Rejected)?;
+        self.signal_emitter
+            .emit_file_rejected(Some(file_id), reason.clone());
+        Ok(())
+    }
+}
+
+fn resolve_receipt_path(
+    conn: &Connection,
+    request: &IngestRequest,
+    category: Option<&WorkspaceCategory>,
+    filename: &str,
+) -> Result<Option<String>, IngestError> {
+    if let Some(entity) = request.entity.as_ref() {
+        let entity_name = entity
+            .entity_name
+            .as_deref()
+            .unwrap_or(entity.entity_id.0.as_str());
+        let path = WorkspaceCategoryRegistry::resolve_path(
+            conn,
+            entity.entity_type,
+            entity_name,
+            category,
+            filename,
+            request.source_type.clone(),
+        )?;
+        return Ok(Some(path.to_string_lossy().to_string()));
+    }
+
+    let relative = request
+        .identity
+        .canonical_path
+        .strip_prefix(PathBuf::from("."))
+        .ok()
+        .map(|p| p.to_string_lossy().to_string());
+    Ok(relative.or_else(|| Some(filename.to_string())))
+}
+
+fn frontmatter_block(content_head: &str) -> Option<&str> {
+    let trimmed = content_head
+        .strip_prefix('\u{feff}')
+        .unwrap_or(content_head);
+    let rest = trimmed.strip_prefix("---\n")?;
+    let end = rest.find("\n---")?;
+    Some(&rest[..end])
+}
+
+fn category_from_frontmatter(content_head: &str) -> Option<WorkspaceCategory> {
+    let block = frontmatter_block(content_head)?;
+    for line in block.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        if key.trim() != "doc_type" {
+            continue;
+        }
+        let value = value.trim().trim_matches('"').trim_matches('\'');
+        if !is_valid_doc_type(value) {
+            return None;
+        }
+        return match value {
+            "transcript" => Some(WorkspaceCategory::Transcripts),
+            "presentation" | "deck" | "slides" => Some(WorkspaceCategory::Presentations),
+            "meeting" | "1on1" => Some(WorkspaceCategory::Meetings),
+            "note" | "notes" => Some(WorkspaceCategory::Notes),
+            "contract" | "msa" | "sow" => Some(WorkspaceCategory::Contracts),
+            other => WorkspaceCategory::from_slug(other),
+        };
+    }
+    None
+}
+
+fn is_valid_doc_type(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 32 && {
+        let mut chars = value.chars();
+        let first = chars.next().expect("non-empty checked above");
+        first.is_ascii_lowercase()
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+    }
+}
+
+pub fn file_id_from_identity(
+    identity: &FileIdentity,
+    workspace_root: &Path,
+) -> Result<String, FileIdError> {
+    let relative = identity
+        .canonical_path
+        .strip_prefix(workspace_root)
+        .map_err(|_| FileIdError::OutsideWorkspace)?;
+    let mut hasher = Sha256::new();
+    hasher.update(relative.as_os_str().as_encoded_bytes());
+    let hash = hasher.finalize();
+    Ok(hex::encode(hash)[..16].to_string())
+}
+
+pub fn quarantine_source(
+    conn: &Connection,
+    file_id: &str,
+    reason: &str,
+    actor: QuarantineActor,
+) -> Result<(), IngestError> {
+    let actor_id = match actor {
+        QuarantineActor::User { user_id } => user_id,
+    };
+    LifecycleRepo::record_user_override(conn, file_id, &actor_id)?;
+    let lifecycle = LifecycleRepo::get(conn, file_id)?.ok_or(LifecycleError::FileNotFound)?;
+    if lifecycle.lifecycle_state != LifecycleState::Quarantined {
+        LifecycleRepo::transition(
+            conn,
+            file_id,
+            lifecycle.lifecycle_state,
+            LifecycleState::Quarantined,
+        )?;
+    }
+    let _redacted_reason = reason;
+    Ok(())
+}
+
+impl From<LifecycleError> for IngestError {
+    fn from(value: LifecycleError) -> Self {
+        IngestError::DbError(value.to_string())
+    }
+}
+
+impl From<RunsError> for IngestError {
+    fn from(value: RunsError) -> Self {
+        match value {
+            RunsError::AlreadyCompleted { existing } => IngestError::AlreadyProcessed {
+                existing_run_id: existing.run_id,
+            },
+            RunsError::AlreadyInProgress { existing_run_id } => {
+                IngestError::AlreadyProcessed { existing_run_id }
+            }
+            other => IngestError::DbError(other.to_string()),
+        }
+    }
+}
+
+impl From<ResolvePathError> for IngestError {
+    fn from(value: ResolvePathError) -> Self {
+        IngestError::DbError(value.to_string())
+    }
+}
+
+impl std::fmt::Display for IngestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FileIdMismatch { expected, found } => {
+                write!(f, "file_id mismatch: expected {expected}, found {found}")
+            }
+            Self::Rejected(reason) => write!(f, "workspace file rejected: {reason:?}"),
+            Self::AlreadyProcessed { existing_run_id } => {
+                write!(f, "workspace file already processed: {}", existing_run_id.0)
+            }
+            Self::Io(error) => write!(
+                f,
+                "workspace ingestion I/O error: kind={:?} os={:?}",
+                error.kind(),
+                error.raw_os_error()
+            ),
+            Self::DbError(message) => write!(f, "workspace ingestion db error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for IngestError {}

--- a/src-tauri/src/services/workspace_ingestion/pipeline.rs
+++ b/src-tauri/src/services/workspace_ingestion/pipeline.rs
@@ -401,14 +401,16 @@ fn frontmatter_block(content_head: &str) -> Option<&str> {
 /// fire":
 /// - `None` → no frontmatter block, or frontmatter has no `doc_type` key →
 ///   priority 1 did NOT fire, caller should fall through.
-/// - `Some(Some(cat))` → `doc_type` present, valid, mapped to a category →
-///   terminal Some.
-/// - `Some(None)` → `doc_type` present but invalid shape, unknown variant,
-///   or unregistered `Other(s)` slug → priority 1 FIRED with a non-match →
-///   terminal None per packet §3 frozen detection table row 6 ("else None").
+/// - `Some(Some(cat))` → `doc_type` present, shape-valid, mapped to a known
+///   variant OR a shape-valid `Other(slug)` → terminal Some. Registry
+///   validation of `Other(slug)` happens later at `validate_detected_category`.
+/// - `Some(None)` → `doc_type` present but FAILS the shape check
+///   (`^[a-z][a-z0-9_-]{0,31}$`) → priority 1 FIRED with no match → terminal
+///   None per packet §3 frozen detection table row 1.
 ///
-/// This split closes the L2 cycle-1 codex BLOCK on §7: invalid `doc_type`
-/// must not allow filename-glob fallback to override user-supplied intent.
+/// This split closes the L2 cycle-1 codex BLOCK on §7: a shape-invalid
+/// `doc_type` (user-supplied invalid intent) must not allow filename-glob
+/// fallback to override.
 fn frontmatter_doctype_detection(content_head: &str) -> Option<Option<WorkspaceCategory>> {
     let block = frontmatter_block(content_head)?;
     for line in block.lines() {

--- a/src-tauri/src/services/workspace_ingestion/pipeline.rs
+++ b/src-tauri/src/services/workspace_ingestion/pipeline.rs
@@ -299,8 +299,13 @@ impl IngestPipeline {
         filename: &str,
         content_head: &str,
     ) -> Option<WorkspaceCategory> {
-        if let Some(category) = category_from_frontmatter(content_head) {
-            return Some(category);
+        // Priority 1 — frontmatter doc_type. Per packet §3 frozen detection
+        // table, priority 1 is terminal whenever it fires: a present `doc_type`
+        // key (even if invalid or unregistered) resolves the lane at this
+        // priority and lower priorities do not run. Only when frontmatter is
+        // absent / malformed / has no `doc_type` key do we fall through.
+        if let Some(result) = frontmatter_doctype_detection(content_head) {
+            return result;
         }
         if content_head.trim_start().starts_with("---") && frontmatter_block(content_head).is_none()
         {
@@ -392,7 +397,19 @@ fn frontmatter_block(content_head: &str) -> Option<&str> {
     Some(&rest[..end])
 }
 
-fn category_from_frontmatter(content_head: &str) -> Option<WorkspaceCategory> {
+/// Outer `Option` distinguishes "priority 1 fired" from "priority 1 didn't
+/// fire":
+/// - `None` → no frontmatter block, or frontmatter has no `doc_type` key →
+///   priority 1 did NOT fire, caller should fall through.
+/// - `Some(Some(cat))` → `doc_type` present, valid, mapped to a category →
+///   terminal Some.
+/// - `Some(None)` → `doc_type` present but invalid shape, unknown variant,
+///   or unregistered `Other(s)` slug → priority 1 FIRED with a non-match →
+///   terminal None per packet §3 frozen detection table row 6 ("else None").
+///
+/// This split closes the L2 cycle-1 codex BLOCK on §7: invalid `doc_type`
+/// must not allow filename-glob fallback to override user-supplied intent.
+fn frontmatter_doctype_detection(content_head: &str) -> Option<Option<WorkspaceCategory>> {
     let block = frontmatter_block(content_head)?;
     for line in block.lines() {
         let Some((key, value)) = line.split_once(':') else {
@@ -403,9 +420,9 @@ fn category_from_frontmatter(content_head: &str) -> Option<WorkspaceCategory> {
         }
         let value = value.trim().trim_matches('"').trim_matches('\'');
         if !is_valid_doc_type(value) {
-            return None;
+            return Some(None);
         }
-        return match value {
+        let category = match value {
             "transcript" => Some(WorkspaceCategory::Transcripts),
             "presentation" | "deck" | "slides" => Some(WorkspaceCategory::Presentations),
             "meeting" | "1on1" => Some(WorkspaceCategory::Meetings),
@@ -413,6 +430,7 @@ fn category_from_frontmatter(content_head: &str) -> Option<WorkspaceCategory> {
             "contract" | "msa" | "sow" => Some(WorkspaceCategory::Contracts),
             other => WorkspaceCategory::from_slug(other),
         };
+        return Some(category);
     }
     None
 }

--- a/src-tauri/src/services/workspace_ingestion/wiring.rs
+++ b/src-tauri/src/services/workspace_ingestion/wiring.rs
@@ -1,10 +1,14 @@
-//! Pipeline wiring — W2-A creates the `build_pipeline()` constructor
-//! that takes `contracts::NullExtractor` + `contracts::NullSignalEmitter` defaults.
-//! W3-A and W3-B each patch a single argument position to
-//! swap in `WorkspaceExtractor` and `WorkspaceSignalEmitter` respectively.
-//!
-//! The dependency-injection seam lets W3-A and W3-B land without modifying
-//! `pipeline.rs` (W2-A's exclusive) or any earlier-wave file.
-//!
-//! W1-A pre-creates this placeholder so no later lane needs to create a new
-//! file or edit `mod.rs`.
+//! Workspace ingestion dependency wiring.
+
+use std::path::PathBuf;
+
+use super::contracts::{NullExtractor, NullSignalEmitter};
+use super::pipeline::IngestPipeline;
+
+pub fn build_pipeline(workspace_root: PathBuf) -> IngestPipeline {
+    IngestPipeline::default_with(
+        Box::new(NullExtractor),
+        Box::new(NullSignalEmitter),
+        workspace_root,
+    )
+}

--- a/src-tauri/src/services/workspace_ingestion/workspace_intake_impl.rs
+++ b/src-tauri/src/services/workspace_ingestion/workspace_intake_impl.rs
@@ -1,0 +1,204 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use abilities_runtime::abilities::provenance::source::EntityId;
+use abilities_runtime::services::workspace_intake::{
+    EntityRefDto, WorkspaceIntakeError, WorkspaceIntakeReceipt, WorkspaceIntakeRequest,
+    WorkspaceIntakeService,
+};
+use async_trait::async_trait;
+
+use crate::db::{ActionDb, LocalKeychain};
+use crate::entity::EntityType;
+
+use super::contracts::{RejectionReason, WorkspaceCategory, WorkspaceFileKind};
+use super::lifecycle::{lifecycle_state_slug, workspace_file_kind_from_slug};
+use super::pipeline::{file_id_from_identity, EntityRef, FileIdError, IngestError, IngestRequest};
+use super::registry::WorkspaceCategoryRegistry;
+use super::wiring::build_pipeline;
+use super::{registry::WorkspaceSourceRegistry, runs::IngestionMode};
+
+pub struct IngestPipelineWorkspaceIntake {
+    workspace_root: PathBuf,
+}
+
+impl IngestPipelineWorkspaceIntake {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub fn from_config_or_empty() -> Self {
+        let workspace_root = crate::state::load_config()
+            .map(|config| PathBuf::from(config.workspace_path))
+            .unwrap_or_default();
+        Self::new(workspace_root)
+    }
+}
+
+#[async_trait]
+impl WorkspaceIntakeService for IngestPipelineWorkspaceIntake {
+    async fn ingest(
+        &self,
+        _ctx: &abilities_runtime::abilities::registry::AbilityContext<'_>,
+        req: WorkspaceIntakeRequest,
+    ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+        let workspace_root = self.workspace_root.clone();
+        tokio::task::spawn_blocking(move || ingest_sync(workspace_root, req))
+            .await
+            .map_err(|e| WorkspaceIntakeError::Io(format!("workspace intake task failed: {e}")))?
+    }
+}
+
+fn ingest_sync(
+    workspace_root: PathBuf,
+    req: WorkspaceIntakeRequest,
+) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+    let source_type = parse_workspace_file_kind(&req.source_type_slug)
+        .ok_or_else(|| WorkspaceIntakeError::InvalidSourceTypeSlug(req.source_type_slug.clone()))?;
+    let mode = parse_ingestion_mode(&req.mode_slug)
+        .ok_or_else(|| WorkspaceIntakeError::InvalidModeSlug(req.mode_slug.clone()))?;
+    let entity = req.entity.map(parse_entity).transpose()?;
+    let category_hint = req
+        .category_slug
+        .as_deref()
+        .map(parse_category)
+        .transpose()?;
+
+    let db = ActionDb::open(Arc::new(LocalKeychain::new()))
+        .map_err(|e| WorkspaceIntakeError::DbError(e.to_string()))?;
+    let conn = db.conn_ref();
+
+    if let Some(category) = category_hint.as_ref() {
+        let Some(entity_type) = entity.as_ref().map(|e| e.entity_type) else {
+            return Err(WorkspaceIntakeError::CategoryNotAllowed { allowed: vec![] });
+        };
+        WorkspaceCategoryRegistry::validate(conn, category, entity_type)
+            .map_err(|e| WorkspaceIntakeError::CategoryNotAllowed { allowed: e.allowed })?;
+    }
+
+    let (file, identity) =
+        WorkspaceSourceRegistry::open_validated(&workspace_root, Path::new(&req.file_ref))
+            .map_err(intake_error_from_rejection)?;
+    let source_asof = file
+        .metadata()
+        .and_then(|m| m.modified())
+        .map(chrono::DateTime::<chrono::Utc>::from)
+        .map_err(|e| WorkspaceIntakeError::Io(io_error_redacted(e)))?;
+    let file_id =
+        file_id_from_identity(&identity, &workspace_root).map_err(intake_file_id_error)?;
+
+    let request = IngestRequest {
+        file,
+        identity,
+        file_id,
+        source_asof,
+        source_type,
+        entity,
+        mode,
+        category_hint,
+    };
+    let pipeline = build_pipeline(workspace_root);
+    let receipt = pipeline
+        .run(conn, request)
+        .map_err(intake_error_from_ingest)?;
+    Ok(WorkspaceIntakeReceipt {
+        run_id: receipt.ingestion_run_id.0,
+        file_id: receipt.file_id,
+        content_sha256: receipt.content_sha256,
+        lifecycle_state_after_slug: lifecycle_state_slug(receipt.lifecycle_state_after).to_string(),
+        resolved_path: receipt.resolved_path,
+    })
+}
+
+fn parse_workspace_file_kind(slug: &str) -> Option<WorkspaceFileKind> {
+    workspace_file_kind_from_slug(slug)
+}
+
+fn parse_ingestion_mode(slug: &str) -> Option<IngestionMode> {
+    match slug {
+        "initial" => Some(IngestionMode::Initial),
+        "incremental" => Some(IngestionMode::Incremental),
+        "forced" => Some(IngestionMode::Forced),
+        "backfill" => Some(IngestionMode::Backfill),
+        "entity_seeded" => Some(IngestionMode::EntitySeeded),
+        "realtime" => Some(IngestionMode::Realtime),
+        _ => None,
+    }
+}
+
+fn parse_category(slug: &str) -> Result<WorkspaceCategory, WorkspaceIntakeError> {
+    WorkspaceCategory::from_slug(slug)
+        .ok_or_else(|| WorkspaceIntakeError::InvalidCategorySlug(slug.to_string()))
+}
+
+fn parse_entity(dto: EntityRefDto) -> Result<EntityRef, WorkspaceIntakeError> {
+    if !matches!(
+        dto.entity_type_slug.as_str(),
+        "account" | "person" | "project" | "other"
+    ) {
+        return Err(WorkspaceIntakeError::InvalidEntityTypeSlug(
+            dto.entity_type_slug,
+        ));
+    }
+    if dto.entity_id.trim().is_empty() {
+        return Err(WorkspaceIntakeError::InvalidEntityId);
+    }
+    let entity_name = dto
+        .entity_name
+        .ok_or_else(|| WorkspaceIntakeError::InvalidEntityName(String::new()))?;
+    if !is_valid_path_segment_slug(&entity_name) {
+        return Err(WorkspaceIntakeError::InvalidEntityName(entity_name));
+    }
+    Ok(EntityRef {
+        entity_type: EntityType::from_str_lossy(&dto.entity_type_slug),
+        entity_id: EntityId::new(dto.entity_id),
+        entity_name: Some(entity_name),
+    })
+}
+
+fn is_valid_path_segment_slug(slug: &str) -> bool {
+    !slug.is_empty() && slug.len() <= 32 && {
+        let mut chars = slug.chars();
+        let first = chars.next().expect("non-empty checked above");
+        first.is_ascii_lowercase()
+            && chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+    }
+}
+
+fn intake_error_from_rejection(reason: RejectionReason) -> WorkspaceIntakeError {
+    match reason {
+        RejectionReason::PathTraversalAttempt => WorkspaceIntakeError::PathTraversalAttempt,
+        RejectionReason::OutsideWorkspace => WorkspaceIntakeError::OutsideWorkspace,
+        RejectionReason::SymlinkRaced | RejectionReason::SymlinkRefused => {
+            WorkspaceIntakeError::SymlinkRaced
+        }
+        RejectionReason::FileTooLarge => WorkspaceIntakeError::FileTooLarge,
+        RejectionReason::UnsupportedFormat => WorkspaceIntakeError::UnsupportedFormat,
+    }
+}
+
+fn intake_file_id_error(error: FileIdError) -> WorkspaceIntakeError {
+    match error {
+        FileIdError::OutsideWorkspace => WorkspaceIntakeError::OutsideWorkspace,
+    }
+}
+
+fn intake_error_from_ingest(error: IngestError) -> WorkspaceIntakeError {
+    match error {
+        IngestError::Rejected(reason) => intake_error_from_rejection(reason),
+        IngestError::AlreadyProcessed { existing_run_id } => {
+            WorkspaceIntakeError::AlreadyProcessed {
+                existing_run_id: existing_run_id.0,
+            }
+        }
+        IngestError::Io(error) => WorkspaceIntakeError::Io(io_error_redacted(error)),
+        IngestError::DbError(message) => WorkspaceIntakeError::DbError(message),
+        IngestError::FileIdMismatch { .. } => {
+            WorkspaceIntakeError::DbError("file_id mismatch after derivation".to_string())
+        }
+    }
+}
+
+fn io_error_redacted(error: std::io::Error) -> String {
+    format!("kind={:?} os={:?}", error.kind(), error.raw_os_error())
+}

--- a/src-tauri/tests/workspace_ingestion_mod_rs_shape.rs
+++ b/src-tauri/tests/workspace_ingestion_mod_rs_shape.rs
@@ -14,8 +14,17 @@ use std::fs;
 use std::path::PathBuf;
 
 const EXPECTED_PUB_MODS: &[&str] = &[
-    "contracts", "extract", "graph", "lifecycle", "link", "pipeline", "registry", "runs",
-    "signals", "wiring",
+    "contracts",
+    "extract",
+    "graph",
+    "lifecycle",
+    "link",
+    "pipeline",
+    "registry",
+    "runs",
+    "signals",
+    "wiring",
+    "workspace_intake_impl",
 ];
 
 #[test]

--- a/src-tauri/tests/workspace_ingestion_w2a_auto_detect_category.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_auto_detect_category.rs
@@ -45,6 +45,58 @@ fn auto_detect_category_uses_frozen_priority_table() {
     );
 }
 
+/// Regression for L2 cycle-1 codex BLOCK: a SHAPE-INVALID frontmatter
+/// `doc_type` MUST resolve to terminal None at priority 1, not fall through
+/// to filename-glob at priority 2. §7 security gate requires user-supplied
+/// invalid intent to suppress filename override. Codex's exact example:
+/// `doc_type: Bad` (uppercase B fails the shape check) plus a filename
+/// that would otherwise match the `meeting` glob.
+///
+/// Note: shape-valid but unregistered `Other(s)` slugs are NOT this case —
+/// they propagate as `Some(Other(s))` from `auto_detect_category_pure` and
+/// get rejected later by `validate_detected_category` at registry-validation
+/// time. That separation is tested in `detected_other_slug_survives_only_after_registry_validation`.
+#[test]
+fn invalid_frontmatter_doctype_is_terminal_none_even_with_filename_match() {
+    // Invalid shape + filename glob that would otherwise match `meeting`.
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure(
+            "meeting-notes.md",
+            "---\ndoc_type: Bad\n---\nbody"
+        ),
+        None,
+        "invalid-shape doc_type must suppress filename-glob fallback"
+    );
+    // Invalid shape with leading digit + filename glob that would match
+    // `transcript`.
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure(
+            "q3-transcript-notes.md",
+            "---\ndoc_type: 1on1\n---\nbody"
+        ),
+        None,
+        "leading-digit doc_type is shape-invalid; filename-glob fallback suppressed"
+    );
+    // Sanity: same filenames WITHOUT frontmatter still hit the filename glob.
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("meeting-notes.md", ""),
+        Some(WorkspaceCategory::Meetings)
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("q3-transcript-notes.md", ""),
+        Some(WorkspaceCategory::Transcripts)
+    );
+    // Sanity: frontmatter without `doc_type:` key still falls through.
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure(
+            "meeting-notes.md",
+            "---\nauthor: jamesgiroux\n---\nbody"
+        ),
+        Some(WorkspaceCategory::Meetings),
+        "frontmatter without doc_type key MUST fall through to priority 2"
+    );
+}
+
 #[test]
 fn detected_other_slug_survives_only_after_registry_validation() {
     let conn = registry_conn();

--- a/src-tauri/tests/workspace_ingestion_w2a_auto_detect_category.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_auto_detect_category.rs
@@ -1,0 +1,70 @@
+use dailyos_lib::entity::EntityType;
+use dailyos_lib::services::workspace_ingestion::contracts::WorkspaceCategory;
+use dailyos_lib::services::workspace_ingestion::pipeline::IngestPipeline;
+use dailyos_lib::services::workspace_ingestion::registry::WorkspaceCategoryRegistry;
+use rusqlite::Connection;
+
+fn registry_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/252_workspace_source_registry.sql"
+    ))
+    .expect("v252");
+    conn
+}
+
+#[test]
+fn auto_detect_category_uses_frozen_priority_table() {
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure(
+            "q1-transcript-notes.md",
+            "---\ndoc_type: deck\n---\nbody"
+        ),
+        Some(WorkspaceCategory::Presentations)
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("ACME-DECK-FINAL.txt", ""),
+        Some(WorkspaceCategory::Presentations)
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("meeting-contract.pdf", ""),
+        Some(WorkspaceCategory::Meetings),
+        "filename rules are first-match within priority 2"
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("plain.pdf", ""),
+        Some(WorkspaceCategory::Attachments)
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("plain.md", ""),
+        Some(WorkspaceCategory::Notes)
+    );
+    assert_eq!(
+        IngestPipeline::auto_detect_category_pure("plain.bin", "---\ndoc_type: Bad\n---\n"),
+        None
+    );
+}
+
+#[test]
+fn detected_other_slug_survives_only_after_registry_validation() {
+    let conn = registry_conn();
+    WorkspaceCategoryRegistry::register_other(&conn, EntityType::Account, "briefs")
+        .expect("register custom category");
+    let detected =
+        IngestPipeline::auto_detect_category_pure("file.txt", "---\ndoc_type: briefs\n---\n");
+    assert_eq!(detected, Some(WorkspaceCategory::Other("briefs".into())));
+    assert_eq!(
+        IngestPipeline::validate_detected_category(&conn, detected, EntityType::Account)
+            .expect("validate"),
+        Some(WorkspaceCategory::Other("briefs".into()))
+    );
+    assert_eq!(
+        IngestPipeline::validate_detected_category(
+            &conn,
+            Some(WorkspaceCategory::Other("missing".into())),
+            EntityType::Account,
+        )
+        .expect("validate"),
+        None
+    );
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_content_head_bound.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_content_head_bound.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+#[test]
+fn pipeline_uses_four_kib_content_head_constant_for_sniffing() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(root.join("src/services/workspace_ingestion/pipeline.rs"))
+        .expect("read pipeline");
+    assert!(source.contains("const CONTENT_HEAD_BYTES: usize = 4 * 1024;"));
+    assert!(source.contains("CONTENT_HEAD_BYTES"));
+    assert!(source.contains("auto_detect_category_pure(filename, content_head)"));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_file_cursor.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_file_cursor.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+#[test]
+fn pipeline_rewinds_file_before_extractor_handoff() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(root.join("src/services/workspace_ingestion/pipeline.rs"))
+        .expect("read pipeline");
+    let seek = source
+        .find(".seek(SeekFrom::Start(0))")
+        .expect("seek before extractor");
+    let extract = source.find(".extract(").expect("extract call");
+    assert!(
+        seek < extract,
+        "pipeline must rewind before Extractor::extract"
+    );
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_file_id.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_file_id.rs
@@ -1,0 +1,16 @@
+use dailyos_lib::services::workspace_ingestion::contracts::FileIdentity;
+use dailyos_lib::services::workspace_ingestion::pipeline::file_id_from_identity;
+use sha2::{Digest, Sha256};
+
+#[test]
+fn file_id_uses_sha256_of_workspace_relative_path() {
+    let root = std::path::PathBuf::from("/tmp/workspace");
+    let identity = FileIdentity {
+        canonical_path: root.join("Accounts/acme/file.md"),
+        device: 1,
+        inode: 2,
+    };
+    let file_id = file_id_from_identity(&identity, &root).expect("file id");
+    let digest = Sha256::digest(b"Accounts/acme/file.md");
+    assert_eq!(file_id, hex::encode(digest)[..16].to_string());
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_inline_mod_services.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_inline_mod_services.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+#[test]
+fn workspace_intake_is_declared_inside_inline_services_module() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lib_rs = std::fs::read_to_string(root.join("abilities-runtime/src/lib.rs"))
+        .expect("read abilities-runtime lib.rs");
+    assert!(lib_rs.contains("pub mod services {"));
+    assert!(lib_rs.contains("pub mod workspace_intake;"));
+    assert!(
+        !root.join("abilities-runtime/src/services/mod.rs").exists(),
+        "W2-A must not create a separate services/mod.rs"
+    );
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_intake_impl_category_validate.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_intake_impl_category_validate.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+#[test]
+fn intake_impl_validates_category_before_pipeline_invocation() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(
+        root.join("src/services/workspace_ingestion/workspace_intake_impl.rs"),
+    )
+    .expect("read bridge");
+    let validate = source
+        .find("WorkspaceCategoryRegistry::validate")
+        .expect("validate call");
+    let run = source.find(".run(conn, request)").expect("pipeline run");
+    assert!(
+        validate < run,
+        "category validation must precede pipeline.run"
+    );
+    assert!(source.contains("WorkspaceIntakeError::CategoryNotAllowed"));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_intake_impl_slug_parse.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_intake_impl_slug_parse.rs
@@ -1,0 +1,21 @@
+use abilities_runtime::services::workspace_intake::WorkspaceIntakeError;
+
+#[test]
+fn workspace_intake_error_has_typed_invalid_slug_variants() {
+    assert!(matches!(
+        WorkspaceIntakeError::InvalidSourceTypeSlug("bad".into()),
+        WorkspaceIntakeError::InvalidSourceTypeSlug(_)
+    ));
+    assert!(matches!(
+        WorkspaceIntakeError::InvalidModeSlug("bad".into()),
+        WorkspaceIntakeError::InvalidModeSlug(_)
+    ));
+    assert!(matches!(
+        WorkspaceIntakeError::InvalidCategorySlug("bad".into()),
+        WorkspaceIntakeError::InvalidCategorySlug(_)
+    ));
+    assert!(matches!(
+        WorkspaceIntakeError::InvalidEntityName("Bad Name".into()),
+        WorkspaceIntakeError::InvalidEntityName(_)
+    ));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo.rs
@@ -1,0 +1,57 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::Utc;
+use dailyos_lib::services::workspace_ingestion::contracts::{FileIdentity, WorkspaceCategory};
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use rusqlite::Connection;
+
+fn conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/250_workspace_file_lifecycle.sql"
+    ))
+    .expect("v250");
+    conn.execute_batch(include_str!(
+        "../src/migrations/251_workspace_file_lifecycle_category.sql"
+    ))
+    .expect("v251");
+    conn
+}
+
+fn identity() -> FileIdentity {
+    FileIdentity {
+        canonical_path: "/tmp/workspace/file.md".into(),
+        device: 1,
+        inode: 2,
+    }
+}
+
+#[test]
+fn lifecycle_repo_writes_pending_transition_override_and_category() {
+    let conn = conn();
+    LifecycleRepo::insert_pending(
+        &conn,
+        "wf-1",
+        &identity(),
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect("insert pending");
+    LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("transition");
+    LifecycleRepo::record_user_override(&conn, "wf-1", "user-1").expect("override");
+    LifecycleRepo::update_category(&conn, "wf-1", Some(&WorkspaceCategory::Notes))
+        .expect("category");
+
+    let row = LifecycleRepo::get(&conn, "wf-1")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.lifecycle_state, LifecycleState::Ingesting);
+    assert_eq!(row.category, Some(WorkspaceCategory::Notes));
+    assert_eq!(row.user_override.expect("override").actor_id, "user-1");
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo_get.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo_get.rs
@@ -1,0 +1,40 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::Utc;
+use dailyos_lib::services::workspace_ingestion::contracts::FileIdentity;
+use dailyos_lib::services::workspace_ingestion::lifecycle::LifecycleRepo;
+use rusqlite::Connection;
+
+#[test]
+fn lifecycle_get_returns_none_or_populated_row() {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/250_workspace_file_lifecycle.sql"
+    ))
+    .expect("v250");
+    conn.execute_batch(include_str!(
+        "../src/migrations/251_workspace_file_lifecycle_category.sql"
+    ))
+    .expect("v251");
+    assert!(LifecycleRepo::get(&conn, "missing").expect("get").is_none());
+    let identity = FileIdentity {
+        canonical_path: "/tmp/workspace/file.md".into(),
+        device: 1,
+        inode: 2,
+    };
+    LifecycleRepo::insert_pending(
+        &conn,
+        "wf-1",
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect("insert");
+    assert_eq!(
+        LifecycleRepo::get(&conn, "wf-1")
+            .expect("get")
+            .expect("row")
+            .file_id,
+        "wf-1"
+    );
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo_set_entity.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo_set_entity.rs
@@ -1,0 +1,44 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::Utc;
+use dailyos_lib::entity::EntityType;
+use dailyos_lib::services::workspace_ingestion::contracts::FileIdentity;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleError, LifecycleRepo};
+use rusqlite::Connection;
+
+#[test]
+fn lifecycle_set_entity_updates_pending_row_and_rejects_missing_file() {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/250_workspace_file_lifecycle.sql"
+    ))
+    .expect("v250");
+    conn.execute_batch(include_str!(
+        "../src/migrations/251_workspace_file_lifecycle_category.sql"
+    ))
+    .expect("v251");
+    let identity = FileIdentity {
+        canonical_path: "/tmp/workspace/file.md".into(),
+        device: 1,
+        inode: 2,
+    };
+    LifecycleRepo::insert_pending(
+        &conn,
+        "wf-1",
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect("insert");
+    LifecycleRepo::set_entity(&conn, "wf-1", EntityType::Account, "acct-1", Some("acme"))
+        .expect("set entity");
+    let row = LifecycleRepo::get(&conn, "wf-1")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.entity_type.as_deref(), Some("account"));
+    assert_eq!(row.entity_id.as_deref(), Some("acct-1"));
+
+    let err = LifecycleRepo::set_entity(&conn, "missing", EntityType::Account, "acct-1", None)
+        .expect_err("missing");
+    assert!(matches!(err, LifecycleError::FileNotFound));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_transitions.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_transitions.rs
@@ -1,0 +1,54 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::Utc;
+use dailyos_lib::services::workspace_ingestion::contracts::FileIdentity;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{
+    LifecycleError, LifecycleRepo, LifecycleState,
+};
+use rusqlite::Connection;
+
+fn seeded_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/250_workspace_file_lifecycle.sql"
+    ))
+    .expect("v250");
+    conn.execute_batch(include_str!(
+        "../src/migrations/251_workspace_file_lifecycle_category.sql"
+    ))
+    .expect("v251");
+    let identity = FileIdentity {
+        canonical_path: "/tmp/workspace/file.md".into(),
+        device: 1,
+        inode: 2,
+    };
+    LifecycleRepo::insert_pending(
+        &conn,
+        "wf-1",
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect("seed");
+    conn
+}
+
+#[test]
+fn legal_and_illegal_lifecycle_transitions_are_enforced() {
+    let conn = seeded_conn();
+    LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("legal");
+    let err = LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::Ingesting,
+        LifecycleState::Pending,
+    )
+    .expect_err("illegal");
+    assert!(matches!(err, LifecycleError::InvalidStateTransition { .. }));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_no_direct_open.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_no_direct_open.rs
@@ -1,0 +1,52 @@
+#[test]
+fn pipeline_never_opens_paths_directly() {
+    let source = std::fs::read_to_string("src/services/workspace_ingestion/pipeline.rs")
+        .expect("pipeline.rs should be readable");
+
+    let forbidden = [
+        "File::open",
+        "std::fs::File::open",
+        "std::fs::File::options",
+        "std::fs::OpenOptions",
+        "tokio::fs::File::open",
+        "tokio::fs::File::options",
+        "tokio::fs::OpenOptions",
+        "std::fs::read",
+        "std::fs::read_to_string",
+        "std::fs::metadata",
+        "memmap",
+        "std::process::Command",
+    ];
+    let forbidden_imports = [
+        "OpenOptions",
+        "tokio::fs",
+        "read_to_string",
+        "metadata",
+        "memmap",
+        "Command",
+    ];
+
+    for (line_no, raw_line) in source.lines().enumerate() {
+        let line = raw_line.trim_start();
+        if line.starts_with("//") {
+            continue;
+        }
+        if line.starts_with("use ") {
+            for token in forbidden_imports {
+                assert!(
+                    !line.contains(token),
+                    "pipeline.rs must not import path-opening helper {token:?} at line {}",
+                    line_no + 1,
+                );
+            }
+            continue;
+        }
+        for token in forbidden {
+            assert!(
+                !line.contains(token),
+                "pipeline.rs must consume the validated File handle; forbidden token {token:?} at line {}",
+                line_no + 1,
+            );
+        }
+    }
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_quarantine_actor.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_quarantine_actor.rs
@@ -1,0 +1,43 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::Utc;
+use dailyos_lib::services::workspace_ingestion::contracts::FileIdentity;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use dailyos_lib::services::workspace_ingestion::pipeline::{quarantine_source, QuarantineActor};
+use rusqlite::Connection;
+
+#[test]
+fn quarantine_source_records_typed_actor_and_is_idempotent() {
+    let conn = Connection::open_in_memory().expect("in-memory sqlite");
+    conn.execute_batch(include_str!(
+        "../src/migrations/250_workspace_file_lifecycle.sql"
+    ))
+    .expect("v250");
+    conn.execute_batch(include_str!(
+        "../src/migrations/251_workspace_file_lifecycle_category.sql"
+    ))
+    .expect("v251");
+    let identity = FileIdentity {
+        canonical_path: "/tmp/workspace/file.md".into(),
+        device: 1,
+        inode: 2,
+    };
+    LifecycleRepo::insert_pending(
+        &conn,
+        "wf-1",
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect("insert");
+    let actor = QuarantineActor::User {
+        user_id: "user-1".into(),
+    };
+    quarantine_source(&conn, "wf-1", "bad file", actor.clone()).expect("quarantine");
+    quarantine_source(&conn, "wf-1", "bad file", actor).expect("idempotent");
+    let row = LifecycleRepo::get(&conn, "wf-1")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.lifecycle_state, LifecycleState::Quarantined);
+    assert_eq!(row.user_override.expect("override").actor_id, "user-1");
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_rejection_privacy.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_rejection_privacy.rs
@@ -1,0 +1,10 @@
+use dailyos_lib::services::workspace_ingestion::pipeline::IngestError;
+
+#[test]
+fn io_error_display_redacts_paths_to_kind_and_os_code() {
+    let error = IngestError::Io(std::io::Error::from_raw_os_error(2));
+    let rendered = error.to_string();
+    assert!(rendered.contains("kind="));
+    assert!(rendered.contains("os="));
+    assert!(!rendered.contains("/tmp/"));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_service_context_registration.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_service_context_registration.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[test]
+fn service_context_exposes_optional_workspace_intake_and_live_registration() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let context = std::fs::read_to_string(root.join("abilities-runtime/src/services/context.rs"))
+        .expect("read abilities-runtime context");
+    assert!(context.contains("workspace_intake: Option<Arc<dyn WorkspaceIntakeService>>"));
+    assert!(
+        context.contains("pub fn workspace_intake(&self) -> Option<&dyn WorkspaceIntakeService>")
+    );
+
+    let app_context = std::fs::read_to_string(root.join("src/services/context.rs"))
+        .expect("read app service context");
+    assert!(app_context.contains("IngestPipelineWorkspaceIntake::from_config_or_empty()"));
+    assert!(app_context.contains(".with_workspace_intake("));
+}

--- a/src-tauri/tests/workspace_ingestion_w2a_workspace_intake_impl.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_workspace_intake_impl.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+#[test]
+fn workspace_intake_impl_bridges_raw_slugs_through_spawn_blocking() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(
+        root.join("src/services/workspace_ingestion/workspace_intake_impl.rs"),
+    )
+    .expect("read bridge");
+    assert!(source.contains("tokio::task::spawn_blocking"));
+    assert!(source.contains("WorkspaceSourceRegistry::open_validated"));
+    assert!(source.contains("file_id_from_identity"));
+    assert!(source.contains("build_pipeline(workspace_root)"));
+    assert!(source.contains(".run(conn, request)"));
+    assert!(source.contains("resolved_path: receipt.resolved_path"));
+}

--- a/src-tauri/tests/workspace_mutation_allowlist_test.rs
+++ b/src-tauri/tests/workspace_mutation_allowlist_test.rs
@@ -1,0 +1,26 @@
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn workspace_mutation_allowlist_script_exists_is_executable_and_passes() {
+    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = root.join("scripts/check_workspace_mutation_allowlist.sh");
+    let meta = std::fs::metadata(&script).expect("script metadata");
+    assert_ne!(
+        meta.permissions().mode() & 0o111,
+        0,
+        "script must be executable"
+    );
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .current_dir(&root)
+        .output()
+        .expect("run workspace mutation allowlist");
+    assert!(
+        output.status.success(),
+        "allowlist failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

W2-A — staged ingestion service shell. Implements DOS-466 per L0 packet V1.6.

- **`IngestPipeline`** consuming `(File, FileIdentity)` from `WorkspaceSourceRegistry::open_validated` — no direct path opens. Owns `workspace_root` field for caller-derived `file_id` revalidation (V1.5 precondition #2). Returns zero claim proposals (W3-A owns claim production).
- **`LifecycleRepo`** write helpers (`insert_pending`, `transition`, `record_user_override`, `update_category`, `set_entity`, `get`).
- **`auto_detect_category_pure`** + `validate_detected_category` implementing the frozen 4-priority detection table from packet §3, with priority 1 (frontmatter `doc_type`) terminal — closes the L2 cycle-1 codex BLOCK on §7.
- **Crate-boundary bridge** at `abilities-runtime::services::workspace_intake` — async raw-slug DTO trait. SLUG→TYPED translation in dailyos_lib's `workspace_intake_impl.rs`. `ServiceContext::workspace_intake` accessor + bootstrap registration of `IngestPipelineWorkspaceIntake`.
- **CI gates**: `workspace_ingestion_w2a_no_direct_open.rs` (line-anchored grep against `File::open` / `OpenOptions` / `tokio::fs` / `std::fs::read*` / `mmap` / `std::process::Command` in `pipeline.rs`); `scripts/check_workspace_mutation_allowlist.sh` (workspace lifecycle/run/link table writes + direct FS writes allowlisted only inside `services/workspace_ingestion/`).

No migration shipped — inherits W1's v250–v254.

## Wave protocol trail

- **L0 V1.6** packet at `.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-A-DOS-466.md` with three L1-precondition resolutions (entity_name path-segment validation, workspace_root threading, §0 typed-DTO dedup) folded as V1.5 and the L2 cycle-1 codex BLOCK fold as V1.6.
- **L1** implementation via codex task — 28 files, +1721/-48 in the substrate commit.
- **L2 cycle 1**: 4-reviewer panel.
  - codex challenge: BLOCK on §3+§7 frontmatter `doc_type` fallback violation.
  - code-reviewer (correctness): APPROVE.
  - architect-reviewer: APPROVE-WITH-PATH-ALPHA.
  - /cso (security-reviewer): APPROVE.
- **L2 cycle 2**: BLOCK fold + codex re-review.
  - Patch at `d580896c` introduces `frontmatter_doctype_detection -> Option<Option<WorkspaceCategory>>` distinguishing "priority 1 didn't fire" from "priority 1 fired with no match". Shape-invalid `doc_type` is terminal None at priority 1; shape-valid unknown slugs flow as `Other(slug)` for registry validation later.
  - Regression test at `workspace_ingestion_w2a_auto_detect_category.rs::invalid_frontmatter_doctype_is_terminal_none_even_with_filename_match`.
  - codex challenge cycle 2: **APPROVE**.

**L2 final: unanimous APPROVE.**

## V1.5 preconditions resolved

1. `entity_name` IS a path segment per live `registry.rs:448` — bridge slug-validates via `is_valid_slug_shape` before constructing `IngestRequest`; invalid → `WorkspaceIntakeError::InvalidEntityName(String)`.
2. `workspace_root` threaded via `IngestPipeline` constructor field; `build_pipeline(workspace_root: PathBuf)` infallible; `pipeline.run` revalidates `file_id` against `file_id_from_identity`. Also resolves W2-B residual #2.
3. §0 V1.3 raw-slug `WorkspaceIntakeRequest` is the canonical bridge shape — stale typed-DTO duplicate removed.

## Path-α follow-ups (filed for DOS-751)

- `ServiceContext::workspace_intake` field shape: impl uses `Option<Arc<dyn WorkspaceIntakeService>>` matching live builder-handle convention; packet §9 stub specified non-Option borrowed ref. Per `feedback_l2_path_alpha_to_maintenance_project`, code-stub drift without AC/ADR/regression violation is path-α. Revisit when W2-C consumer pattern stabilizes.
- `IngestError::FileIdMismatch → WorkspaceIntakeError::DbError(...)` lossy bridge translation — add typed variant when surface stabilizes.
- `is_valid_path_segment_slug` in bridge duplicates `registry::is_valid_slug_shape` (private) — expose `pub(crate)` from registry to dedupe.
- `RejectionMetadata` constructed but not threaded into signal emission — wire when W3-B's real `SignalEmitter` lands.
- `content_head_bound` test is a string-grep; expand to behavioral exercise of the 4KB read bound on `IngestPipeline::run`.
- `set_entity` accepts `entity_name` parameter but only writes entity_type+entity_id columns — wire path-segment column when W2-D needs it.

## Verification

```bash
cd src-tauri
cargo check --lib                                      # ✅
cargo clippy --lib -- -D warnings                      # ✅
cargo test --lib services::workspace_ingestion         # ✅ 59 tests
cargo test --test workspace_ingestion_w2a_no_direct_open  # ✅
scripts/check_workspace_mutation_allowlist.sh          # ✅
# All 16 W2-A integration tests:
cargo test --test workspace_ingestion_w2a_auto_detect_category        # ✅ 3
cargo test --test workspace_ingestion_w2a_content_head_bound          # ✅ 1
cargo test --test workspace_ingestion_w2a_file_cursor                 # ✅ 1
cargo test --test workspace_ingestion_w2a_file_id                     # ✅ 1
cargo test --test workspace_ingestion_w2a_inline_mod_services         # ✅ 1
cargo test --test workspace_ingestion_w2a_intake_impl_category_validate  # ✅ 1
cargo test --test workspace_ingestion_w2a_intake_impl_slug_parse      # ✅ 1
cargo test --test workspace_ingestion_w2a_lifecycle_repo              # ✅ 1
cargo test --test workspace_ingestion_w2a_lifecycle_repo_get          # ✅ 1
cargo test --test workspace_ingestion_w2a_lifecycle_repo_set_entity   # ✅ 1
cargo test --test workspace_ingestion_w2a_lifecycle_transitions       # ✅ 1
cargo test --test workspace_ingestion_w2a_quarantine_actor            # ✅ 1
cargo test --test workspace_ingestion_w2a_rejection_privacy           # ✅ 1
cargo test --test workspace_ingestion_w2a_service_context_registration  # ✅ 1
cargo test --test workspace_ingestion_w2a_workspace_intake_impl       # ✅ 1
cargo test --test workspace_mutation_allowlist_test                   # ✅ 1
```

## What's next

W2-A unblocks W2-B (DOS-467), W2-C (DOS-468), W2-D (DOS-469) — those can fan out in parallel after this merges. W2-B/C/D consume `IngestPipeline::run` + `WorkspaceCategoryRegistry::open_validated` + `RunsRepo::start_run` + `LinkRepo::add_link` + the `WorkspaceIntakeService` bridge.

## Test plan

- [ ] CI cargo + clippy + tsc green on PR check
- [ ] Codex pre-landing review (if requested via /codex:review)
- [ ] Hands-on smoke not required — substrate-only PR, no user-visible surface yet

## Security review

`security_auditor_invoked: true`

Local-to-local trust topology — single-user James-only principal. Per memory `feedback_local_to_local_security_overreach_primary_concern`, multi-actor gates are correctly absent. /cso L2 review APPROVED with 4 path-α residuals (all already in packet §13 path-α appendix or filed for DOS-751). No exemption needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)