### PR TITLE
v1.4.5 W2-C: entity_intake ability + WP block scaffold (DOS-468)

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-C.md
+++ b/.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-C.md
@@ -1,0 +1,14 @@
+# v1.4.6 Follow-ups - W2-C Entity Intake
+
+## Editor Write Transport
+
+Precondition #2 found no generic WordPress REST invoke route such as `dailyos/v1/ability/invoke` or `dailyos/v1/invoke` in `wp/dailyos/includes/class-dailyos-plugin.php` or adjacent transport files.
+
+Per the W2-C packet, this lane did not extend `class-dailyos-plugin.php`. The `dailyos/entity-intake` block is scaffolded and server rendering invokes the read-only `entity_intake_render` ability through the existing runtime client. The editor write gesture remains deferred until v1.4.6 adds the confirmation-token/generic SurfaceClient transport extension.
+
+Required v1.4.6 work:
+
+- Add a scoped editor REST invoke route or a generic `dailyos/v1/ability/invoke` route.
+- Route `entity_intake` invocations with the `write.entity_intake` scope through the existing signed runtime client.
+- Enable `wp/dailyos/blocks/entity-intake/edit.js` to call the route from the Ingest button.
+- Add PHP/JS tests for the editor write gesture and route permission callback.

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/contracts.rs
@@ -1,0 +1,86 @@
+use schemars::gen::SchemaGenerator;
+use schemars::schema::Schema;
+use schemars::JsonSchema;
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::abilities::trust::types::TrustBand;
+use crate::services::workspace_intake::EntityRefDto;
+use crate::types::ClaimSensitivity;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityIntakeInput {
+    pub file_ref: String,
+    pub entity_seed: Option<EntityRefDto>,
+    pub category: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityIntakeRenderInput {
+    pub entity_type: String,
+    pub entity_id: String,
+    pub file_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityIntakeOutput {
+    pub run_id: String,
+    pub file_id: String,
+    pub resolved_path: Option<String>,
+    pub claims: Vec<EntityIntakeClaim>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityIntakeClaim {
+    pub claim_id: String,
+    pub display_text: String,
+    pub trust_band: TrustBand,
+    pub sensitivity: ClaimSensitivity,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum EntityIntakeError {
+    InvalidEntityType { value: String },
+    InvalidEntityId { value: String },
+    EntityNotFound,
+    InvalidCategorySlug { value: String },
+    CategoryNotAllowed { allowed: Vec<String> },
+    FileNotFound,
+    PathTraversalAttempt,
+    IngestionFailed { message: String },
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct EntityRefDtoSchema {
+    entity_type_slug: String,
+    entity_id: String,
+    entity_name: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for EntityRefDto {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = EntityRefDtoSchema::deserialize(deserializer)?;
+        Ok(Self {
+            entity_type_slug: wire.entity_type_slug,
+            entity_id: wire.entity_id,
+            entity_name: wire.entity_name,
+        })
+    }
+}
+
+impl JsonSchema for EntityRefDto {
+    fn schema_name() -> String {
+        "EntityRefDto".to_string()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        EntityRefDtoSchema::json_schema(gen)
+    }
+}

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/mod.rs
@@ -1,0 +1,55 @@
+pub mod contracts;
+pub mod producer;
+
+pub use contracts::{
+    EntityIntakeClaim, EntityIntakeError, EntityIntakeInput, EntityIntakeOutput,
+    EntityIntakeRenderInput,
+};
+
+use dailyos_abilities_macro::ability;
+
+use crate::abilities::{AbilityContext, AbilityResult};
+
+#[ability(
+    name = "entity_intake",
+    category = Transform,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [SurfaceClient],
+    allowed_modes = [Live, Simulate, Evaluate],
+    requires_confirmation = false,
+    may_publish = true,
+    required_scopes = ["write.entity_intake"],
+    mcp_exposure = None,
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn entity_intake(
+    ctx: &AbilityContext<'_>,
+    input: EntityIntakeInput,
+) -> AbilityResult<EntityIntakeOutput> {
+    producer::entity_intake(ctx, input).await
+}
+
+#[ability(
+    name = "entity_intake_render",
+    category = Read,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [SurfaceClient],
+    allowed_modes = [Live, Simulate, Evaluate],
+    requires_confirmation = false,
+    may_publish = false,
+    required_scopes = ["read.entity_intelligence"],
+    mcp_exposure = None,
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn entity_intake_render(
+    ctx: &AbilityContext<'_>,
+    input: EntityIntakeRenderInput,
+) -> AbilityResult<EntityIntakeOutput> {
+    producer::entity_intake_render(ctx, input).await
+}

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
@@ -1,0 +1,237 @@
+use crate::abilities::provenance::{
+    AbilityExecutionMode, AbilityVersion, FieldAttribution, FieldPath, ProvenanceBuilder,
+    ProvenanceBuilderConfig, SchemaVersion, SubjectAttribution, SubjectRef,
+};
+use crate::abilities::provenance::trust::claim_trust_band_from_score;
+use crate::abilities::{
+    AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
+};
+use crate::sensitivity::{renderable_claim_text_with_value, RenderActor, RenderSurface};
+use crate::services::workspace_intake::{WorkspaceIntakeError, WorkspaceIntakeRequest};
+use crate::types::IntelligenceClaim;
+
+use super::contracts::{
+    EntityIntakeClaim, EntityIntakeInput, EntityIntakeOutput, EntityIntakeRenderInput,
+};
+
+pub async fn entity_intake(
+    ctx: &AbilityContext<'_>,
+    input: EntityIntakeInput,
+) -> AbilityResult<EntityIntakeOutput> {
+    let entity_seed = input.entity_seed.clone();
+    let receipt = ctx
+        .services()
+        .workspace_intake()
+        .ok_or_else(|| hard_error("WorkspaceIntakeUnavailable", "workspace intake service unavailable"))?
+        .ingest(
+            ctx,
+            WorkspaceIntakeRequest {
+                file_ref: input.file_ref,
+                source_type_slug: "entity_doc".to_string(),
+                entity: input.entity_seed,
+                mode_slug: "entity_seeded".to_string(),
+                category_slug: input.category,
+            },
+        )
+        .await
+        .map_err(workspace_intake_error)?;
+
+    let claims = match entity_seed {
+        Some(entity) => {
+            read_claims_for_block_render(ctx, &entity.entity_type_slug, &entity.entity_id).await?
+        }
+        None => Vec::new(),
+    };
+
+    finalize_entity_intake_output(
+        ctx,
+        "entity_intake",
+        1,
+        AbilityCategory::Transform,
+        SubjectRef::Global,
+        EntityIntakeOutput {
+            run_id: receipt.run_id,
+            file_id: receipt.file_id,
+            resolved_path: receipt.resolved_path,
+            claims,
+        },
+    )
+}
+
+pub async fn entity_intake_render(
+    ctx: &AbilityContext<'_>,
+    input: EntityIntakeRenderInput,
+) -> AbilityResult<EntityIntakeOutput> {
+    let claims = read_claims_for_block_render(ctx, &input.entity_type, &input.entity_id).await?;
+    finalize_entity_intake_output(
+        ctx,
+        "entity_intake_render",
+        1,
+        AbilityCategory::Read,
+        SubjectRef::Global,
+        EntityIntakeOutput {
+            run_id: String::new(),
+            file_id: input.file_ref,
+            resolved_path: None,
+            claims,
+        },
+    )
+}
+
+async fn read_claims_for_block_render(
+    ctx: &AbilityContext<'_>,
+    entity_type: &str,
+    entity_id: &str,
+) -> Result<Vec<EntityIntakeClaim>, AbilityError> {
+    let claims = ctx
+        .services()
+        .read_entity_context_claims(
+            entity_type.to_string(),
+            entity_id.to_string(),
+            ctx.entity_context_claim_surface(),
+            2,
+        )
+        .await
+        .map_err(|error| hard_error("EntityIntakeClaimReadFailed", error))?;
+
+    let render_actor = render_actor_for_context(ctx);
+    Ok(claims
+        .into_iter()
+        .filter_map(|claim| project_claim(claim, &render_actor))
+        .collect())
+}
+
+fn project_claim(claim: IntelligenceClaim, render_actor: &RenderActor) -> Option<EntityIntakeClaim> {
+    let rendered = renderable_claim_text_with_value(
+        &claim,
+        &claim.text,
+        RenderSurface::TauriEntityDetail,
+        render_actor,
+    )?;
+
+    Some(EntityIntakeClaim {
+        claim_id: claim.id,
+        display_text: rendered.text,
+        trust_band: claim_trust_band_from_score(claim.trust_score),
+        sensitivity: claim.sensitivity,
+    })
+}
+
+fn finalize_entity_intake_output(
+    ctx: &AbilityContext<'_>,
+    ability_name: &'static str,
+    ability_schema_version: u32,
+    category: AbilityCategory,
+    subject: SubjectRef,
+    output: EntityIntakeOutput,
+) -> AbilityResult<EntityIntakeOutput> {
+    let mut config = ProvenanceBuilderConfig::new(ability_name, ctx.services().clock.now());
+    config.ability_version = AbilityVersion::new(1, 0);
+    config.ability_schema_version = SchemaVersion(ability_schema_version);
+    config.actor = provenance_actor(ctx.actor.clone(), ability_name);
+    config.mode = AbilityExecutionMode::from(ctx.mode());
+    config.category = category;
+
+    let mut builder = ProvenanceBuilder::new(config);
+    let subject_attr = SubjectAttribution::direct_confident(subject);
+    builder.set_subject(subject_attr.clone());
+    builder
+        .attribute_subtree(
+            FieldPath::new("").map_err(field_error)?,
+            FieldAttribution::constant(subject_attr),
+        )
+        .map_err(provenance_error)?;
+    builder.finalize(output).map_err(provenance_error)
+}
+
+fn workspace_intake_error(error: WorkspaceIntakeError) -> AbilityError {
+    match error {
+        WorkspaceIntakeError::InvalidEntityTypeSlug(value) => {
+            hard_error("InvalidEntityType", value)
+        }
+        WorkspaceIntakeError::InvalidEntityId => hard_error("InvalidEntityId", "entity_id is invalid"),
+        WorkspaceIntakeError::EntityNotFound => hard_error("EntityNotFound", "entity not found"),
+        WorkspaceIntakeError::InvalidCategorySlug(value) => {
+            hard_error("InvalidCategorySlug", value)
+        }
+        WorkspaceIntakeError::CategoryNotAllowed { allowed } => hard_error(
+            "CategoryNotAllowed",
+            format!("category not allowed; allowed={}", allowed.join(",")),
+        ),
+        WorkspaceIntakeError::FileNotFound => hard_error("FileNotFound", "file not found"),
+        WorkspaceIntakeError::PathTraversalAttempt | WorkspaceIntakeError::OutsideWorkspace => {
+            hard_error("PathTraversalAttempt", "file_ref is outside the workspace")
+        }
+        WorkspaceIntakeError::InvalidSourceTypeSlug(value) => {
+            hard_error("InvalidSourceType", value)
+        }
+        WorkspaceIntakeError::InvalidModeSlug(value) => hard_error("InvalidMode", value),
+        WorkspaceIntakeError::InvalidEntityName(value) => hard_error("InvalidEntityName", value),
+        WorkspaceIntakeError::SymlinkRaced => hard_error("PathTraversalAttempt", "symlink race"),
+        WorkspaceIntakeError::FileTooLarge => hard_error("IngestionFailed", "file too large"),
+        WorkspaceIntakeError::UnsupportedFormat => {
+            hard_error("IngestionFailed", "unsupported format")
+        }
+        WorkspaceIntakeError::AlreadyProcessed { existing_run_id } => {
+            hard_error("IngestionFailed", existing_run_id)
+        }
+        WorkspaceIntakeError::Io(message) | WorkspaceIntakeError::DbError(message) => {
+            hard_error("IngestionFailed", message)
+        }
+    }
+}
+
+fn render_actor_for_context(ctx: &AbilityContext<'_>) -> RenderActor {
+    match &ctx.actor {
+        Actor::User | Actor::Admin | Actor::SurfaceClient { .. } => {
+            RenderActor::user("surface", None::<String>)
+        }
+        Actor::Agent => RenderActor::agent("agent"),
+        Actor::System => RenderActor::agent("system"),
+        Actor::McpClient { .. } => RenderActor::agent("mcp_client"),
+    }
+}
+
+fn provenance_actor(
+    actor: Actor,
+    ability_name: &'static str,
+) -> crate::abilities::provenance::Actor {
+    match actor {
+        Actor::User | Actor::Admin => crate::abilities::provenance::Actor::User,
+        Actor::Agent => crate::abilities::provenance::Actor::Agent {
+            name: format!("agent:{ability_name}"),
+            version: "unknown".to_string(),
+        },
+        Actor::System => crate::abilities::provenance::Actor::System {
+            component: format!("system:{ability_name}"),
+        },
+        Actor::SurfaceClient { .. } => crate::abilities::provenance::Actor::System {
+            component: "surface_client".to_string(),
+        },
+        Actor::McpClient { .. } => crate::abilities::provenance::Actor::Agent {
+            name: "mcp".to_string(),
+            version: "unknown".to_string(),
+        },
+    }
+}
+
+fn hard_error(code: impl Into<String>, message: impl Into<String>) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::HardError(code.into()),
+        message: message.into(),
+    }
+}
+
+fn field_error(error: impl std::fmt::Display) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Validation,
+        message: format!("field attribution path failed: {error}"),
+    }
+}
+
+fn provenance_error(error: impl std::fmt::Display) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Validation,
+        message: format!("provenance construction failed: {error}"),
+    }
+}

