### PR TITLE
feat(mcp_v2): McpToolHandler request-scoped context + re-entrancy guard (DOS-758)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run claim projection roundtrip regression
         run: cargo test --manifest-path src-tauri/Cargo.toml -p dailyos --test dos301_claim_projection_roundtrip_test
 
+      - name: Run MCP v2 handler DB boundary gate
+        run: ./scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh
+
       - name: Run Rust clippy (production targets)
         run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-features --lib --bins -- -D warnings
 
@@ -80,3 +83,7 @@ jobs:
       - name: Run MCP dynamic reader harness test
         working-directory: src-tauri
         run: cargo test --features test-harness --test w05_a_mcp_dynamic_tool_readers_test
+
+      - name: Run MCP v2 gateway smoke
+        working-directory: src-tauri
+        run: cargo test --features test-harness --test mcp_v2_gateway_smoke

--- a/scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh
+++ b/scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HANDLER_DIR="$ROOT_DIR/src-tauri/src/services/mcp_v2/handlers"
+
+if [[ ! -d "$HANDLER_DIR" ]]; then
+  echo "MCP v2 handler directory not found: $HANDLER_DIR" >&2
+  exit 1
+fi
+
+if rg -n 'ActionDb::open|LocalKeychain::new' "$HANDLER_DIR" -g '*.rs'; then
+  cat >&2 <<'EOF'
+MCP v2 handlers must receive DB and service access through McpHandlerContext.
+Direct database opens and keychain provider construction are not allowed here.
+EOF
+  exit 1
+fi
+
+echo "MCP v2 handler DB-open boundary check passed."

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -94,6 +94,7 @@ run_step "Tauri externalBin sidecar stub" bash -c '
 
 # 3. Service-layer boundary
 run_step "service-layer boundary" ./scripts/check_service_layer_boundary.sh
+run_step "MCP v2 handler DB boundary" ./scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh
 
 # 4. must_use on DB mutation methods
 run_step "db mutator must_use" ./scripts/check_db_mutator_must_use.sh

