### PR TITLE
feat(transport): DOS-761 — first-party WP loopback as Actor::User

### DIFF
--- a/docs/solutions/architecture-patterns/local-loopback-multisite-blog-id-decorative-2026-05-21.md
+++ b/docs/solutions/architecture-patterns/local-loopback-multisite-blog-id-decorative-2026-05-21.md
@@ -1,0 +1,19 @@
+---
+title: Local loopback multisite blog ID invariant
+problem_type: architecture_pattern
+track: knowledge
+module: wp-runtime-loopback
+tags: [wordpress, multisite, loopback, trust-boundary, dos-761]
+date: 2026-05-21
+related_linear: DOS-761
+---
+
+# Local loopback multisite blog ID invariant
+
+DailyOS is single-tenant per OS user. Runtime substrate routing is never selected by a WordPress blog ID.
+
+The signed SurfaceClient path may carry `X-DailyOS-Multisite-Blog-Id` as part of the WordPress pairing/signing identity, but the substrate treats that value as decorative transport metadata. It is not an account selector, database selector, tenant selector, or claim-substrate routing key.
+
+For first-party local loopback calls such as `POST /v1/local/invoke`, the runtime materializes `Actor::User` from the same-user loopback boundary. The request body and headers must not introduce a `blog_id` routing contract. The server-derived audit origin is `loopback_origin: "wp_plugin"`; WordPress multisite identity does not participate in local invoke authorization or substrate reads.
+
+If DailyOS ever becomes multi-tenant per OS user, that product model needs an explicit tenant boundary and substrate contract. Do not infer one from `X-DailyOS-Multisite-Blog-Id`.