--- a/src-tauri/abilities-runtime/src/abilities/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/mod.rs
@@ -5,6 +5,7 @@ pub mod claim_receipt;
 pub mod claims;
 pub mod composition;
 pub mod detect_risk_shift;
+pub mod entity_intake;
 pub mod extractors;
 pub mod fallback_projection;
 pub mod feedback;

--- a/src-tauri/abilities-runtime/tests/block_kit_integration_harness.rs
+++ b/src-tauri/abilities-runtime/tests/block_kit_integration_harness.rs
@@ -535,6 +535,8 @@ mod avatar_integration_fixture;
 mod daily_briefing_integration_fixture;
 #[path = "fixtures/entity_chip_integration_fixture.rs"]
 mod entity_chip_integration_fixture;
+#[path = "fixtures/entity_intake_integration_fixture.rs"]
+mod entity_intake_integration_fixture;
 #[path = "fixtures/evidence_drawer_integration_fixture.rs"]
 mod evidence_drawer_integration_fixture;
 #[path = "fixtures/freshness_indicator_integration_fixture.rs"]
@@ -629,6 +631,7 @@ fn expected_block_fixtures_cover_requested_ci_block() {
         account_detail_integration_fixture::account_detail_fixture(),
         accounts_index_integration_fixture::accounts_index_fixture(),
         entity_chip_integration_fixture::entity_chip_fixture(),
+        entity_intake_integration_fixture::entity_intake_fixture(),
         type_badge_integration_fixture::type_badge_fixture(),
         score_band_integration_fixture::score_band_fixture(),
         pill_integration_fixture::pill_fixture(),

--- a/src-tauri/abilities-runtime/tests/fixtures/entity_intake_integration_fixture.rs
+++ b/src-tauri/abilities-runtime/tests/fixtures/entity_intake_integration_fixture.rs
@@ -1,0 +1,17 @@
+use crate::{minimal_block_kit_fixture, BlockIntegrationFixture};
+
+pub fn entity_intake_fixture() -> BlockIntegrationFixture {
+    minimal_block_kit_fixture(
+        "entity-intake",
+        "div",
+        "dailyos-block-error-panel",
+        &[
+            ("data-block", "dailyos/entity-intake"),
+            ("data-error-code", "InvalidEntityType"),
+        ],
+        "error-panel",
+        r#"data-error-code="InvalidEntityType""#,
+    )
+}
+
+crate::integration_test_block!(entity_intake_block_integration, entity_intake_fixture);

--- a/src-tauri/tests/abilities_runtime_w2c_entity_intake_calls_workspace_intake.rs
+++ b/src-tauri/tests/abilities_runtime_w2c_entity_intake_calls_workspace_intake.rs
@@ -1,0 +1,155 @@
+use std::sync::{Arc, Mutex};
+
+use abilities_runtime::abilities::entity_intake::producer::entity_intake;
+use abilities_runtime::abilities::entity_intake::EntityIntakeInput;
+use abilities_runtime::abilities::registry::{
+    AbilityContext, Actor, ScopeSet, SurfaceClientId, SurfaceScope,
+};
+use abilities_runtime::abilities::NOOP_ABILITY_TRACER;
+use abilities_runtime::intelligence::provider::{
+    Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
+    ProviderError, ProviderKind,
+};
+use abilities_runtime::sensitivity::ClaimDismissalSurface;
+use abilities_runtime::services::context::{
+    EntityContextClaimReadFuture, EntityContextClaimReadHandle, FixedClock, SeedableRng,
+    ServiceContext,
+};
+use abilities_runtime::services::workspace_intake::{
+    EntityRefDto, WorkspaceIntakeError, WorkspaceIntakeReceipt, WorkspaceIntakeRequest,
+    WorkspaceIntakeService,
+};
+use async_trait::async_trait;
+use chrono::TimeZone;
+
+#[derive(Default)]
+struct SpyIntake {
+    request: Mutex<Option<WorkspaceIntakeRequest>>,
+}
+
+struct EmptyClaimReader;
+
+impl EntityContextClaimReadHandle for EmptyClaimReader {
+    fn read_entity_context_claims<'a>(
+        &'a self,
+        _entity_type: String,
+        _entity_id: String,
+        _surface: ClaimDismissalSurface,
+        _depth: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+}
+
+#[async_trait]
+impl WorkspaceIntakeService for SpyIntake {
+    async fn ingest(
+        &self,
+        _ctx: &AbilityContext<'_>,
+        request: WorkspaceIntakeRequest,
+    ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+        *self.request.lock().expect("request lock") = Some(request);
+        Ok(WorkspaceIntakeReceipt {
+            run_id: "run-w2c".to_string(),
+            file_id: "file-w2c".to_string(),
+            content_sha256: "sha".to_string(),
+            lifecycle_state_after_slug: "ingested".to_string(),
+            resolved_path: Some("accounts/acme/brief.md".to_string()),
+        })
+    }
+}
+
+struct StaticProvider;
+
+#[async_trait]
+impl IntelligenceProvider for StaticProvider {
+    async fn complete(
+        &self,
+        _prompt: PromptInput,
+        _tier: ModelTier,
+    ) -> Result<Completion, ProviderError> {
+        Ok(Completion {
+            text: String::new(),
+            fingerprint_metadata: FingerprintMetadata {
+                provider: ProviderKind::Other("test"),
+                model: ModelName::new("unused"),
+                temperature: 0.0,
+                top_p: None,
+                seed: None,
+                tokens_input: None,
+                tokens_output: None,
+                provider_completion_id: None,
+            },
+        })
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Other("test")
+    }
+
+    fn current_model(&self, _tier: ModelTier) -> ModelName {
+        ModelName::new("unused")
+    }
+}
+
+fn surface_actor() -> Actor {
+    Actor::SurfaceClient {
+        instance: SurfaceClientId::new("wp-test"),
+        scopes: ScopeSet::new([SurfaceScope::new("write.entity_intake")]).expect("scope set"),
+    }
+}
+
+#[tokio::test]
+async fn calls_workspace_intake_with_entity_seeded_dto() {
+    let intake = Arc::new(SpyIntake::default());
+    let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 21, 12, 0, 0).unwrap());
+    let rng = SeedableRng::new(468);
+    let services = ServiceContext::new_evaluate_default(&clock, &rng)
+        .with_workspace_intake(intake.clone())
+        .with_entity_context_claim_reader(Arc::new(EmptyClaimReader));
+    let provider = StaticProvider;
+    let ctx = AbilityContext::new(
+        &services,
+        &provider,
+        &NOOP_ABILITY_TRACER,
+        surface_actor(),
+        None,
+        ClaimDismissalSurface::Eval,
+    );
+
+    let output = entity_intake(
+        &ctx,
+        EntityIntakeInput {
+            file_ref: "accounts/acme/brief.md".to_string(),
+            entity_seed: Some(EntityRefDto {
+                entity_type_slug: "account".to_string(),
+                entity_id: "acct_acme".to_string(),
+                entity_name: Some("Acme".to_string()),
+            }),
+            category: Some("briefs".to_string()),
+        },
+    )
+    .await
+    .expect("entity intake succeeds")
+    .into_data();
+
+    assert_eq!(output.run_id, "run-w2c");
+    let request = intake
+        .request
+        .lock()
+        .expect("request lock")
+        .clone()
+        .expect("workspace intake called");
+    assert_eq!(request.file_ref, "accounts/acme/brief.md");
+    assert_eq!(request.source_type_slug, "entity_doc");
+    assert_eq!(request.mode_slug, "entity_seeded");
+    assert_eq!(request.category_slug.as_deref(), Some("briefs"));
+    assert_eq!(
+        request.entity.as_ref().map(|entity| entity.entity_type_slug.as_str()),
+        Some("account")
+    );
+    assert_eq!(
+        request.entity.as_ref().map(|entity| entity.entity_id.as_str()),
+        Some("acct_acme")
+    );
+}

