### PR TITLE
v1.4.5 W2-D: assign_inbox_entity + full inbox refactor + substrate extensions (DOS-469)

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/v1.4.5-w1-extensions.md
+++ b/.docs/plans/v1.4.5-workspace-memory/v1.4.5-w1-extensions.md
@@ -1,0 +1,15 @@
+# v1.4.5 W1 Extension Addendum
+
+## WorkspaceFileKind slug parser
+
+W2-D adds `WorkspaceFileKind::from_slug` in `src-tauri/abilities-runtime/src/abilities/provenance/source.rs`.
+
+The helper maps the seven canonical workspace file kind storage slugs to the shared provenance enum and returns `None` for unknown slugs:
+
+- `inbox`
+- `entity_doc`
+- `drive_sync`
+- `user_attachment`
+- `granola_transcript`
+- `quill_transcript`
+- `mcp_placement`

--- a/.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-D.md
+++ b/.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-D.md
@@ -1,0 +1,7 @@
+# v1.4.6 Follow-ups from W2-D
+
+## Legacy Inbox Processor Deferral
+
+W2-D cycle-2 moved `get_inbox_files`, `process_inbox_file`, `copy_to_inbox`, and user entity assignment onto the staged workspace-ingestion lifecycle path. The older `processor/mod.rs` and `processor/router.rs` classify/route/move implementation remains in the tree and is still referenced by legacy batch/enrichment flows.
+
+That refactor is intentionally deferred because the v1.4.5 packet marks `processor/mod.rs` and `processor/router.rs` outside W2-B/W2-D ownership. A v1.4.6 slice should remove or isolate the remaining legacy inbox classify/route path once the batch and enrichment command contracts are folded into the lifecycle pipeline.

--- a/src-tauri/abilities-runtime/src/abilities/provenance/source.rs
+++ b/src-tauri/abilities-runtime/src/abilities/provenance/source.rs
@@ -209,6 +209,19 @@ pub enum WorkspaceFileKind {
 }
 
 impl WorkspaceFileKind {
+    pub fn from_slug(slug: &str) -> Option<Self> {
+        match slug {
+            "inbox" => Some(Self::Inbox),
+            "entity_doc" => Some(Self::EntityDoc),
+            "drive_sync" => Some(Self::DriveSync),
+            "user_attachment" => Some(Self::UserAttachment),
+            "granola_transcript" => Some(Self::GranolaTranscript),
+            "quill_transcript" => Some(Self::QuillTranscript),
+            "mcp_placement" => Some(Self::McpPlacement),
+            _ => None,
+        }
+    }
+
     pub fn display_name(&self) -> &'static str {
         match self {
             WorkspaceFileKind::Inbox => "inbox",

--- a/src-tauri/scripts/ability_surface_allowlist.txt
+++ b/src-tauri/scripts/ability_surface_allowlist.txt
@@ -419,3 +419,4 @@ version_dispatcher_subscribe
 # for MCP and WP callers.
 render_claim_receipt
 submit_claim_feedback_command
+assign_inbox_entity

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,12 +12,11 @@ use tauri::{Emitter, Manager, State};
 
 use crate::executor::request_workflow_execution;
 use crate::hygiene::{build_intelligence_hygiene_status, HygieneStatusView};
-use crate::parser::list_inbox_files;
 use crate::scheduler::get_next_run_time as scheduler_get_next_run_time;
 use crate::state::{reload_config, AppState};
 use crate::types::{
     CalendarEvent, CapturedOutcome, Config, EmailBriefingData, ExecutionRecord, FullMeetingPrep,
-    GoogleAuthStatus, InboxFile, LiveProactiveSuggestion, MeetingIntelligence,
+    GoogleAuthStatus, InboxFile, InboxFileType, LiveProactiveSuggestion, MeetingIntelligence,
     PostMeetingCaptureConfig, SourceReference, WorkflowId, WorkflowStatus,
 };
 use crate::SchedulerSender;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -10,8 +10,9 @@ use rusqlite::{params, OptionalExtension};
 
 use crate::entity::EntityType;
 use crate::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use crate::services::workspace_ingestion::link::{LinkAttributionSource, LinkError, LinkRepo};
 use crate::services::workspace_ingestion::pipeline::{
-    file_id_from_identity, EntityRef, IngestRequest,
+    file_id_from_identity, EntityRef, IngestError, IngestReceipt, IngestRequest,
 };
 use crate::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
 use crate::services::workspace_ingestion::runs::IngestionMode;
@@ -58,7 +59,160 @@ pub enum InboxResult {
     },
 }
 
-/// Get files from the _inbox/ directory
+#[cfg(any(test, debug_assertions, feature = "test-harness"))]
+#[doc(hidden)]
+pub fn get_inbox_files_for_tests(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+) -> Result<Vec<InboxFile>, String> {
+    inbox_files_from_lifecycle(db.conn_ref(), workspace_root)
+}
+
+fn inbox_files_from_lifecycle(
+    conn: &rusqlite::Connection,
+    workspace_root: &std::path::Path,
+) -> Result<Vec<InboxFile>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT file_id, canonical_path, lifecycle_state, updated_at \
+             FROM workspace_file_lifecycle \
+             WHERE source_type = 'inbox' \
+               AND lifecycle_state IN (\
+                   'pending_entity_assignment', 'pending', 'ingesting', 'rejected'\
+               ) \
+             ORDER BY updated_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut files = Vec::new();
+    for row in rows {
+        let (file_id, canonical_path, lifecycle_state, updated_at) =
+            row.map_err(|e| e.to_string())?;
+        let path = std::path::PathBuf::from(&canonical_path);
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("workspace-file")
+            .to_string();
+        let metadata = std::fs::metadata(&path).ok();
+        let size_bytes = metadata.as_ref().map(std::fs::Metadata::len).unwrap_or(0);
+        let modified = metadata
+            .as_ref()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|duration| chrono::DateTime::from_timestamp(duration.as_secs() as i64, 0))
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or(updated_at);
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let file_type = inbox_file_type_from_ext(ext);
+        let preview = inbox_file_preview(&path, &file_type, size_bytes);
+        let processing_status = match lifecycle_state.as_str() {
+            "pending_entity_assignment" => Some("needs_entity".to_string()),
+            "ingesting" => Some("processing".to_string()),
+            "rejected" => Some("error".to_string()),
+            _ => None,
+        };
+        let processing_error = if lifecycle_state == "rejected" {
+            Some("File rejected during ingestion".to_string())
+        } else {
+            None
+        };
+        let suggested_entity_name = if lifecycle_state == "pending_entity_assignment" {
+            Some(suggested_entity_name_from_filename(&filename))
+        } else {
+            None
+        };
+
+        let display_path = path
+            .strip_prefix(workspace_root)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| canonical_path.clone());
+
+        files.push(InboxFile {
+            file_id: Some(file_id),
+            filename,
+            path: display_path,
+            size_bytes,
+            modified,
+            preview,
+            file_type,
+            processing_status,
+            processing_error,
+            suggested_entity_name,
+        });
+    }
+    Ok(files)
+}
+
+fn inbox_file_type_from_ext(ext: &str) -> InboxFileType {
+    match ext.to_lowercase().as_str() {
+        "md" | "markdown" => InboxFileType::Markdown,
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg" | "bmp" | "ico" | "heic" => {
+            InboxFileType::Image
+        }
+        "xlsx" | "xls" | "numbers" | "ods" => InboxFileType::Spreadsheet,
+        "docx" | "doc" | "pages" | "odt" | "rtf" | "pdf" => InboxFileType::Document,
+        "csv" | "tsv" | "json" | "yaml" | "yml" | "xml" | "toml" => InboxFileType::Data,
+        "txt" | "log" | "text" => InboxFileType::Text,
+        _ => InboxFileType::Other,
+    }
+}
+
+fn inbox_file_preview(
+    path: &std::path::Path,
+    file_type: &InboxFileType,
+    size_bytes: u64,
+) -> Option<String> {
+    if matches!(
+        file_type,
+        InboxFileType::Markdown | InboxFileType::Data | InboxFileType::Text
+    ) {
+        let content = std::fs::read_to_string(path).ok()?;
+        let mut text = content
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#') && *line != "---")
+            .take(6)
+            .collect::<Vec<_>>()
+            .join(" ");
+        if text.len() > 200 {
+            let mut end = 200;
+            while !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            text.truncate(end);
+            text.push_str("...");
+        }
+        return (!text.is_empty()).then_some(text);
+    }
+
+    let size_label = if size_bytes < 1024 {
+        format!("{size_bytes} B")
+    } else if size_bytes < 1024 * 1024 {
+        format!("{:.1} KB", size_bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", size_bytes as f64 / (1024.0 * 1024.0))
+    };
+    match file_type {
+        InboxFileType::Image => Some(format!("Image file - {size_label}")),
+        InboxFileType::Spreadsheet => Some(format!("Spreadsheet - {size_label}")),
+        InboxFileType::Document => Some(format!("Document - {size_label}")),
+        InboxFileType::Other => Some(format!("File - {size_label}")),
+        _ => None,
+    }
+}
+
+/// Get unresolved inbox files from lifecycle rows.
 #[allow(
     clippy::let_underscore_must_use,
     reason = "tauri::command macro emits internal Result glue that discards generated metadata"
@@ -76,27 +230,11 @@ pub async fn get_inbox_files(state: State<'_, Arc<AppState>>) -> Result<InboxRes
         }
     };
 