--- a/src-tauri/src/audit_log.rs
+++ b/src-tauri/src/audit_log.rs
@@ -62,6 +62,10 @@ pub struct AuditRecord {
     /// entered the surface audit path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
+    /// Server-derived origin for first-party loopback emissions. This is
+    /// trace metadata, not caller-supplied identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loopback_origin: Option<String>,
 
     // --- W1-A0 actor attribution (ADR-0102 §7.6, ADR-0111 §8) ---
     /// Kind tag for the invoking [`Actor`]: `"agent"`, `"user"`, `"admin"`,
@@ -164,6 +168,8 @@ pub struct AuditFields {
     /// Server-generated request correlation id. Required by the surface audit
     /// migration for user-initiated Tauri command emissions.
     pub request_id: Option<String>,
+    /// Server-derived first-party loopback origin for traceability.
+    pub loopback_origin: Option<String>,
 }
 
 impl AuditFields {
@@ -177,6 +183,7 @@ impl AuditFields {
             wp_user_id: None,
             wp_user_hash: None,
             request_id: None,
+            loopback_origin: None,
         }
     }
 
@@ -200,6 +207,13 @@ impl AuditFields {
     #[must_use]
     pub fn with_request_id(mut self, request_id: impl Into<String>) -> Self {
         self.request_id = Some(request_id.into());
+        self
+    }
+
+    /// Attach server-derived first-party loopback origin metadata.
+    #[must_use]
+    pub fn with_loopback_origin(mut self, loopback_origin: impl Into<String>) -> Self {
+        self.loopback_origin = Some(loopback_origin.into());
         self
     }
 }
@@ -299,7 +313,7 @@ impl AuditLogger {
         event: &str,
         detail: serde_json::Value,
     ) -> Result<(), String> {
-        self.write_record(category, event, detail, None, None, None, None, None)
+        self.write_record(category, event, detail, None, None, None, None, None, None)
             .map_err(|err| match err {
                 AuditError::Write(msg) => msg,
                 AuditError::SurfaceClientMissingWpUserId => {
@@ -364,6 +378,7 @@ impl AuditLogger {
             wp_user_hash,
             actor_scopes,
             fields.request_id,
+            fields.loopback_origin,
         )
     }
 
@@ -382,6 +397,7 @@ impl AuditLogger {
         wp_user_hash: Option<String>,
         actor_scopes: Option<Vec<String>>,
         request_id: Option<String>,
+        loopback_origin: Option<String>,
     ) -> Result<(), AuditError> {
         let record = AuditRecord {
             ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
@@ -391,6 +407,7 @@ impl AuditLogger {
             detail,
             prev_hash: self.last_hash.clone(),
             request_id,
+            loopback_origin,
             actor_kind,
             actor_instance,
             wp_user_id: None,
@@ -687,6 +704,7 @@ mod tests {
                 detail: serde_json::json!({}),
                 prev_hash: logger.last_hash.clone(),
                 request_id: None,
+                loopback_origin: None,
                 actor_kind: None,
                 actor_instance: None,
                 wp_user_id: None,

--- a/src-tauri/src/bridges/types.rs
+++ b/src-tauri/src/bridges/types.rs
@@ -81,6 +81,7 @@ pub enum BridgeSurface {
     Worker,
     Eval,
     SurfaceClient,
+    LocalLoopback,
 }
 
 #[non_exhaustive]
@@ -282,7 +283,10 @@ impl Serialize for AbilityResponseJson {
     {
         let include_diagnostics = !matches!(
             self.rendered_provenance.surface,
-            BridgeSurface::McpTool | BridgeSurface::McpToolDetail | BridgeSurface::SurfaceClient
+            BridgeSurface::McpTool
+                | BridgeSurface::McpToolDetail
+                | BridgeSurface::SurfaceClient
+                | BridgeSurface::LocalLoopback
         );
         let mut state = serializer.serialize_struct(
             "AbilityResponseJson",
@@ -630,6 +634,7 @@ pub(crate) fn claim_dismissal_surface_for_non_tauri_bridge(
         BridgeSurface::Worker => Some(ClaimDismissalSurface::Worker),
         BridgeSurface::Eval => Some(ClaimDismissalSurface::Eval),
         BridgeSurface::SurfaceClient => Some(ClaimDismissalSurface::LogStructured),
+        BridgeSurface::LocalLoopback => Some(ClaimDismissalSurface::LogStructured),
     }
 }
 
@@ -896,7 +901,10 @@ fn maintenance_blocked_for_surface(descriptor: &AbilityDescriptor, surface: Brid
     descriptor.category == AbilityCategory::Maintenance
         && matches!(
             surface,
-            BridgeSurface::TauriApp | BridgeSurface::McpTool | BridgeSurface::McpToolDetail
+            BridgeSurface::TauriApp
+                | BridgeSurface::McpTool
+                | BridgeSurface::McpToolDetail
+                | BridgeSurface::LocalLoopback
         )
 }
 
@@ -967,6 +975,7 @@ fn provenance_surface_for_bridge(surface: BridgeSurface) -> Option<ProvenanceSur
         BridgeSurface::McpTool => Some(ProvenanceSurface::McpTool),
         BridgeSurface::McpToolDetail => Some(ProvenanceSurface::McpToolDetail),
         BridgeSurface::SurfaceClient => Some(ProvenanceSurface::LogStructured),
+        BridgeSurface::LocalLoopback => Some(ProvenanceSurface::LogStructured),
         BridgeSurface::Worker | BridgeSurface::Eval => None,
     }
 }
@@ -1006,7 +1015,8 @@ fn render_ability_data(
         BridgeSurface::TauriApp
         | BridgeSurface::Worker
         | BridgeSurface::Eval
-        | BridgeSurface::SurfaceClient => data,
+        | BridgeSurface::SurfaceClient
+        | BridgeSurface::LocalLoopback => data,
     }
 }
 
@@ -1028,9 +1038,10 @@ fn render_mcp_ability_data_with_authoritative_claims(
 
 fn render_diagnostics(surface: BridgeSurface, diagnostics: serde_json::Value) -> serde_json::Value {
     match surface {
-        BridgeSurface::McpTool | BridgeSurface::McpToolDetail | BridgeSurface::SurfaceClient => {
-            serde_json::json!({ "warnings": [] })
-        }
+        BridgeSurface::McpTool
+        | BridgeSurface::McpToolDetail
+        | BridgeSurface::SurfaceClient
+        | BridgeSurface::LocalLoopback => serde_json::json!({ "warnings": [] }),
         BridgeSurface::TauriApp | BridgeSurface::Worker | BridgeSurface::Eval => diagnostics,
     }
 }

--- a/src-tauri/src/operations/mod.rs
+++ b/src-tauri/src/operations/mod.rs
@@ -267,7 +267,8 @@ fn is_remote_bound_surface(surface: BridgeSurface) -> bool {
         BridgeSurface::TauriApp
         | BridgeSurface::Worker
         | BridgeSurface::Eval
-        | BridgeSurface::SurfaceClient => false,
+        | BridgeSurface::SurfaceClient
+        | BridgeSurface::LocalLoopback => false,
     }
 }
 
@@ -628,7 +629,9 @@ mod tests {
                         BridgeSurface::McpToolDetail => ClaimDismissalSurface::McpToolDetail,
                         BridgeSurface::Worker => ClaimDismissalSurface::Worker,
                         BridgeSurface::Eval => ClaimDismissalSurface::Eval,
-                        BridgeSurface::SurfaceClient => ClaimDismissalSurface::LogStructured,
+                        BridgeSurface::SurfaceClient | BridgeSurface::LocalLoopback => {
+                            ClaimDismissalSurface::LogStructured
+                        }
                     },
                 ),
             )

--- a/src-tauri/src/services/composition_render_orchestrator.rs
+++ b/src-tauri/src/services/composition_render_orchestrator.rs
@@ -86,14 +86,21 @@ impl CompositionRenderOrchestrator {
         composition_id: &str,
         composition_version: i64,
     ) -> Option<CacheKey> {
-        let scopes = match actor {
-            Actor::SurfaceClient { scopes, .. } => scopes,
+        // DOS-761 codex P2: first-party loopback runs as Actor::User and
+        // needs the cache to function the same as Actor::SurfaceClient.
+        // Without an Actor::User branch the new /v1/local/project-composition
+        // route would re-run the producer on every render. Use a fixed
+        // "local_first_party" canonical id since first-party invocations
+        // share the full scope set.
+        let scopes_canonical = match actor {
+            Actor::SurfaceClient { scopes, .. } => scopes_canonical_id(scopes),
+            Actor::User => "local_first_party".to_string(),
             _ => return None,
         };
         Some(CacheKey {
             composition_id: composition_id.to_string(),
             composition_version,
-            scopes_canonical_id: scopes_canonical_id(scopes),
+            scopes_canonical_id: scopes_canonical,
         })
     }
 

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -1010,7 +1010,13 @@ async fn handle_hyper_request(
     let request_id = request_id_from_headers(request.headers());
     let method = request.method().clone();
     let uri = request.uri().clone();
-    if method == Method::POST && uri.path() == "/v1/local/invoke" && !peer_addr.ip().is_loopback() {
+    if method == Method::POST
+        && matches!(
+            uri.path(),
+            "/v1/local/invoke" | "/v1/local/project-composition"
+        )
+        && !peer_addr.ip().is_loopback()
+    {
         return Ok(error_response(
             SurfaceHttpError::route_not_found().with_request_id(request_id),
         ));

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -30,6 +30,7 @@ use tokio::task::{AbortHandle, JoinHandle, JoinSet};
 use uuid::Uuid;
 
 use crate::abilities::NOOP_ABILITY_TRACER;
+use crate::audit_log::{emit_surface_audit, AuditFields};
 use crate::bridges::correction_payload::{
     project_claim_for_scope, project_composition_for_scope, CorrectionPayload,
 };
@@ -39,6 +40,7 @@ use crate::bridges::surface_client::{
     SurfaceClientBridgeError, SurfaceClientRateLimitAxis, SurfaceClientRateLimitBudget,
     SurfaceClientRequestClassLimits,
 };
+use crate::bridges::tauri::{TauriAbilityBridge, TauriInvokeContext};
 use crate::bridges::types::{
     invoke_registry_json_for_actor, provider_from_context_snapshot, surface_error,
     AbilityResponseJson, BridgeActor, BridgeSurface, RequestScopedInvocation,
@@ -68,6 +70,7 @@ const DEFAULT_PAIRING_CODE_FAILED_ATTEMPTS: u32 = 5;
 const MAX_HANDSHAKE_BODY_BYTES: usize = 4 * 1024;
 const MAX_SESSION_REFRESH_BODY_BYTES: usize = 1024;
 const DEFAULT_SIGNED_REQUEST_MAX_BODY_BYTES: usize = 256 * 1024;
+const LOCAL_LOOPBACK_ORIGIN_WP_PLUGIN: &str = "wp_plugin";
 
 type ResponseBody = Full<Bytes>;
 
@@ -968,13 +971,13 @@ async fn run_listener(
             }
             accepted = listener.accept() => {
                 match accepted {
-                    Ok((stream, _peer_addr)) => {
+                    Ok((stream, peer_addr)) => {
                         let runtime = Arc::clone(&runtime);
                         connection_tasks.spawn(async move {
                             let io = TokioIo::new(stream);
                             let service = service_fn(move |request: Request<Incoming>| {
                                 let runtime = Arc::clone(&runtime);
-                                async move { handle_hyper_request(request, runtime).await }
+                                async move { handle_hyper_request(request, runtime, peer_addr).await }
                             });
                             if let Err(error) = http1::Builder::new().serve_connection(io, service).await {
                                 log::debug!("surface endpoint connection ended with error: {error}");
@@ -1002,8 +1005,17 @@ async fn run_listener(
 async fn handle_hyper_request(
     request: Request<Incoming>,
     runtime: Arc<EndpointRuntime>,
+    peer_addr: SocketAddr,
 ) -> Result<Response<ResponseBody>, Infallible> {
     let request_id = request_id_from_headers(request.headers());
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    if method == Method::POST && uri.path() == "/v1/local/invoke" && !peer_addr.ip().is_loopback() {
+        return Ok(error_response(
+            SurfaceHttpError::route_not_found().with_request_id(request_id),
+        ));
+    }
+
     let transport_check = {
         let origins = runtime.paired_site_origins.read();
         validate_transport_headers(request.headers(), runtime.bound_port, &origins)
@@ -1019,14 +1031,14 @@ async fn handle_hyper_request(
         ));
     }
 
-    let method = request.method().clone();
-    let uri = request.uri().clone();
     let headers = request.headers().clone();
     let body_limit = if method == Method::POST && uri.path() == "/v1/pairing/handshake" {
         Some(MAX_HANDSHAKE_BODY_BYTES)
     } else if method == Method::POST && uri.path() == "/v1/surface/session/refresh" {
         Some(MAX_SESSION_REFRESH_BODY_BYTES)
-    } else if is_signed_route_candidate(uri.path()) {
+    } else if is_local_loopback_body_route(&method, uri.path())
+        || is_signed_route_candidate(uri.path())
+    {
         Some(runtime.signed_request_max_body_bytes)
     } else {
         None
@@ -1048,6 +1060,7 @@ async fn handle_hyper_request(
             uri,
             headers,
             body,
+            peer_addr,
         },
         runtime,
         request_id,
@@ -1076,6 +1089,7 @@ struct SurfaceHttpRequest {
     uri: Uri,
     headers: HeaderMap,
     body: Bytes,
+    peer_addr: SocketAddr,
 }
 
 async fn dispatch_surface_request(
@@ -1091,6 +1105,12 @@ async fn dispatch_surface_request(
         }
         (&Method::POST, "/v1/surface/session/refresh") => {
             surface_session_refresh_response(request.body, runtime, request_id).await
+        }
+        (&Method::POST, "/v1/local/invoke") => {
+            local_loopback_invoke_response(&request, runtime, request_id).await
+        }
+        (&Method::POST, "/v1/local/project-composition") => {
+            local_loopback_project_composition_response(&request, runtime, request_id).await
         }
         _ if is_signed_route_candidate(path.as_str()) => {
             let route_supported = is_supported_signed_route(&request.method, path.as_str());
@@ -1234,6 +1254,10 @@ async fn signed_transport_response(
     }
 
     signed_route_response(&request, &runtime, validated, request_id).await
+}
+
+fn is_local_loopback_body_route(method: &Method, path: &str) -> bool {
+    *method == Method::POST && matches!(path, "/v1/local/invoke" | "/v1/local/project-composition")
 }
 
 fn is_supported_signed_route(method: &Method, path: &str) -> bool {
@@ -2204,6 +2228,301 @@ async fn signed_route_response(
         }
         _ => error_response(SurfaceHttpError::runtime_unavailable().with_request_id(request_id)),
     }
+}
+
+async fn local_loopback_invoke_response(
+    request: &SurfaceHttpRequest,
+    runtime: Arc<EndpointRuntime>,
+    request_id: String,
+) -> Response<ResponseBody> {
+    if !request.peer_addr.ip().is_loopback() {
+        return error_response(SurfaceHttpError::route_not_found().with_request_id(request_id));
+    }
+
+    let invoke = match serde_json::from_slice::<SurfaceInvokeRequest>(&request.body) {
+        Ok(invoke) if is_safe_ability_name(&invoke.ability) => invoke,
+        Ok(_) | Err(_) => {
+            return error_response(
+                SurfaceHttpError::bad_request("local_invoke_invalid").with_request_id(request_id),
+            );
+        }
+    };
+
+    let Some(app_state) = runtime.app_state.as_ref().cloned() else {
+        return error_response(SurfaceHttpError::runtime_unavailable().with_request_id(request_id));
+    };
+
+    #[cfg(test)]
+    let registry_override = runtime.ability_registry_override.clone();
+    #[cfg(test)]
+    let registry = if let Some(registry) = registry_override.as_deref() {
+        registry
+    } else {
+        match crate::abilities::AbilityRegistry::global_checked() {
+            Ok(registry) => registry,
+            Err(_) => {
+                return error_response(
+                    SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+                );
+            }
+        }
+    };
+    #[cfg(not(test))]
+    let registry = match crate::abilities::AbilityRegistry::global_checked() {
+        Ok(registry) => registry,
+        Err(_) => {
+            return error_response(
+                SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+            );
+        }
+    };
+
+    let audit_input = invoke.input.clone();
+    match TauriAbilityBridge::new(registry)
+        .invoke(
+            app_state.as_ref(),
+            &invoke.ability,
+            invoke.input,
+            TauriInvokeContext::new(
+                Actor::User,
+                BridgeSurface::LocalLoopback,
+                ClaimDismissalSurface::LogStructured,
+                false,
+                None,
+            ),
+        )
+        .await
+    {
+        Ok(ability) => {
+            emit_successful_local_loopback_invocation_audit(
+                app_state.as_ref(),
+                &request_id,
+                &audit_input,
+                &ability,
+            );
+            json_response(
+                StatusCode::OK,
+                json!({
+                    "ok": true,
+                    "request_id": request_id,
+                    "ability": ability,
+                }),
+            )
+        }
+        Err(error) => {
+            emit_local_loopback_invocation_failure_audit(
+                app_state.as_ref(),
+                &request_id,
+                &invoke.ability,
+                &error,
+            );
+            error_response(local_bridge_surface_error(error).with_request_id(request_id))
+        }
+    }
+}
+
+async fn local_loopback_project_composition_response(
+    request: &SurfaceHttpRequest,
+    runtime: Arc<EndpointRuntime>,
+    request_id: String,
+) -> Response<ResponseBody> {
+    use crate::services::composition_render_orchestrator::{
+        extract_account_id_from_composition_id, project_from_ability_data,
+        resolve_producer_ability_name, FALLBACK_POLICY_VERSION,
+    };
+
+    if !request.peer_addr.ip().is_loopback() {
+        return error_response(SurfaceHttpError::route_not_found().with_request_id(request_id));
+    }
+
+    let request_payload: SurfaceProjectCompositionRequest =
+        match serde_json::from_slice(&request.body) {
+            Ok(r) => r,
+            Err(_) => {
+                return error_response(
+                    SurfaceHttpError::bad_request("project_composition_invalid")
+                        .with_request_id(request_id),
+                );
+            }
+        };
+
+    let Some(app_state) = runtime.app_state.as_ref().cloned() else {
+        log::warn!("local_project_composition: app_state is None");
+        return error_response(SurfaceHttpError::runtime_unavailable().with_request_id(request_id));
+    };
+
+    let Some(ability_name) = resolve_producer_ability_name(&request_payload.composition_id) else {
+        return error_response(
+            SurfaceHttpError::bad_request("project_composition_unknown_producer")
+                .with_request_id(request_id),
+        );
+    };
+    let Some(account_id) = extract_account_id_from_composition_id(&request_payload.composition_id)
+    else {
+        return error_response(
+            SurfaceHttpError::bad_request("project_composition_invalid_id")
+                .with_request_id(request_id),
+        );
+    };
+    let account_id = account_id.to_string();
+
+    #[cfg(test)]
+    let registry_override = runtime.ability_registry_override.clone();
+    #[cfg(test)]
+    let registry = if let Some(registry) = registry_override.as_deref() {
+        registry
+    } else {
+        match crate::abilities::AbilityRegistry::global_checked() {
+            Ok(registry) => registry,
+            Err(_) => {
+                return error_response(
+                    SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+                );
+            }
+        }
+    };
+    #[cfg(not(test))]
+    let registry = match crate::abilities::AbilityRegistry::global_checked() {
+        Ok(registry) => registry,
+        Err(_) => {
+            return error_response(
+                SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+            );
+        }
+    };
+
+    let actor = Actor::User;
+    let orchestrator = app_state.composition_render_orchestrator.clone();
+    let composition_id_for_lookup = request_payload.composition_id.clone();
+    let current_db_version_for_producer = app_state
+        .db_read(move |db| {
+            let clock = crate::services::context::SystemClock;
+            let rng = crate::services::context::SystemRng;
+            let external = crate::services::context::ExternalClients::default();
+            let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external);
+            crate::services::compositions::current_composition_version_for_composition_id(
+                &ctx,
+                db,
+                &composition_id_for_lookup,
+            )
+            .map_err(|e| e.to_string())
+        })
+        .await
+        .ok()
+        .unwrap_or(0);
+    let current_db_version = i64::try_from(current_db_version_for_producer).unwrap_or(i64::MAX);
+
+    if let Some(cached) =
+        orchestrator.cache_lookup(&actor, &request_payload.composition_id, current_db_version)
+    {
+        let projection_json = match serde_json::to_value(&cached.projection) {
+            Ok(value) => value,
+            Err(_) => {
+                return error_response(
+                    SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+                );
+            }
+        };
+        return json_response(
+            StatusCode::OK,
+            json!({
+                "ok": true,
+                "request_id": request_id,
+                "projection": projection_json,
+                "cache_hint_token": cached.cache_hint_token,
+                "served_from_cache": true,
+            }),
+        );
+    }
+
+    let expected_version_for_producer: u64 = current_db_version_for_producer;
+    let input = json!({
+        "account_id": account_id,
+        "composition_id": request_payload.composition_id.clone(),
+        "schema_version": 1,
+        "expected_composition_version": expected_version_for_producer,
+    });
+
+    let response_json = match TauriAbilityBridge::new(registry)
+        .invoke(
+            app_state.as_ref(),
+            ability_name,
+            input.clone(),
+            TauriInvokeContext::new(
+                Actor::User,
+                BridgeSurface::LocalLoopback,
+                ClaimDismissalSurface::LogStructured,
+                false,
+                None,
+            ),
+        )
+        .await
+    {
+        Ok(response_json) => {
+            emit_successful_local_loopback_invocation_audit(
+                app_state.as_ref(),
+                &request_id,
+                &input,
+                &response_json,
+            );
+            response_json
+        }
+        Err(error) => {
+            emit_local_loopback_invocation_failure_audit(
+                app_state.as_ref(),
+                &request_id,
+                ability_name,
+                &error,
+            );
+            return error_response(local_bridge_surface_error(error).with_request_id(request_id));
+        }
+    };
+
+    let (projection, _audits) = match project_from_ability_data(
+        &response_json.data,
+        Actor::User,
+        FALLBACK_POLICY_VERSION,
+    ) {
+        Ok(tuple) => tuple,
+        Err(err) => {
+            log::warn!("local_project_composition: project_from_ability_data failed: {err:?}");
+            return error_response(
+                SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+            );
+        }
+    };
+
+    let projection_cache_version = projection
+        .composition_version
+        .unwrap_or(current_db_version_for_producer);
+    let projection_cache_version = i64::try_from(projection_cache_version).unwrap_or(i64::MAX);
+    let cache_hint_token = orchestrator
+        .cache_store(
+            &actor,
+            &request_payload.composition_id,
+            projection_cache_version,
+            projection.clone(),
+        )
+        .unwrap_or_default();
+    let projection_json = match serde_json::to_value(&projection) {
+        Ok(value) => value,
+        Err(_) => {
+            return error_response(
+                SurfaceHttpError::runtime_unavailable().with_request_id(request_id),
+            );
+        }
+    };
+
+    json_response(
+        StatusCode::OK,
+        json!({
+            "ok": true,
+            "request_id": request_id,
+            "projection": projection_json,
+            "cache_hint_token": cache_hint_token,
+            "served_from_cache": false,
+        }),
+    )
 }
 
 async fn surface_subscribe_response(
@@ -3346,6 +3665,25 @@ fn surface_bridge_error(error: SurfaceClientBridgeError) -> SurfaceHttpError {
     }
 }
 
+fn local_bridge_surface_error(error: BridgeSurfaceError) -> SurfaceHttpError {
+    match error {
+        BridgeSurfaceError::AbilityUnavailable => SurfaceHttpError::new(
+            StatusCode::BAD_REQUEST,
+            "ability_not_registered",
+            "The requested DailyOS ability is not available.",
+            "Use a registered DailyOS ability.",
+        ),
+        BridgeSurfaceError::Ownership(_) => SurfaceHttpError::new(
+            StatusCode::FORBIDDEN,
+            "ownership_denied",
+            "The requested DailyOS ability is not available for this actor.",
+            "Use an ability exposed to the local loopback surface.",
+        ),
+        BridgeSurfaceError::Validation(_) => SurfaceHttpError::bad_request("input_schema_invalid"),
+        other => bridge_surface_error(other),
+    }
+}
+
 fn bridge_surface_error(error: BridgeSurfaceError) -> SurfaceHttpError {
     match error {
         BridgeSurfaceError::ProjectionTampered { .. } => SurfaceHttpError::new(
@@ -3529,6 +3867,98 @@ fn signed_transport_failure_event(
             "decision": "rejected"
         }),
     })
+}
+
+fn emit_successful_local_loopback_invocation_audit(
+    app_state: &AppState,
+    request_id: &str,
+    input: &Value,
+    ability: &AbilityResponseJson,
+) {
+    let mut detail = json!({
+        "ability_name": &ability.ability_name,
+        "ability_version": &ability.ability_version,
+        "schema_version": ability.schema_version,
+        "claim_ref_count": composition_claim_ref_count(&ability.data),
+    });
+    if let Some(account_id) = input
+        .get("account_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        detail["account_id"] = json!(account_id);
+    }
+    if let Some(composition_id) = ability.data.get("id").and_then(Value::as_str) {
+        detail["composition_id"] = json!(composition_id);
+    }
+    if let Some(composition_version) = ability
+        .data
+        .pointer("/metadata/composition_version")
+        .and_then(Value::as_u64)
+    {
+        detail["composition_version"] = json!(composition_version);
+    }
+
+    emit_local_loopback_audit(
+        app_state,
+        "data_access",
+        "ability_invoked",
+        request_id,
+        detail,
+    );
+}
+
+fn emit_local_loopback_invocation_failure_audit(
+    app_state: &AppState,
+    request_id: &str,
+    ability_name: &str,
+    error: &BridgeSurfaceError,
+) {
+    emit_local_loopback_audit(
+        app_state,
+        "security",
+        "ability_invoke_rejected",
+        request_id,
+        json!({
+            "ability_name": ability_name,
+            "reason": bridge_surface_error_code(error),
+            "decision": "rejected",
+        }),
+    );
+}
+
+fn emit_local_loopback_audit(
+    app_state: &AppState,
+    category: &'static str,
+    event_kind: &'static str,
+    request_id: &str,
+    detail: Value,
+) {
+    let mut audit = app_state.audit_log.lock();
+    let fields = AuditFields::new(category, detail)
+        .with_request_id(request_id.to_string())
+        .with_loopback_origin(LOCAL_LOOPBACK_ORIGIN_WP_PLUGIN);
+    if let Err(error) = emit_surface_audit(&mut audit, event_kind, &Actor::User, fields) {
+        log::warn!("local loopback audit write failed: {error}");
+    }
+}
+
+fn bridge_surface_error_code(error: &BridgeSurfaceError) -> &'static str {
+    match error {
+        BridgeSurfaceError::ProjectionTampered { .. } => "projection_tampered",
+        BridgeSurfaceError::ProjectionVersionRollback { .. } => "projection_version_rollback",
+        BridgeSurfaceError::MissingExpectedClaimVersion { .. } => "expected_version_missing",
+        BridgeSurfaceError::MidFlightMutation { .. } => "mid_flight_mutation",
+        BridgeSurfaceError::ClaimVersionOverflow { .. } => "claim_version_overflow",
+        BridgeSurfaceError::StaleVersion { .. } => "stale_watermark",
+        BridgeSurfaceError::StaleComposition { .. } => "stale_composition",
+        BridgeSurfaceError::CompositionVersionOverflow { .. } => "composition_version_overflow",
+        BridgeSurfaceError::Validation(_) => "validation_error",
+        BridgeSurfaceError::AbilityUnavailable | BridgeSurfaceError::Ownership(_) => {
+            "ability_unavailable"
+        }
+    }
 }
 
 fn successful_surface_invocation_audit_event(
@@ -4517,6 +4947,42 @@ mod tests {
         )
     }
 
+    fn local_loopback_descriptor() -> AbilityDescriptor {
+        AbilityDescriptor {
+            name: "surface_route_test",
+            version: "1.0.0",
+            schema_version: 1,
+            category: AbilityCategory::Read,
+            policy: AbilityPolicy {
+                allowed_actors: &[ActorKind::User],
+                allowed_modes: &[crate::services::context::ExecutionMode::Live],
+                requires_confirmation: false,
+                may_publish: false,
+                required_scopes: &[],
+                mcp_exposure: McpExposure::None,
+                client_side_executable: true,
+                rate_limit: None,
+            },
+            composes: &[],
+            mutates: &[],
+            experimental: false,
+            registered_at: None,
+            signal_policy: SignalPolicy::default(),
+            invoke_erased: surface_route_dispatch_erased,
+            input_schema: surface_route_schema,
+            output_schema: surface_route_schema,
+        }
+    }
+
+    fn local_loopback_registry() -> Arc<crate::abilities::AbilityRegistry> {
+        SURFACE_ROUTE_DISPATCH_COUNT.store(0, Ordering::SeqCst);
+        Arc::new(
+            crate::abilities::AbilityRegistry::from_descriptors_unchecked_for_runtime_validation_tests(
+                vec![local_loopback_descriptor()],
+            ),
+        )
+    }
+
     fn surface_route_limit_registry() -> Arc<crate::abilities::AbilityRegistry> {
         SURFACE_ROUTE_LIMIT_COUNT.store(0, Ordering::SeqCst);
         Arc::new(
@@ -4536,7 +5002,7 @@ mod tests {
             schema_version: 1,
             category: AbilityCategory::Read,
             policy: AbilityPolicy {
-                allowed_actors: &[ActorKind::SurfaceClient],
+                allowed_actors: &[ActorKind::User, ActorKind::SurfaceClient],
                 allowed_modes: &[crate::services::context::ExecutionMode::Live],
                 requires_confirmation: false,
                 may_publish: false,
@@ -4747,6 +5213,7 @@ mod tests {
             uri: path.parse::<Uri>().unwrap(),
             headers,
             body,
+            peer_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
         }
     }
 
@@ -5748,6 +6215,80 @@ mod tests {
         assert_eq!(invoked.wp_user_hash.as_deref(), Some("wp_user_hash_test"));
         assert_eq!(invoked.detail["ability_name"], json!("surface_route_test"));
         assert_eq!(invoked.detail["claim_ref_count"], json!(0));
+    }
+
+    #[test]
+    fn local_loopback_invoke_dispatches_as_user_without_signed_headers() {
+        let _counter_guard = SURFACE_ROUTE_COUNTER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let runtime = runtime_for_surface_route_tests(
+            local_loopback_registry(),
+            SurfaceClientBridgeConfig::default(),
+        );
+        let request = request_for_tests(
+            Method::POST,
+            "/v1/local/invoke",
+            Bytes::from_static(
+                br#"{"ability":"surface_route_test","input":{"value":761},"loopback_origin":"spoofed"}"#,
+            ),
+        );
+
+        let response = dispatch_for_tests(request, Arc::clone(&runtime), "req_local_invoke".into());
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(SURFACE_ROUTE_DISPATCH_COUNT.load(Ordering::SeqCst), 1);
+        let body = body_json(response);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["request_id"], "req_local_invoke");
+        assert_eq!(body["ability"]["data"]["input"]["value"], 761);
+        assert_eq!(body["ability"]["data"]["actor"], "User");
+        assert_eq!(
+            body["ability"]["rendered_provenance"]["surface"],
+            "local_loopback"
+        );
+        assert!(body["ability"].get("diagnostics").is_none());
+
+        let audit_path = runtime
+            .app_state
+            .as_ref()
+            .expect("test app state")
+            .audit_log
+            .lock()
+            .path()
+            .to_path_buf();
+        let audit_records = crate::audit_log::read_records(&audit_path, 10, Some("data_access"));
+        let invoked = audit_records
+            .iter()
+            .find(|record| record.event == "ability_invoked")
+            .expect("successful local invoke audit is written");
+        assert_eq!(invoked.actor_kind.as_deref(), Some("user"));
+        assert_eq!(invoked.loopback_origin.as_deref(), Some("wp_plugin"));
+        assert!(invoked.actor_instance.is_none());
+        assert!(invoked.wp_user_id.is_none());
+        assert!(invoked.wp_user_hash.is_none());
+        assert_eq!(invoked.detail["ability_name"], json!("surface_route_test"));
+    }
+
+    #[test]
+    fn local_loopback_invoke_rejects_non_loopback_peer_with_404() {
+        let runtime = runtime_for_surface_route_tests(
+            local_loopback_registry(),
+            SurfaceClientBridgeConfig::default(),
+        );
+        let mut request = request_for_tests(
+            Method::POST,
+            "/v1/local/invoke",
+            Bytes::from_static(br#"{"ability":"surface_route_test","input":{"value":1}}"#),
+        );
+        request.peer_addr = SocketAddr::from(([192, 0, 2, 10], 8080));
+
+        let response = dispatch_for_tests(request, runtime, "req_non_loopback".into());
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = body_json(response);
+        assert_eq!(body["error"]["code"], "route_not_found");
+        assert_eq!(body["error"]["request_id"], "req_non_loopback");
     }
 
     #[test]

--- a/wp/dailyos/blocks/project-detail/render-functions.php
+++ b/wp/dailyos/blocks/project-detail/render-functions.php
@@ -169,6 +169,11 @@ if ( ! function_exists( 'dailyos_project_detail_render' ) ) {
 	 * @return string Block markup for the default template.
 	 */
 	function dailyos_project_detail_default_template_markup(): string {
+		// DOS-761 codex P1: surface-prefixed inner block names per PR #351
+		// commit `52a2c49f` so the fallback template uses the project-detail
+		// renderers, not the top-level person-detail registrations (which is
+		// what `register_block_type` first-wins resolves the unprefixed
+		// names to). Keep in sync with `block.json` template entries.
 		$blocks = [
 			'dailyos/project-hero',
 			'dailyos/vitals-strip',
@@ -179,11 +184,11 @@ if ( ! function_exists( 'dailyos_project_detail_render' ) ) {
 			'dailyos/watch-list-milestones',
 			'dailyos/stakeholder-gallery',
 			'dailyos/the-work',
-			'dailyos/touchpoints-feed',
-			'dailyos/open-loops-feed',
+			'dailyos/project-detail-touchpoints-feed',
+			'dailyos/project-detail-open-loops-feed',
 			'dailyos/linear-issues-chapter',
-			'dailyos/unified-timeline',
-			'dailyos/recommended-actions',
+			'dailyos/project-detail-unified-timeline',
+			'dailyos/project-detail-recommended-actions',
 			'dailyos/project-appendix',
 		];
 		$out = '';

--- a/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
+++ b/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
@@ -83,6 +83,7 @@ final class DailyOS_Runtime_Client {
 	 * @return array<string, mixed>|\WP_Error Runtime response envelope or typed pairing error.
 	 */
 	public function invoke_ability( string $name, array $payload, array $scope_set ): array|\WP_Error {
+		unset( $scope_set );
 		// Wire key is `input` per src-tauri/src/surface_runtime/mod.rs::SurfaceInvokeRequest.
 		// Sending `payload` (the legacy key) gets dropped during deserialization,
 		// invoke.input defaults to Value::Null, the producer fails to deserialize
@@ -92,7 +93,6 @@ final class DailyOS_Runtime_Client {
 			[
 				'ability' => $name,
 				'input'   => $payload,
-				'scopes'  => $scope_set,
 			]
 		);
 
@@ -100,14 +100,14 @@ final class DailyOS_Runtime_Client {
 			return $this->error_response( 'json_encode_failed', 'DailyOS ability request could not be encoded.' );
 		}
 
-		return $this->signed_post( '/v1/surface/invoke', $body_bytes );
+		return $this->local_post( '/v1/local/invoke', $body_bytes );
 	}
 
 
 	/**
 	 * Request a scope-filtered projected composition for a WordPress render.
 	 *
-	 * Calls POST /v1/surface/project-composition. The substrate side
+	 * Calls POST /v1/local/project-composition. The substrate side
 	 * orchestrates: cache lookup → producer ability invocation → W4-D
 	 * projection → cache store → response. The block surface receives only
 	 * the scope-filtered ProjectedComposition DTO plus an opaque
@@ -139,7 +139,7 @@ final class DailyOS_Runtime_Client {
 			);
 		}
 
-		return $this->signed_post( '/v1/surface/project-composition', $body_bytes );
+		return $this->local_post( '/v1/local/project-composition', $body_bytes );
 	}
 
 	/**
@@ -155,6 +155,7 @@ final class DailyOS_Runtime_Client {
 			return $this->error_response( 'json_encode_failed', 'DailyOS nonce request could not be encoded.' );
 		}
 
+		// dormant: only signed-path callers remain for the legacy presence-nonce contract.
 		return $this->signed_post( '/v1/surface/nonce/issue', $body_bytes );
 	}
 
@@ -171,6 +172,7 @@ final class DailyOS_Runtime_Client {
 			return $this->error_response( 'json_encode_failed', 'DailyOS nonce verify request could not be encoded.' );
 		}
 
+		// dormant: only signed-path callers remain for the legacy presence-nonce contract.
 		return $this->signed_post( '/v1/surface/nonce/verify', $body_bytes );
 	}
 
@@ -200,6 +202,7 @@ final class DailyOS_Runtime_Client {
 			);
 		}
 
+		// dormant: only signed-path callers remain for pairing-maintenance refreshes.
 		return $this->signed_post( '/v1/surface/pairing/refresh-scopes', $body_bytes );
 	}
 
@@ -218,7 +221,7 @@ final class DailyOS_Runtime_Client {
 			return $this->not_paired_error();
 		}
 
-		$runtime_base_url = $this->runtime_base_url_for_signed_request( $marker );
+		$runtime_base_url = $this->discover_runtime_base_url( $marker );
 
 		if ( null === $runtime_base_url ) {
 			return $this->not_paired_error();
@@ -300,7 +303,61 @@ final class DailyOS_Runtime_Client {
 		// differs" guard missed same-port transient refusals.
 		if ( self::is_connection_refused( $response ) ) {
 			\DailyOS\DailyOS_Plugin::invalidate_runtime_endpoint_cache();
-			$retry_base_url = $this->runtime_base_url_for_signed_request( $marker );
+			$retry_base_url = $this->discover_runtime_base_url( $marker );
+			if ( null !== $retry_base_url ) {
+				$response = wp_remote_post( $this->runtime_url( $retry_base_url, $path ), $post_args );
+			}
+		}
+
+		$parsed = $this->parse_response( $response );
+
+		if ( true === ( $parsed['ok'] ?? false ) ) {
+			$this->credential_store->update_last_use();
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Send a first-party local loopback JSON POST request.
+	 *
+	 * @param string $path Runtime local path.
+	 * @param string $body_bytes Exact body bytes to send.
+	 * @return array<string, mixed>|\WP_Error Runtime response envelope or typed pairing error.
+	 */
+	private function local_post( string $path, string $body_bytes ): array|\WP_Error {
+		$marker = $this->credential_store->get_marker();
+
+		if ( null === $marker ) {
+			return $this->not_paired_error();
+		}
+
+		$runtime_base_url = $this->discover_runtime_base_url( $marker );
+
+		if ( null === $runtime_base_url ) {
+			return $this->not_paired_error();
+		}
+
+		$request_id = wp_generate_uuid4();
+		$url        = $this->runtime_url( $runtime_base_url, $path );
+		$post_args  = [
+			'body'        => $body_bytes,
+			'headers'     => [
+				'Content-Type'          => self::CONTENT_TYPE,
+				'X-DailyOS-Request-Id' => $request_id,
+			],
+			'redirection' => 0,
+			'timeout'     => 30,
+			'sslverify'   => false,
+			'blocking'    => true,
+			'data_format' => 'body',
+		];
+
+		$response = wp_remote_post( $url, $post_args );
+
+		if ( self::is_connection_refused( $response ) ) {
+			\DailyOS\DailyOS_Plugin::invalidate_runtime_endpoint_cache();
+			$retry_base_url = $this->discover_runtime_base_url( $marker );
 			if ( null !== $retry_base_url ) {
 				$response = wp_remote_post( $this->runtime_url( $retry_base_url, $path ), $post_args );
 			}
@@ -490,7 +547,7 @@ final class DailyOS_Runtime_Client {
 	private function not_paired_error(): \WP_Error {
 		return new \WP_Error(
 			'dailyos_not_paired',
-			__( 'DailyOS is not paired with an active loopback runtime. Pair this site before making signed requests.', 'dailyos' )
+			__( 'DailyOS is not paired with an active loopback runtime. Pair this site before making runtime requests.', 'dailyos' )
 		);
 	}
 
@@ -523,17 +580,16 @@ final class DailyOS_Runtime_Client {
 	}
 
 	/**
-	 * Return the signed-request runtime base URL from marker and gated filter.
+	 * Discover the loopback runtime base URL from sentinel, marker, and gated filter.
 	 *
 	 * @param array<string, mixed> $marker Pairing marker.
 	 * @return string|null Base URL, or null when not paired.
 	 */
-	private function runtime_base_url_for_signed_request( array $marker ): ?string {
+	private function discover_runtime_base_url( array $marker ): ?string {
 		// Prefer the sentinel-discovered URL (current runtime port across
 		// restarts) over the stored marker (may be stale after the runtime
-		// restarts on a new port). The sentinel is HMAC-defended: a
-		// substituted sentinel cannot produce valid signed responses, so
-		// WP detects impersonation at first request.
+		// restarts on a new port). Signed callers still authenticate at the
+		// route; local callers only need this shared discovery result.
 		$sentinel_url = \DailyOS\DailyOS_Plugin::discover_runtime_base_url();
 
 		$marker_url = isset( $marker['runtime_url'] ) ? self::normalize_loopback_runtime_url( (string) $marker['runtime_url'] ) : null;

--- a/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
+++ b/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
@@ -85,10 +85,11 @@ final class DailyOS_Runtime_Client {
 	public function invoke_ability( string $name, array $payload, array $scope_set ): array|\WP_Error {
 		unset( $scope_set );
 		// Wire key is `input` per src-tauri/src/surface_runtime/mod.rs::SurfaceInvokeRequest.
-		// Sending `payload` (the legacy key) gets dropped during deserialization,
-		// invoke.input defaults to Value::Null, the producer fails to deserialize
-		// EntityIntelligenceInput, and the bridge maps the ability error to
-		// AbilityUnavailable → wire code `auth_missing`.
+		// Sending `payload` (the legacy key) gets dropped during deserialization
+		// and invoke.input defaults to Value::Null, so the producer fails to
+		// deserialize EntityIntelligenceInput. With the DOS-762 wire-code split
+		// the bridge now maps that case to AbilityUnavailable → wire code
+		// `ability_not_registered` (HTTP 404) rather than `auth_missing`.
 		$body_bytes = $this->encode_json(
 			[
 				'ability' => $name,

--- a/wp/dailyos/tests/transport/RuntimeClientTest.php
+++ b/wp/dailyos/tests/transport/RuntimeClientTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use DailyOS\DailyOS_Plugin;
 use DailyOS\Transport\DailyOS_Credential_Store;
-use DailyOS\Transport\DailyOS_Hmac_Key;
 use DailyOS\Transport\DailyOS_Hmac_Signer;
 use DailyOS\Transport\DailyOS_Runtime_Client;
 use PHPUnit\Framework\TestCase;
@@ -30,14 +29,10 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 	}
 
 	/**
-	 * Signed requests send string bodies and sign the exact transmitted bytes.
+	 * Local ability invokes send string bodies and only trace headers.
 	 */
-	public function test_signed_post_uses_string_body_headers_and_byte_exact_signature(): void {
-		$hmac_key_bytes = str_repeat( "\x02", 32 );
-
-		$GLOBALS['dailyos_test_current_user_id'] = 42;
+	public function test_local_post_uses_string_body_two_headers_and_request_id(): void {
 		$this->save_marker();
-		$this->add_session_key_filter();
 
 		$GLOBALS['dailyos_test_remote_post_response'] = [
 			'response' => [
@@ -56,34 +51,24 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 		$headers = $args['headers'];
 
 		$this->assertSame( 'string', gettype( $args['body'] ) );
-		$this->assertSame( 'application/json', $headers['Content-Type'] );
-		$this->assertSame( 0, $args['redirection'] );
-
-		$expected_signature = ( new DailyOS_Hmac_Signer() )->sign_request(
-			new DailyOS_Hmac_Key( $hmac_key_bytes ),
-			'POST',
-			'/v1/surface/invoke',
-			'application/json',
-			$args['body'],
-			$this->canonical_identity(),
-			$headers['X-DailyOS-Nonce'],
-			$headers['X-DailyOS-Timestamp'],
-			$headers['X-DailyOS-Request-Id']
+		$this->assertSame(
+			[
+				'ability' => 'briefing.daily',
+				'input'   => [ 'depth' => 'standard' ],
+			],
+			json_decode( $args['body'], true )
 		);
-
-		$this->assertSame( $expected_signature, $headers['X-DailyOS-Signature'] );
-		$this->assertSame( 'http://127.0.0.1:54321/v1/surface/invoke', $call['url'] );
-		$this->assertSame( 'surface-session-id', $headers['X-DailyOS-Session-Id'] );
-		$this->assertSame( 'surface-client-123', $headers['X-DailyOS-SurfaceClient'] );
-		$this->assertSame( str_repeat( 'a', 64 ), $headers['X-DailyOS-Site-Binding-Digest'] );
-		$this->assertSame( 'siteNonceAlpha123', $headers['X-DailyOS-Site-Nonce'] );
-		$this->assertSame( '42', $headers['X-DailyOS-WP-User-Id'] );
+		$this->assertSame( 'application/json', $headers['Content-Type'] );
+		$this->assertArrayHasKey( 'X-DailyOS-Request-Id', $headers );
+		$this->assertSame( [ 'Content-Type', 'X-DailyOS-Request-Id' ], array_keys( $headers ) );
+		$this->assertSame( 0, $args['redirection'] );
+		$this->assertSame( 'http://127.0.0.1:54321/v1/local/invoke', $call['url'] );
 	}
 
 	/**
-	 * Signed requests refuse to guess a default runtime URL when no marker exists.
+	 * Local requests refuse to guess a default runtime URL when no marker exists.
 	 */
-	public function test_signed_post_returns_not_paired_without_marker(): void {
+	public function test_local_post_returns_not_paired_without_marker(): void {
 		$this->add_session_key_filter();
 
 		$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
@@ -113,7 +98,7 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 		$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
 		$client->invoke_ability( 'briefing.daily', [], [] );
 
-		$this->assertSame( 'http://127.0.0.1:54322/v1/surface/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+		$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
 	}
 
 	/**
@@ -137,13 +122,13 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 			DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
 			$client->invoke_ability( 'briefing.daily', [], [] );
-			$this->assertSame( 'http://127.0.0.1:54322/v1/surface/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+			$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
 
 			$this->write_runtime_sentinel( $home, 54323 );
 			DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			$GLOBALS['dailyos_test_remote_post_calls'] = [];
 			$client->invoke_ability( 'briefing.daily', [], [] );
-			$this->assertSame( 'http://127.0.0.1:54323/v1/surface/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+			$this->assertSame( 'http://127.0.0.1:54323/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
 		} finally {
 			DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			if ( false === $original_home ) {
@@ -178,7 +163,7 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 		$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
 		$client->invoke_ability( 'briefing.daily', [], [] );
 
-		$this->assertSame( 'http://127.0.0.1:54321/v1/surface/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+		$this->assertSame( 'http://127.0.0.1:54321/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds `POST /v1/local/invoke` route for first-party WP plugin loopback. The DailyOS WP plugin is code we ship; it belongs in the same trust column as the React Tauri renderer, not as a third-party HTTP API.

Per the L0 packet at [.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/L0-packet.md §3a](.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/L0-packet.md).

**Rust side**: new `BridgeSurface::LocalLoopback` variant; route handler verifies loopback peer, materializes `Actor::User`, calls `TauriAbilityBridge::invoke` directly. Skips HMAC, session validate, scope intersection, wp_user_id contract — same trust as React `tauri::invoke`.

**WP side**: new `local_post()` method at `class-dailyos-runtime-client.php:328`. `invoke_ability()` and `project_composition_for_surface()` cut over to `local_post()` (lines 103 + 142). Pairing handshake stays on unsigned `plain_post()` channel — unchanged.

## Threat model

Per packet §1: same-user processes are inside the personal-tier trust boundary. No shared-secret header, no peer-pid check, no codesign verification. Any process running as the user already has more direct attack vectors (filesystem, keychain prompt, screenshot, keystrokes) — adding ceremony to `/v1/local/invoke` would be security theater.

## Test plan

- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --lib` — 2715 passed; 3 failed (pre-existing `surface_runtime::session_refresh_*` failures from dev tip; documented same-3 in PR #355 description, not introduced by this PR)
- [ ] L4: pair WP plugin to Tauri, hard-refresh WP block render, confirm Tauri log shows zero `auth_missing` from WP path

🤖 Generated with [Claude Code](https://claude.com/claude-code)