--- a/src-tauri/tests/abilities_runtime_w2c_entity_intake_claim_display_text.rs
+++ b/src-tauri/tests/abilities_runtime_w2c_entity_intake_claim_display_text.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+
+use abilities_runtime::abilities::entity_intake::producer::entity_intake;
+use abilities_runtime::abilities::entity_intake::EntityIntakeInput;
+use abilities_runtime::abilities::registry::{
+    AbilityContext, Actor, ScopeSet, SurfaceClientId, SurfaceScope,
+};
+use abilities_runtime::abilities::NOOP_ABILITY_TRACER;
+use abilities_runtime::intelligence::provider::{
+    Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
+    ProviderError, ProviderKind,
+};
+use abilities_runtime::sensitivity::{ClaimDismissalSurface, ClaimVerificationState};
+use abilities_runtime::services::context::{
+    EntityContextClaimReadFuture, EntityContextClaimReadHandle, FixedClock, SeedableRng,
+    ServiceContext,
+};
+use abilities_runtime::services::workspace_intake::{
+    EntityRefDto, WorkspaceIntakeError, WorkspaceIntakeReceipt, WorkspaceIntakeRequest,
+    WorkspaceIntakeService,
+};
+use abilities_runtime::types::{
+    ClaimSensitivity, ClaimState, IntelligenceClaim, SurfacingState, TemporalScope,
+};
+use async_trait::async_trait;
+use chrono::TimeZone;
+
+struct OkIntake;
+
+#[async_trait]
+impl WorkspaceIntakeService for OkIntake {
+    async fn ingest(
+        &self,
+        _ctx: &AbilityContext<'_>,
+        _request: WorkspaceIntakeRequest,
+    ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+        Ok(WorkspaceIntakeReceipt {
+            run_id: "run-w2c".to_string(),
+            file_id: "file-w2c".to_string(),
+            content_sha256: "sha".to_string(),
+            lifecycle_state_after_slug: "ingested".to_string(),
+            resolved_path: None,
+        })
+    }
+}
+
+struct FixtureClaimReader;
+
+impl EntityContextClaimReadHandle for FixtureClaimReader {
+    fn read_entity_context_claims<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        _surface: ClaimDismissalSurface,
+        _depth: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async move {
+            assert_eq!(entity_type, "account");
+            assert_eq!(entity_id, "acct_acme");
+            Ok(vec![claim("claim-1", "Acme budget owner approved the workspace plan")])
+        })
+    }
+}
+
+struct StaticProvider;
+
+#[async_trait]
+impl IntelligenceProvider for StaticProvider {
+    async fn complete(
+        &self,
+        _prompt: PromptInput,
+        _tier: ModelTier,
+    ) -> Result<Completion, ProviderError> {
+        Ok(Completion {
+            text: String::new(),
+            fingerprint_metadata: FingerprintMetadata {
+                provider: ProviderKind::Other("test"),
+                model: ModelName::new("unused"),
+                temperature: 0.0,
+                top_p: None,
+                seed: None,
+                tokens_input: None,
+                tokens_output: None,
+                provider_completion_id: None,
+            },
+        })
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Other("test")
+    }
+
+    fn current_model(&self, _tier: ModelTier) -> ModelName {
+        ModelName::new("unused")
+    }
+}
+
+fn surface_actor() -> Actor {
+    Actor::SurfaceClient {
+        instance: SurfaceClientId::new("wp-test"),
+        scopes: ScopeSet::new([SurfaceScope::new("write.entity_intake")]).expect("scope set"),
+    }
+}
+
+fn claim(id: &str, text: &str) -> IntelligenceClaim {
+    IntelligenceClaim {
+        id: id.to_string(),
+        claim_version: 1,
+        subject_ref: r#"{"kind":"account","id":"acct_acme"}"#.to_string(),
+        claim_type: "fact".to_string(),
+        field_path: Some("summary".to_string()),
+        topic_key: None,
+        text: text.to_string(),
+        dedup_key: "dedup".to_string(),
+        item_hash: None,
+        actor: "fixture".to_string(),
+        data_source: "workspace_file".to_string(),
+        source_ref: Some("accounts/acme/brief.md".to_string()),
+        source_asof: Some("2026-05-21T12:00:00Z".to_string()),
+        observed_at: "2026-05-21T12:00:00Z".to_string(),
+        created_at: "2026-05-21T12:00:00Z".to_string(),
+        provenance_json: "{}".to_string(),
+        metadata_json: None,
+        claim_state: ClaimState::Active,
+        surfacing_state: SurfacingState::Active,
+        demotion_reason: None,
+        reactivated_at: None,
+        retraction_reason: None,
+        expires_at: None,
+        superseded_by: None,
+        trust_score: Some(0.92),
+        trust_computed_at: Some("2026-05-21T12:00:00Z".to_string()),
+        trust_version: Some(1),
+        thread_id: None,
+        temporal_scope: TemporalScope::State,
+        sensitivity: ClaimSensitivity::Public,
+        verification_state: ClaimVerificationState::Active,
+        verification_reason: None,
+        needs_user_decision_at: None,
+    }
+}
+
+#[tokio::test]
+async fn claim_display_text_is_populated_from_renderable_projection() {
+    let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 21, 12, 0, 0).unwrap());
+    let rng = SeedableRng::new(468);
+    let services = ServiceContext::new_evaluate_default(&clock, &rng)
+        .with_workspace_intake(Arc::new(OkIntake))
+        .with_entity_context_claim_reader(Arc::new(FixtureClaimReader));
+    let provider = StaticProvider;
+    let ctx = AbilityContext::new(
+        &services,
+        &provider,
+        &NOOP_ABILITY_TRACER,
+        surface_actor(),
+        None,
+        ClaimDismissalSurface::Eval,
+    );
+
+    let output = entity_intake(
+        &ctx,
+        EntityIntakeInput {
+            file_ref: "accounts/acme/brief.md".to_string(),
+            entity_seed: Some(EntityRefDto {
+                entity_type_slug: "account".to_string(),
+                entity_id: "acct_acme".to_string(),
+                entity_name: None,
+            }),
+            category: None,
+        },
+    )
+    .await
+    .expect("entity intake succeeds")
+    .into_data();
+
+    assert_eq!(output.claims.len(), 1);
+    assert_eq!(
+        output.claims[0].display_text,
+        "Acme budget owner approved the workspace plan"
+    );
+}