--- a/scripts/suite-s.sh
+++ b/scripts/suite-s.sh
@@ -32,6 +32,7 @@ trap 'rm -f "$OAUTH_SECRET_SCAN_SCRIPT"' EXIT
 # Each entry: "label::command"
 CHECKS=(
   "service-layer-boundary::./scripts/check_service_layer_boundary.sh"
+  "mcp-v2-handler-db-boundary::./scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh"
   "no-let-underscore::./scripts/check_no_let_underscore_feedback.sh"
   "write-fence-usage::./scripts/check_write_fence_usage.sh"
   "ability-surface-drift::bash src-tauri/scripts/check_ability_surface_drift.sh"

--- a/src-tauri/src/db_service.rs
+++ b/src-tauri/src/db_service.rs
@@ -20,6 +20,7 @@
 //!   SQLCipher WAL read-verify races on `Connection::open()` verification.
 
 use std::any::Any;
+use std::cell::Cell;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -63,10 +64,19 @@ pub enum PooledCallError {
     Closed,
     #[error("pooled call panicked: {0}")]
     Panic(String),
+    #[error("re-entrant pooled call rejected: {0}")]
+    ReentrantCall(String),
 }
+
+thread_local! {
+    static CURRENT_POOLED_CONNECTION_ID: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+static NEXT_POOLED_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
 
 /// Shared worker internals.
 struct PooledConnectionInner {
+    id: usize,
     sender: mpsc::Sender<CallMessage>,
     handle: StdMutex<Option<std::thread::JoinHandle<()>>>,
 }
@@ -115,7 +125,14 @@ fn run_task(task: WorkerTask, conn: &mut Connection) -> CallResult {
 
 impl PooledConnection {
     fn new(conn: Connection) -> Result<Self, DbError> {
+        let id = NEXT_POOLED_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = mpsc::channel();
+        let inner = Arc::new(PooledConnectionInner {
+            id,
+            sender,
+            handle: StdMutex::new(None),
+        });
+        let worker_id = inner.id;
         let handle = thread::Builder::new()
             .name("dailyos-db-connection".to_string())
             .spawn(move || {
@@ -124,11 +141,11 @@ impl PooledConnection {
                     match message {
                         CallMessage::Async { task, respond_to } => {
                             #[allow(clippy::let_underscore_must_use, reason = "intentional best-effort discard; preserves existing non-blocking behavior")]
-                            let _ = respond_to.send(run_task(task, &mut conn));
+                            let _ = respond_to.send(run_task_on_worker(worker_id, task, &mut conn));
                         }
                         CallMessage::Sync { task, respond_to } => {
                             #[allow(clippy::let_underscore_must_use, reason = "intentional best-effort discard; preserves existing non-blocking behavior")]
-                            let _ = respond_to.send(run_task(task, &mut conn));
+                            let _ = respond_to.send(run_task_on_worker(worker_id, task, &mut conn));
                         }
                         CallMessage::Shutdown => {
                             break;
@@ -138,12 +155,8 @@ impl PooledConnection {
             })
             .map_err(|e| DbError::Migration(format!("failed to start DB worker thread: {e}")))?;
 
-        Ok(Self {
-            inner: Arc::new(PooledConnectionInner {
-                sender,
-                handle: StdMutex::new(Some(handle)),
-            }),
-        })
+        *inner.handle.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle);
+        Ok(Self { inner })
     }
 
     fn split_payload<T: Send + 'static>(payload: CallResult) -> Result<T, PooledCallError> {
@@ -179,6 +192,14 @@ impl PooledConnection {
         F: FnOnce(&mut Connection) -> rusqlite::Result<T> + Send + 'static,
         T: Send + 'static,
     {
+        let is_reentrant =
+            CURRENT_POOLED_CONNECTION_ID.with(|current| current.get() == Some(self.inner.id));
+        if is_reentrant {
+            let message = "call_sync invoked from the same pooled connection worker".to_string();
+            debug_assert!(false, "{message}");
+            return Err(PooledCallError::ReentrantCall(message));
+        }
+
         let (tx, rx) = mpsc::channel();
         let task: WorkerTask = Box::new(move |conn| f(conn).map(|value| Box::new(value) as Box<_>));
         self.inner
@@ -194,6 +215,15 @@ impl PooledConnection {
     pub(crate) fn shutdown(&self) {
         self.inner.shutdown();
     }
+}
+
+fn run_task_on_worker(worker_id: usize, task: WorkerTask, conn: &mut Connection) -> CallResult {
+    CURRENT_POOLED_CONNECTION_ID.with(|current| {
+        let previous = current.replace(Some(worker_id));
+        let result = run_task(task, conn);
+        current.set(previous);
+        result
+    })
 }
 
 /// Apply standard pragmas to a connection. `read_only` adds `query_only=ON`.
@@ -456,6 +486,9 @@ impl DbService {
             Err(PooledCallError::TypeMismatch) => Err(DbError::Migration(
                 "open_fresh_serialized result type mismatch".to_string(),
             )),
+            Err(PooledCallError::ReentrantCall(message)) => Err(DbError::Migration(format!(
+                "open_fresh_serialized {message}"
+            ))),
         }
     }
 
@@ -676,6 +709,29 @@ mod tests {
     impl Drop for GlobalServiceGuard {
         fn drop(&mut self) {
             uninstall_global();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn call_sync_reentrant_on_same_worker_fails_without_blocking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let svc = DbService::open_at_unencrypted(dir.path().join("reentrant.db"))
+            .await
+            .expect("open svc");
+        let writer = svc.writer();
+        let nested_writer = writer.clone();
+
+        let result = writer.call_sync(move |_conn| {
+            let nested = nested_writer.call_sync(|_conn| Ok(()));
+            Ok(matches!(nested, Err(PooledCallError::ReentrantCall(_))))
+        });
+
+        if cfg!(debug_assertions) {
+            assert!(
+                matches!(result, Err(PooledCallError::Panic(message)) if message.contains("call_sync"))
+            );
+        } else {
+            assert_eq!(result.expect("outer call"), true);
         }
     }
 

--- a/src-tauri/src/release_gate.rs
+++ b/src-tauri/src/release_gate.rs
@@ -1379,10 +1379,7 @@ fn w6_report_status(report: &W6FixtureReport, runner_success: Option<bool>) -> G
                 .unwrap_or(GateStatus::InfraFailure)
         })
         .collect::<Vec<_>>();
-    if fixture_statuses
-        .iter()
-        .any(|status| *status == GateStatus::InfraFailure)
-    {
+    if fixture_statuses.contains(&GateStatus::InfraFailure) {
         return GateStatus::InfraFailure;
     }
     if fixture_statuses

--- a/src-tauri/src/services/mcp_v2/contracts.rs
+++ b/src-tauri/src/services/mcp_v2/contracts.rs
@@ -1,4 +1,10 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
+
+use crate::db::ActionDb;
+use crate::db_service::{DbService, PooledCallError};
+use crate::state::AppState;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -297,11 +303,119 @@ pub enum McpToolResult {
     Error { error: ToolError },
 }
 
+/// Request-scoped dependency bundle for MCP v2 handlers.
+///
+/// Handlers receive this from the gateway and must use it for DB and
+/// service access instead of constructing process-global resources.
+pub struct McpHandlerContext<'a> {
+    app_state: &'a AppState,
+    db_service: Arc<DbService>,
+    services: crate::services::context::ServiceContext<'a>,
+}
+
+impl<'a> McpHandlerContext<'a> {
+    pub async fn from_state(app_state: &'a AppState) -> Result<Self, ToolError> {
+        {
+            let guard = app_state.db_service.read().await;
+            if guard.is_none() {
+                drop(guard);
+                app_state
+                    .init_db_service()
+                    .await
+                    .map_err(|error| ToolError::UpstreamFailure {
+                        detail: format!("database service unavailable: {error}"),
+                    })?;
+            }
+        }
+
+        let db_service = {
+            let guard = app_state.db_service.read().await;
+            guard
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| ToolError::UpstreamFailure {
+                    detail: "database service unavailable".to_string(),
+                })?
+        };
+
+        Ok(Self {
+            app_state,
+            db_service,
+            services: app_state.live_service_context().with_actor("mcp_client"),
+        })
+    }
+
+    pub fn app_state(&self) -> &'a AppState {
+        self.app_state
+    }
+
+    pub fn services(&self) -> &crate::services::context::ServiceContext<'a> {
+        &self.services
+    }
+
+    pub fn db_service(&self) -> Arc<DbService> {
+        Arc::clone(&self.db_service)
+    }
+
+    pub fn read_db<T, F>(&self, f: F) -> Result<T, ToolError>
+    where
+        F: FnOnce(&ActionDb) -> Result<T, ToolError> + Send + 'static,
+        T: Send + 'static,
+    {
+        let reader = self.db_service.reader();
+        match reader.call_sync(move |conn| {
+            let db = ActionDb::from_conn(conn);
+            Ok(f(db))
+        }) {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(error),
+            Err(error) => Err(pooled_call_error(error, "database read failed")),
+        }
+    }
+
+    pub fn write_db<T, F>(&self, f: F) -> Result<T, ToolError>
+    where
+        F: FnOnce(&ActionDb) -> Result<T, ToolError> + Send + 'static,
+        T: Send + 'static,
+    {
+        let writer = self.db_service.writer();
+        match writer.call_sync(move |conn| {
+            let db = ActionDb::from_conn(conn);
+            Ok(f(db))
+        }) {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(error),
+            Err(error) => Err(pooled_call_error(error, "database write failed")),
+        }
+    }
+}
+
+fn pooled_call_error(error: PooledCallError, context: &str) -> ToolError {
+    match error {
+        PooledCallError::ReentrantCall(message) => ToolError::UpstreamFailure {
+            detail: format!("{context}: {message}"),
+        },
+        PooledCallError::Rusqlite(error) => ToolError::UpstreamFailure {
+            detail: format!("{context}: {error}"),
+        },
+        PooledCallError::Closed => ToolError::UpstreamFailure {
+            detail: format!("{context}: pooled connection unavailable"),
+        },
+        PooledCallError::Panic(message) => ToolError::UpstreamFailure {
+            detail: format!("{context}: pooled call panicked: {message}"),
+        },
+        PooledCallError::TypeMismatch => ToolError::Internal {
+            trace_id: format!("mcp-v2-{}", uuid::Uuid::new_v4()),
+        },
+    }
+}
+
 pub trait McpToolHandler: Send + Sync {
     fn description(&self) -> &ToolDescription;
 
     fn invoke(
         &self,
+        ctx: &McpHandlerContext<'_>,
         actor: &McpActor,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, ToolError>;

--- a/src-tauri/src/services/mcp_v2/gateway.rs
+++ b/src-tauri/src/services/mcp_v2/gateway.rs
@@ -1,10 +1,185 @@
 //! MCP v2 gateway: the single entry point that receives MCP tool calls.
 //!
-//! Validates Actor::McpClient policy against the server-side scope
-//! manifest loaded by auth; dispatches through registered McpToolHandler
-//! implementations; records audit attribution; emits McpToolInvoked
-//! signals — signal type registration happens in signals/policy_registry.rs
-//! when the first handler lands.
-//!
-//! Implementation pending — see ADR-0102 amendment §C for the contract
-//! and ADR-0128 for the product-surface frame.
+//! The gateway resolves handler dependencies once per request, validates the
+//! granted scope set, dispatches through registered handlers, and returns the
+//! stable MCP v2 response envelope.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::services::mcp_v2::contracts::{
+    McpActor, McpClientId, McpHandlerContext, McpToolHandler, McpToolRequestEnvelope,
+    McpToolResponseEnvelope, McpToolResult, OpaqueConversationHandle, Scope, ScopedName, ToolError,
+};
+use crate::services::mcp_v2::handlers::tool_account_status::AccountStatusToolHandler;
+use crate::state::AppState;
+
+pub struct McpGateway {
+    state: Arc<AppState>,
+    handlers: BTreeMap<String, Arc<dyn McpToolHandler>>,
+}
+
+impl McpGateway {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self {
+            state,
+            handlers: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_default_handlers(state: Arc<AppState>) -> Self {
+        Self::new(state).with_handler(Arc::new(AccountStatusToolHandler::default()))
+    }
+
+    pub fn with_handler(mut self, handler: Arc<dyn McpToolHandler>) -> Self {
+        self.register_handler(handler);
+        self
+    }
+
+    pub fn register_handler(&mut self, handler: Arc<dyn McpToolHandler>) {
+        self.handlers.insert(
+            handler.description().name.as_str().to_string(),
+            Arc::clone(&handler),
+        );
+    }
+
+    pub async fn invoke(
+        &self,
+        client_id: McpClientId,
+        granted_scopes: Vec<Scope>,
+        request: McpToolRequestEnvelope,
+    ) -> McpToolResponseEnvelope {
+        let conversation_handle = request.conversation_handle.clone().unwrap_or_else(|| {
+            OpaqueConversationHandle::new(format!("mcp-{}", uuid::Uuid::new_v4()))
+        });
+
+        let result = self
+            .invoke_result(
+                client_id,
+                conversation_handle.clone(),
+                granted_scopes,
+                request,
+            )
+            .await;
+
+        McpToolResponseEnvelope {
+            conversation_handle,
+            result: match result {
+                Ok(value) => McpToolResult::Ok { value },
+                Err(error) => McpToolResult::Error { error },
+            },
+        }
+    }
+
+    async fn invoke_result(
+        &self,
+        client_id: McpClientId,
+        conversation_handle: OpaqueConversationHandle,
+        granted_scopes: Vec<Scope>,
+        request: McpToolRequestEnvelope,
+    ) -> Result<serde_json::Value, ToolError> {
+        let handler = self
+            .handlers
+            .get(request.tool_name.as_str())
+            .cloned()
+            .ok_or_else(|| ToolError::NotFound {
+                resource: format!("tool:{}", request.tool_name.as_str()),
+            })?;
+
+        authorize(
+            handler.description().scopes_required.as_slice(),
+            &granted_scopes,
+        )?;
+
+        let actor = McpActor::Client {
+            client_id,
+            conversation_handle: Some(conversation_handle),
+            tool_name: ScopedName::new(request.tool_name.as_str()),
+            granted_scopes,
+        };
+        let ctx = McpHandlerContext::from_state(&self.state).await?;
+
+        handler.invoke(&ctx, &actor, request.params)
+    }
+}
+
+fn authorize(required: &[Scope], granted: &[Scope]) -> Result<(), ToolError> {
+    for required_scope in required {
+        if !granted.iter().any(|scope| scope == required_scope) {
+            return Err(ToolError::Unauthorized {
+                missing_scope: required_scope.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::mcp_v2::contracts::{ParamSchema, ReturnSpec, Side, ToolDescription};
+    use serde_json::json;
+
+    struct FixtureHandler {
+        description: ToolDescription,
+    }
+
+    impl FixtureHandler {
+        fn new() -> Self {
+            Self {
+                description: ToolDescription {
+                    name: ScopedName::new("dailyos.read.fixture"),
+                    summary: "fixture".to_string(),
+                    when_to_call: "fixture".to_string(),
+                    when_not_to_call: "fixture".to_string(),
+                    side: Side::Read,
+                    parameters: Vec::new(),
+                    returns: ReturnSpec {
+                        schema: ParamSchema(json!({ "type": "object" })),
+                        description: "fixture".to_string(),
+                    },
+                    examples: Vec::new(),
+                    scopes_required: vec![Scope::new("dailyos.read.fixture")],
+                },
+            }
+        }
+    }
+
+    impl McpToolHandler for FixtureHandler {
+        fn description(&self) -> &ToolDescription {
+            &self.description
+        }
+
+        fn invoke(
+            &self,
+            _ctx: &McpHandlerContext<'_>,
+            _actor: &McpActor,
+            _params: serde_json::Value,
+        ) -> Result<serde_json::Value, ToolError> {
+            Ok(json!({ "ok": true }))
+        }
+    }
+
+    #[test]
+    fn authorize_rejects_missing_scope() {
+        let err = authorize(
+            &[Scope::new("dailyos.read.fixture")],
+            &[Scope::new("other")],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            ToolError::Unauthorized {
+                missing_scope: Scope::new("dailyos.read.fixture")
+            }
+        );
+    }
+
+    #[test]
+    fn gateway_registers_handlers_by_scoped_name() {
+        let state = Arc::new(AppState::new());
+        let gateway = McpGateway::new(state).with_handler(Arc::new(FixtureHandler::new()));
+
+        assert!(gateway.handlers.contains_key("dailyos.read.fixture"));
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/mod.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/mod.rs
@@ -1,6 +1,7 @@
 //! Per-tool MCP handler modules. Each handler implements McpToolHandler.
 //! Module names match the canonical scoped names declared in taxonomy.
 
+pub mod tool_account_status;
 pub mod tool_briefing;
 pub mod tool_create_action;
 pub mod tool_note;

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -1,0 +1,374 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::services::mcp_v2::contracts::{
+    compose_scope, compose_scoped_name, McpActor, McpHandlerContext, McpToolHandler, ParamSchema,
+    ReturnSpec, Side, ToolDescription, ToolError, ToolExample, Verb,
+};
+
+const ACCOUNT_STATUS_NOUN: &str = "account_status";
+
+#[derive(Debug, Clone)]
+pub struct AccountStatusToolHandler {
+    description: ToolDescription,
+}
+
+impl Default for AccountStatusToolHandler {
+    fn default() -> Self {
+        Self {
+            description: account_status_description(),
+        }
+    }
+}
+
+impl McpToolHandler for AccountStatusToolHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext<'_>,
+        _actor: &McpActor,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolError> {
+        let params = AccountStatusParams::try_from_value(params)?;
+        let generated_at = ctx.services().clock.now().to_rfc3339();
+        let account = ctx.read_db(move |db| {
+            let account = match params.lookup {
+                AccountStatusLookup::Id(account_id) => db
+                    .get_account(&account_id)
+                    .map_err(db_error)?
+                    .ok_or_else(|| account_not_found(&account_id))?,
+                AccountStatusLookup::Name(account_name) => db
+                    .get_account_by_name(&account_name)
+                    .map_err(db_error)?
+                    .ok_or_else(|| account_not_found(&account_name))?,
+            };
+            let renewal_stage = db
+                .get_account_renewal_stage(&account.id)
+                .map_err(db_error)?;
+            let open_action_count = db.get_account_actions(&account.id).map_err(db_error)?.len();
+
+            Ok(AccountStatusPayload {
+                account_id: account.id,
+                name: account.name,
+                lifecycle: account.lifecycle,
+                health: account.health,
+                customer_status: account.customer_status,
+                renewal_date: account.contract_end,
+                renewal_stage,
+                account_type: account.account_type.as_db_str().to_string(),
+                archived: account.archived,
+                open_action_count,
+            })
+        })?;
+
+        serde_json::to_value(AccountStatusResponse {
+            generated_at,
+            account,
+        })
+        .map_err(|_| ToolError::Internal {
+            trace_id: format!("mcp-v2-{}", uuid::Uuid::new_v4()),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RawAccountStatusParams {
+    account_id: Option<String>,
+    account_name: Option<String>,
+}
+
+struct AccountStatusParams {
+    lookup: AccountStatusLookup,
+}
+
+enum AccountStatusLookup {
+    Id(String),
+    Name(String),
+}
+
+impl AccountStatusParams {
+    fn try_from_value(value: serde_json::Value) -> Result<Self, ToolError> {
+        let raw: RawAccountStatusParams =
+            serde_json::from_value(value).map_err(|error| ToolError::BadParams {
+                detail: error.to_string(),
+            })?;
+
+        let account_id = normalize_optional(raw.account_id);
+        let account_name = normalize_optional(raw.account_name);
+        match (account_id, account_name) {
+            (Some(account_id), None) => Ok(Self {
+                lookup: AccountStatusLookup::Id(account_id),
+            }),
+            (None, Some(account_name)) => Ok(Self {
+                lookup: AccountStatusLookup::Name(account_name),
+            }),
+            (None, None) => Err(ToolError::BadParams {
+                detail: "provide exactly one of accountId or accountName".to_string(),
+            }),
+            (Some(_), Some(_)) => Err(ToolError::BadParams {
+                detail: "accountId and accountName are mutually exclusive".to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct AccountStatusResponse {
+    generated_at: String,
+    account: AccountStatusPayload,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct AccountStatusPayload {
+    account_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lifecycle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    customer_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    renewal_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    renewal_stage: Option<String>,
+    account_type: String,
+    archived: bool,
+    open_action_count: usize,
+}
+
+fn account_status_description() -> ToolDescription {
+    ToolDescription {
+        name: compose_scoped_name(Verb::Read, ACCOUNT_STATUS_NOUN),
+        summary: "Returns the current status snapshot for one account.".to_string(),
+        when_to_call: "Use when the user asks for the status of a specific account.".to_string(),
+        when_not_to_call: "Do NOT use for broad portfolio search or updates.".to_string(),
+        side: Side::Read,
+        parameters: vec![
+            crate::services::mcp_v2::contracts::ParamSpec {
+                name: "accountId".to_string(),
+                schema: ParamSchema(json!({ "type": "string", "minLength": 1 })),
+                required: false,
+                description: "Stable account identifier.".to_string(),
+            },
+            crate::services::mcp_v2::contracts::ParamSpec {
+                name: "accountName".to_string(),
+                schema: ParamSchema(json!({ "type": "string", "minLength": 1 })),
+                required: false,
+                description: "Exact account name, case-insensitive.".to_string(),
+            },
+        ],
+        returns: ReturnSpec {
+            schema: ParamSchema(json!({
+                "type": "object",
+                "required": ["generatedAt", "account"],
+                "properties": {
+                    "generatedAt": { "type": "string" },
+                    "account": { "type": "object" }
+                }
+            })),
+            description: "Account status snapshot with lifecycle, health, and open action count."
+                .to_string(),
+        },
+        examples: vec![ToolExample {
+            prompt: "What is the status of Acme?".to_string(),
+            invocation: json!({
+                "toolName": "dailyos.read.account_status",
+                "params": { "accountName": "Acme" }
+            }),
+            expected_response_shape: json!({
+                "generatedAt": "string",
+                "account": {
+                    "accountId": "string",
+                    "name": "string",
+                    "openActionCount": 0
+                }
+            }),
+        }],
+        scopes_required: vec![compose_scope(Verb::Read, ACCOUNT_STATUS_NOUN)],
+    }
+}
+
+fn normalize_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn db_error(error: crate::db::DbError) -> ToolError {
+    ToolError::UpstreamFailure {
+        detail: format!("account status read failed: {error}"),
+    }
+}
+
+fn account_not_found(identifier: &str) -> ToolError {
+    ToolError::NotFound {
+        resource: format!("account:{identifier}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::db::{ActionDb, DbAccount};
+    use crate::db_service::DbService;
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, Scope, ScopedName,
+    };
+    use crate::state::AppState;
+
+    struct Fixture {
+        _dir: TempDir,
+        state: Arc<AppState>,
+        handler: AccountStatusToolHandler,
+    }
+
+    async fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_service = DbService::open_at_unencrypted(dir.path().join("account-status.db"))
+            .await
+            .expect("db service");
+
+        db_service
+            .writer()
+            .call(|conn| {
+                let db = ActionDb::from_conn(conn);
+                let account = DbAccount {
+                    id: "acct-example".to_string(),
+                    name: "Example Account".to_string(),
+                    lifecycle: Some("renewing".to_string()),
+                    health: Some("yellow".to_string()),
+                    contract_end: Some("2026-12-31".to_string()),
+                    updated_at: "2026-05-21T12:00:00Z".to_string(),
+                    ..Default::default()
+                };
+                if let Err(error) = db.upsert_account(&account) {
+                    return Ok(Err(error.to_string()));
+                }
+                conn.execute(
+                    "UPDATE accounts SET customer_status = 'active' WHERE id = 'acct-example'",
+                    [],
+                )?;
+                Ok(Ok(()))
+            })
+            .await
+            .expect("seed task")
+            .expect("seed account");
+
+        Fixture {
+            _dir: dir,
+            state: Arc::new(AppState::test_with_db_service(db_service)),
+            handler: AccountStatusToolHandler::default(),
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conversation-test")),
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+            granted_scopes: vec![Scope::new("dailyos.read.account_status")],
+        }
+    }
+
+    async fn invoke(
+        fixture: &Fixture,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolError> {
+        let ctx = McpHandlerContext::from_state(&fixture.state)
+            .await
+            .expect("context");
+        fixture.handler.invoke(&ctx, &actor(), params)
+    }
+
+    #[tokio::test]
+    async fn description_declares_account_status_scope() {
+        let fixture = fixture().await;
+        let description = fixture.handler.description();
+
+        assert_eq!(description.name.as_str(), "dailyos.read.account_status");
+        assert_eq!(
+            description.scopes_required,
+            vec![Scope::new("dailyos.read.account_status")]
+        );
+    }
+
+    #[tokio::test]
+    async fn invoke_rejects_missing_account_identifier() {
+        let fixture = fixture().await;
+        let err = invoke(&fixture, json!({})).await.unwrap_err();
+
+        assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[tokio::test]
+    async fn invoke_rejects_multiple_account_identifiers() {
+        let fixture = fixture().await;
+        let err = invoke(
+            &fixture,
+            json!({ "accountId": "acct-example", "accountName": "Example Account" }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ToolError::BadParams {
+                detail: "accountId and accountName are mutually exclusive".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn invoke_returns_not_found_for_unknown_account() {
+        let fixture = fixture().await;
+        let err = invoke(&fixture, json!({ "accountId": "missing-account" }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ToolError::NotFound {
+                resource: "account:missing-account".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn invoke_reads_account_by_id_from_context() {
+        let fixture = fixture().await;
+        let value = invoke(&fixture, json!({ "accountId": "acct-example" }))
+            .await
+            .expect("account status");
+
+        assert_eq!(value["account"]["accountId"], "acct-example");
+        assert_eq!(value["account"]["name"], "Example Account");
+        assert_eq!(value["account"]["health"], "yellow");
+        assert_eq!(value["account"]["openActionCount"], 0);
+    }
+
+    #[tokio::test]
+    async fn invoke_reads_account_by_name_and_shapes_status() {
+        let fixture = fixture().await;
+        let value = invoke(&fixture, json!({ "accountName": "example account" }))
+            .await
+            .expect("account status");
+
+        assert_eq!(value["account"]["accountId"], "acct-example");
+        assert_eq!(value["account"]["lifecycle"], "renewing");
+        assert_eq!(value["account"]["customerStatus"], "active");
+        assert_eq!(value["account"]["renewalDate"], "2026-12-31");
+        assert_eq!(value["account"]["accountType"], "customer");
+    }
+}

--- a/src-tauri/tests/mcp_v2_gateway_smoke.rs
+++ b/src-tauri/tests/mcp_v2_gateway_smoke.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "test-harness")]
+
+use std::sync::Arc;
+
+use dailyos_lib::db::{ActionDb, DbAccount};
+use dailyos_lib::db_service::DbService;
+use dailyos_lib::services::mcp_v2::contracts::{
+    McpClientId, McpToolRequestEnvelope, McpToolResult, Scope, ScopedName,
+};
+use dailyos_lib::services::mcp_v2::gateway::McpGateway;
+use dailyos_lib::state::AppState;
+use serde_json::json;
+
+#[tokio::test]
+async fn gateway_dispatches_account_status_with_request_context() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_service = DbService::open_at_unencrypted_for_tests(dir.path().join("mcp-v2-smoke.db"))
+        .await
+        .expect("db service");
+
+    db_service
+        .writer()
+        .call(|conn| {
+            let db = ActionDb::from_conn(conn);
+            let account = DbAccount {
+                id: "acct-smoke".to_string(),
+                name: "Smoke Account".to_string(),
+                lifecycle: Some("active".to_string()),
+                health: Some("green".to_string()),
+                updated_at: "2026-05-21T12:00:00Z".to_string(),
+                ..Default::default()
+            };
+            Ok(db
+                .upsert_account(&account)
+                .map_err(|error| error.to_string()))
+        })
+        .await
+        .expect("seed task")
+        .expect("seed account");
+
+    let state = Arc::new(AppState::test_with_db_service(db_service));
+    let gateway = McpGateway::with_default_handlers(state);
+    let response = gateway
+        .invoke(
+            McpClientId::new("client-smoke"),
+            vec![Scope::new("dailyos.read.account_status")],
+            McpToolRequestEnvelope {
+                conversation_handle: None,
+                tool_name: ScopedName::new("dailyos.read.account_status"),
+                params: json!({ "accountId": "acct-smoke" }),
+            },
+        )
+        .await;
+
+    let McpToolResult::Ok { value } = response.result else {
+        panic!("expected account status result");
+    };
+
+    assert_eq!(value["account"]["accountId"], "acct-smoke");
+    assert_eq!(value["account"]["name"], "Smoke Account");
+    assert_eq!(value["account"]["health"], "green");
+}


### PR DESCRIPTION
## Summary

- `McpToolHandler::invoke` takes a `&McpHandlerContext<'_>` parameter carrying DB access, services, and readers — handlers stop self-opening `ActionDb` mid-execution.
- New `account_status` handler implementing the new contract (`services/mcp_v2/handlers/tool_account_status.rs`).
- `McpGateway` constructs `McpHandlerContext` per request and threads it through dispatch.
- `db_service.rs` thread-local re-entrancy guard: nested `writer.call_sync` inside `writer.call_sync` returns `PooledCallError::ReentrantCall` instead of deadlocking.
- CI gate `scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh` forbids `ActionDb::open` and `LocalKeychain::new` inside `mcp_v2/handlers/*`. Hooked into `rust.yml`, `preflight.sh`, `suite-s.sh`.
- New integration smoke: `tests/mcp_v2_gateway_smoke.rs`.
- Drive-by clippy fix at `release_gate.rs:1382` (pre-existing `manual_contains` lint from clippy 1.95+).

## Why

Substrate prerequisite for [DOS-647-C](https://linear.app/a8c/issue/DOS-759) (in-process MCP hosting). Self-opening `ActionDb` inside a handler that itself runs inside `writer.call_sync` would deadlock by construction once handlers move from the standalone binary to the in-process signed-route server. This PR makes the interface deadlock-proof and the CI gate prevents regression.

Today's binary flow continues to work — this changes the trait shape, not the binary process boundaries. The binary still owns its own Connection until DOS-647-C cuts it over to the HTTP adapter.

Spec: [DOS-758](https://linear.app/a8c/issue/DOS-758). Parent umbrella: [DOS-647](https://linear.app/a8c/issue/DOS-647).

## Test plan

- [x] `cargo clippy --workspace --all-features --lib --bins -- -D warnings` clean
- [x] `cargo test --workspace --all-features --lib` — 2723 passed; 3 failed; 11 ignored
  - The 3 failures (`surface_runtime::tests::session_refresh_*`) are pre-existing on `dev` HEAD — `scope_denied` from `surface_pairing::complete_handshake`. This PR doesn't touch `surface_runtime` or `surface_pairing`; same 3 fail in DOS-757. Not introduced here.
- [x] CI gate runs locally: `bash scripts/ci/check_mcp_v2_handlers_no_direct_db_open.sh` → passes on the new `tool_account_status.rs` (no `ActionDb::open` / `LocalKeychain::new`)
- [ ] L1 verification of re-entrancy guard via a synthetic handler that attempts nested `writer.call_sync` (covered by new debug_assert + test that fires on nested dispatch)

L2-status: not-run-acknowledged (substrate-only interface refactor + CI gate; full L2 runs in DOS-647-C where in-process hosting actually lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)