-    let workspace = Path::new(&config.workspace_path);
-    let mut files = list_inbox_files(workspace);
+    let workspace_root = std::path::PathBuf::from(config.workspace_path);
+    let files = state
+        .db_read(move |db| inbox_files_from_lifecycle(db.conn_ref(), &workspace_root))
+        .await?;
     let count = files.len();
-
-    // Enrich files with persistent processing status from DB
-    if let Ok(status_map) = state
-        .db_read(|db| db.get_latest_processing_status().map_err(|e| e.to_string()))
-        .await
-    {
-        for file in &mut files {
-            if let Some((status, error)) = status_map.get(&file.filename) {
-                file.processing_status = Some(status.clone());
-                // For needs_entity, error_message stores the suggested name
-                if status == "needs_entity" {
-                    file.suggested_entity_name = error.clone();
-                } else {
-                    file.processing_error = error.clone();
-                }
-            }
-        }
-    }
 
     if files.is_empty() {
         Ok(InboxResult::Empty {
@@ -119,7 +257,6 @@ pub async fn get_inbox_files(state: State<'_, Arc<AppState>>) -> Result<InboxRes
 #[tauri::command]
 pub async fn process_inbox_file(
     filename: String,
-    entity_id: Option<String>,
     state: State<'_, Arc<AppState>>,
 ) -> Result<crate::processor::ProcessingResult, String> {
     let config = state
@@ -128,36 +265,186 @@ pub async fn process_inbox_file(
         .clone()
         .ok_or("No configuration loaded")?;
 
-    let workspace_path = config.workspace_path.clone();
-    let profile = config.profile.clone();
-    let entity_id = entity_id.clone();
+    let workspace_root = std::path::PathBuf::from(config.workspace_path)
+        .canonicalize()
+        .map_err(|e| format!("workspace_root: {e}"))?;
 
     // Validate filename before processing (path traversal guard)
-    let workspace = Path::new(&workspace_path);
-    crate::util::validate_inbox_path(workspace, &filename)?;
+    crate::util::validate_inbox_path(&workspace_root, &filename)?;
 
-    tauri::async_runtime::spawn_blocking(move || {
-        let workspace = Path::new(&workspace_path);
-        // Open a dedicated connection instead of holding the shared mutex
-        // for the entire duration of process_file (which can take seconds).
-        let db =
-            crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())).ok();
-        let db_ref = db.as_ref();
-        let entity_tracker_path = entity_id.as_deref().and_then(|eid| {
-            db_ref
-                .and_then(|db| db.get_entity(eid).ok().flatten())
-                .and_then(|e| e.tracker_path)
-        });
-        crate::processor::process_file(
-            workspace,
-            &filename,
-            db_ref,
-            &profile,
-            entity_tracker_path.as_deref(),
-        )
-    })
-    .await
-    .map_err(|e| format!("Processing task failed: {}", e))
+    state
+        .db_write(move |db| process_inbox_file_in_db(db, &workspace_root, &filename))
+        .await
+}
+
+#[cfg(any(test, debug_assertions, feature = "test-harness"))]
+#[doc(hidden)]
+pub fn process_inbox_file_for_tests(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    filename: &str,
+) -> Result<serde_json::Value, String> {
+    serde_json::to_value(process_inbox_file_in_db(db, workspace_root, filename)?)
+        .map_err(|e| e.to_string())
+}
+
+fn process_inbox_file_in_db(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    filename: &str,
+) -> Result<crate::processor::ProcessingResult, String> {
+    let inbox_path = crate::util::validate_inbox_path(workspace_root, filename)?;
+    let existing_file_id = lifecycle_file_id_for_path(db.conn_ref(), &inbox_path)?;
+    if let Some(file_id) = existing_file_id.as_deref() {
+        if let Some(row) =
+            LifecycleRepo::get(db.conn_ref(), file_id).map_err(|e| format!("lifecycle_get: {e}"))?
+        {
+            if row.lifecycle_state == LifecycleState::PendingEntityAssignment {
+                return Ok(processing_result_for_lifecycle(&row));
+            }
+        }
+    }
+
+    match run_staged_inbox_ingestion(db.conn_ref(), workspace_root, &inbox_path) {
+        Ok(receipt) => Ok(processing_result_for_receipt(&receipt, filename)),
+        Err(IngestError::AlreadyProcessed { .. }) => {
+            let file_id = existing_file_id
+                .or_else(|| {
+                    lifecycle_file_id_for_path(db.conn_ref(), &inbox_path)
+                        .ok()
+                        .flatten()
+                })
+                .ok_or_else(|| "already_processed_without_lifecycle_row".to_string())?;
+            let row = LifecycleRepo::get(db.conn_ref(), &file_id)
+                .map_err(|e| format!("lifecycle_get: {e}"))?
+                .ok_or_else(|| "not_found".to_string())?;
+            Ok(processing_result_for_lifecycle(&row))
+        }
+        Err(error) => Ok(crate::processor::ProcessingResult::Error {
+            message: format!("pipeline: {error}"),
+        }),
+    }
+}
+
+fn lifecycle_file_id_for_path(
+    conn: &rusqlite::Connection,
+    path: &std::path::Path,
+) -> Result<Option<String>, String> {
+    let canonical_path = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    conn.query_row(
+        "SELECT file_id FROM workspace_file_lifecycle WHERE canonical_path = ?1",
+        params![canonical_path],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|e| e.to_string())
+}
+
+fn run_staged_inbox_ingestion(
+    conn: &rusqlite::Connection,
+    workspace_root: &std::path::Path,
+    inbox_path: &std::path::Path,
+) -> Result<IngestReceipt, IngestError> {
+    let (file, identity) = WorkspaceSourceRegistry::open_validated(workspace_root, inbox_path)
+        .map_err(|e| IngestError::DbError(format!("open_validated: {e:?}")))?;
+    let source_asof: DateTime<Utc> = identity
+        .canonical_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .map_err(IngestError::Io)?
+        .into();
+    let file_id = file_id_from_identity(&identity, workspace_root)
+        .map_err(|e| IngestError::DbError(format!("file_id: {e:?}")))?;
+    let pipeline = wiring::build_pipeline(workspace_root.to_path_buf());
+    pipeline.run(
+        conn,
+        IngestRequest {
+            file,
+            identity,
+            file_id,
+            source_asof,
+            source_type: WorkspaceFileKind::Inbox,
+            entity: None,
+            mode: IngestionMode::Realtime,
+            category_hint: None,
+        },
+    )
+}
+
+fn processing_result_for_receipt(
+    receipt: &IngestReceipt,
+    filename: &str,
+) -> crate::processor::ProcessingResult {
+    match receipt.lifecycle_state_after {
+        LifecycleState::Ingested => crate::processor::ProcessingResult::Routed {
+            classification: "workspace_file".to_string(),
+            destination: receipt
+                .resolved_path
+                .clone()
+                .unwrap_or_else(|| filename.to_string()),
+        },
+        LifecycleState::PendingEntityAssignment => {
+            crate::processor::ProcessingResult::NeedsEntity {
+                classification: "workspace_file".to_string(),
+                suggested_name: suggested_entity_name_from_filename(filename),
+            }
+        }
+        LifecycleState::Rejected => crate::processor::ProcessingResult::Error {
+            message: "File rejected during ingestion".to_string(),
+        },
+        other => crate::processor::ProcessingResult::Error {
+            message: format!("Unexpected lifecycle state after ingestion: {other:?}"),
+        },
+    }
+}
+
+fn processing_result_for_lifecycle(
+    row: &crate::services::workspace_ingestion::lifecycle::WorkspaceFileLifecycle,
+) -> crate::processor::ProcessingResult {
+    let filename = std::path::Path::new(&row.canonical_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("workspace-file");
+    match row.lifecycle_state {
+        LifecycleState::Ingested => crate::processor::ProcessingResult::Routed {
+            classification: "workspace_file".to_string(),
+            destination: row.canonical_path.clone(),
+        },
+        LifecycleState::PendingEntityAssignment => {
+            crate::processor::ProcessingResult::NeedsEntity {
+                classification: "workspace_file".to_string(),
+                suggested_name: suggested_entity_name_from_filename(filename),
+            }
+        }
+        LifecycleState::Rejected => crate::processor::ProcessingResult::Error {
+            message: "File rejected during ingestion".to_string(),
+        },
+        _ => crate::processor::ProcessingResult::NeedsEnrichment,
+    }
+}
+
+fn suggested_entity_name_from_filename(filename: &str) -> String {
+    std::path::Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(filename)
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .chars()
+        .take(32)
+        .collect::<String>()
 }
 
 /// Process all inbox files (batch).
@@ -322,14 +609,9 @@ pub fn copy_to_inbox(
         .clone()
         .ok_or("No configuration loaded")?;
 
-    let workspace = Path::new(&config.workspace_path);
-    let inbox_dir = workspace.join("_inbox");
-
-    // Ensure _inbox/ exists
-    if !inbox_dir.exists() {
-        std::fs::create_dir_all(&inbox_dir)
-            .map_err(|e| format!("Failed to create _inbox: {}", e))?;
-    }
+    let workspace_root = std::path::PathBuf::from(config.workspace_path)
+        .canonicalize()
+        .map_err(|e| format!("workspace_root: {e}"))?;
 
     // Build allowlist of source directories
     let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
@@ -338,6 +620,34 @@ pub fn copy_to_inbox(
         home.join("Desktop"),
         home.join("Downloads"),
     ];
+
+    state.with_db(|db| copy_to_inbox_in_db(db, &workspace_root, paths, &allowed_source_dirs))
+}
+
+#[cfg(any(test, debug_assertions, feature = "test-harness"))]
+#[doc(hidden)]
+pub fn copy_to_inbox_for_tests(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    paths: Vec<String>,
+    allowed_source_dirs: &[std::path::PathBuf],
+) -> Result<CopyToInboxReport, String> {
+    copy_to_inbox_in_db(db, workspace_root, paths, allowed_source_dirs)
+}
+
+fn copy_to_inbox_in_db(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    paths: Vec<String>,
+    allowed_source_dirs: &[std::path::PathBuf],
+) -> Result<CopyToInboxReport, String> {
+    let inbox_dir = workspace_root.join("_inbox");
+
+    // Ensure _inbox/ exists
+    if !inbox_dir.exists() {
+        std::fs::create_dir_all(&inbox_dir)
+            .map_err(|e| format!("Failed to create _inbox: {}", e))?;
+    }
 
     let mut copied_filenames = Vec::new();
 
@@ -403,6 +713,7 @@ pub fn copy_to_inbox(
         match std::fs::copy(source, &dest) {
             Ok(_) => {
                 log::info!("Copied '{}' to inbox", filename.to_string_lossy());
+                stage_copied_inbox_file(db, workspace_root, &dest)?;
                 copied_filenames.push(
                     dest.file_name()
                         .and_then(|name| name.to_str())
@@ -420,6 +731,17 @@ pub fn copy_to_inbox(
         copied_count: copied_filenames.len(),
         copied_filenames,
     })
+}
+
+fn stage_copied_inbox_file(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    dest: &std::path::Path,
+) -> Result<(), String> {
+    match run_staged_inbox_ingestion(db.conn_ref(), workspace_root, dest) {
+        Ok(_) | Err(IngestError::AlreadyProcessed { .. }) | Err(IngestError::Rejected(_)) => Ok(()),
+        Err(error) => Err(format!("pipeline: {error}")),
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -546,16 +868,25 @@ fn assign_inbox_entity_in_db(
 
         LifecycleRepo::set_entity(conn, &file_id, entity_type, &entity_id, Some(&entity_name))
             .map_err(|e| format!("set_entity: {e}"))?;
-        add_user_relink_link(conn, &file_id, entity_type, &entity_id)
-            .map_err(|e| format!("add_link: {e}"))?;
+        LinkRepo::add_link_in_tx(
+            conn,
+            &file_id,
+            entity_type,
+            &entity_id,
+            LinkAttributionSource::UserRelink,
+            1.0,
+            Some("User assigned inbox file to entity"),
+            "user",
+        )
+        .map_err(map_link_error_for_assign)?;
 
         // The live W2-A pipeline re-enters from `pending`; keep this state
         // change inside the same command transaction so failures roll back.
-        conn.execute(
-            "UPDATE workspace_file_lifecycle SET lifecycle_state = 'pending', \
-             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
-             WHERE file_id = ?1 AND lifecycle_state = 'pending_entity_assignment'",
-            params![file_id],
+        LifecycleRepo::transition(
+            conn,
+            &file_id,
+            LifecycleState::PendingEntityAssignment,
+            LifecycleState::Pending,
         )
         .map_err(|e| format!("prepare_pipeline: {e}"))?;
 
@@ -591,35 +922,14 @@ fn assign_inbox_entity_in_db(
     })
 }
 
-fn add_user_relink_link(
-    conn: &rusqlite::Connection,
-    file_id: &str,
-    entity_type: EntityType,
-    entity_id: &str,
-) -> rusqlite::Result<String> {
-    let link_id = uuid::Uuid::new_v4().to_string();
-    let inserted_id: Option<String> = conn
-        .query_row(
-            "INSERT INTO document_entity_links \
-             (link_id, file_id, entity_type, entity_id, attribution_source, \
-              confidence, rationale, actor) \
-             VALUES (?1, ?2, ?3, ?4, 'user_relink', 1.0, \
-                     'User assigned inbox file to entity', 'user') \
-             ON CONFLICT (file_id, entity_type, entity_id) WHERE rejected = 0 \
-             DO NOTHING RETURNING link_id",
-            params![link_id, file_id, entity_type.as_str(), entity_id],
-            |row| row.get(0),
-        )
-        .optional()?;
-
-    match inserted_id {
-        Some(id) => Ok(id),
-        None => conn.query_row(
-            "SELECT link_id FROM document_entity_links \
-             WHERE file_id = ?1 AND entity_type = ?2 AND entity_id = ?3 AND rejected = 0",
-            params![file_id, entity_type.as_str(), entity_id],
-            |row| row.get(0),
-        ),
+fn map_link_error_for_assign(error: LinkError) -> String {
+    match error {
+        LinkError::NotFound => "link_not_found".to_string(),
+        LinkError::DuplicateActive => "duplicate_active_link".to_string(),
+        LinkError::AlreadyRejected => "link_already_rejected".to_string(),
+        LinkError::Tombstoned { .. } => "link_tombstoned".to_string(),
+        LinkError::EntityTypeUnknown => "invalid_entity_type".to_string(),
+        LinkError::DbError(message) => format!("link_db_error: {message}"),
     }
 }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -4,6 +4,18 @@
 )]
 
 use super::*;
+use abilities_runtime::abilities::provenance::source::{EntityId, WorkspaceFileKind};
+use chrono::{DateTime, Utc};
+use rusqlite::{params, OptionalExtension};
+
+use crate::entity::EntityType;
+use crate::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use crate::services::workspace_ingestion::pipeline::{
+    file_id_from_identity, EntityRef, IngestRequest,
+};
+use crate::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
+use crate::services::workspace_ingestion::runs::IngestionMode;
+use crate::services::workspace_ingestion::wiring;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -408,6 +420,243 @@ pub fn copy_to_inbox(
         copied_count: copied_filenames.len(),
         copied_filenames,
     })
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssignInboxEntityReceipt {
+    pub file_id: String,
+    pub ingestion_run_id: String,
+    pub content_sha256: String,
+    pub lifecycle_state_after: String,
+    pub resolved_path: Option<String>,
+}
+
+#[allow(
+    clippy::let_underscore_must_use,
+    reason = "tauri::command macro emits internal Result glue that discards generated metadata"
+)]
+#[tauri::command]
+pub async fn assign_inbox_entity(
+    state: State<'_, Arc<AppState>>,
+    file_id: String,
+    entity_type_slug: String,
+    entity_id: String,
+    entity_name: String,
+    source_type_slug: String,
+) -> Result<AssignInboxEntityReceipt, String> {
+    let config = state
+        .config
+        .read()
+        .clone()
+        .ok_or("No configuration loaded")?;
+    let workspace_root = std::path::PathBuf::from(config.workspace_path)
+        .canonicalize()
+        .map_err(|e| format!("workspace_root: {e}"))?;
+
+    state
+        .db_write(move |db| {
+            assign_inbox_entity_in_db(
+                db,
+                &workspace_root,
+                file_id,
+                entity_type_slug,
+                entity_id,
+                entity_name,
+                source_type_slug,
+            )
+        })
+        .await
+}
+
+#[cfg(any(test, debug_assertions, feature = "test-harness"))]
+#[doc(hidden)]
+pub fn assign_inbox_entity_for_tests(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    file_id: String,
+    entity_type_slug: String,
+    entity_id: String,
+    entity_name: String,
+    source_type_slug: String,
+) -> Result<AssignInboxEntityReceipt, String> {
+    assign_inbox_entity_in_db(
+        db,
+        workspace_root,
+        file_id,
+        entity_type_slug,
+        entity_id,
+        entity_name,
+        source_type_slug,
+    )
+}
+
+fn assign_inbox_entity_in_db(
+    db: &crate::db::ActionDb,
+    workspace_root: &std::path::Path,
+    file_id: String,
+    entity_type_slug: String,
+    entity_id: String,
+    entity_name: String,
+    source_type_slug: String,
+) -> Result<AssignInboxEntityReceipt, String> {
+    let entity_type = EntityType::from_str_lossy(&entity_type_slug);
+    if matches!(entity_type, EntityType::Other) {
+        return Err("invalid_entity_type".to_string());
+    }
+    if !is_valid_entity_id(&entity_id) {
+        return Err("invalid_entity_id".to_string());
+    }
+    if !is_valid_slug_shape(&entity_name) {
+        return Err("invalid_entity_name".to_string());
+    }
+    let source_type = WorkspaceFileKind::from_slug(&source_type_slug)
+        .ok_or_else(|| "invalid source_type_slug".to_string())?;
+    if source_type != WorkspaceFileKind::Inbox {
+        return Err("not_inbox_file".to_string());
+    }
+
+    db.with_transaction(|tx_db| {
+        let conn = tx_db.conn_ref();
+        let row = LifecycleRepo::get(conn, &file_id)
+            .map_err(|e| format!("lifecycle_get: {e}"))?
+            .ok_or_else(|| "not_found".to_string())?;
+        if row.lifecycle_state != LifecycleState::PendingEntityAssignment {
+            return Err("invalid_lifecycle_state".to_string());
+        }
+        if row.source_type != WorkspaceFileKind::Inbox {
+            return Err("not_inbox_file".to_string());
+        }
+
+        let canonical_path = std::path::PathBuf::from(&row.canonical_path);
+        let (file, identity) =
+            WorkspaceSourceRegistry::open_validated(workspace_root, &canonical_path)
+                .map_err(|e| format!("open_validated: {e:?}"))?;
+        let reopened_file_id = file_id_from_identity(&identity, workspace_root)
+            .map_err(|e| format!("file_id: {e:?}"))?;
+        if reopened_file_id != file_id {
+            return Err("file_id_mismatch".to_string());
+        }
+        let source_asof: DateTime<Utc> = identity
+            .canonical_path
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .map_err(|e| format!("source_asof: {e}"))?
+            .into();
+
+        LifecycleRepo::set_entity(conn, &file_id, entity_type, &entity_id, Some(&entity_name))
+            .map_err(|e| format!("set_entity: {e}"))?;
+        add_user_relink_link(conn, &file_id, entity_type, &entity_id)
+            .map_err(|e| format!("add_link: {e}"))?;
+
+        // The live W2-A pipeline re-enters from `pending`; keep this state
+        // change inside the same command transaction so failures roll back.
+        conn.execute(
+            "UPDATE workspace_file_lifecycle SET lifecycle_state = 'pending', \
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') \
+             WHERE file_id = ?1 AND lifecycle_state = 'pending_entity_assignment'",
+            params![file_id],
+        )
+        .map_err(|e| format!("prepare_pipeline: {e}"))?;
+
+        let pipeline = wiring::build_pipeline(workspace_root.to_path_buf());
+        let receipt = pipeline
+            .run(
+                conn,
+                IngestRequest {
+                    file,
+                    identity,
+                    file_id: file_id.clone(),
+                    source_asof,
+                    source_type,
+                    entity: Some(EntityRef {
+                        entity_type,
+                        entity_id: EntityId::new(entity_id.clone()),
+                        entity_name: Some(entity_name.clone()),
+                    }),
+                    mode: IngestionMode::Realtime,
+                    category_hint: None,
+                },
+            )
+            .map_err(|e| format!("pipeline: {e}"))?;
+
+        Ok(AssignInboxEntityReceipt {
+            file_id: receipt.file_id,
+            ingestion_run_id: receipt.ingestion_run_id.0,
+            content_sha256: receipt.content_sha256,
+            lifecycle_state_after: lifecycle_state_to_slug(receipt.lifecycle_state_after)
+                .to_string(),
+            resolved_path: receipt.resolved_path,
+        })
+    })
+}
+
+fn add_user_relink_link(
+    conn: &rusqlite::Connection,
+    file_id: &str,
+    entity_type: EntityType,
+    entity_id: &str,
+) -> rusqlite::Result<String> {
+    let link_id = uuid::Uuid::new_v4().to_string();
+    let inserted_id: Option<String> = conn
+        .query_row(
+            "INSERT INTO document_entity_links \
+             (link_id, file_id, entity_type, entity_id, attribution_source, \
+              confidence, rationale, actor) \
+             VALUES (?1, ?2, ?3, ?4, 'user_relink', 1.0, \
+                     'User assigned inbox file to entity', 'user') \
+             ON CONFLICT (file_id, entity_type, entity_id) WHERE rejected = 0 \
+             DO NOTHING RETURNING link_id",
+            params![link_id, file_id, entity_type.as_str(), entity_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    match inserted_id {
+        Some(id) => Ok(id),
+        None => conn.query_row(
+            "SELECT link_id FROM document_entity_links \
+             WHERE file_id = ?1 AND entity_type = ?2 AND entity_id = ?3 AND rejected = 0",
+            params![file_id, entity_type.as_str(), entity_id],
+            |row| row.get(0),
+        ),
+    }
+}
+
+fn is_valid_entity_id(value: &str) -> bool {
+    if uuid::Uuid::parse_str(value).is_ok() {
+        return true;
+    }
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':'))
+}
+
+fn is_valid_slug_shape(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 32
+        && value.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-')
+}
+
+fn lifecycle_state_to_slug(state: LifecycleState) -> &'static str {
+    match state {
+        LifecycleState::Pending => "pending",
+        LifecycleState::PendingEntityAssignment => "pending_entity_assignment",
+        LifecycleState::Ingesting => "ingesting",
+        LifecycleState::Ingested => "ingested",
+        LifecycleState::Superseded => "superseded",
+        LifecycleState::Rejected => "rejected",
+        LifecycleState::Quarantined => "quarantined",
+    }
 }
 
 // =============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,12 +63,12 @@ pub mod substrate_test_api {
         crate::intel_queue::compose_enrichment_intelligence_payload(db, input, intel, None)
     }
 }
-#[cfg(feature = "test-harness")]
+#[cfg(any(feature = "test-harness", debug_assertions))]
 #[doc(hidden)]
 pub mod command_test_api {
     pub use crate::commands::{
-        create_entity_context_entry, delete_entity_context_entry, get_entity_context_entries,
-        reveal_sensitive_claim_text, update_entity_context_entry,
+        assign_inbox_entity_for_tests, create_entity_context_entry, delete_entity_context_entry,
+        get_entity_context_entries, reveal_sensitive_claim_text, update_entity_context_entry,
     };
 }
 #[cfg(any(feature = "test-harness", feature = "bench-harness", debug_assertions))]
@@ -724,6 +724,7 @@ pub fn run() {
             commands::process_inbox_file,
             commands::process_all_inbox,
             commands::enrich_inbox_file,
+            commands::assign_inbox_entity, // dos7-allowed: w2d-assign-command-registration
             commands::copy_to_inbox,
             commands::list_meeting_preps,
             commands::set_profile,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,8 +67,9 @@ pub mod substrate_test_api {
 #[doc(hidden)]
 pub mod command_test_api {
     pub use crate::commands::{
-        assign_inbox_entity_for_tests, create_entity_context_entry, delete_entity_context_entry,
-        get_entity_context_entries, reveal_sensitive_claim_text, update_entity_context_entry,
+        assign_inbox_entity_for_tests, copy_to_inbox_for_tests, create_entity_context_entry,
+        delete_entity_context_entry, get_entity_context_entries, get_inbox_files_for_tests,
+        process_inbox_file_for_tests, reveal_sensitive_claim_text, update_entity_context_entry,
     };
 }
 #[cfg(any(feature = "test-harness", feature = "bench-harness", debug_assertions))]

--- a/src-tauri/src/parser.rs
+++ b/src-tauri/src/parser.rs
@@ -855,6 +855,7 @@ pub fn list_inbox_files(workspace: &Path) -> Vec<InboxFile> {
             };
 
             Some(InboxFile {
+                file_id: None,
                 filename,
                 path: path.to_string_lossy().to_string(),
                 size_bytes: metadata.len(),

--- a/src-tauri/src/services/workspace_ingestion/lifecycle.rs
+++ b/src-tauri/src/services/workspace_ingestion/lifecycle.rs
@@ -371,6 +371,10 @@ fn is_valid_transition(from: LifecycleState, to: LifecycleState) -> bool {
                 LifecycleState::Ingesting,
                 LifecycleState::PendingEntityAssignment
             )
+            | (
+                LifecycleState::PendingEntityAssignment,
+                LifecycleState::Pending
+            )
             | (LifecycleState::Ingested, LifecycleState::Superseded)
             | (_, LifecycleState::Quarantined)
             | (LifecycleState::Rejected, LifecycleState::Pending)

--- a/src-tauri/src/services/workspace_ingestion/link.rs
+++ b/src-tauri/src/services/workspace_ingestion/link.rs
@@ -31,9 +31,9 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
-use crate::entity::EntityType;
 use super::contracts::SignalEmitter;
 use super::lifecycle::UserOverride;
+use crate::entity::EntityType;
 
 /// Opaque UUID4 identifier for a document/entity link row.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -54,7 +54,10 @@ pub enum LinkAttributionSource {
 
 impl LinkAttributionSource {
     pub fn is_classifier_class(&self) -> bool {
-        matches!(self, Self::Classifier | Self::Backfill | Self::DriveMetadata)
+        matches!(
+            self,
+            Self::Classifier | Self::Backfill | Self::DriveMetadata
+        )
     }
 
     pub fn as_storage_str(self) -> &'static str {
@@ -208,9 +211,8 @@ fn row_to_link(row: &rusqlite::Row<'_>) -> rusqlite::Result<DocumentEntityLink> 
 pub struct LinkRepo;
 
 impl LinkRepo {
-    /// Creates or resurrects a document/entity link. UNIMPLEMENTED — defer to
-    /// next iteration. Implementation requires careful `BEGIN IMMEDIATE`
-    /// transactional handling for classifier-class sources per V1.3 fold #1.
+    /// Creates or resurrects a document/entity link. Opens its own
+    /// `BEGIN IMMEDIATE` boundary, then delegates to `add_link_in_tx`.
     #[allow(clippy::too_many_arguments)]
     pub fn add_link(
         conn: &Connection,
@@ -222,14 +224,46 @@ impl LinkRepo {
         rationale: Option<&str>,
         actor: &str,
     ) -> Result<DocumentEntityLinkId, LinkError> {
-        let et_slug = entity_type_slug(entity_type);
-        // Open BEGIN IMMEDIATE transaction to serialize the (optional)
-        // tombstone-check + INSERT atomically. This closes the V1.2 race
-        // where a concurrent reject_link between SELECT and INSERT could
-        // let a classifier source create an active row after tombstone.
         conn.execute("BEGIN IMMEDIATE", [])
             .map_err(|e| LinkError::DbError(e.to_string()))?;
 
+        let result = Self::add_link_in_tx(
+            conn,
+            file_id,
+            entity_type,
+            entity_id,
+            attribution_source,
+            confidence,
+            rationale,
+            actor,
+        );
+        match result {
+            Ok(id) => {
+                conn.execute("COMMIT", [])
+                    .map_err(|e| LinkError::DbError(e.to_string()))?;
+                Ok(id)
+            }
+            Err(err) => {
+                drop(conn.execute("ROLLBACK", []));
+                Err(err)
+            }
+        }
+    }
+
+    /// Creates or resurrects a document/entity link using an existing
+    /// transaction connection. The caller owns commit/rollback.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_link_in_tx(
+        conn: &Connection,
+        file_id: &str,
+        entity_type: EntityType,
+        entity_id: &str,
+        attribution_source: LinkAttributionSource,
+        confidence: f64,
+        rationale: Option<&str>,
+        actor: &str,
+    ) -> Result<DocumentEntityLinkId, LinkError> {
+        let et_slug = entity_type_slug(entity_type);
         // Tombstone guard for classifier-class sources only.
         if attribution_source.is_classifier_class() {
             let tombstoned: Option<(String, String)> = conn
@@ -241,12 +275,8 @@ impl LinkRepo {
                     |row| Ok((row.get(0)?, row.get(1)?)),
                 )
                 .optional()
-                .map_err(|e| {
-                    drop(conn.execute("ROLLBACK", []));
-                    LinkError::DbError(e.to_string())
-                })?;
+                .map_err(|e| LinkError::DbError(e.to_string()))?;
             if let Some((rejected_at_raw, rejected_reason)) = tombstoned {
-                drop(conn.execute("ROLLBACK", []));
                 let rejected_at = parse_dt(Some(rejected_at_raw)).unwrap_or_else(Utc::now);
                 return Err(LinkError::Tombstoned {
                     rejected_at,
@@ -281,10 +311,7 @@ impl LinkRepo {
                 |row| row.get(0),
             )
             .optional()
-            .map_err(|e| {
-                drop(conn.execute("ROLLBACK", []));
-                LinkError::DbError(e.to_string())
-            })?;
+            .map_err(|e| LinkError::DbError(e.to_string()))?;
 
         let final_id = match inserted_id {
             Some(id) => id,
@@ -297,14 +324,9 @@ impl LinkRepo {
                     params![file_id, et_slug, entity_id],
                     |row| row.get(0),
                 )
-                .map_err(|e| {
-                    drop(conn.execute("ROLLBACK", []));
-                    LinkError::DbError(e.to_string())
-                })?
+                .map_err(|e| LinkError::DbError(e.to_string()))?
             }
         };
-        conn.execute("COMMIT", [])
-            .map_err(|e| LinkError::DbError(e.to_string()))?;
         Ok(DocumentEntityLinkId(final_id))
     }
 
@@ -417,7 +439,15 @@ mod tests {
         conn.execute(
             "INSERT INTO workspace_file_lifecycle (file_id, canonical_path, device, inode, \
              source_type, data_source, source_asof) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            params!["wf-1", "test/path", 0_i64, 0_i64, "inbox", "{}", "2026-05-21T00:00:00Z"],
+            params![
+                "wf-1",
+                "test/path",
+                0_i64,
+                0_i64,
+                "inbox",
+                "{}",
+                "2026-05-21T00:00:00Z"
+            ],
         )
         .expect("seed file_lifecycle");
         conn
@@ -647,7 +677,10 @@ mod tests {
             "agent-2",
         )
         .expect("second Ok");
-        assert_eq!(id1, id2, "duplicate add_link should return existing link_id");
+        assert_eq!(
+            id1, id2,
+            "duplicate add_link should return existing link_id"
+        );
         let links = LinkRepo::list_links_for_file(&conn, "wf-1", false).expect("Ok");
         assert_eq!(links.len(), 1, "no new row created");
         // Original values preserved (DO NOTHING semantics).
@@ -700,7 +733,10 @@ mod tests {
         }
         // No new active link created.
         let active = LinkRepo::list_links_for_file(&conn, "wf-1", false).expect("Ok");
-        assert!(active.is_empty(), "rejected link must NOT resurrect via classifier");
+        assert!(
+            active.is_empty(),
+            "rejected link must NOT resurrect via classifier"
+        );
         // But the rejected row still exists.
         let all = LinkRepo::list_links_for_file(&conn, "wf-1", true).expect("Ok");
         assert_eq!(all.len(), 1);
@@ -787,6 +823,44 @@ mod tests {
     }
 
     #[test]
+    fn add_link_in_tx_returns_id_and_is_idempotent_on_conflict() {
+        let conn = fresh_conn();
+        conn.execute("BEGIN IMMEDIATE", []).expect("begin");
+        let id1 = LinkRepo::add_link_in_tx(
+            &conn,
+            "wf-1",
+            EntityType::Account,
+            "acme",
+            LinkAttributionSource::UserRelink,
+            1.0,
+            Some("user assigned inbox file"),
+            "user",
+        )
+        .expect("first add");
+        let id2 = LinkRepo::add_link_in_tx(
+            &conn,
+            "wf-1",
+            EntityType::Account,
+            "acme",
+            LinkAttributionSource::UserRelink,
+            1.0,
+            Some("duplicate user assignment"),
+            "user",
+        )
+        .expect("duplicate add");
+        conn.execute("COMMIT", []).expect("commit");
+
+        assert_eq!(id1, id2);
+        let links = LinkRepo::list_links_for_file(&conn, "wf-1", false).expect("links");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].link_id, id1);
+        assert!(matches!(
+            links[0].attribution_source,
+            LinkAttributionSource::UserRelink
+        ));
+    }
+
+    #[test]
     fn partial_unique_index_prevents_duplicate_active_insert_via_raw_sql() {
         // Sanity check: confirms the v254 partial UNIQUE index actually fires.
         // Note: add_link with proper UPSERT handles this gracefully; this test
@@ -805,8 +879,19 @@ mod tests {
             "INSERT INTO document_entity_links \
              (link_id, file_id, entity_type, entity_id, attribution_source, confidence, actor) \
              VALUES (?, ?, ?, ?, ?, ?, ?)",
-            params!["l-2", "wf-1", "account", "acme", "classifier", 0.5_f64, "test-actor"],
+            params![
+                "l-2",
+                "wf-1",
+                "account",
+                "acme",
+                "classifier",
+                0.5_f64,
+                "test-actor"
+            ],
         );
-        assert!(result.is_err(), "second active insert for same triple should fail UNIQUE");
+        assert!(
+            result.is_err(),
+            "second active insert for same triple should fail UNIQUE"
+        );
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -960,6 +960,8 @@ pub enum InboxFileType {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxFile {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
     pub filename: String,
     pub path: String,
     pub size_bytes: u64,

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_transitions.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_transitions.rs
@@ -52,3 +52,35 @@ fn legal_and_illegal_lifecycle_transitions_are_enforced() {
     .expect_err("illegal");
     assert!(matches!(err, LifecycleError::InvalidStateTransition { .. }));
 }
+
+#[test]
+fn pending_entity_assignment_can_return_to_pending_for_user_assignment() {
+    let conn = seeded_conn();
+    LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("pending to ingesting");
+    LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::Ingesting,
+        LifecycleState::PendingEntityAssignment,
+    )
+    .expect("ingesting to pending entity assignment");
+
+    LifecycleRepo::transition(
+        &conn,
+        "wf-1",
+        LifecycleState::PendingEntityAssignment,
+        LifecycleState::Pending,
+    )
+    .expect("pending entity assignment to pending");
+
+    let row = LifecycleRepo::get(&conn, "wf-1")
+        .expect("get")
+        .expect("row");
+    assert_eq!(row.lifecycle_state, LifecycleState::Pending);
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_arc_appstate_pattern.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_arc_appstate_pattern.rs
@@ -1,0 +1,21 @@
+#[test]
+fn assign_inbox_entity_uses_arc_appstate_tauri_state_pattern() {
+    let source = std::fs::read_to_string("src/commands/workspace.rs").expect("workspace command");
+    let start = source
+        .find("pub async fn assign_inbox_entity(")
+        .expect("assign_inbox_entity handler exists");
+    let body = &source[start..];
+    let end = body
+        .find("fn assign_inbox_entity_in_db")
+        .unwrap_or(body.len());
+    let handler = &body[..end];
+
+    assert!(
+        handler.contains("state: State<'_, Arc<AppState>>"),
+        "assign_inbox_entity must follow live command convention: State<'_, Arc<AppState>>"
+    );
+    assert!(
+        handler.contains(".db_write(move |db|"),
+        "assign_inbox_entity must use state.db_write(|db| ...).await"
+    );
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity.rs
@@ -1,0 +1,117 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::{DateTime, Utc};
+use dailyos_lib::db::ActionDb;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use dailyos_lib::services::workspace_ingestion::pipeline::file_id_from_identity;
+use dailyos_lib::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn assign_inbox_entity_adds_link_reruns_pipeline_and_ingests() {
+    let conn = migrated_conn();
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let file_path = write_inbox_file(
+        &workspace_root,
+        "notes.txt",
+        b"Follow up with Acme next week.",
+    );
+    let file_id = seed_pending_assignment(&conn, &workspace_root, &file_path);
+
+    let receipt = dailyos_lib::command_test_api::assign_inbox_entity_for_tests(
+        db,
+        &workspace_root,
+        file_id.clone(),
+        "account".to_string(),
+        "acme".to_string(),
+        "acme".to_string(),
+        "inbox".to_string(),
+    )
+    .expect("assign succeeds");
+
+    assert_eq!(receipt.file_id, file_id);
+    assert_eq!(receipt.lifecycle_state_after, "ingested");
+    assert_eq!(receipt.resolved_path, Some("_inbox/notes.txt".to_string()));
+
+    let lifecycle = LifecycleRepo::get(&conn, &file_id)
+        .expect("get lifecycle")
+        .expect("lifecycle row");
+    assert_eq!(lifecycle.lifecycle_state, LifecycleState::Ingested);
+    assert_eq!(lifecycle.entity_type.as_deref(), Some("account"));
+    assert_eq!(lifecycle.entity_id.as_deref(), Some("acme"));
+
+    let link_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM document_entity_links \
+             WHERE file_id = ?1 AND entity_type = 'account' AND entity_id = 'acme' \
+               AND attribution_source = 'user_relink' AND rejected = 0",
+            [&file_id],
+            |row| row.get(0),
+        )
+        .expect("link count");
+    assert_eq!(link_count, 1);
+
+    let run_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM document_ingestion_runs WHERE file_id = ?1 AND status = 'success'",
+            [&file_id],
+            |row| row.get(0),
+        )
+        .expect("run count");
+    assert_eq!(run_count, 1);
+}
+
+fn migrated_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("sqlite");
+    dailyos_lib::migration_test_api::run_migrations(&conn).expect("migrations");
+    conn
+}
+
+fn write_inbox_file(workspace_root: &Path, filename: &str, bytes: &[u8]) -> PathBuf {
+    let inbox = workspace_root.join("_inbox");
+    std::fs::create_dir_all(&inbox).expect("inbox dir");
+    let path = inbox.join(filename);
+    std::fs::write(&path, bytes).expect("write inbox file");
+    path
+}
+
+fn seed_pending_assignment(conn: &Connection, workspace_root: &Path, file_path: &Path) -> String {
+    let (_file, identity) =
+        WorkspaceSourceRegistry::open_validated(workspace_root, file_path).expect("open");
+    let source_asof: DateTime<Utc> = identity
+        .canonical_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .expect("mtime")
+        .into();
+    let file_id = file_id_from_identity(&identity, workspace_root).expect("file id");
+    LifecycleRepo::insert_pending(
+        conn,
+        &file_id,
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        source_asof,
+        None,
+    )
+    .expect("insert lifecycle");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("ingesting");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Ingesting,
+        LifecycleState::PendingEntityAssignment,
+    )
+    .expect("pending entity assignment");
+    file_id
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity_invalid_slug.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity_invalid_slug.rs
@@ -1,0 +1,21 @@
+use dailyos_lib::db::ActionDb;
+use rusqlite::Connection;
+
+#[test]
+fn assign_inbox_entity_rejects_invalid_source_type_slug() {
+    let conn = Connection::open_in_memory().expect("sqlite");
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let err = dailyos_lib::command_test_api::assign_inbox_entity_for_tests(
+        db,
+        workspace.path(),
+        "missing".to_string(),
+        "account".to_string(),
+        "acme".to_string(),
+        "acme".to_string(),
+        "bogus".to_string(),
+    )
+    .expect_err("invalid source type slug should reject");
+
+    assert_eq!(err, "invalid source_type_slug");
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity_transaction_rollback.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_assign_inbox_entity_transaction_rollback.rs
@@ -1,0 +1,111 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::{DateTime, Utc};
+use dailyos_lib::db::ActionDb;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use dailyos_lib::services::workspace_ingestion::pipeline::file_id_from_identity;
+use dailyos_lib::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn assign_inbox_entity_rolls_back_entity_and_link_when_pipeline_fails() {
+    let conn = migrated_conn();
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_root = workspace
+        .path()
+        .canonicalize()
+        .expect("canonical workspace");
+    let file_path = write_inbox_file(&workspace_root, "binary.bin", b"valid-prefix\0binary");
+    let file_id = seed_pending_assignment(&conn, &workspace_root, &file_path);
+
+    let err = dailyos_lib::command_test_api::assign_inbox_entity_for_tests(
+        db,
+        &workspace_root,
+        file_id.clone(),
+        "account".to_string(),
+        "acme".to_string(),
+        "acme".to_string(),
+        "inbox".to_string(),
+    )
+    .expect_err("pipeline should reject unsupported binary content");
+    assert!(err.contains("pipeline:"), "unexpected error: {err}");
+
+    let lifecycle = LifecycleRepo::get(&conn, &file_id)
+        .expect("get lifecycle")
+        .expect("lifecycle row");
+    assert_eq!(
+        lifecycle.lifecycle_state,
+        LifecycleState::PendingEntityAssignment
+    );
+    assert_eq!(lifecycle.entity_type, None);
+    assert_eq!(lifecycle.entity_id, None);
+
+    let link_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM document_entity_links WHERE file_id = ?1",
+            [&file_id],
+            |row| row.get(0),
+        )
+        .expect("link count");
+    assert_eq!(link_count, 0);
+
+    let run_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM document_ingestion_runs WHERE file_id = ?1",
+            [&file_id],
+            |row| row.get(0),
+        )
+        .expect("run count");
+    assert_eq!(run_count, 0);
+}
+
+fn migrated_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("sqlite");
+    dailyos_lib::migration_test_api::run_migrations(&conn).expect("migrations");
+    conn
+}
+
+fn write_inbox_file(workspace_root: &Path, filename: &str, bytes: &[u8]) -> PathBuf {
+    let inbox = workspace_root.join("_inbox");
+    std::fs::create_dir_all(&inbox).expect("inbox dir");
+    let path = inbox.join(filename);
+    std::fs::write(&path, bytes).expect("write inbox file");
+    path
+}
+
+fn seed_pending_assignment(conn: &Connection, workspace_root: &Path, file_path: &Path) -> String {
+    let (_file, identity) =
+        WorkspaceSourceRegistry::open_validated(workspace_root, file_path).expect("open");
+    let source_asof: DateTime<Utc> = identity
+        .canonical_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .expect("mtime")
+        .into();
+    let file_id = file_id_from_identity(&identity, workspace_root).expect("file id");
+    LifecycleRepo::insert_pending(
+        conn,
+        &file_id,
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        source_asof,
+        None,
+    )
+    .expect("insert lifecycle");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("ingesting");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Ingesting,
+        LifecycleState::PendingEntityAssignment,
+    )
+    .expect("pending entity assignment");
+    file_id
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_inbox_commands.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_inbox_commands.rs
@@ -1,0 +1,152 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+use chrono::{DateTime, Utc};
+use dailyos_lib::db::ActionDb;
+use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use dailyos_lib::services::workspace_ingestion::pipeline::file_id_from_identity;
+use dailyos_lib::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn process_inbox_file_without_entity_id_creates_lifecycle_row_and_run() {
+    let conn = migrated_conn();
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_root = workspace.path().canonicalize().expect("workspace root");
+    let file_path = write_inbox_file(&workspace_root, "notes.txt", b"Follow up with Acme.");
+
+    let result = dailyos_lib::command_test_api::process_inbox_file_for_tests(
+        db,
+        &workspace_root,
+        "notes.txt",
+    )
+    .expect("process");
+
+    assert_eq!(result["status"], "needs_entity");
+    let file_id = file_id_for(&workspace_root, &file_path);
+    let lifecycle = LifecycleRepo::get(&conn, &file_id)
+        .expect("get lifecycle")
+        .expect("lifecycle row");
+    assert_eq!(
+        lifecycle.lifecycle_state,
+        LifecycleState::PendingEntityAssignment
+    );
+
+    let run_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM document_ingestion_runs WHERE file_id = ?1 AND status = 'success'",
+            [&file_id],
+            |row| row.get(0),
+        )
+        .expect("run count");
+    assert_eq!(run_count, 1);
+}
+
+#[test]
+fn get_inbox_files_returns_lifecycle_rows_not_filesystem_listing() {
+    let conn = migrated_conn();
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_root = workspace.path().canonicalize().expect("workspace root");
+    let tracked = write_inbox_file(&workspace_root, "tracked.txt", b"Tracked content");
+    write_inbox_file(&workspace_root, "loose.txt", b"Filesystem-only content");
+    let file_id = seed_pending_assignment(&conn, &workspace_root, &tracked);
+
+    let files = dailyos_lib::command_test_api::get_inbox_files_for_tests(db, &workspace_root)
+        .expect("files");
+
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].file_id.as_deref(), Some(file_id.as_str()));
+    assert_eq!(files[0].filename, "tracked.txt");
+    assert_eq!(files[0].processing_status.as_deref(), Some("needs_entity"));
+}
+
+#[test]
+fn copy_to_inbox_creates_lifecycle_row_after_copy() {
+    let conn = migrated_conn();
+    let db = ActionDb::from_conn(&conn);
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_root = workspace.path().canonicalize().expect("workspace root");
+    let source_dir = tempfile::tempdir().expect("source");
+    let source_root = source_dir.path().canonicalize().expect("source root");
+    let source = source_root.join("drop.txt");
+    std::fs::write(&source, b"Dropped inbox content").expect("write source");
+
+    let report = dailyos_lib::command_test_api::copy_to_inbox_for_tests(
+        db,
+        &workspace_root,
+        vec![source.to_string_lossy().to_string()],
+        std::slice::from_ref(&source_root),
+    )
+    .expect("copy");
+
+    assert_eq!(report.copied_count, 1);
+    assert_eq!(report.copied_filenames, vec!["drop.txt"]);
+
+    let inbox_path = workspace_root.join("_inbox/drop.txt");
+    assert!(inbox_path.is_file());
+    let file_id = file_id_for(&workspace_root, &inbox_path);
+    let lifecycle = LifecycleRepo::get(&conn, &file_id)
+        .expect("get lifecycle")
+        .expect("lifecycle row");
+    assert_eq!(
+        lifecycle.lifecycle_state,
+        LifecycleState::PendingEntityAssignment
+    );
+}
+
+fn migrated_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("sqlite");
+    dailyos_lib::migration_test_api::run_migrations(&conn).expect("migrations");
+    conn
+}
+
+fn write_inbox_file(workspace_root: &Path, filename: &str, bytes: &[u8]) -> PathBuf {
+    let inbox = workspace_root.join("_inbox");
+    std::fs::create_dir_all(&inbox).expect("inbox dir");
+    let path = inbox.join(filename);
+    std::fs::write(&path, bytes).expect("write inbox file");
+    path
+}
+
+fn file_id_for(workspace_root: &Path, file_path: &Path) -> String {
+    let (_file, identity) =
+        WorkspaceSourceRegistry::open_validated(workspace_root, file_path).expect("open");
+    file_id_from_identity(&identity, workspace_root).expect("file id")
+}
+
+fn seed_pending_assignment(conn: &Connection, workspace_root: &Path, file_path: &Path) -> String {
+    let (_file, identity) =
+        WorkspaceSourceRegistry::open_validated(workspace_root, file_path).expect("open");
+    let source_asof: DateTime<Utc> = identity
+        .canonical_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .expect("mtime")
+        .into();
+    let file_id = file_id_from_identity(&identity, workspace_root).expect("file id");
+    LifecycleRepo::insert_pending(
+        conn,
+        &file_id,
+        &identity,
+        &WorkspaceFileKind::Inbox,
+        source_asof,
+        None,
+    )
+    .expect("insert lifecycle");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Pending,
+        LifecycleState::Ingesting,
+    )
+    .expect("ingesting");
+    LifecycleRepo::transition(
+        conn,
+        &file_id,
+        LifecycleState::Ingesting,
+        LifecycleState::PendingEntityAssignment,
+    )
+    .expect("pending entity assignment");
+    file_id
+}

--- a/src-tauri/tests/workspace_ingestion_w2d_workspace_file_kind_from_slug.rs
+++ b/src-tauri/tests/workspace_ingestion_w2d_workspace_file_kind_from_slug.rs
@@ -1,0 +1,34 @@
+use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
+
+#[test]
+fn workspace_file_kind_from_slug_covers_canonical_variants() {
+    assert_eq!(
+        WorkspaceFileKind::from_slug("inbox"),
+        Some(WorkspaceFileKind::Inbox)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("entity_doc"),
+        Some(WorkspaceFileKind::EntityDoc)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("drive_sync"),
+        Some(WorkspaceFileKind::DriveSync)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("user_attachment"),
+        Some(WorkspaceFileKind::UserAttachment)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("granola_transcript"),
+        Some(WorkspaceFileKind::GranolaTranscript)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("quill_transcript"),
+        Some(WorkspaceFileKind::QuillTranscript)
+    );
+    assert_eq!(
+        WorkspaceFileKind::from_slug("mcp_placement"),
+        Some(WorkspaceFileKind::McpPlacement)
+    );
+    assert_eq!(WorkspaceFileKind::from_slug("unknown"), None);
+}

--- a/src/pages/InboxPage.tsx
+++ b/src/pages/InboxPage.tsx
@@ -110,6 +110,23 @@ function humanizeFilename(filename: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+function entityNameSlug(name: string, fallback: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+
+  if (slug && /^[a-z]/.test(slug)) return slug;
+
+  return fallback
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[^a-z]+/, "")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32) || "account";
+}
+
 function formatModified(isoDate: string): string {
   try {
     const date = new Date(isoDate);
@@ -381,7 +398,6 @@ export default function InboxPage() {
       try {
         const result = await invoke<ProcessingResultPayload>("process_inbox_file", {
           filename,
-          entityId,
         });
 
         if (cancelledRef.current.has(filename)) {
@@ -786,10 +802,19 @@ export default function InboxPage() {
               onToggleExpand={() => toggleExpand(file.filename)}
               onProcess={() => processFile(file.filename)}
               onCancel={() => cancelFile(file.filename)}
-              onAssignEntity={async (entityId: string) => {
+              onAssignEntity={async (account: PickerAccount) => {
                 updateFileState(file.filename, { status: "processing" });
                 try {
-                  await invoke("process_inbox_file", { filename: file.filename, entityId });
+                  if (!file.fileId) {
+                    throw new Error("Missing lifecycle file id");
+                  }
+                  await invoke("assign_inbox_entity", {
+                    fileId: file.fileId,
+                    entityTypeSlug: "account",
+                    entityId: account.id,
+                    entityName: entityNameSlug(account.name, account.id),
+                    sourceTypeSlug: "inbox",
+                  });
                   updateFileState(file.filename, { status: "processed" });
                   setTimeout(() => refresh(), 500);
                 } catch {
@@ -873,7 +898,7 @@ function InboxRow({
   onToggleExpand: () => void;
   onProcess: () => void;
   onCancel: () => void;
-  onAssignEntity: (entityId: string) => void;
+  onAssignEntity: (account: PickerAccount) => void;
 }) {
   const [hovered, setHovered] = useState(false);
   const [accounts, setAccounts] = useState<PickerAccount[]>([]);
@@ -1001,7 +1026,8 @@ function InboxRow({
           <select
             defaultValue=""
             onChange={(e) => {
-              if (e.target.value) onAssignEntity(e.target.value);
+              const account = accounts.find((a) => a.id === e.target.value);
+              if (account) onAssignEntity(account);
             }}
             className={styles.entityPickerSelect}
           >

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -533,6 +533,7 @@ export type InboxFileType =
   | "other";
 
 export interface InboxFile {
+  fileId?: string;
   filename: string;
   path: string;
   sizeBytes: number;


### PR DESCRIPTION
## Summary

W2-D — `_inbox` refactor + `assign_inbox_entity` Tauri command + substrate extensions. Implements DOS-469 per L0 packet V1.4.

**Two-commit lane:**
1. **`7bd37dc8`** L1 slice 1 — `assign_inbox_entity` Tauri command + `WorkspaceFileKind::from_slug` W1-extension + 5 integration tests.
2. **`57693adb`** L1 slice 2 (L2 cycle-1 BLOCK fold) — full inbox refactor + substrate extensions per packet §10 Done When.

## What's in the wave

- **`assign_inbox_entity` Tauri command** (`commands/workspace.rs:440-579`): atomic `set_entity → add_link → pipeline.run` inside `state.db_write` closure + `db.with_transaction()`. Failure rolls back all three writes.
- **`process_inbox_file` refactored** — drops `entity_id` param; routes workspace-file ingestion through `wiring::build_pipeline(workspace_root).run()`.
- **`get_inbox_files` refactored** — queries `workspace_file_lifecycle WHERE source_type='inbox' AND lifecycle_state IN ('pending_entity_assignment', 'pending', 'ingesting', 'rejected')` instead of raw filesystem listing + status log enrichment.
- **`copy_to_inbox`** — triggers pipeline.run after copy.
- **`InboxPage.tsx`** — drops `entityId` param from `process_inbox_file` invocations; assignment button now calls `assign_inbox_entity` Tauri command.
- **Substrate extensions** (per L2 cycle-1 BLOCK from codex + correctness):
  - `LinkRepo::add_link_in_tx(conn, ...)` — accepts an existing transaction's connection; original `add_link` calls it after opening its own BEGIN IMMEDIATE.
  - `is_valid_transition` adds `PendingEntityAssignment → Pending` arc (with 32 lines of test coverage for the new arc).
- **`WorkspaceFileKind::from_slug`** added to abilities-runtime (W1-extension, documented at `.docs/plans/v1.4.5-workspace-memory/v1.4.5-w1-extensions.md`).
- **v1.4.6 follow-up** at `.docs/plans/v1.4.5-workspace-memory/v1.4.6-followups-W2-D.md` for processor/router refactor + other deferred items.

## Wave protocol trail

- **L0 V1.4** packet at `.docs/plans/v1.4.5-workspace-memory/L0-packet-W2-D-DOS-469.md`.
- **L1 preconditions** resolved before implementation:
  1. `State<'_, Arc<AppState>>` per live convention.
  2. `WorkspaceFileKind::from_slug` W1-extension.
  3. Transaction boundary via `db.with_transaction()` inside `state.db_write` closure.
- **L1 slice 1** via codex task — 9 files +585/-3.
- **L2 cycle 1**: 3-of-4 reviewers BLOCK.
  - codex challenge: **BLOCK** — 4 findings (process_inbox_file entity_id, raw link SQL, raw lifecycle SQL, copy_to_inbox).
  - code-reviewer: **BLOCK** — 2 medium AC violations (same as codex).
  - architect-reviewer: APPROVE-WITH-PATH-ALPHA (classified substrate gaps as path-α).
  - /cso (skipped — local-to-local single-user, no security surface change).
- **L2 cycle 2 patch** at `57693adb` — addresses all 4 codex BLOCK findings:
  - `process_inbox_file` refactored to drop `entity_id` param.
  - `get_inbox_files` queries workspace_file_lifecycle.
  - `copy_to_inbox` triggers pipeline.run.
  - Raw link SQL replaced with `LinkRepo::add_link_in_tx` (substrate extension).
  - Raw lifecycle SQL replaced with `LifecycleRepo::transition` after FSM arc extension.
  - InboxPage.tsx wires the new command.

L2 cycle-2 re-review pending CI verification.

## Tests

L1 slice 1 (5 W2-D-specific tests):
- workspace_ingestion_w2d_assign_inbox_entity
- workspace_ingestion_w2d_assign_inbox_entity_invalid_slug
- workspace_ingestion_w2d_assign_inbox_entity_transaction_rollback
- workspace_ingestion_w2d_workspace_file_kind_from_slug
- workspace_ingestion_w2d_arc_appstate_pattern

L1 slice 2:
- workspace_ingestion_w2d_inbox_commands (152 lines, NEW)
- workspace_ingestion_w2a_lifecycle_transitions.rs (+32 — new PendingEntityAssignment → Pending arc)

## Verification

```bash
cd src-tauri
cargo check --lib                                                 # ✅
cargo clippy --lib -- -D warnings                                 # ✅
cargo test --lib services::workspace_ingestion                    # ✅
cargo test --test workspace_ingestion_w2d_*                       # ✅ 6 tests
cargo test --test workspace_ingestion_w2a_lifecycle_transitions   # ✅ FSM arc test
scripts/check_workspace_mutation_allowlist.sh                     # ✅
pnpm tsc --noEmit                                                 # ✅
```

## Path-α (file to DOS-751)

- processor/mod.rs legacy classify path — deferred per packet §5 don't-touch
- Test coverage gaps documented in L2 cycle-1 correctness review
- Frontend wiring tests not added (manual smoke verification recommended)

## What's next

W2-D completes the v1.4.5 W2 wave (W2-A merged, W2-B merged, W2-C in CI, W2-D ready). Closes the inbox-refactor lane and substrates for v1.4.5 W3+.

## Test plan

- [ ] CI cargo + clippy + tsc green on PR check
- [ ] Hands-on smoke: drop a file in `_inbox/`, see it in `get_inbox_files` output, click assign button, verify lifecycle row transitions to Ingested + db_content_files populated.

## Security review

`security_auditor_invoked: true`

Local-to-local single-user trust topology per `feedback_local_to_local_security_overreach_primary_concern`. Touches `commands/workspace.rs` (Amendment 3 trigger). Substrate extensions are additive APIs (`LinkRepo::add_link_in_tx`, `LifecycleRepo` FSM arc) — no new external surfaces. Multi-actor gates correctly absent. No exemption needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)