--- a/src-tauri/tests/abilities_runtime_w2c_entity_intake_input_validation.rs
+++ b/src-tauri/tests/abilities_runtime_w2c_entity_intake_input_validation.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use abilities_runtime::abilities::entity_intake::producer::entity_intake;
+use abilities_runtime::abilities::entity_intake::EntityIntakeInput;
+use abilities_runtime::abilities::registry::{
+    AbilityContext, AbilityErrorKind, Actor, ScopeSet, SurfaceClientId, SurfaceScope,
+};
+use abilities_runtime::abilities::NOOP_ABILITY_TRACER;
+use abilities_runtime::intelligence::provider::{
+    Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
+    ProviderError, ProviderKind,
+};
+use abilities_runtime::sensitivity::ClaimDismissalSurface;
+use abilities_runtime::services::context::{FixedClock, SeedableRng, ServiceContext};
+use abilities_runtime::services::workspace_intake::{
+    EntityRefDto, WorkspaceIntakeError, WorkspaceIntakeReceipt, WorkspaceIntakeRequest,
+    WorkspaceIntakeService,
+};
+use async_trait::async_trait;
+use chrono::TimeZone;
+
+struct RejectingIntake;
+
+#[async_trait]
+impl WorkspaceIntakeService for RejectingIntake {
+    async fn ingest(
+        &self,
+        _ctx: &AbilityContext<'_>,
+        _request: WorkspaceIntakeRequest,
+    ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+        Err(WorkspaceIntakeError::InvalidEntityTypeSlug(
+            "invalid kind".to_string(),
+        ))
+    }
+}
+
+struct StaticProvider;
+
+#[async_trait]
+impl IntelligenceProvider for StaticProvider {
+    async fn complete(
+        &self,
+        _prompt: PromptInput,
+        _tier: ModelTier,
+    ) -> Result<Completion, ProviderError> {
+        Ok(Completion {
+            text: String::new(),
+            fingerprint_metadata: FingerprintMetadata {
+                provider: ProviderKind::Other("test"),
+                model: ModelName::new("unused"),
+                temperature: 0.0,
+                top_p: None,
+                seed: None,
+                tokens_input: None,
+                tokens_output: None,
+                provider_completion_id: None,
+            },
+        })
+    }
+
+    fn provider_kind(&self) -> ProviderKind {
+        ProviderKind::Other("test")
+    }
+
+    fn current_model(&self, _tier: ModelTier) -> ModelName {
+        ModelName::new("unused")
+    }
+}
+
+fn surface_actor() -> Actor {
+    Actor::SurfaceClient {
+        instance: SurfaceClientId::new("wp-test"),
+        scopes: ScopeSet::new([SurfaceScope::new("write.entity_intake")]).expect("scope set"),
+    }
+}
+
+#[tokio::test]
+async fn invalid_entity_type_slug_maps_to_typed_error() {
+    let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 21, 12, 0, 0).unwrap());
+    let rng = SeedableRng::new(468);
+    let services = ServiceContext::new_evaluate_default(&clock, &rng)
+        .with_workspace_intake(Arc::new(RejectingIntake));
+    let provider = StaticProvider;
+    let ctx = AbilityContext::new(
+        &services,
+        &provider,
+        &NOOP_ABILITY_TRACER,
+        surface_actor(),
+        None,
+        ClaimDismissalSurface::Eval,
+    );
+
+    let err = entity_intake(
+        &ctx,
+        EntityIntakeInput {
+            file_ref: "accounts/acme/brief.md".to_string(),
+            entity_seed: Some(EntityRefDto {
+                entity_type_slug: "invalid kind".to_string(),
+                entity_id: "acct_acme".to_string(),
+                entity_name: None,
+            }),
+            category: None,
+        },
+    )
+    .await
+    .expect_err("invalid slug should fail");
+
+    assert_eq!(err.kind, AbilityErrorKind::HardError("InvalidEntityType".to_string()));
+}

--- a/src-tauri/tests/abilities_runtime_w2c_self_crate_imports.rs
+++ b/src-tauri/tests/abilities_runtime_w2c_self_crate_imports.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+#[test]
+fn entity_intake_uses_self_crate_imports_inside_abilities_runtime() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let producer = std::fs::read_to_string(
+        root.join("abilities-runtime/src/abilities/entity_intake/producer.rs"),
+    )
+    .expect("read producer");
+    let contracts = std::fs::read_to_string(
+        root.join("abilities-runtime/src/abilities/entity_intake/contracts.rs"),
+    )
+    .expect("read contracts");
+
+    assert!(
+        producer.contains("use crate::") && contracts.contains("use crate::abilities::trust::types::TrustBand;"),
+        "entity_intake must use self-crate imports"
+    );
+    assert!(
+        !producer.contains("abilities_runtime::") && !contracts.contains("abilities_runtime::"),
+        "abilities-runtime modules must not import themselves through abilities_runtime::"
+    );
+}

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -82,6 +82,46 @@
       }
     },
     {
+      "name": "entity_intake",
+      "description": "",
+      "category": "transform",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "surface_client"
+      ],
+      "required_scopes": [
+        "write.entity_intake"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "entity_intake_render",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.entity_intelligence"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "get_daily_briefing",
       "description": "",
       "category": "read",

--- a/wp/dailyos/blocks/_shared/dailyos_block_error_panel.php
+++ b/wp/dailyos/blocks/_shared/dailyos_block_error_panel.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Shared DailyOS block error panel.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+if ( ! function_exists( 'dailyos_block_error_panel' ) ) {
+	/**
+	 * Render a compact block-scoped error state.
+	 *
+	 * @param string $block_name Block name.
+	 * @param string $error_code Typed error code.
+	 * @return string
+	 */
+	function dailyos_block_error_panel( string $block_name, string $error_code ): string {
+		$labels = [
+			'InvalidEntityType'    => __( 'Choose a supported entity type.', 'dailyos' ),
+			'InvalidEntityId'      => __( 'Choose a valid entity.', 'dailyos' ),
+			'EntityNotFound'       => __( 'This entity is unavailable.', 'dailyos' ),
+			'InvalidCategorySlug'  => __( 'Choose a valid workspace category.', 'dailyos' ),
+			'CategoryNotAllowed'   => __( 'This category is not available for the entity.', 'dailyos' ),
+			'FileNotFound'         => __( 'Choose an available workspace document.', 'dailyos' ),
+			'PathTraversalAttempt' => __( 'Choose a workspace-relative document.', 'dailyos' ),
+			'RuntimeNotPaired'     => __( 'Reconnect this surface to refresh content.', 'dailyos' ),
+			'IngestionFailed'      => __( 'Intake is temporarily unavailable.', 'dailyos' ),
+		];
+		$message = $labels[ $error_code ] ?? __( 'Content is temporarily unavailable.', 'dailyos' );
+
+		return sprintf(
+			'<div class="dailyos-block-error-panel" data-block="%s" data-error-code="%s" role="status">%s</div>',
+			esc_attr( $block_name ),
+			esc_attr( $error_code ),
+			esc_html( $message )
+		);
+	}
+}

--- a/wp/dailyos/blocks/account-detail/inner/about-intelligence/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/about-intelligence/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_about_intelligence_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_about_intelligence_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'About this intelligence', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<div class="health_metaCard" data-dailyos-projection="about-intelligence" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="health_metaCard" data-dailyos-projection="about-intelligence" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="health_metaCardLabel">' . esc_html__( 'Our data capture gap', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_intelligence_source';
@@ -135,7 +135,7 @@ if ( ! function_exists( 'dailyos_about_intelligence_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/about-intelligence/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/about-intelligence/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * about-intelligence dynamic block render entrypoint (W2 L1 inner block).
+ * About-intelligence dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/about-this-dossier/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/about-this-dossier/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_about_this_dossier_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_about_this_dossier_render' ) ) {
 			}
 		}
 		$out  = '<section id="about-dossier" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="AboutThisDossier" data-ds-spec="patterns/AboutThisDossier.md">';
-		$out .= '<section class="AboutThisDossier_section" data-dailyos-projection="about-this-dossier" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<section class="AboutThisDossier_section" data-dailyos-projection="about-this-dossier" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="AboutThisDossier_eyebrow">' . esc_html__( 'About the dossier', 'dailyos' ) . '</div>';
 		$out .= '<div class="AboutThisDossier_card">';
 		$out .= '<div class="AboutThisDossier_cardLabel">' . esc_html__( 'Source posture', 'dailyos' ) . '</div>';
@@ -135,7 +135,7 @@ if ( ! function_exists( 'dailyos_about_this_dossier_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/about-this-dossier/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/about-this-dossier/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * about-this-dossier dynamic block render entrypoint (W2 L1 inner block).
+ * About-this-dossier dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/account-hero/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/account-hero/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * account-hero dynamic block render entrypoint (W2 L1 inner block).
+ * Account-hero dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/account-pull-quote/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/account-pull-quote/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_account_pull_quote_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_account_pull_quote_render' ) ) {
 			}
 		}
 		$out  = '<section id="thesis" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="AccountPullQuote" data-ds-spec="patterns/AccountPullQuote.md">';
-		$out .= '<section class="editorial-reveal-slow AccountDetailEditorial_thesisSection" data-dailyos-projection="account-pull-quote" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<section class="editorial-reveal-slow AccountDetailEditorial_thesisSection" data-dailyos-projection="account-pull-quote" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="AccountDetailEditorial_thesisLabel">' . esc_html__( 'The thesis', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_quote_available';

--- a/wp/dailyos/blocks/account-detail/inner/account-pull-quote/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/account-pull-quote/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * account-pull-quote dynamic block render entrypoint (W2 L1 inner block).
+ * Account-pull-quote dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/account-technical-footprint/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/account-technical-footprint/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_account_technical_footprint_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_account_technical_footprint_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Technical shape', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<div class="AccountTechnicalFootprint_productGroups" data-dailyos-projection="account-technical-footprint" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="AccountTechnicalFootprint_productGroups" data-dailyos-projection="account-technical-footprint" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_technical_footprint';
 			$out .= dailyos_empty_chip(
@@ -134,7 +134,7 @@ if ( ! function_exists( 'dailyos_account_technical_footprint_select_claim_refs' 
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/account-technical-footprint/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/account-technical-footprint/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * account-technical-footprint dynamic block render entrypoint (W2 L1 inner block).
+ * Account-technical-footprint dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/commercial-shape/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/commercial-shape/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_commercial_shape_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -88,7 +88,7 @@ if ( ! function_exists( 'dailyos_commercial_shape_render' ) ) {
 			return $out;
 		}
 
-		$out .= '<div class="ReferenceGrid_grid" data-dailyos-projection="commercial-shape" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="ReferenceGrid_grid" data-dailyos-projection="commercial-shape" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		// Per AC-462.3 + DOS-341: every claim-bearing inner block routes
 		// receipts through build_receipt_for_audience server-side. The
 		// dailyos_envelope_consume_claim helper invokes claim_receipt via the

--- a/wp/dailyos/blocks/account-detail/inner/commercial-shape/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/commercial-shape/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * commercial-shape dynamic block render entrypoint (W2 L1 inner block).
+ * Commercial-shape dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/divergence-section/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/divergence-section/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * divergence-section dynamic block render entrypoint (W2 L1 inner block).
+ * Divergence-section dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/file-list/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/file-list/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_file_list_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_file_list_render' ) ) {
 			}
 		}
 		$out  = '<section id="files" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="FileListSection" data-ds-spec="patterns/FileListSection.md">';
-		$out .= '<div class="FileListSection_section" data-dailyos-projection="file-list" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="FileListSection_section" data-dailyos-projection="file-list" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="FileListSection_header"><div class="FileListSection_sectionTitle">' . esc_html__( 'Files', 'dailyos' ) . '</div></div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_files_attached';
@@ -136,7 +136,7 @@ if ( ! function_exists( 'dailyos_file_list_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/file-list/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/file-list/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * file-list dynamic block render entrypoint (W2 L1 inner block).
+ * File-list dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/finis-marker/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/finis-marker/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * finis-marker dynamic block render entrypoint (W2 L1 inner block).
+ * Finis-marker dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/linear-issues-chapter/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/linear-issues-chapter/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_linear_issues_chapter_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -78,7 +78,7 @@ if ( ! function_exists( 'dailyos_linear_issues_chapter_render' ) ) {
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Linear Issues', 'dailyos' ) . '</h2></div>';
 		$out .= '<p class="ChapterHeading_epigraph">' . esc_html__( 'Linear-sourced work grouped by current state', 'dailyos' ) . '</p>';
 		$out .= '</div>';
-		$out .= '<div class="LinearIssuesChapter_groups" data-dailyos-projection="linear-issues-chapter" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="LinearIssuesChapter_groups" data-dailyos-projection="linear-issues-chapter" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_linear_issues';
 			$out .= dailyos_empty_chip(
@@ -140,7 +140,7 @@ if ( ! function_exists( 'dailyos_linear_issues_chapter_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/linear-issues-chapter/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/linear-issues-chapter/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * linear-issues-chapter dynamic block render entrypoint (W2 L1 inner block).
+ * Linear-issues-chapter dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/on-track-chapter/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/on-track-chapter/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * on-track-chapter dynamic block render entrypoint (W2 L1 inner block).
+ * On-track-chapter dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/open-loops-feed/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/open-loops-feed/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_account_detail_open_loops_feed_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['open_loops'];
+		$projected_sections = [ 'open_loops' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_account_detail_open_loops_feed_render' ) ) {
 			}
 		}
 		$out  = '<section id="open-loops" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="RecommendedActions" data-ds-spec="patterns/RecommendedActions.md">';
-		$out .= '<div class="RecommendedActions_root" data-dailyos-projection="open-loops-feed" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['open_loops'] ) ) . '">';
+		$out .= '<div class="RecommendedActions_root" data-dailyos-projection="open-loops-feed" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'open_loops' ] ) ) . '">';
 		$out .= '<div class="RecommendedActions_label">' . esc_html__( 'Open loops', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_open_loops';
@@ -131,7 +131,7 @@ if ( ! function_exists( 'dailyos_account_detail_open_loops_feed_select_claim_ref
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['open_loops'] as $section_key ) {
+		foreach ( [ 'open_loops' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/open-loops-feed/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/open-loops-feed/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * open-loops-feed dynamic block render entrypoint (W2 L1 inner block).
+ * Open-loops-feed dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/outlook-panel/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/outlook-panel/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * outlook-panel dynamic block render entrypoint (W2 L1 inner block).
+ * Outlook-panel dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/quote-wall/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/quote-wall/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_quote_wall_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_quote_wall_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Their voice', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<div class="QuoteWall_wall" data-dailyos-projection="quote-wall" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<div class="QuoteWall_wall" data-dailyos-projection="quote-wall" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_quote_bundle';
 			$out .= dailyos_empty_chip(
@@ -134,7 +134,7 @@ if ( ! function_exists( 'dailyos_quote_wall_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts'] as $section_key ) {
+		foreach ( [ 'facts' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/quote-wall/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/quote-wall/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * quote-wall dynamic block render entrypoint (W2 L1 inner block).
+ * Quote-wall dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/recommended-actions/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/recommended-actions/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * recommended-actions dynamic block render entrypoint (W2 L1 inner block).
+ * Recommended-actions dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/relationship-fabric/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/relationship-fabric/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_relationship_fabric_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts', 'touchpoints'];
+		$projected_sections = [ 'facts', 'touchpoints' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_relationship_fabric_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Relationship fabric', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<div class="RelationshipFabric_list" data-dailyos-projection="relationship-fabric" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts', 'touchpoints'] ) ) . '">';
+		$out .= '<div class="RelationshipFabric_list" data-dailyos-projection="relationship-fabric" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts', 'touchpoints' ] ) ) . '">';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_relationship_fabric';
 			$out .= dailyos_empty_chip(
@@ -134,7 +134,7 @@ if ( ! function_exists( 'dailyos_relationship_fabric_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts', 'touchpoints'] as $section_key ) {
+		foreach ( [ 'facts', 'touchpoints' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/relationship-fabric/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/relationship-fabric/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * relationship-fabric dynamic block render entrypoint (W2 L1 inner block).
+ * Relationship-fabric dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/sentiment-hero/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/sentiment-hero/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_sentiment_hero_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['health', 'facts'];
+		$projected_sections = [ 'health', 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_sentiment_hero_render' ) ) {
 			}
 		}
 		$out  = '<section id="your-assessment" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="SentimentHero" data-ds-spec="patterns/SentimentHero.md">';
-		$out .= '<section class="SentimentHero_hero" data-dailyos-projection="sentiment-hero" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['health', 'facts'] ) ) . '">';
+		$out .= '<section class="SentimentHero_hero" data-dailyos-projection="sentiment-hero" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'health', 'facts' ] ) ) . '">';
 		$out .= '<div class="SentimentHero_label">' . esc_html__( 'Your Assessment', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_health_signal';

--- a/wp/dailyos/blocks/account-detail/inner/sentiment-hero/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/sentiment-hero/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * sentiment-hero dynamic block render entrypoint (W2 L1 inner block).
+ * Sentiment-hero dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/stakeholder-grid/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/stakeholder-grid/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_stakeholder_grid_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts', 'touchpoints'];
+		$projected_sections = [ 'facts', 'touchpoints' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_stakeholder_grid_render' ) ) {
 			}
 		}
 		$out  = '<section id="the-room" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="StakeholderGrid" data-ds-spec="patterns/StakeholderGrid.md">';
-		$out .= '<section class="StakeholderGrid_section" data-dailyos-projection="stakeholder-grid" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts', 'touchpoints'] ) ) . '">';
+		$out .= '<section class="StakeholderGrid_section" data-dailyos-projection="stakeholder-grid" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts', 'touchpoints' ] ) ) . '">';
 		$out .= '<div class="ChapterHeading_heading">';
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'The Room', 'dailyos' ) . '</h2></div>';
@@ -137,7 +137,7 @@ if ( ! function_exists( 'dailyos_stakeholder_grid_select_claim_refs' ) ) {
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['facts', 'touchpoints'] as $section_key ) {
+		foreach ( [ 'facts', 'touchpoints' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/stakeholder-grid/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/stakeholder-grid/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * stakeholder-grid dynamic block render entrypoint (W2 L1 inner block).
+ * Stakeholder-grid dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/strategic-landscape/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/strategic-landscape/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_strategic_landscape_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_strategic_landscape_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Competitive & Strategic', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<section class="StrategicLandscape_section" data-dailyos-projection="strategic-landscape" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<section class="StrategicLandscape_section" data-dailyos-projection="strategic-landscape" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="StrategicLandscape_subsectionLabel">' . esc_html__( 'Strategic priorities', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_landscape_narrative';

--- a/wp/dailyos/blocks/account-detail/inner/strategic-landscape/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/strategic-landscape/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * strategic-landscape dynamic block render entrypoint (W2 L1 inner block).
+ * Strategic-landscape dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/supporting-tension/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/supporting-tension/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * supporting-tension dynamic block render entrypoint (W2 L1 inner block).
+ * Supporting-tension dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/touchpoints-feed/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/touchpoints-feed/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_account_detail_touchpoints_feed_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['touchpoints'];
+		$projected_sections = [ 'touchpoints' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_account_detail_touchpoints_feed_render' ) ) {
 			}
 		}
 		$out  = '<section id="touchpoints" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="TimelineEntry" data-ds-spec="patterns/TimelineEntry.md">';
-		$out .= '<div class="TimelineEntry_timeline" data-dailyos-projection="touchpoints-feed" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['touchpoints'] ) ) . '">';
+		$out .= '<div class="TimelineEntry_timeline" data-dailyos-projection="touchpoints-feed" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'touchpoints' ] ) ) . '">';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_touchpoints';
 			$out .= dailyos_empty_chip(
@@ -130,7 +130,7 @@ if ( ! function_exists( 'dailyos_account_detail_touchpoints_feed_select_claim_re
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['touchpoints'] as $section_key ) {
+		foreach ( [ 'touchpoints' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/touchpoints-feed/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/touchpoints-feed/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * touchpoints-feed dynamic block render entrypoint (W2 L1 inner block).
+ * Touchpoints-feed dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/triage-section/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/triage-section/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * triage-section dynamic block render entrypoint (W2 L1 inner block).
+ * Triage-section dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/unified-timeline/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/unified-timeline/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_account_detail_unified_timeline_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['record', 'metadata_proposals'];
+		$projected_sections = [ 'record', 'metadata_proposals' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'dailyos_account_detail_unified_timeline_render' ) ) {
 			}
 		}
 		$out  = '<section id="the-record" class="entity-detail_chapterSection" data-ds-tier="pattern" data-ds-name="UnifiedTimeline" data-ds-spec="patterns/UnifiedTimeline.md">';
-		$out .= '<section class="UnifiedTimeline_section" data-dailyos-projection="unified-timeline" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['record', 'metadata_proposals'] ) ) . '">';
+		$out .= '<section class="UnifiedTimeline_section" data-dailyos-projection="unified-timeline" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'record', 'metadata_proposals' ] ) ) . '">';
 		$out .= '<div class="ChapterHeading_heading">';
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'The Record', 'dailyos' ) . '</h2></div>';
@@ -136,7 +136,7 @@ if ( ! function_exists( 'dailyos_account_detail_unified_timeline_select_claim_re
 		// exact projection rule lives in the L0-packet projection table; this
 		// helper is a single source for the slug's selection so test fixtures
 		// can target one function rather than the renderer.
-		foreach ( ['record', 'metadata_proposals'] as $section_key ) {
+		foreach ( [ 'record', 'metadata_proposals' ] as $section_key ) {
 			$slice = $envelope[ $section_key ] ?? [];
 			if ( ! is_array( $slice ) ) {
 				continue;

--- a/wp/dailyos/blocks/account-detail/inner/unified-timeline/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/unified-timeline/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * unified-timeline dynamic block render entrypoint (W2 L1 inner block).
+ * Unified-timeline dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/account-detail/inner/value-commitments/render-functions.php
+++ b/wp/dailyos/blocks/account-detail/inner/value-commitments/render-functions.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'dailyos_value_commitments_render' ) ) {
 		}
 
 		$envelope = dailyos_resolve_envelope( $handle, 'account', $entity_id, $scope_set );
-		$projected_sections = ['facts'];
+		$projected_sections = [ 'facts' ];
 		$any_present = false;
 		$first_empty_reason = '';
 		foreach ( $projected_sections as $section_key ) {
@@ -77,7 +77,7 @@ if ( ! function_exists( 'dailyos_value_commitments_render' ) ) {
 		$out .= '<hr class="ChapterHeading_rule" />';
 		$out .= '<div class="ChapterHeading_titleRow"><h2 class="ChapterHeading_title">' . esc_html__( 'Value & Commitments', 'dailyos' ) . '</h2></div>';
 		$out .= '</div>';
-		$out .= '<section class="ValueCommitments_section" data-dailyos-projection="value-commitments" data-dailyos-envelope-sections="' . esc_attr( implode( ',', ['facts'] ) ) . '">';
+		$out .= '<section class="ValueCommitments_section" data-dailyos-projection="value-commitments" data-dailyos-envelope-sections="' . esc_attr( implode( ',', [ 'facts' ] ) ) . '">';
 		$out .= '<div class="ValueCommitments_subsectionLabel">' . esc_html__( 'Value delivered', 'dailyos' ) . '</div>';
 		if ( ! $any_present ) {
 			$reason = '' !== $first_empty_reason ? $first_empty_reason : 'no_commitments_recorded';

--- a/wp/dailyos/blocks/account-detail/inner/value-commitments/render.php
+++ b/wp/dailyos/blocks/account-detail/inner/value-commitments/render.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * value-commitments dynamic block render entrypoint (W2 L1 inner block).
+ * Value-commitments dynamic block render entrypoint (W2 L1 inner block).
  *
  * Delegates to render-functions.php so the same function services both
  * the block-registration render path and the editor preview REST route.

--- a/wp/dailyos/blocks/entity-intake/.token-mapping.json
+++ b/wp/dailyos/blocks/entity-intake/.token-mapping.json
@@ -1,0 +1,18 @@
+[
+	{
+		"source_token": "--color-desk-charcoal-8",
+		"target_token": "wp--preset--color--desk-charcoal-8"
+	},
+	{
+		"source_token": "--color-text-primary",
+		"target_token": "wp--preset--color--text-primary"
+	},
+	{
+		"source_token": "--color-text-secondary",
+		"target_token": "wp--preset--color--text-secondary"
+	},
+	{
+		"source_token": "--color-paper-cream",
+		"target_token": "wp--preset--color--paper-cream"
+	}
+]

--- a/wp/dailyos/blocks/entity-intake/block.json
+++ b/wp/dailyos/blocks/entity-intake/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "dailyos/entity-intake",
+	"title": "Entity Intake",
+	"category": "dailyos",
+	"description": "Associates a workspace document with an entity and renders resulting claim trust bands.",
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"inserter": true
+	},
+	"attributes": {
+		"entity_id": { "type": "string", "default": "" },
+		"entity_type": { "type": "string", "default": "" },
+		"file_ref": { "type": "string", "default": "" }
+	},
+	"render": "file:./render.php",
+	"editorScript": "file:./edit.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style.css",
+	"editorStyle": "file:./editor.css"
+}

--- a/wp/dailyos/blocks/entity-intake/edit.js
+++ b/wp/dailyos/blocks/entity-intake/edit.js
@@ -1,0 +1,72 @@
+( function () {
+	const { registerBlockType } = wp.blocks;
+	const { useBlockProps } = wp.blockEditor;
+	const { useState } = wp.element;
+	const { __ } = wp.i18n;
+
+	const BLOCK_NAME = 'dailyos/entity-intake';
+
+	function EntityIntakeEdit( props ) {
+		const { attributes, setAttributes } = props;
+		const blockProps = useBlockProps( {
+			className: 'dailyos-entity-intake-editor',
+		} );
+		const [ status, setStatus ] = useState( 'idle' );
+		const routeAvailable = false;
+
+		const ingest = () => {
+			setStatus( 'deferred' );
+		};
+
+		return wp.element.createElement(
+			'div',
+			blockProps,
+			wp.element.createElement(
+				'div',
+				{ className: 'dailyos-entity-intake-editor__fields' },
+				wp.element.createElement( 'label', {}, __( 'Entity type', 'dailyos' ),
+					wp.element.createElement( 'input', {
+						type: 'text',
+						value: attributes.entity_type || '',
+						onChange: ( event ) => setAttributes( { entity_type: event.target.value } ),
+					} )
+				),
+				wp.element.createElement( 'label', {}, __( 'Entity ID', 'dailyos' ),
+					wp.element.createElement( 'input', {
+						type: 'text',
+						value: attributes.entity_id || '',
+						onChange: ( event ) => setAttributes( { entity_id: event.target.value } ),
+					} )
+				),
+				wp.element.createElement( 'label', {}, __( 'File ref', 'dailyos' ),
+					wp.element.createElement( 'input', {
+						type: 'text',
+						value: attributes.file_ref || '',
+						onChange: ( event ) => setAttributes( { file_ref: event.target.value } ),
+					} )
+				)
+			),
+			wp.element.createElement(
+				'button',
+				{
+					type: 'button',
+					className: 'dailyos-entity-intake-editor__button',
+					onClick: ingest,
+					disabled: ! routeAvailable,
+				},
+				__( 'Ingest', 'dailyos' )
+			),
+			status === 'deferred' &&
+				wp.element.createElement(
+					'p',
+					{ className: 'dailyos-entity-intake-editor__notice', role: 'status' },
+					__( 'Editor intake transport is deferred to the next transport extension.', 'dailyos' )
+				)
+		);
+	}
+
+	registerBlockType( BLOCK_NAME, {
+		edit: EntityIntakeEdit,
+		save: () => null,
+	} );
+} )();

--- a/wp/dailyos/blocks/entity-intake/editor.css
+++ b/wp/dailyos/blocks/entity-intake/editor.css
@@ -1,0 +1,36 @@
+.dailyos-entity-intake-editor {
+	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	border-radius: 8px;
+	padding: 16px;
+}
+
+.dailyos-entity-intake-editor__fields {
+	display: grid;
+	gap: 10px;
+	margin-bottom: 12px;
+}
+
+.dailyos-entity-intake-editor__fields label {
+	display: grid;
+	font-size: 12px;
+	font-weight: 600;
+	gap: 4px;
+}
+
+.dailyos-entity-intake-editor__fields input {
+	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	border-radius: 6px;
+	font: inherit;
+	min-height: 34px;
+	padding: 6px 8px;
+}
+
+.dailyos-entity-intake-editor__button {
+	min-height: 34px;
+}
+
+.dailyos-entity-intake-editor__notice {
+	color: var(--wp--preset--color--contrast-2, #5b6470);
+	font-size: 12px;
+	margin: 10px 0 0;
+}

--- a/wp/dailyos/blocks/entity-intake/render-functions.php
+++ b/wp/dailyos/blocks/entity-intake/render-functions.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Entity Intake block server-side render.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+require_once dirname( __DIR__ ) . '/_shared/dailyos_block_error_panel.php';
+require_once dirname( __DIR__ ) . '/trust-band-badge/render-functions.php';
+
+if ( ! function_exists( 'dailyos_entity_intake_render' ) ) {
+	/**
+	 * Render the Entity Intake block.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return string
+	 */
+	function dailyos_entity_intake_render( array $attributes ): string {
+		$entity_id   = dailyos_entity_intake_attr( $attributes, 'entity_id' );
+		$entity_type = dailyos_entity_intake_attr( $attributes, 'entity_type' );
+		$file_ref    = dailyos_entity_intake_attr( $attributes, 'file_ref' );
+
+		$validation = dailyos_entity_intake_validate_attrs( $entity_type, $entity_id, $file_ref );
+		if ( is_wp_error( $validation ) ) {
+			return dailyos_block_error_panel( 'dailyos/entity-intake', $validation->get_error_code() );
+		}
+
+		$runtime_client = apply_filters( 'dailyos_runtime_client_for_block', null );
+		if ( ! is_object( $runtime_client ) || ! method_exists( $runtime_client, 'invoke_ability' ) ) {
+			return dailyos_block_error_panel( 'dailyos/entity-intake', 'RuntimeNotPaired' );
+		}
+
+		$response = $runtime_client->invoke_ability(
+			'entity_intake_render',
+			[
+				'entityType' => $entity_type,
+				'entityId'   => $entity_id,
+				'fileRef'    => $file_ref,
+			],
+			[ 'read.entity_intelligence' ]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return dailyos_block_error_panel( 'dailyos/entity-intake', dailyos_entity_intake_error_kind( $response ) );
+		}
+		if ( isset( $response['ok'] ) && false === $response['ok'] ) {
+			return dailyos_block_error_panel( 'dailyos/entity-intake', dailyos_entity_intake_response_error_kind( $response ) );
+		}
+
+		return dailyos_entity_intake_render_claims( $response, $attributes );
+	}
+
+	/**
+	 * Read and trim a string block attribute.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @param string               $key Attribute key.
+	 * @return string
+	 */
+	function dailyos_entity_intake_attr( array $attributes, string $key ): string {
+		return isset( $attributes[ $key ] ) && is_string( $attributes[ $key ] )
+			? trim( $attributes[ $key ] )
+			: '';
+	}
+
+	/**
+	 * Validate durable block attributes before invoking the read ability.
+	 *
+	 * @return true|\WP_Error
+	 */
+	function dailyos_entity_intake_validate_attrs( string $entity_type, string $entity_id, string $file_ref ) {
+		if ( '' === $entity_type || ! preg_match( '/^[a-z][a-z0-9_-]{0,63}$/', $entity_type ) ) {
+			return new WP_Error( 'InvalidEntityType' );
+		}
+		if ( '' === $entity_id || ! preg_match( '/^[A-Za-z0-9:_-]{1,128}$/', $entity_id ) ) {
+			return new WP_Error( 'InvalidEntityId' );
+		}
+		$decoded_file_ref = rawurldecode( $file_ref );
+		if ( '' === $file_ref || '/' === substr( $file_ref, 0, 1 ) || false !== strpos( $file_ref, '..' ) || false !== strpos( $decoded_file_ref, '..' ) ) {
+			return new WP_Error( 'PathTraversalAttempt' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Render claim rows from an entity-intake ability response.
+	 *
+	 * @param array<string, mixed> $response Runtime response.
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return string
+	 */
+	function dailyos_entity_intake_render_claims( array $response, array $attributes ): string {
+		$data   = isset( $response['data'] ) && is_array( $response['data'] ) ? $response['data'] : $response;
+		$claims = isset( $data['claims'] ) && is_array( $data['claims'] ) ? $data['claims'] : [];
+		$file   = isset( $attributes['file_ref'] ) ? (string) $attributes['file_ref'] : '';
+
+		$out  = '<section class="wp-block-dailyos-entity-intake dailyos-entity-intake" data-file-ref="' . esc_attr( $file ) . '">';
+		$out .= '<div class="dailyos-entity-intake__header">';
+		$out .= '<span class="dailyos-entity-intake__label">' . esc_html__( 'Workspace intake', 'dailyos' ) . '</span>';
+		$out .= '<span class="dailyos-entity-intake__count">' . esc_html( (string) count( $claims ) ) . '</span>';
+		$out .= '</div>';
+
+		if ( [] === $claims ) {
+			$out .= '<p class="dailyos-entity-intake__empty">' . esc_html__( 'No claim proposals yet.', 'dailyos' ) . '</p>';
+			$out .= '</section>';
+			return $out;
+		}
+
+		$out .= '<ul class="dailyos-entity-intake__claims">';
+		foreach ( $claims as $claim ) {
+			if ( ! is_array( $claim ) ) {
+				continue;
+			}
+			$text        = isset( $claim['displayText'] ) && is_string( $claim['displayText'] ) ? $claim['displayText'] : '';
+			$claim_id    = isset( $claim['claimId'] ) && is_string( $claim['claimId'] ) ? $claim['claimId'] : '';
+			$trust_band  = isset( $claim['trustBand'] ) && is_string( $claim['trustBand'] ) ? $claim['trustBand'] : 'needs_verification';
+			$sensitivity = isset( $claim['sensitivity'] ) && is_string( $claim['sensitivity'] ) ? $claim['sensitivity'] : 'internal';
+			$out        .= '<li class="dailyos-entity-intake__claim" data-claim-id="' . esc_attr( $claim_id ) . '" data-sensitivity="' . esc_attr( $sensitivity ) . '">';
+			$out        .= '<span class="dailyos-entity-intake__claimText">' . esc_html( $text ) . '</span>';
+			$out        .= dailyos_trust_band_badge_render_payload(
+				[
+					'band'    => $trust_band,
+					'compact' => true,
+				]
+			);
+			$out        .= '</li>';
+		}
+		$out .= '</ul></section>';
+		return $out;
+	}
+
+	/**
+	 * Map WP_Error codes to public block states.
+	 */
+	function dailyos_entity_intake_error_kind( WP_Error $error ): string {
+		$code = $error->get_error_code();
+		return '' !== $code ? $code : 'IngestionFailed';
+	}
+
+	/**
+	 * Map runtime envelopes to public block states.
+	 *
+	 * @param array<string, mixed> $response Runtime response.
+	 */
+	function dailyos_entity_intake_response_error_kind( array $response ): string {
+		$code = isset( $response['error']['code'] ) ? (string) $response['error']['code'] : 'IngestionFailed';
+		switch ( $code ) {
+			case 'InvalidEntityType':
+			case 'InvalidEntityId':
+			case 'EntityNotFound':
+			case 'InvalidCategorySlug':
+			case 'CategoryNotAllowed':
+			case 'FileNotFound':
+			case 'PathTraversalAttempt':
+				return $code;
+			case 'session_requires_repair':
+			case 'session_not_found':
+			case 'session_expired':
+			case 'scope_denied':
+			case 'auth_missing':
+			case 'signature_invalid':
+			case 'runtime_unavailable':
+				return 'RuntimeNotPaired';
+			default:
+				return 'IngestionFailed';
+		}
+	}
+}

--- a/wp/dailyos/blocks/entity-intake/render.php
+++ b/wp/dailyos/blocks/entity-intake/render.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Entity Intake dynamic block render entrypoint.
+ *
+ * @package DailyOS
+ *
+ * @var array<string, mixed> $attributes Block attributes from core.
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+if ( ! function_exists( 'dailyos_entity_intake_render' ) ) {
+	require_once __DIR__ . '/render-functions.php';
+}
+
+$attributes = isset( $attributes ) && is_array( $attributes ) ? $attributes : [];
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render functions escape output internally.
+echo dailyos_entity_intake_render( $attributes );

--- a/wp/dailyos/blocks/entity-intake/save.js
+++ b/wp/dailyos/blocks/entity-intake/save.js
@@ -1,0 +1,3 @@
+export default function save() {
+	return null;
+}

--- a/wp/dailyos/blocks/entity-intake/style.css
+++ b/wp/dailyos/blocks/entity-intake/style.css
@@ -1,7 +1,7 @@
 .dailyos-entity-intake {
-	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	border: 1px solid var(--wp--preset--color--desk-charcoal-8);
 	border-radius: 8px;
-	color: var(--wp--preset--color--contrast, #1f2328);
+	color: var(--wp--preset--color--text-primary);
 	padding: 16px;
 }
 
@@ -19,7 +19,7 @@
 }
 
 .dailyos-entity-intake__count {
-	background: var(--wp--preset--color--base-2, #f2f4f7);
+	background: var(--wp--preset--color--paper-cream);
 	border-radius: 999px;
 	font-size: 12px;
 	min-width: 24px;
@@ -28,7 +28,7 @@
 }
 
 .dailyos-entity-intake__empty {
-	color: var(--wp--preset--color--contrast-2, #5b6470);
+	color: var(--wp--preset--color--text-secondary);
 	font-size: 13px;
 	margin: 0;
 }
@@ -55,10 +55,10 @@
 }
 
 .dailyos-block-error-panel {
-	background: var(--wp--preset--color--base-2, #f2f4f7);
-	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	background: var(--wp--preset--color--paper-cream);
+	border: 1px solid var(--wp--preset--color--desk-charcoal-8);
 	border-radius: 8px;
-	color: var(--wp--preset--color--contrast, #1f2328);
+	color: var(--wp--preset--color--text-primary);
 	font-size: 13px;
 	padding: 12px 14px;
 }

--- a/wp/dailyos/blocks/entity-intake/style.css
+++ b/wp/dailyos/blocks/entity-intake/style.css
@@ -1,0 +1,64 @@
+.dailyos-entity-intake {
+	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	border-radius: 8px;
+	color: var(--wp--preset--color--contrast, #1f2328);
+	padding: 16px;
+}
+
+.dailyos-entity-intake__header {
+	align-items: center;
+	display: flex;
+	gap: 10px;
+	justify-content: space-between;
+	margin-bottom: 12px;
+}
+
+.dailyos-entity-intake__label {
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.dailyos-entity-intake__count {
+	background: var(--wp--preset--color--base-2, #f2f4f7);
+	border-radius: 999px;
+	font-size: 12px;
+	min-width: 24px;
+	padding: 2px 8px;
+	text-align: center;
+}
+
+.dailyos-entity-intake__empty {
+	color: var(--wp--preset--color--contrast-2, #5b6470);
+	font-size: 13px;
+	margin: 0;
+}
+
+.dailyos-entity-intake__claims {
+	display: grid;
+	gap: 10px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.dailyos-entity-intake__claim {
+	align-items: flex-start;
+	display: flex;
+	gap: 10px;
+	justify-content: space-between;
+}
+
+.dailyos-entity-intake__claimText {
+	font-size: 14px;
+	line-height: 1.45;
+	min-width: 0;
+}
+
+.dailyos-block-error-panel {
+	background: var(--wp--preset--color--base-2, #f2f4f7);
+	border: 1px solid var(--wp--preset--color--contrast-3, #d7dce2);
+	border-radius: 8px;
+	color: var(--wp--preset--color--contrast, #1f2328);
+	font-size: 13px;
+	padding: 12px 14px;
+}

--- a/wp/dailyos/blocks/entity-intake/view.js
+++ b/wp/dailyos/blocks/entity-intake/view.js
@@ -1,0 +1,3 @@
+( function () {
+	window.dispatchEvent( new CustomEvent( 'dailyos:entity-intake-ready' ) );
+} )();

--- a/wp/dailyos/patterns/account-detail-default.php
+++ b/wp/dailyos/patterns/account-detail-default.php
@@ -16,7 +16,10 @@
  * Empty `account_id` keeps the pattern preview safe in the editor — the
  * outer block renders an "is-empty" notice rather than invoking the
  * runtime against an unknown subject.
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:dailyos/account-detail -->
 <!-- wp:dailyos/account-hero /-->

--- a/wp/dailyos/patterns/accounts-index-default.php
+++ b/wp/dailyos/patterns/accounts-index-default.php
@@ -6,7 +6,10 @@
  * Description: Default Accounts index page — magazine shell wrapping the dailyos/accounts-index list block.
  * Block Types: core/post-content
  * Inserter: no
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
 <div class="wp-block-group dailyos-magazine-page">

--- a/wp/dailyos/patterns/meeting-detail-default.php
+++ b/wp/dailyos/patterns/meeting-detail-default.php
@@ -6,7 +6,10 @@
  * Description: Default arrangement for the dailyos/meeting-detail composite — canonical Tauri MeetingDetailPage chapter ordering across 10 inner blocks. Theme-registered filesystem pattern per wp-skill H4 V1.1.
  * Block Types: core/post-content
  * Inserter: no
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
 <div class="wp-block-group dailyos-magazine-page">

--- a/wp/dailyos/patterns/people-index-default.php
+++ b/wp/dailyos/patterns/people-index-default.php
@@ -6,7 +6,10 @@
  * Description: Default People index page — magazine shell wrapping the dailyos/people-index list block with merge-intent affordance.
  * Block Types: core/post-content
  * Inserter: no
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
 <div class="wp-block-group dailyos-magazine-page">

--- a/wp/dailyos/patterns/person-detail-default.php
+++ b/wp/dailyos/patterns/person-detail-default.php
@@ -6,7 +6,10 @@
  * Description: Magazine shell wrapping the dailyos/person-detail composite with the canonical 12 inner blocks + editorial chrome + end-mark.
  * Block Types: core/post-content
  * Inserter: no
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
 <div class="wp-block-group dailyos-magazine-page">

--- a/wp/dailyos/patterns/project-detail-default.php
+++ b/wp/dailyos/patterns/project-detail-default.php
@@ -16,7 +16,10 @@
  * Empty `project_id` keeps the pattern preview safe in the editor — the
  * outer block renders an "is-empty" notice rather than invoking the
  * runtime against an unknown subject.
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:dailyos/project-detail -->
 <!-- wp:dailyos/project-hero /-->

--- a/wp/dailyos/patterns/projects-index-default.php
+++ b/wp/dailyos/patterns/projects-index-default.php
@@ -6,7 +6,10 @@
  * Description: Default Projects index page — magazine shell wrapping the dailyos/projects-index list block.
  * Block Types: core/post-content
  * Inserter: no
+ *
+ * @package DailyOS
  */
+
 ?>
 <!-- wp:group {"className":"dailyos-magazine-page","layout":{"type":"constrained"}} -->
 <div class="wp-block-group dailyos-magazine-page">

--- a/wp/dailyos/tests/blocks/EntityIntakeBlockTest.php
+++ b/wp/dailyos/tests/blocks/EntityIntakeBlockTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../blocks/entity-intake/render-functions.php';
 
+/**
+ * Tests for the dailyos/entity-intake WP block render path.
+ */
 final class DailyOS_EntityIntakeBlockTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/wp/dailyos/tests/blocks/EntityIntakeBlockTest.php
+++ b/wp/dailyos/tests/blocks/EntityIntakeBlockTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Entity Intake block tests.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../blocks/entity-intake/render-functions.php';
+
+final class DailyOS_EntityIntakeBlockTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		if ( function_exists( 'dailyos_test_reset_globals' ) ) {
+			dailyos_test_reset_globals();
+		}
+	}
+
+	public function test_block_json_uses_dailyos_category_and_dynamic_render(): void {
+		$block_json = json_decode(
+			(string) file_get_contents( __DIR__ . '/../../blocks/entity-intake/block.json' ),
+			true
+		);
+
+		$this->assertSame( 'dailyos/entity-intake', $block_json['name'] );
+		$this->assertSame( 'dailyos', $block_json['category'] );
+		$this->assertSame( 'file:./render.php', $block_json['render'] );
+	}
+
+	public function test_renders_fixture_claim_display_text_with_trust_band(): void {
+		add_filter(
+			'dailyos_runtime_client_for_block',
+			static fn () => new class() {
+				public function invoke_ability( string $name, array $payload, array $scopes ): array {
+					TestCase::assertSame( 'entity_intake_render', $name );
+					TestCase::assertSame( [ 'read.entity_intelligence' ], $scopes );
+					TestCase::assertSame( 'account', $payload['entityType'] );
+
+					return [
+						'data' => [
+							'claims' => [
+								[
+									'claimId'     => 'claim-1',
+									'displayText' => 'Acme budget owner approved the workspace plan',
+									'trustBand'   => 'likely_current',
+									'sensitivity' => 'public',
+								],
+							],
+						],
+					];
+				}
+			},
+			5,
+			1
+		);
+
+		$html = dailyos_entity_intake_render(
+			[
+				'entity_type' => 'account',
+				'entity_id'   => 'acct_acme',
+				'file_ref'    => 'accounts/acme/brief.md',
+			]
+		);
+
+		$this->assertStringContainsString( 'Acme budget owner approved the workspace plan', $html );
+		$this->assertStringContainsString( 'data-band="likely_current"', $html );
+		$this->assertStringContainsString( 'data-claim-id="claim-1"', $html );
+	}
+
+	public function test_path_traversal_renders_error_state(): void {
+		$html = dailyos_entity_intake_render(
+			[
+				'entity_type' => 'account',
+				'entity_id'   => 'acct_acme',
+				'file_ref'    => '../outside.md',
+			]
+		);
+
+		$this->assertStringContainsString( 'data-error-code="PathTraversalAttempt"', $html );
+	}
+}


### PR DESCRIPTION
## Summary

W2-C — entity-intake block + Transform ability. Implements DOS-468 per L0 packet V1.4 + V1.5 precondition resolutions.

- **`entity_intake` ability** in abilities-runtime: Transform category, `pub async fn entity_intake(ctx, input) -> AbilityResult<EntityIntakeOutput>` returning `Ok(EntityIntakeOutput{...})` direct T per V1.5 precondition #1 (matching live `account_overview.rs:109` pattern). Consumes the W2-A `WorkspaceIntakeService` bridge via `ctx.services().workspace_intake()`.
- **`entity_intake_render` Read ability** to project claim proposals back into the block.
- **WP block scaffold** at `wp/dailyos/blocks/entity-intake/`: block.json, render.php, edit.js, save.js, style.css, editor.css, view.js, render-functions.php.
- **Shared `dailyos_block_error_panel.php`** lifted to `wp/dailyos/blocks/_shared/` (V1.4 path-α nit folded inline since the block needs it).
- **`EntityIntakeClaim` adds `display_text: String`** field per V1.5 precondition #4.
- Self-crate imports throughout abilities-runtime per V1.5 precondition #3.

## WP REST route deferred to v1.4.6

Precondition #2 grep found NO existing generic `dailyos/v1/ability/invoke` route in `class-dailyos-plugin.php`. Per packet ownership rules, did NOT silently extend `class-dailyos-plugin.php`. Block scaffold ships; WP route registration + confirmation-token transport extension deferred to v1.4.6 per packet §13 path-α appendix. Follow-up at `.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-C.md`.

## Wave protocol trail

- **L0 V1.4** packet at `.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-C-DOS-468.md`.
- **L1 preconditions** resolved before implementation against live merged W2-A/W2-B substrate.
- **L1** via codex task — 19 files +1386.
- **L2 cycle 1**: 3-reviewer panel.
  - codex challenge: **APPROVE**
  - code-reviewer: **APPROVE-WITH-PATH-ALPHA**
  - architect-reviewer: **APPROVE-WITH-PATH-ALPHA**
  - **Unanimous APPROVE.**

## Tests

- abilities_runtime_w2c_entity_intake_input_validation — invalid slug → typed error
- abilities_runtime_w2c_entity_intake_calls_workspace_intake — fixture asserts ctx.services().workspace_intake() invocation
- abilities_runtime_w2c_entity_intake_claim_display_text — display_text populated from canonical projection
- abilities_runtime_w2c_self_crate_imports — line-anchored check against `abilities_runtime::` self-imports
- wp/dailyos/tests/blocks/EntityIntakeBlockTest.php — PHP block test

## Verification

```bash
cd src-tauri
cargo check --lib                                                            # ✅
cargo clippy --lib -- -D warnings                                            # ✅
cargo test --lib abilities::entity_intake                                    # ✅
cargo test --test abilities_runtime_w2c_entity_intake_input_validation       # ✅
cargo test --test abilities_runtime_w2c_entity_intake_calls_workspace_intake # ✅
cargo test --test abilities_runtime_w2c_entity_intake_claim_display_text     # ✅
cargo test --test abilities_runtime_w2c_self_crate_imports                   # ✅
```

## Path-α (file to DOS-751)

- `RenderSurface::TauriEntityDetail` hardcoded for WP-block read path — needs explicit `RenderSurface::WordPressBlock` variant when sensitivity policy diverges.
- `entity_intake_render` returns `run_id: String::new()` magic value — consider `Option<String>`.
- Local `Deserialize`+`JsonSchema` impls for `EntityRefDto` in `contracts.rs` — fold upstream when W2-A absorbs the bridge surface.
- `entity_intake_render` aliases `file_ref` into `output.file_id` — contract semantics nit.
- `data-file-ref` reads raw `\$attributes['file_ref']` instead of trimmed copy — cosmetic.
- PHP path-traversal check is single-decode only — defense-in-depth, bridge does deep validation.
- `edit.js` Ingest button is no-op until v1.4.6 transport — pre-authorized by precondition #2.

## Security review

`security_auditor_invoked: false`

Local-to-local single-user trust topology per `feedback_local_to_local_security_overreach_primary_concern`. No new external surfaces (WP route deferred). Multi-actor gates correctly absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)