### PR TITLE
feat(mcp_v2): DOS-168 amended — substrate at simplified shape

### DIFF
--- a/.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/pr-c-masking-table.md
+++ b/.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/pr-c-masking-table.md
@@ -1,0 +1,14 @@
+# PR C MCP v2 Write-Class Audit Masking Table
+
+`audit::detail_with_attribution` preserves plaintext detail for `Side::Read`.
+For `Side::Write` and `Side::SubmitCorrection`, it calls `sanitize_detail`,
+which removes the top-level keys in `PARAM_PAYLOAD_KEYS` (`params`,
+`parameters`) and `RESPONSE_PAYLOAD_KEYS` before the audit row is appended.
+
+| handler file | declared Side | params field list | fields hit by `PARAM_PAYLOAD_KEYS` mask |
+| --- | --- | --- | --- |
+| `src-tauri/src/services/mcp_v2/handlers/tool_placement.rs` | `Side::Write` | `topic`, `content` | All params, via top-level `params` removal |
+| `src-tauri/src/services/mcp_v2/handlers/tool_note.rs` | `Side::SubmitCorrection` | `text`, `subject` | All params, via top-level `params` removal |
+| `src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs` | `Side::SubmitCorrection` | `description`, `due_at`, `subject` | All params, via top-level `params` removal |
+| `src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs` | `Side::SubmitCorrection` | `action_id`, `status` | All params, via top-level `params` removal |
+

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -995,6 +995,22 @@ const MIGRATIONS: &[Migration] = &[
         version: 254,
         sql: include_str!("migrations/254_document_entity_links.sql"),
     },
+    // DOS-168 amended (v1.4.7 W1-A MCP v2 substrate at simplified shape).
+    // Migration 257 (mcp_transport_nonce_ledger) is intentionally absent —
+    // the nonce ledger defended replay over a wire that doesn't exist for
+    // stdio / loopback MCP. See L0 packet §3e.
+    Migration::Sql {
+        version: 255,
+        sql: include_str!("migrations/255_mcp_client_manifest.sql"),
+    },
+    Migration::Sql {
+        version: 256,
+        sql: include_str!("migrations/256_mcp_conversation_handle.sql"),
+    },
+    Migration::Sql {
+        version: 258,
+        sql: include_str!("migrations/258_mcp_rate_limit_and_audit_outbox.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;

--- a/src-tauri/src/migrations/255_mcp_client_manifest.sql
+++ b/src-tauri/src/migrations/255_mcp_client_manifest.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS mcp_client_manifest (
+    client_id TEXT PRIMARY KEY,
+    paired_at INTEGER NOT NULL,
+    revoked_at INTEGER NULL,
+    transport_key_ref TEXT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mcp_tool_grant (
+    client_id TEXT,
+    tool_name TEXT,
+    scopes_granted_json TEXT NOT NULL,
+    exposure TEXT NOT NULL CHECK (exposure IN ('None','MetadataOnly','Invocable')),
+    rate_limit_max INTEGER NOT NULL,
+    rate_limit_window_secs INTEGER NOT NULL,
+    PRIMARY KEY (client_id, tool_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_grant_client_tool
+    ON mcp_tool_grant (client_id, tool_name);

--- a/src-tauri/src/migrations/255_mcp_client_manifest.sql
+++ b/src-tauri/src/migrations/255_mcp_client_manifest.sql
@@ -1,3 +1,7 @@
+-- DOS-168 amended: transport_key_ref retained as nullable column for schema
+-- stability (DOS-758's McpHandlerContext interface references the column
+-- name); always NULL post-rip because the personal-tier model has no
+-- transport key material to bind. See L0 packet §3e.
 CREATE TABLE IF NOT EXISTS mcp_client_manifest (
     client_id TEXT PRIMARY KEY,
     paired_at INTEGER NOT NULL,

--- a/src-tauri/src/migrations/256_mcp_conversation_handle.sql
+++ b/src-tauri/src/migrations/256_mcp_conversation_handle.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS mcp_conversation_handle (
+    handle TEXT,
+    client_id TEXT,
+    mint_at INTEGER NOT NULL,
+    last_touched_at INTEGER NOT NULL,
+    revoked_at INTEGER NULL,
+    UNIQUE (handle, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_conversation_handle_lookup
+    ON mcp_conversation_handle (client_id, handle);

--- a/src-tauri/src/migrations/258_mcp_rate_limit_and_audit_outbox.sql
+++ b/src-tauri/src/migrations/258_mcp_rate_limit_and_audit_outbox.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS mcp_tool_call_ledger (
+    client_id TEXT,
+    tool_name TEXT,
+    called_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_call_ledger_window
+    ON mcp_tool_call_ledger (client_id, tool_name, called_at);
+
+CREATE TABLE IF NOT EXISTS mcp_audit_outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event TEXT,
+    detail_json TEXT,
+    actor_kind TEXT,
+    request_id TEXT,
+    created_at INTEGER,
+    drained_at INTEGER NULL
+);

--- a/src-tauri/src/release_gate.rs
+++ b/src-tauri/src/release_gate.rs
@@ -1379,10 +1379,7 @@ fn w6_report_status(report: &W6FixtureReport, runner_success: Option<bool>) -> G
                 .unwrap_or(GateStatus::InfraFailure)
         })
         .collect::<Vec<_>>();
-    if fixture_statuses
-        .iter()
-        .any(|status| *status == GateStatus::InfraFailure)
-    {
+    if fixture_statuses.contains(&GateStatus::InfraFailure) {
         return GateStatus::InfraFailure;
     }
     if fixture_statuses

--- a/src-tauri/src/services/mcp_v2/actor_policy.rs
+++ b/src-tauri/src/services/mcp_v2/actor_policy.rs
@@ -1,6 +1,79 @@
-//! Scope/permission matrix for Actor::McpClient.
+//! MCP v2 actor and ability-policy projection.
 //!
-//! Consumed by gateway after auth resolves the per-client scope manifest.
-//! Per ADR-0102 §B — 2026-05-19 amendment — scope authorization for
-//! McpClient invocations is gateway-mediated; the runtime variant carries
-//! no scopes. Implementation pending.
+//! ADR-0102 §B makes MCP asymmetric with `SurfaceClient`: MCP grants are
+//! resolved and enforced at the gateway, while the runtime actor variant
+//! carries only identity and optional conversation continuity. This module is
+//! the small adapter between the MCP manifest records and the abilities
+//! runtime shapes.
+
+use std::time::SystemTime;
+
+use abilities_runtime::abilities::registry::{
+    AbilityPolicy, Actor, ActorKind, McpClientId as RuntimeMcpClientId, McpExposure,
+    OpaqueConversationHandle as RuntimeOpaqueConversationHandle,
+};
+
+use super::contracts::{McpClientId, OpaqueConversationHandle, Scope, ScopedName};
+
+const MCP_CLIENT_ACTORS: &[ActorKind] = &[ActorKind::McpClient];
+
+/// Schema-stability reference retained for the manifest column.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeychainRef(pub String);
+
+/// Gateway-loaded pairing record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientRecord {
+    pub client_id: McpClientId,
+    pub paired_at: SystemTime,
+    pub revoked_at: Option<SystemTime>,
+    pub transport_key_ref: KeychainRef,
+}
+
+/// Per-tool invocation rate limit from the MCP client manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolRateLimit {
+    pub max_calls: u32,
+    pub window_seconds: u32,
+}
+
+/// Per-call manifest grant resolved by indexed `(client_id, tool_name)` lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolGrant {
+    pub tool_name: ScopedName,
+    pub scopes_granted: Vec<Scope>,
+    pub exposure: McpExposure,
+    pub rate_limit: ToolRateLimit,
+}
+
+/// Project a manifest grant into the runtime policy shell used by the
+/// abilities gate for MCP-originated calls.
+///
+/// MCP scope checks are gateway-mediated against [`ToolGrant::scopes_granted`].
+/// The runtime actor carries no scopes, so `required_scopes` stays empty here.
+pub fn project_policy(tool_grant: &ToolGrant) -> AbilityPolicy {
+    AbilityPolicy {
+        allowed_actors: MCP_CLIENT_ACTORS,
+        mcp_exposure: tool_grant.exposure,
+        ..AbilityPolicy::default()
+    }
+}
+
+/// Construct the runtime actor variant for an MCP-originated invocation.
+///
+/// `tool_grant` is intentionally accepted here even though scopes are not put
+/// on the actor. Passing it through this API makes the gateway call site read
+/// as "manifest resolved before runtime actor construction", which is the
+/// ADR-0102 asymmetry this module exists to preserve.
+pub fn project_actor(
+    client_id: &McpClientId,
+    tool_grant: &ToolGrant,
+    conversation_handle: Option<&OpaqueConversationHandle>,
+) -> Actor {
+    let _ = project_policy(tool_grant);
+    Actor::McpClient {
+        client_id: RuntimeMcpClientId::new(client_id.as_str()),
+        conversation_handle: conversation_handle
+            .map(|handle| RuntimeOpaqueConversationHandle::new(handle.as_str())),
+    }
+}

--- a/src-tauri/src/services/mcp_v2/audit.rs
+++ b/src-tauri/src/services/mcp_v2/audit.rs
@@ -1,7 +1,238 @@
 //! MCP v2 audit log writer.
 //!
-//! Records client_id, conversation_handle, tool_name, params_hash,
-//! response_hash, timestamp for every gateway dispatch. Hashes are
-//! keyed HMAC-SHA256 over canonical JSON with a per-install audit key —
-//! raw param/response data never lands in audit storage.
-//! Implementation pending.
+//! This module is intentionally a thin MCP-specific layer over
+//! [`crate::audit_log::AuditLogger::append_with_actor`]. It owns the MCP
+//! success-row privacy contract: read-class tools persist plaintext detail in
+//! the encrypted audit substrate; write-class tools drop top-level payload
+//! fields before append.
+
+use std::sync::Arc;
+
+use chrono::{SecondsFormat, Utc};
+use rusqlite::params;
+use serde_json::{Map, Value};
+
+use abilities_runtime::abilities::registry::Actor;
+
+use crate::audit_log::{AuditError as AuditLogError, AuditFields, AuditLogger};
+
+use super::contracts::Side;
+
+pub const PARAM_PAYLOAD_KEYS: &[&str] = &["params", "parameters"];
+pub const RESPONSE_PAYLOAD_KEYS: &[&str] = &["response", "response_or_error", "result"];
+
+/// MCP-specific audit write failures.
+#[derive(Debug, thiserror::Error)]
+pub enum AuditError {
+    #[error("audit detail serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("audit log append failed: {0}")]
+    Append(String),
+    #[error("audit log append failed and audit outbox insert also failed: append={append_error}; outbox={outbox_error}")]
+    DoubleFailure {
+        append_error: String,
+        outbox_error: String,
+    },
+}
+
+/// Write an MCP success-row audit event.
+///
+/// Read-side abilities keep their top-level `params` and `response` fields in
+/// plaintext. Write and submit-correction abilities remove the keys named in
+/// [`PARAM_PAYLOAD_KEYS`] and [`RESPONSE_PAYLOAD_KEYS`]. Actor attribution is
+/// always inserted or preserved.
+pub fn write(
+    actor: &Actor,
+    event: &str,
+    detail: Value,
+    request_id: Option<String>,
+    side: Side,
+) -> Result<(), AuditError> {
+    let detail_with_attribution = detail_with_attribution(actor, detail, side);
+
+    let mut fields = AuditFields::new("security", detail_with_attribution.clone());
+    if let Some(id) = request_id.clone() {
+        fields = fields.with_request_id(id);
+    }
+
+    let mut logger = AuditLogger::new(crate::audit_log::default_audit_log_path());
+    match logger.append_with_actor(event, actor, fields) {
+        Ok(()) => Ok(()),
+        Err(AuditLogError::Write(append_error)) => {
+            let detail_json = serde_json::to_string(&detail_with_attribution)?;
+            insert_outbox(
+                event,
+                &detail_json,
+                actor_kind(actor),
+                request_id.as_deref(),
+            )
+            .map_err(|outbox_error| AuditError::DoubleFailure {
+                append_error,
+                outbox_error,
+            })
+        }
+        Err(error) => Err(AuditError::Append(error.to_string())),
+    }
+}
+
+fn detail_with_attribution(actor: &Actor, detail: Value, side: Side) -> Value {
+    let mut detail = match side {
+        Side::Read => object_detail(detail),
+        Side::Write | Side::SubmitCorrection => sanitize_detail(detail),
+    };
+    add_actor_attribution(actor, &mut detail);
+    Value::Object(detail)
+}
+
+fn object_detail(detail: Value) -> Map<String, Value> {
+    match detail {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    }
+}
+
+fn sanitize_detail(detail: Value) -> Map<String, Value> {
+    let mut map = object_detail(detail);
+    for key in PARAM_PAYLOAD_KEYS
+        .iter()
+        .chain(RESPONSE_PAYLOAD_KEYS.iter())
+        .copied()
+    {
+        map.remove(key);
+    }
+    map
+}
+
+fn add_actor_attribution(actor: &Actor, detail: &mut Map<String, Value>) {
+    if let Actor::McpClient {
+        client_id,
+        conversation_handle,
+    } = actor
+    {
+        detail
+            .entry("client_id".to_string())
+            .or_insert_with(|| Value::String(client_id.as_str().to_string()));
+        detail
+            .entry("conversation_handle".to_string())
+            .or_insert_with(|| {
+                conversation_handle
+                    .as_ref()
+                    .map(|handle| Value::String(handle.as_str().to_string()))
+                    .unwrap_or(Value::Null)
+            });
+    }
+}
+
+fn actor_kind(actor: &Actor) -> &'static str {
+    match actor {
+        Actor::Agent => "agent",
+        Actor::User => "user",
+        Actor::Admin => "admin",
+        Actor::System => "system",
+        Actor::SurfaceClient { .. } => "surface_client",
+        Actor::McpClient { .. } => "mcp_client",
+    }
+}
+
+fn insert_outbox(
+    event: &str,
+    detail_json: &str,
+    actor_kind: &str,
+    request_id: Option<&str>,
+) -> Result<(), String> {
+    let event = event.to_string();
+    let detail_json = detail_json.to_string();
+    let actor_kind = actor_kind.to_string();
+    let request_id = request_id.map(str::to_string);
+    let created_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+
+    if let Some(service) = crate::db_service::try_global() {
+        let writer = service.writer();
+        return writer
+            .call_sync(move |conn| {
+                insert_outbox_row(
+                    conn,
+                    &event,
+                    &detail_json,
+                    &actor_kind,
+                    request_id.as_deref(),
+                    &created_at,
+                )
+            })
+            .map_err(|error| error.to_string());
+    }
+
+    let db = crate::db::ActionDb::open(Arc::new(crate::db::LocalKeychain::new()))
+        .map_err(|error| error.to_string())?;
+    insert_outbox_row(
+        db.conn_ref(),
+        &event,
+        &detail_json,
+        &actor_kind,
+        request_id.as_deref(),
+        &created_at,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn insert_outbox_row(
+    conn: &rusqlite::Connection,
+    event: &str,
+    detail_json: &str,
+    actor_kind: &str,
+    request_id: Option<&str>,
+    created_at: &str,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO mcp_audit_outbox \
+         (event, detail_json, actor_kind, request_id, created_at, drained_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, NULL)",
+        params![event, detail_json, actor_kind, request_id, created_at],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use abilities_runtime::abilities::registry::{
+        McpClientId as RuntimeMcpClientId,
+        OpaqueConversationHandle as RuntimeOpaqueConversationHandle,
+    };
+    use serde_json::json;
+
+    fn actor() -> Actor {
+        Actor::McpClient {
+            client_id: RuntimeMcpClientId::new("client-a"),
+            conversation_handle: Some(RuntimeOpaqueConversationHandle::new("conv-a")),
+        }
+    }
+
+    #[test]
+    fn read_detail_keeps_plaintext_payloads() {
+        let detail = json!({
+            "tool_name": "dailyos.read.account_status",
+            "params": { "subject": "Acme" },
+            "response": { "status": "active" }
+        });
+        let out = detail_with_attribution(&actor(), detail, Side::Read);
+        assert_eq!(out["params"]["subject"], "Acme");
+        assert_eq!(out["response"]["status"], "active");
+        assert_eq!(out["client_id"], "client-a");
+    }
+
+    #[test]
+    fn write_detail_masks_payload_keys() {
+        let detail = json!({
+            "tool_name": "dailyos.submit.note",
+            "params": { "text": "sensitive note" },
+            "response": { "note_id": "note-1" },
+            "mutation_cursor": { "note_id": "note-1" }
+        });
+        let out = detail_with_attribution(&actor(), detail, Side::SubmitCorrection);
+        assert!(out.get("params").is_none());
+        assert!(out.get("response").is_none());
+        assert_eq!(out["mutation_cursor"]["note_id"], "note-1");
+        assert_eq!(out["conversation_handle"], "conv-a");
+    }
+}

--- a/src-tauri/src/services/mcp_v2/auth.rs
+++ b/src-tauri/src/services/mcp_v2/auth.rs
@@ -1,6 +1,299 @@
-//! MCP client authentication + session.
+//! MCP v2 authentication + session: pairing, manifest load, and
+//! conversation handle lifecycle.
 //!
-//! Per ADR-0102 §C — 2026-05-19 amendment — pairing handshake issues
-//! McpClientId; loads server-side scope manifest per client; revocation
-//! path; per-message HMAC-SHA256 transport verification; opaque
-//! conversation handle minting per §D lifecycle. Implementation pending.
+//! Local MCP v2 treats the OS user as the trust boundary. This module keeps the
+//! authorization machinery: per-client manifests, grant resolution, revocation,
+//! and server-minted conversation handles.
+
+use std::time::SystemTime;
+
+use rand::Rng;
+use rusqlite::{params, Connection, OptionalExtension};
+
+use abilities_runtime::abilities::registry::McpExposure;
+
+use super::actor_policy::{ClientRecord, KeychainRef, ToolGrant, ToolRateLimit};
+use super::contracts::{McpClientId, OpaqueConversationHandle, Scope, ScopedName};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// MCP auth-state errors. Distinct from `ToolError` because these fire before
+/// the gateway reaches the typed-tool layer.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("client unknown")]
+    UnknownClient,
+    #[error("client pairing revoked")]
+    PairingRevoked,
+    #[error("conversation handle unknown or revoked")]
+    ConversationRevoked,
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("manifest JSON encoding failed: {0}")]
+    Encoding(#[from] serde_json::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const HANDLE_BYTES: usize = 16;
+const CLIENT_ID_BYTES: usize = 16;
+const HANDLE_EXPIRY_SECONDS: i64 = 24 * 60 * 60; // 24h sliding per §D.
+
+/// Operator-supplied pairing input that the MCP server uses to mint a new
+/// `McpClientId` and manifest rows.
+#[derive(Debug, Clone)]
+pub struct PairingHandshake {
+    /// Caller-supplied opaque label (e.g. "claude-desktop-2026-05-20") —
+    /// retained only for the pairing audit event sink in later wiring.
+    pub client_label: String,
+    /// Initial per-tool grant set chosen by the operator at pairing time.
+    pub tool_grants: Vec<ToolGrant>,
+}
+
+/// Server-issued pairing response returned to the client.
+#[derive(Debug)]
+pub struct PairingResponse {
+    pub client_id: McpClientId,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Pair a new MCP client: mint client_id and manifest rows.
+pub fn pair_client(
+    conn: &mut Connection,
+    handshake: PairingHandshake,
+) -> Result<PairingResponse, AuthError> {
+    let client_id = McpClientId::new(random_hex(CLIENT_ID_BYTES));
+    let now = now_millis();
+    let tx = conn.transaction()?;
+    tx.execute(
+        "INSERT INTO mcp_client_manifest \
+         (client_id, paired_at, revoked_at, transport_key_ref) \
+         VALUES (?1, ?2, NULL, NULL)",
+        params![client_id.as_str(), now],
+    )?;
+    for grant in &handshake.tool_grants {
+        tx.execute(
+            "INSERT INTO mcp_tool_grant \
+             (client_id, tool_name, scopes_granted_json, exposure, rate_limit_max, rate_limit_window_secs) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                client_id.as_str(),
+                grant.tool_name.as_str(),
+                serde_json::to_string(&grant.scopes_granted)?,
+                exposure_tag(grant.exposure),
+                grant.rate_limit.max_calls,
+                grant.rate_limit.window_seconds,
+            ],
+        )?;
+    }
+    // client_label retained only for operator-visible audit attribution at the
+    // pairing audit event sink; not stored on the manifest schema for v1.4.7.
+    let _ = handshake.client_label;
+    tx.commit()?;
+
+    Ok(PairingResponse { client_id })
+}
+
+/// Load the manifest record for a client — indexed PK lookup; no cache so
+/// revocation propagates within one in-flight call.
+pub fn load_client_record(
+    conn: &Connection,
+    client_id: &McpClientId,
+) -> Result<ClientRecord, AuthError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT paired_at, revoked_at, transport_key_ref \
+         FROM mcp_client_manifest WHERE client_id = ?1",
+    )?;
+    let row = stmt
+        .query_row(params![client_id.as_str()], |row| {
+            let paired_at: i64 = row.get(0)?;
+            let revoked_at: Option<i64> = row.get(1)?;
+            let transport_key_ref: Option<String> = row.get(2)?;
+            Ok((paired_at, revoked_at, transport_key_ref))
+        })
+        .optional()?;
+    let (paired_at, revoked_at, transport_key_ref) = row.ok_or(AuthError::UnknownClient)?;
+    Ok(ClientRecord {
+        client_id: client_id.clone(),
+        paired_at: millis_to_system_time(paired_at),
+        revoked_at: revoked_at.map(millis_to_system_time),
+        transport_key_ref: KeychainRef(transport_key_ref.unwrap_or_default()),
+    })
+}
+
+/// Indexed `(client_id, tool_name)` lookup per L0 packet AC-2 step (ii).
+pub fn resolve_tool_grant(
+    conn: &Connection,
+    client_id: &McpClientId,
+    tool_name: &ScopedName,
+) -> Result<Option<ToolGrant>, AuthError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT scopes_granted_json, exposure, rate_limit_max, rate_limit_window_secs \
+         FROM mcp_tool_grant WHERE client_id = ?1 AND tool_name = ?2",
+    )?;
+    let row = stmt
+        .query_row(params![client_id.as_str(), tool_name.as_str()], |row| {
+            let scopes_json: String = row.get(0)?;
+            let exposure: String = row.get(1)?;
+            let max_calls: u32 = row.get(2)?;
+            let window_seconds: u32 = row.get(3)?;
+            Ok((scopes_json, exposure, max_calls, window_seconds))
+        })
+        .optional()?;
+    let Some((scopes_json, exposure, max_calls, window_seconds)) = row else {
+        return Ok(None);
+    };
+    let scopes_granted: Vec<Scope> = serde_json::from_str(&scopes_json)?;
+    Ok(Some(ToolGrant {
+        tool_name: tool_name.clone(),
+        scopes_granted,
+        exposure: parse_exposure(&exposure),
+        rate_limit: ToolRateLimit {
+            max_calls,
+            window_seconds,
+        },
+    }))
+}
+
+/// Resolve presented handle to a server-side record (or mint a new one if
+/// absent). Composite `(handle, client_id)` binding rejects cross-client reuse.
+pub fn resolve_or_mint_handle(
+    conn: &mut Connection,
+    client_id: &McpClientId,
+    presented: Option<&OpaqueConversationHandle>,
+) -> Result<OpaqueConversationHandle, AuthError> {
+    let now = now_millis();
+    let Some(handle) = presented else {
+        return mint_handle(conn, client_id, now);
+    };
+    let mut stmt = conn.prepare_cached(
+        "SELECT revoked_at, last_touched_at FROM mcp_conversation_handle \
+         WHERE handle = ?1 AND client_id = ?2",
+    )?;
+    let row: Option<(Option<i64>, i64)> = stmt
+        .query_row(params![handle.as_str(), client_id.as_str()], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .optional()?;
+    drop(stmt);
+    let Some((revoked_at, last_touched_at)) = row else {
+        return Err(AuthError::ConversationRevoked);
+    };
+    if revoked_at.is_some() {
+        return Err(AuthError::ConversationRevoked);
+    }
+    if now - last_touched_at > HANDLE_EXPIRY_SECONDS * 1000 {
+        // Expired (sliding 24h): silent mint replacement per ADR-0102 §D.
+        return mint_handle(conn, client_id, now);
+    }
+    conn.execute(
+        "UPDATE mcp_conversation_handle SET last_touched_at = ?3 \
+         WHERE handle = ?1 AND client_id = ?2",
+        params![handle.as_str(), client_id.as_str(), now],
+    )?;
+    Ok(handle.clone())
+}
+
+fn mint_handle(
+    conn: &mut Connection,
+    client_id: &McpClientId,
+    now: i64,
+) -> Result<OpaqueConversationHandle, AuthError> {
+    let handle = OpaqueConversationHandle::new(random_hex(HANDLE_BYTES));
+    conn.execute(
+        "INSERT INTO mcp_conversation_handle \
+         (handle, client_id, mint_at, last_touched_at, revoked_at) \
+         VALUES (?1, ?2, ?3, ?3, NULL)",
+        params![handle.as_str(), client_id.as_str(), now],
+    )?;
+    Ok(handle)
+}
+
+/// Admin: revoke a conversation handle. Subsequent presentations →
+/// `ConversationRevoked`.
+pub fn revoke_handle(
+    conn: &Connection,
+    handle: &OpaqueConversationHandle,
+) -> Result<(), AuthError> {
+    conn.execute(
+        "UPDATE mcp_conversation_handle SET revoked_at = ?2 WHERE handle = ?1",
+        params![handle.as_str(), now_millis()],
+    )?;
+    Ok(())
+}
+
+/// Admin: revoke a paired client. Subsequent invocations → `PairingRevoked`.
+pub fn revoke_client(conn: &Connection, client_id: &McpClientId) -> Result<(), AuthError> {
+    conn.execute(
+        "UPDATE mcp_client_manifest SET revoked_at = ?2 WHERE client_id = ?1",
+        params![client_id.as_str(), now_millis()],
+    )?;
+    Ok(())
+}
+
+/// Return every tool name from `mcp_tool_grant` for `client_id` where
+/// exposure = `Invocable`. Consumed by the transport `tools/list` so only
+/// Invocable-tier grants are surfaced to the host model.
+pub fn list_invocable_tool_grants(
+    conn: &Connection,
+    client_id: &McpClientId,
+) -> Result<Vec<ScopedName>, AuthError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT tool_name FROM mcp_tool_grant \
+         WHERE client_id = ?1 AND exposure = 'Invocable' \
+         ORDER BY tool_name ASC",
+    )?;
+    let rows = stmt.query_map(params![client_id.as_str()], |row| {
+        let name: String = row.get(0)?;
+        Ok(ScopedName::new(name))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Internals: RNG, time, encoding helpers
+// ---------------------------------------------------------------------------
+
+fn random_hex(byte_len: usize) -> String {
+    let mut bytes = vec![0u8; byte_len];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(&bytes)
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn millis_to_system_time(ms: i64) -> SystemTime {
+    SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(ms.max(0) as u64)
+}
+
+fn exposure_tag(exposure: McpExposure) -> &'static str {
+    match exposure {
+        McpExposure::None => "None",
+        McpExposure::MetadataOnly => "MetadataOnly",
+        McpExposure::Invocable => "Invocable",
+    }
+}
+
+fn parse_exposure(tag: &str) -> McpExposure {
+    match tag {
+        "Invocable" => McpExposure::Invocable,
+        "MetadataOnly" => McpExposure::MetadataOnly,
+        _ => McpExposure::None,
+    }
+}

--- a/src-tauri/src/services/mcp_v2/contracts.rs
+++ b/src-tauri/src/services/mcp_v2/contracts.rs
@@ -211,6 +211,28 @@ impl std::fmt::Display for OpaqueConversationHandle {
     }
 }
 
+/// Reserved opaque nonce newtype retained for compatibility with older local
+/// callers. The simplified local MCP v2 envelopes do not carry nonce fields.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OpaqueNonce(pub String);
+
+impl OpaqueNonce {
+    pub fn new(nonce: impl Into<String>) -> Self {
+        Self(nonce.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OpaqueNonce {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
 /// wire envelope mirror of the runtime type.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -311,12 +333,12 @@ pub trait McpToolHandler: Send + Sync {
 ///
 /// `ConversationRequired` is intentionally absent — the gateway mints
 /// handles transparently on first write per ADR-0102 §D (2026-05-19
-/// amendment). Auth-state-revocation cases (`PairingRevoked`,
-/// `ConversationRevoked`) live as their own variants rather than abusing
-/// `Unauthorized::missing_scope` with sentinel strings: the [`Scope`]
-/// type is reserved for `<namespace>.<verb>.<noun>` (or pre-amendment
-/// substrate) values per §E, so auth-state sentinels do not belong on
-/// that field.
+/// amendment). Auth-state cases — `PairingRevoked`,
+/// `ConversationRevoked`, `ExposureForbidden` — live as their own
+/// variants rather than abusing `Unauthorized::missing_scope` with
+/// sentinel strings: the [`Scope`] type is reserved for
+/// `<namespace>.<verb>.<noun>` (or pre-amendment substrate) values
+/// per §E, so auth-state sentinels do not belong on that field.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(
     tag = "kind",
@@ -340,6 +362,15 @@ pub enum ToolError {
     /// caller must restart with a fresh conversation (the gateway will
     /// mint a new handle on the next call).
     ConversationRevoked,
+    /// The caller's manifest does not include an invocable grant for
+    /// this tool — either no grant exists for `tool_name` OR the grant's
+    /// `exposure` tier is `None` / `MetadataOnly` per ADR-0102 §G. Use
+    /// this rather than abusing `Unauthorized::missing_scope` with a
+    /// sentinel `Scope` value: exposure is an auth-state distinct from
+    /// scope-deficit (per ADR-0102 §C/§G cycle-7 amendment).
+    ExposureForbidden {
+        tool_name: ScopedName,
+    },
     NotFound {
         resource: String,
     },
@@ -674,6 +705,28 @@ mod tests {
     }
 
     #[test]
+    fn tool_error_exposure_forbidden_wire_shape() {
+        // Per ADR-0102 §C/§G cycle-7 amendment: absent grant or
+        // exposure tier of None / MetadataOnly returns a dedicated
+        // variant rather than abusing `Unauthorized::missing_scope`
+        // with a sentinel `Scope` value. Wire shape mirrors the other
+        // typed errors: snake_case tag + camelCase fields.
+        let err = ToolError::ExposureForbidden {
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+        };
+        let encoded = serde_json::to_value(&err).expect("serializes");
+        assert_eq!(
+            encoded,
+            json!({
+                "kind": "exposure_forbidden",
+                "toolName": "dailyos.read.account_status",
+            })
+        );
+        let decoded: ToolError = serde_json::from_value(encoded).expect("deserializes");
+        assert_eq!(decoded, err);
+    }
+
+    #[test]
     fn mcp_tool_request_envelope_wire_shape() {
         let envelope = McpToolRequestEnvelope {
             conversation_handle: Some(OpaqueConversationHandle::new("conv-abc-123")),
@@ -754,5 +807,16 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn opaque_nonce_wire_is_transparent_string() {
+        // Kept as a transparent string for compatibility; simplified local
+        // MCP v2 envelopes do not carry this value.
+        let nonce = OpaqueNonce::new("nonce-abc-123");
+        let encoded = serde_json::to_string(&nonce).expect("serializes");
+        assert_eq!(encoded, "\"nonce-abc-123\"");
+        let decoded: OpaqueNonce = serde_json::from_str(&encoded).expect("deserializes");
+        assert_eq!(decoded, nonce);
     }
 }

--- a/src-tauri/src/services/mcp_v2/gateway.rs
+++ b/src-tauri/src/services/mcp_v2/gateway.rs
@@ -1,10 +1,761 @@
 //! MCP v2 gateway: the single entry point that receives MCP tool calls.
 //!
-//! Validates Actor::McpClient policy against the server-side scope
-//! manifest loaded by auth; dispatches through registered McpToolHandler
-//! implementations; records audit attribution; emits McpToolInvoked
-//! signals — signal type registration happens in signals/policy_registry.rs
-//! when the first handler lands.
+//! Validates Actor::McpClient policy against the server-side scope manifest
+//! loaded by `auth`; dispatches through registered `McpToolHandler`
+//! implementations; records audit attribution on success; emits
+//! `McpToolInvoked` / `McpInvocationRejected` signals on success / rejection
+//! respectively via the [`SignalEmitter`] trait (W2+ wires a production
+//! emitter that calls `crate::signals::bus::emit_signal_and_propagate`).
 //!
-//! Implementation pending — see ADR-0102 amendment §C for the contract
-//! and ADR-0128 for the product-surface frame.
+//! Per ADR-0102 §C authorization machinery and the DOS-168-amended local MCP
+//! trust model: authorization and operational controls live here; local
+//! transport ceremony does not.
+
+use rusqlite::{params, Connection};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::actor_policy::{self, ToolGrant};
+use super::audit;
+use super::auth::{self, AuthError};
+use super::contracts::{
+    McpActor, McpClientId, McpToolHandler, McpToolRequestEnvelope, McpToolResponseEnvelope,
+    McpToolResult, OpaqueConversationHandle, Scope, ScopedName, Side, ToolError,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default rate-limit retry-after when the gateway has nothing better.
+const RATE_LIMIT_RETRY_DEFAULT_SECONDS: u32 = 60;
+
+/// Mutation-cursor caps per L0 packet AC-6 (cycle-6 devex MED).
+const MUTATION_CURSOR_MAX_DEPTH: usize = 4;
+const MUTATION_CURSOR_MAX_BYTES: usize = 2 * 1024;
+const MUTATION_CURSOR_TRUNCATION_SENTINEL: &str = "truncated_oversize";
+
+// ---------------------------------------------------------------------------
+// SignalEmitter trait
+// ---------------------------------------------------------------------------
+
+/// Abstract signal-emission seam between the gateway and the production
+/// signals bus. The default `StderrSignalEmitter` is for tests and dev
+/// dispatch (so the gateway doesn't take a hard `ActionDb` dependency in
+/// W1-A); W2+ supplies a real emitter that calls
+/// `crate::signals::bus::emit_signal_and_propagate` with a real `ActionDb`.
+///
+/// Both methods MUST be infallible from the gateway's perspective — the
+/// emit-or-log discipline (L0 packet AC-7) means emission failure logs +
+/// emits a `mcp_reject_signal_emit_failed` operator alert but never
+/// propagates back to the caller. Implementers handle that internally.
+pub trait SignalEmitter: Send + Sync {
+    /// `SignalType::McpToolInvoked` on successful dispatch.
+    /// Payload: `(client_id, conversation_handle, tool_name)`. No raw
+    /// params/response per AC-7.
+    fn emit_invoked(
+        &self,
+        client_id: &McpClientId,
+        conversation_handle: &OpaqueConversationHandle,
+        tool_name: &ScopedName,
+    );
+
+    /// `SignalType::McpInvocationRejected` on auth-state rejection.
+    /// `client_id` is `None` for missing-client rejection (per AC-7
+    /// wording, attribution is "unresolved").
+    fn emit_rejected(
+        &self,
+        client_id: Option<&McpClientId>,
+        tool_name: Option<&ScopedName>,
+        reject_reason: &str,
+    );
+
+    /// Suite-S warning for successful invocations that violated a soft
+    /// contract (e.g. `mcp_write_handler_missing_cursor` per AC-6 cycle-6
+    /// devex MED, or `mcp_write_handler_cursor_truncated` per AC-6
+    /// cycle-2 devex MED). Distinct from [`Self::emit_rejected`] so
+    /// operator dashboards can separate auth rejections from handler
+    /// soft-warnings (closes L2 cycle-2 convergent 3/4 MED on
+    /// warning-as-rejection pollution).
+    ///
+    /// Carries `conversation_handle` for per-call triage correlation with
+    /// the success audit row (closes L2 cycle-3 devex MED on warning
+    /// correlation).
+    fn emit_warning(
+        &self,
+        client_id: &McpClientId,
+        conversation_handle: &OpaqueConversationHandle,
+        tool_name: &ScopedName,
+        warning_reason: &str,
+    );
+}
+
+/// Default emitter used when the gateway is constructed without an explicit
+/// production emitter (tests, dev). Writes to stderr so events stay
+/// operator-visible; per AC-7 emit-or-log this satisfies the "fallback log"
+/// arm of emit-or-log when production wiring is absent.
+pub struct StderrSignalEmitter;
+
+impl SignalEmitter for StderrSignalEmitter {
+    fn emit_invoked(
+        &self,
+        client_id: &McpClientId,
+        conversation_handle: &OpaqueConversationHandle,
+        tool_name: &ScopedName,
+    ) {
+        eprintln!(
+            "mcp.signal.invoked client_id={} conversation_handle={} tool_name={}",
+            client_id.as_str(),
+            conversation_handle.as_str(),
+            tool_name.as_str()
+        );
+    }
+
+    fn emit_rejected(
+        &self,
+        client_id: Option<&McpClientId>,
+        tool_name: Option<&ScopedName>,
+        reject_reason: &str,
+    ) {
+        let client = client_id.map(|c| c.as_str()).unwrap_or("unresolved");
+        let tool = tool_name.map(|t| t.as_str()).unwrap_or("unresolved");
+        eprintln!(
+            "mcp.signal.rejected client_id={client} tool_name={tool} reject_reason={reject_reason}"
+        );
+    }
+
+    fn emit_warning(
+        &self,
+        client_id: &McpClientId,
+        conversation_handle: &OpaqueConversationHandle,
+        tool_name: &ScopedName,
+        warning_reason: &str,
+    ) {
+        eprintln!(
+            "mcp.signal.warning client_id={} conversation_handle={} tool_name={} warning_reason={warning_reason}",
+            client_id.as_str(),
+            conversation_handle.as_str(),
+            tool_name.as_str()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gateway
+// ---------------------------------------------------------------------------
+
+/// MCP v2 dispatch entry point. Holds the registered handler set + the
+/// signal emitter and runs the per-dispatch flow defined in L0 packet §1 #1.
+pub struct Gateway {
+    handlers: HashMap<ScopedName, Arc<dyn McpToolHandler>>,
+    emitter: Arc<dyn SignalEmitter>,
+    taxonomy: Option<Arc<dyn super::taxonomy::TaxonomyCatalog>>,
+}
+
+impl Gateway {
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+            emitter: Arc::new(StderrSignalEmitter),
+            taxonomy: None,
+        }
+    }
+
+    pub fn with_emitter(emitter: Arc<dyn SignalEmitter>) -> Self {
+        Self {
+            handlers: HashMap::new(),
+            emitter,
+            taxonomy: None,
+        }
+    }
+
+    pub fn register(&mut self, handler: Arc<dyn McpToolHandler>) {
+        let name = handler.description().name.clone();
+        self.handlers.insert(name, handler);
+    }
+
+    pub fn registered_tools(&self) -> impl Iterator<Item = &ScopedName> {
+        self.handlers.keys()
+    }
+
+    /// Register the taxonomy catalog. Production callers wire this with
+    /// `YamlTaxonomyCatalog::load_embedded()`. Tests may use a stub.
+    pub fn set_taxonomy(&mut self, catalog: Arc<dyn super::taxonomy::TaxonomyCatalog>) {
+        self.taxonomy = Some(catalog);
+    }
+
+    /// Seal the gateway after all handlers are registered. Validates
+    /// every registered handler has a matching catalog entry with matching
+    /// `Side` (per DOS-478 L0 AC-7). Returns operator-readable error if
+    /// mismatch. Also returns catalog→handler pending-tool list as
+    /// operator info; callers log it.
+    ///
+    /// Production `main.rs` calls `gateway.seal()?` after registration.
+    /// No `panic!()` — fail-fast via structured `Result`.
+    pub fn seal(&self) -> Result<Vec<ScopedName>, super::taxonomy::TaxonomyError> {
+        let Some(catalog) = self.taxonomy.as_ref() else {
+            // No taxonomy registered: tests / dev mode skip validation.
+            return Ok(Vec::new());
+        };
+        let handlers: Vec<&dyn McpToolHandler> =
+            self.handlers.values().map(|h| h.as_ref()).collect();
+        catalog.validate_against_handlers(&handlers)?;
+        Ok(catalog.validate_catalog_against_handlers(&handlers))
+    }
+
+    /// Handle a single MCP tool invocation. Full per-dispatch contract per
+    /// L0 packet §1 #1 after DOS-168-amended: local transport identity is the
+    /// asserted `McpClientId`; the gateway enforces manifest authorization and
+    /// operational controls.
+    pub fn handle_tool_call(
+        &self,
+        conn: &mut Connection,
+        asserted_client_id: &McpClientId,
+        envelope: McpToolRequestEnvelope,
+    ) -> McpToolResponseEnvelope {
+        match self.dispatch(conn, asserted_client_id, &envelope) {
+            Ok(Dispatched {
+                result,
+                conversation_handle,
+            }) => McpToolResponseEnvelope {
+                conversation_handle,
+                result,
+            },
+            Err(failure) => {
+                let GatewayFailure {
+                    error,
+                    reject_reason,
+                    tool_name_for_signal,
+                    client_id_for_signal,
+                } = *failure;
+                self.emitter.emit_rejected(
+                    client_id_for_signal.as_ref(),
+                    tool_name_for_signal.as_ref(),
+                    &reject_reason,
+                );
+                McpToolResponseEnvelope {
+                    conversation_handle: OpaqueConversationHandle::new(
+                        envelope_handle_str(&envelope).to_string(),
+                    ),
+                    result: McpToolResult::Error { error },
+                }
+            }
+        }
+    }
+
+    /// Inner per-dispatch flow. On success: handler result + active
+    /// conversation handle. On failure: `GatewayFailure` with attribution for
+    /// the rejection signal.
+    fn dispatch(
+        &self,
+        conn: &mut Connection,
+        asserted_client_id: &McpClientId,
+        envelope: &McpToolRequestEnvelope,
+    ) -> Result<Dispatched, Box<GatewayFailure>> {
+        // Manifest gates per AC-2 decision order. Unknown clients are
+        // unresolved for rejection attribution; once the manifest row loads,
+        // the asserted client_id is admissible for operational attribution.
+        let record = match auth::load_client_record(conn, asserted_client_id) {
+            Ok(r) => r,
+            Err(err) => return Err(auth_to_failure(err, envelope, None)),
+        };
+        if record.revoked_at.is_some() {
+            return Err(Box::new(GatewayFailure {
+                error: ToolError::PairingRevoked,
+                reject_reason: "pairing_revoked".to_string(),
+                tool_name_for_signal: Some(envelope.tool_name.clone()),
+                client_id_for_signal: Some(asserted_client_id.clone()),
+            }));
+        }
+
+        let grant = match auth::resolve_tool_grant(conn, asserted_client_id, &envelope.tool_name) {
+            Ok(g) => g,
+            Err(err) => return Err(auth_to_failure(err, envelope, Some(asserted_client_id))),
+        };
+        let Some(grant) = grant else {
+            return Err(Box::new(GatewayFailure {
+                error: ToolError::ExposureForbidden {
+                    tool_name: envelope.tool_name.clone(),
+                },
+                reject_reason: "absent_grant".to_string(),
+                tool_name_for_signal: Some(envelope.tool_name.clone()),
+                client_id_for_signal: Some(asserted_client_id.clone()),
+            }));
+        };
+        if !matches!(
+            grant.exposure,
+            abilities_runtime::abilities::registry::McpExposure::Invocable
+        ) {
+            return Err(Box::new(GatewayFailure {
+                error: ToolError::ExposureForbidden {
+                    tool_name: envelope.tool_name.clone(),
+                },
+                reject_reason: "non_invocable".to_string(),
+                tool_name_for_signal: Some(envelope.tool_name.clone()),
+                client_id_for_signal: Some(asserted_client_id.clone()),
+            }));
+        }
+
+        // Handler lookup. Unknown tool → BadParams per AC-1.
+        let Some(handler) = self.handlers.get(&envelope.tool_name) else {
+            return Err(Box::new(GatewayFailure {
+                error: ToolError::BadParams {
+                    detail: "unknown tool name".to_string(),
+                },
+                reject_reason: "unknown_tool".to_string(),
+                tool_name_for_signal: Some(envelope.tool_name.clone()),
+                client_id_for_signal: Some(asserted_client_id.clone()),
+            }));
+        };
+
+        // Scope subset per AC-2 step (iii).
+        let required: &[Scope] = &handler.description().scopes_required;
+        if !scope_is_subset(required, &grant.scopes_granted) {
+            let missing = required
+                .iter()
+                .find(|r| !grant.scopes_granted.contains(r))
+                .cloned()
+                .unwrap_or_else(|| Scope::new(""));
+            return Err(Box::new(GatewayFailure {
+                error: ToolError::Unauthorized {
+                    missing_scope: missing.clone(),
+                },
+                reject_reason: format!("missing_scope:{}", missing.as_str()),
+                tool_name_for_signal: Some(envelope.tool_name.clone()),
+                client_id_for_signal: Some(asserted_client_id.clone()),
+            }));
+        }
+
+        // Reject caller-asserted scope/conversation fields in params per AC-2 (iv).
+        if let Some(params_obj) = envelope.params.as_object() {
+            if params_obj.contains_key("granted_scopes") {
+                return Err(Box::new(GatewayFailure {
+                    error: ToolError::BadParams {
+                        detail: "granted_scopes not accepted in params".to_string(),
+                    },
+                    reject_reason: "caller_asserted_scopes".to_string(),
+                    tool_name_for_signal: Some(envelope.tool_name.clone()),
+                    client_id_for_signal: Some(asserted_client_id.clone()),
+                }));
+            }
+            if params_obj.contains_key("conversation_id") {
+                return Err(Box::new(GatewayFailure {
+                    error: ToolError::BadParams {
+                        detail: "use envelope conversation_handle".to_string(),
+                    },
+                    reject_reason: "caller_asserted_conversation_id".to_string(),
+                    tool_name_for_signal: Some(envelope.tool_name.clone()),
+                    client_id_for_signal: Some(asserted_client_id.clone()),
+                }));
+            }
+        }
+
+        // Resolve/mint conversation handle per AC-3a/AC-3b §D.bis.
+        let conversation_handle = match auth::resolve_or_mint_handle(
+            conn,
+            asserted_client_id,
+            envelope.conversation_handle.as_ref(),
+        ) {
+            Ok(h) => h,
+            Err(err) => return Err(auth_to_failure(err, envelope, Some(asserted_client_id))),
+        };
+
+        // Rate limit per AC-5: BEGIN IMMEDIATE → prune → count → reserve OR ROLLBACK.
+        match reserve_rate_limit(conn, asserted_client_id, &envelope.tool_name, &grant) {
+            Ok(()) => {}
+            Err(retry_after) => {
+                return Err(Box::new(GatewayFailure {
+                    error: ToolError::RateLimited {
+                        retry_after_seconds: retry_after,
+                    },
+                    reject_reason: "rate_limited".to_string(),
+                    tool_name_for_signal: Some(envelope.tool_name.clone()),
+                    client_id_for_signal: Some(asserted_client_id.clone()),
+                }));
+            }
+        }
+
+        // Construct the runtime actor and dispatch.
+        let runtime_actor =
+            actor_policy::project_actor(asserted_client_id, &grant, Some(&conversation_handle));
+        let wire_actor = McpActor::Client {
+            client_id: asserted_client_id.clone(),
+            conversation_handle: Some(conversation_handle.clone()),
+            tool_name: envelope.tool_name.clone(),
+            granted_scopes: grant.scopes_granted.clone(),
+        };
+        let invocation = handler.invoke(&wire_actor, envelope.params.clone());
+        let side = handler.description().side;
+
+        let result = match invocation {
+            Ok(value) => {
+                // Extract + cap mutation_cursor for write-class tools per AC-6.
+                let mutation_cursor = if matches!(side, Side::Write | Side::SubmitCorrection) {
+                    let extracted = value.get("mutation_cursor").cloned();
+                    if extracted.is_none() {
+                        self.emitter.emit_warning(
+                            asserted_client_id,
+                            &conversation_handle,
+                            &envelope.tool_name,
+                            "mcp_write_handler_missing_cursor",
+                        );
+                    }
+                    extracted.map(|cursor| {
+                        let (capped, was_truncated) = cap_mutation_cursor(cursor);
+                        if was_truncated {
+                            self.emitter.emit_warning(
+                                asserted_client_id,
+                                &conversation_handle,
+                                &envelope.tool_name,
+                                "mcp_write_handler_cursor_truncated",
+                            );
+                        }
+                        capped
+                    })
+                } else {
+                    None
+                };
+
+                let audit_detail = build_audit_detail(
+                    asserted_client_id,
+                    &conversation_handle,
+                    &envelope.tool_name,
+                    &envelope.params,
+                    Some(&value),
+                    mutation_cursor.as_ref(),
+                );
+                if let Err(err) =
+                    audit::write(&runtime_actor, "mcp.tool_invoked", audit_detail, None, side)
+                {
+                    if matches!(err, audit::AuditError::DoubleFailure { .. }) {
+                        emit_double_failure_alert();
+                        return Ok(Dispatched {
+                            result: McpToolResult::Error {
+                                error: ToolError::Internal {
+                                    trace_id: "mcp_audit_double_failure".to_string(),
+                                },
+                            },
+                            conversation_handle,
+                        });
+                    }
+                    eprintln!("mcp_v2 audit single-failure: {err}");
+                }
+
+                self.emitter.emit_invoked(
+                    asserted_client_id,
+                    &conversation_handle,
+                    &envelope.tool_name,
+                );
+                McpToolResult::Ok { value }
+            }
+            Err(error) => McpToolResult::Error { error },
+        };
+
+        Ok(Dispatched {
+            result,
+            conversation_handle,
+        })
+    }
+}
+
+impl Default for Gateway {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+struct Dispatched {
+    result: McpToolResult,
+    conversation_handle: OpaqueConversationHandle,
+}
+
+/// Carries enough state to (a) build the typed `ToolError` response and
+/// (b) emit the reject signal with operational attribution.
+struct GatewayFailure {
+    error: ToolError,
+    reject_reason: String,
+    tool_name_for_signal: Option<ScopedName>,
+    client_id_for_signal: Option<McpClientId>,
+}
+
+/// Project an `AuthError` to a gateway failure.
+fn auth_to_failure(
+    err: AuthError,
+    envelope: &McpToolRequestEnvelope,
+    attributed_client: Option<&McpClientId>,
+) -> Box<GatewayFailure> {
+    let (tool_error, reason) = match err {
+        AuthError::UnknownClient => (
+            ToolError::BadParams {
+                detail: "unknown_client".to_string(),
+            },
+            "unknown_client".to_string(),
+        ),
+        AuthError::PairingRevoked => (ToolError::PairingRevoked, "pairing_revoked".to_string()),
+        AuthError::ConversationRevoked => (
+            ToolError::ConversationRevoked,
+            "conversation_revoked".to_string(),
+        ),
+        AuthError::Sqlite(detail) => (
+            ToolError::Internal {
+                trace_id: opaque_trace_id("auth_sqlite", &detail.to_string()),
+            },
+            "sqlite_error".to_string(),
+        ),
+        AuthError::Encoding(detail) => (
+            ToolError::Internal {
+                trace_id: opaque_trace_id("auth_encoding", &detail.to_string()),
+            },
+            "encoding_error".to_string(),
+        ),
+    };
+    Box::new(GatewayFailure {
+        error: tool_error,
+        reject_reason: reason,
+        tool_name_for_signal: Some(envelope.tool_name.clone()),
+        client_id_for_signal: attributed_client.cloned(),
+    })
+}
+
+/// Build an opaque `trace_id` for `ToolError::Internal`: never leak raw DB /
+/// encoding error strings on the wire. Format: `<category>-<sha256-hex-12>`.
+/// The detail is logged to stderr server-side so operators can grep by
+/// trace_id.
+fn opaque_trace_id(category: &str, detail: &str) -> String {
+    use ring::digest;
+    let digest = digest::digest(&digest::SHA256, detail.as_bytes());
+    let hex = digest
+        .as_ref()
+        .iter()
+        .take(6)
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    let trace_id = format!("{category}-{hex}");
+    eprintln!("mcp_v2 internal: trace_id={trace_id} detail={detail}");
+    trace_id
+}
+
+fn scope_is_subset(required: &[Scope], granted: &[Scope]) -> bool {
+    required.iter().all(|r| granted.contains(r))
+}
+
+fn build_audit_detail(
+    client_id: &McpClientId,
+    conversation_handle: &OpaqueConversationHandle,
+    tool_name: &ScopedName,
+    params: &serde_json::Value,
+    response: Option<&serde_json::Value>,
+    mutation_cursor: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let mut detail = json!({
+        "client_id": client_id.as_str(),
+        "conversation_handle": conversation_handle.as_str(),
+        "tool_name": tool_name.as_str(),
+        "params": params,
+    });
+    if let Some(value) = response {
+        detail["response"] = value.clone();
+    }
+    if let Some(cursor) = mutation_cursor {
+        if let Some(obj) = detail.as_object_mut() {
+            obj.insert("mutation_cursor".to_string(), cursor.clone());
+        }
+    }
+    detail
+}
+
+/// Enforce AC-6 mutation_cursor caps: depth ≤ 4 + serialized ≤ 2 KiB. On
+/// violation, replace the cursor with the `"truncated_oversize"` sentinel
+/// string so audit detail stays bounded.
+///
+/// Returns `(capped_value, was_truncated)` so the caller can emit a
+/// Suite-S warning per L2 cycle-2 devex MED — silent truncation breaks
+/// the taxonomy.rs rustdoc contract.
+fn cap_mutation_cursor(value: serde_json::Value) -> (serde_json::Value, bool) {
+    if cursor_depth(&value) > MUTATION_CURSOR_MAX_DEPTH {
+        return (
+            serde_json::Value::String(MUTATION_CURSOR_TRUNCATION_SENTINEL.to_string()),
+            true,
+        );
+    }
+    match serde_json::to_vec(&value) {
+        Ok(bytes) if bytes.len() <= MUTATION_CURSOR_MAX_BYTES => (value, false),
+        _ => (
+            serde_json::Value::String(MUTATION_CURSOR_TRUNCATION_SENTINEL.to_string()),
+            true,
+        ),
+    }
+}
+
+fn cursor_depth(value: &serde_json::Value) -> usize {
+    match value {
+        serde_json::Value::Object(map) => 1 + map.values().map(cursor_depth).max().unwrap_or(0),
+        serde_json::Value::Array(items) => 1 + items.iter().map(cursor_depth).max().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// AC-5 rate-limit reservation: `BEGIN IMMEDIATE` → prune expired rows →
+/// SELECT COUNT(*) → if >= max ROLLBACK + RateLimited; else INSERT + COMMIT.
+fn reserve_rate_limit(
+    conn: &mut Connection,
+    client_id: &McpClientId,
+    tool_name: &ScopedName,
+    grant: &ToolGrant,
+) -> Result<(), u32> {
+    let now = current_unix_millis();
+    let window_ms = grant.rate_limit.window_seconds as i64 * 1000;
+
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .map_err(|_| RATE_LIMIT_RETRY_DEFAULT_SECONDS)?;
+
+    let prune_outcome = conn.execute(
+        "DELETE FROM mcp_tool_call_ledger \
+         WHERE client_id = ?1 AND tool_name = ?2 AND called_at < ?3",
+        params![client_id.as_str(), tool_name.as_str(), now - window_ms],
+    );
+    if prune_outcome.is_err() {
+        if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+            eprintln!("mcp_v2 rate-limit ROLLBACK failed: {rollback_err}");
+        }
+        return Err(RATE_LIMIT_RETRY_DEFAULT_SECONDS);
+    }
+
+    // L2 cycle-3 codex review + code-reviewer convergent MED AC-5: a
+    // SELECT failure must NOT fail-open by being treated as 0. ROLLBACK
+    // + reject so the call is gated correctly.
+    let count: i64 = match conn.query_row(
+        "SELECT COUNT(*) FROM mcp_tool_call_ledger \
+         WHERE client_id = ?1 AND tool_name = ?2",
+        params![client_id.as_str(), tool_name.as_str()],
+        |row| row.get(0),
+    ) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("mcp_v2 rate-limit SELECT COUNT failed: {err}");
+            if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+                eprintln!("mcp_v2 rate-limit ROLLBACK after SELECT err: {rollback_err}");
+            }
+            return Err(RATE_LIMIT_RETRY_DEFAULT_SECONDS);
+        }
+    };
+    if count as u32 >= grant.rate_limit.max_calls {
+        if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+            eprintln!("mcp_v2 rate-limit ROLLBACK failed: {rollback_err}");
+        }
+        return Err(grant.rate_limit.window_seconds);
+    }
+
+    let insert_outcome = conn.execute(
+        "INSERT INTO mcp_tool_call_ledger (client_id, tool_name, called_at) \
+         VALUES (?1, ?2, ?3)",
+        params![client_id.as_str(), tool_name.as_str(), now],
+    );
+    if insert_outcome.is_err() {
+        if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+            eprintln!("mcp_v2 rate-limit ROLLBACK failed: {rollback_err}");
+        }
+        return Err(RATE_LIMIT_RETRY_DEFAULT_SECONDS);
+    }
+
+    // L2 cycle-2 code-reviewer NEW: COMMIT failure must roll back the
+    // pending tx to avoid leaving a long-held writer lock open.
+    if let Err(commit_err) = conn.execute_batch("COMMIT") {
+        eprintln!("mcp_v2 rate-limit COMMIT failed; rolling back: {commit_err}");
+        if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+            eprintln!("mcp_v2 rate-limit ROLLBACK after COMMIT failure: {rollback_err}");
+        }
+        return Err(RATE_LIMIT_RETRY_DEFAULT_SECONDS);
+    }
+    Ok(())
+}
+
+fn current_unix_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn envelope_handle_str(envelope: &McpToolRequestEnvelope) -> &str {
+    envelope
+        .conversation_handle
+        .as_ref()
+        .map(|h| h.as_str())
+        .unwrap_or("")
+}
+
+fn emit_double_failure_alert() {
+    eprintln!("mcp.alert.audit_double_failure: handler effects preserved, audit lost");
+}
+
+#[cfg(test)]
+mod tests {
+    //! Gateway tests are minimal here because the per-dispatch flow consumes
+    //! a live SQLite connection + a registered handler set. End-to-end
+    //! gateway tests live in `src-tauri/tests/` and exercise the migrations
+    //! v241-v244 schemas; the unit tests below validate the small pure
+    //! helpers that don't need DB state.
+
+    use super::*;
+
+    #[test]
+    fn scope_subset_empty_required_passes() {
+        assert!(scope_is_subset(&[], &[]));
+        assert!(scope_is_subset(
+            &[],
+            &[Scope::new("dailyos.read.account_status")]
+        ));
+    }
+
+    #[test]
+    fn scope_subset_missing_returns_false() {
+        let required = vec![Scope::new("dailyos.write.place_document")];
+        let granted = vec![Scope::new("dailyos.read.account_status")];
+        assert!(!scope_is_subset(&required, &granted));
+    }
+
+    #[test]
+    fn scope_subset_present_returns_true() {
+        let required = vec![Scope::new("dailyos.read.account_status")];
+        let granted = vec![
+            Scope::new("dailyos.read.account_status"),
+            Scope::new("dailyos.read.portfolio_attention"),
+        ];
+        assert!(scope_is_subset(&required, &granted));
+    }
+
+    #[test]
+    fn cap_mutation_cursor_passes_small_payload() {
+        let cursor = json!({ "claim_id": 42, "signal_id": "abc" });
+        let (capped, was_truncated) = cap_mutation_cursor(cursor.clone());
+        assert_eq!(capped, cursor);
+        assert!(!was_truncated);
+    }
+
+    #[test]
+    fn cap_mutation_cursor_truncates_oversize_bytes() {
+        let huge: Vec<i64> = (0..1000).collect();
+        let cursor = json!({ "ids": huge });
+        let (capped, was_truncated) = cap_mutation_cursor(cursor);
+        assert_eq!(capped, json!("truncated_oversize"));
+        assert!(was_truncated);
+    }
+
+    #[test]
+    fn cap_mutation_cursor_truncates_deep_nesting() {
+        // Build object {a:{a:{a:{a:{a:{a:1}}}}}} — depth 6, > MAX_DEPTH 4.
+        let mut value = json!({ "a": 1 });
+        for _ in 0..6 {
+            value = json!({ "a": value });
+        }
+        let (capped, was_truncated) = cap_mutation_cursor(value);
+        assert_eq!(capped, json!("truncated_oversize"));
+        assert!(was_truncated);
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/mod.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/mod.rs
@@ -1,6 +1,8 @@
 //! Per-tool MCP handler modules. Each handler implements McpToolHandler.
 //! Module names match the canonical scoped names declared in taxonomy.
 
+pub mod registration;
+pub mod tool_account_status;
 pub mod tool_briefing;
 pub mod tool_create_action;
 pub mod tool_note;

--- a/src-tauri/src/services/mcp_v2/handlers/registration.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/registration.rs
@@ -1,0 +1,59 @@
+//! Wave-scoped handler registration helper.
+//!
+//! Called from `mcp_v2/main.rs::run_serve` between `gateway.set_taxonomy(...)`
+//! and `gateway.seal()`. Each wave (W2-A, W2-B, ...) adds its handlers here.
+
+use std::sync::Arc;
+
+use crate::services::mcp_v2::contracts::ScopedName;
+use crate::services::mcp_v2::gateway::Gateway;
+use crate::services::mcp_v2::taxonomy::TaxonomyCatalog;
+
+use super::tool_account_status::AccountStatusHandler;
+
+/// Errors registering wave-scoped handlers at boot.
+#[derive(Debug)]
+pub enum RegistrationError {
+    /// The catalog has no entry for a scoped name the wave expects.
+    CatalogEntryMissing(ScopedName),
+    /// The abilities-runtime registry refused to expose itself at startup
+    /// (validation violations or `global_checked` panic guard).
+    AbilityRegistry(&'static str),
+}
+
+impl std::fmt::Display for RegistrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CatalogEntryMissing(name) => {
+                write!(f, "taxonomy catalog missing entry for {name}")
+            }
+            Self::AbilityRegistry(detail) => {
+                write!(f, "ability registry unavailable: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistrationError {}
+
+/// Register all v1.4.7 W2-A Phase-A handlers on the gateway.
+///
+/// Cycle-1 scope: `dailyos.read.account_status` only. Phase-B (daily_briefing)
+/// adds its handler via this same helper once its sub-ticket lands.
+pub fn register_v147_handlers(
+    gateway: &mut Gateway,
+    catalog: &Arc<dyn TaxonomyCatalog>,
+    runtime: tokio::runtime::Handle,
+) -> Result<(), RegistrationError> {
+    let account_status_name = ScopedName::new("dailyos.read.account_status");
+    let description = catalog
+        .description_for(&account_status_name)
+        .ok_or_else(|| RegistrationError::CatalogEntryMissing(account_status_name.clone()))?
+        .clone();
+
+    let handler = AccountStatusHandler::from_runtime(description, runtime)
+        .map_err(RegistrationError::AbilityRegistry)?;
+    gateway.register(Arc::new(handler));
+
+    Ok(())
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -1,0 +1,288 @@
+//! `dailyos.read.account_status` MCP tool handler.
+//!
+//! Wraps the `dailyos/account-overview` ability from `abilities-runtime`,
+//! dispatched via the same `invoke_registry_json` path the Tauri UI uses.
+//! Per DOS-175 cycle-2 §3: sync `McpToolHandler::invoke` is called from
+//! within `tokio::task::spawn_blocking` at the transport boundary, so
+//! `runtime.block_on(...)` on a captured handle is safe.
+//!
+//! See `.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md` for the L0
+//! contract.
+
+use abilities_runtime::abilities::registry::{AbilityRegistry, McpExposure};
+use abilities_runtime::abilities::tracer::NOOP_ABILITY_TRACER;
+use serde_json::Value;
+
+use crate::bridges::types::{
+    invoke_registry_json_for_actor, AbilityInvokeError, RequestScopedInvocation,
+    BRIDGE_NOOP_INTELLIGENCE_PROVIDER,
+};
+use crate::bridges::{BridgeActor, BridgeSurface};
+use crate::services::context::{
+    attach_live_workspace_readers, ClaimDismissalSurface, ExternalClients, ServiceContext,
+    SystemClock, SystemRng,
+};
+use crate::services::mcp_v2::actor_policy::{project_actor, ToolGrant, ToolRateLimit};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+
+const ACTOR_LABEL: &str = concat!("agent:dailyos-mcp-v2:", env!("CARGO_PKG_VERSION"));
+
+/// Registered ability name in the abilities-runtime registry.
+/// Per `account_overview.rs:84` the registered name uses `/` (not `_`).
+const ABILITY_NAME: &str = "dailyos/account-overview";
+
+/// `AccountOverviewInput` schema version pinned by `account_overview.rs:39`.
+const ACCOUNT_OVERVIEW_SCHEMA_VERSION: u32 = 1;
+
+pub struct AccountStatusHandler {
+    description: ToolDescription,
+    registry: &'static AbilityRegistry,
+    runtime: tokio::runtime::Handle,
+}
+
+impl AccountStatusHandler {
+    pub fn new(
+        description: ToolDescription,
+        registry: &'static AbilityRegistry,
+        runtime: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            description,
+            registry,
+            runtime,
+        }
+    }
+
+    /// Convenience constructor for `mcp_v2/main.rs::run_serve`. Workspace
+    /// readers are attached at invocation time via
+    /// `attach_live_workspace_readers` (each reader opens its own ActionDb
+    /// from LocalKeychain). Runtime handle is passed in explicitly because
+    /// registration runs in the binary's synchronous startup path before
+    /// `runtime.block_on(...)` begins.
+    pub fn from_runtime(
+        description: ToolDescription,
+        runtime: tokio::runtime::Handle,
+    ) -> Result<Self, &'static str> {
+        let registry = AbilityRegistry::global_checked()
+            .map_err(|_| "ability registry violations present at startup")?;
+        Ok(Self::new(description, registry, runtime))
+    }
+}
+
+impl McpToolHandler for AccountStatusHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(&self, actor: &McpActor, params: Value) -> Result<Value, ToolError> {
+        let McpActor::Client {
+            client_id,
+            conversation_handle,
+            tool_name,
+            granted_scopes,
+        } = actor;
+
+        // Synthesize a ToolGrant from the already-resolved McpActor scopes.
+        // The gateway validated grant before dispatch; this is purely for
+        // the ADR-0102 §B "manifest resolved before runtime actor
+        // construction" projection contract that project_actor preserves.
+        let synthetic_grant = ToolGrant {
+            tool_name: tool_name.clone(),
+            scopes_granted: granted_scopes.clone(),
+            exposure: McpExposure::Invocable,
+            rate_limit: ToolRateLimit {
+                max_calls: 0,
+                window_seconds: 0,
+            },
+        };
+        let runtime_actor =
+            project_actor(client_id, &synthetic_grant, conversation_handle.as_ref());
+
+        // The catalog gives us `subject` (string). Pre-read the current
+        // composition version for this account_id so the ability's
+        // optimistic-concurrency commit doesn't trip StaleComposition.
+        // Matches surface_runtime/mod.rs:2545 read-before-invoke pattern.
+        let subject = extract_subject(&params)?;
+        let composition_id = format!("dailyos/account-overview:account:{subject}");
+
+        self.runtime.block_on(async {
+            let clock = SystemClock;
+            let rng = SystemRng;
+            let external = ExternalClients::default();
+            let services = attach_live_workspace_readers(
+                ServiceContext::new_live(&clock, &rng, &external).with_actor(ACTOR_LABEL),
+            );
+
+            // Pre-read current version. If the composition row does not
+            // exist yet, this returns 0; the ability will then commit at
+            // version 1.
+            let composition_id_for_read = composition_id.clone();
+            let current_version = tokio::task::spawn_blocking(move || {
+                let db =
+                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
+                        .map_err(|err| {
+                            eprintln!("mcp_v2 account_status pre-read open_db failed: {err}");
+                            AbilityInvokeError::Surface(
+                                crate::bridges::BridgeSurfaceError::AbilityUnavailable,
+                            )
+                        })?;
+                let clock = SystemClock;
+                let rng = SystemRng;
+                let external = ExternalClients::default();
+                let ctx = ServiceContext::new_live(&clock, &rng, &external);
+                crate::services::compositions::current_composition_version_for_composition_id(
+                    &ctx,
+                    &db,
+                    &composition_id_for_read,
+                )
+                .map_err(|_| {
+                    AbilityInvokeError::Surface(
+                        crate::bridges::BridgeSurfaceError::AbilityUnavailable,
+                    )
+                })
+            })
+            .await
+            .map_err(|_| {
+                AbilityInvokeError::Surface(crate::bridges::BridgeSurfaceError::AbilityUnavailable)
+            })
+            .and_then(|inner| inner)
+            .map_err(map_invoke_error)?;
+
+            let resolved_input = serde_json::json!({
+                "schema_version": ACCOUNT_OVERVIEW_SCHEMA_VERSION,
+                "account_id": subject,
+                "expected_composition_version": current_version,
+            });
+
+            // Use the request-scoped dispatch path — V2 MCP needs to pass
+            // the full `Actor::McpClient { client_id, conversation_handle }`
+            // variant through to the registry so account_overview's
+            // `allowed_actors = [User, SurfaceClient, McpClient]` matches.
+            // The legacy `invoke_registry_json` calls `BridgeActor::Agent
+            // .registry_actor()` which returns `Actor::Agent` — not in the
+            // allowed list, surface-rejected.
+            let invocation = RequestScopedInvocation {
+                registry_actor: runtime_actor,
+                response_actor: BridgeActor::McpClient,
+                surface: BridgeSurface::McpTool,
+                claim_dismissal_surface: ClaimDismissalSurface::McpTool,
+            };
+            let response = invoke_registry_json_for_actor(
+                self.registry,
+                &services,
+                &BRIDGE_NOOP_INTELLIGENCE_PROVIDER,
+                &NOOP_ABILITY_TRACER,
+                invocation,
+                ABILITY_NAME,
+                resolved_input,
+            )
+            .await
+            .map_err(map_invoke_error)?;
+            Ok(response.data)
+        })
+    }
+}
+
+fn extract_subject(params: &Value) -> Result<String, ToolError> {
+    let subject = params
+        .get("subject")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::BadParams {
+            detail: "missing 'subject' parameter (expected non-empty string)".into(),
+        })?
+        .trim();
+    if subject.is_empty() {
+        return Err(ToolError::BadParams {
+            detail: "'subject' must be a non-empty string".into(),
+        });
+    }
+    // Cycle-1 passthrough: treat `subject` as the account_id directly per
+    // DOS-175 §3.4. Phase-A.1 sub-ticket replaces this with a real
+    // subject-to-account_id resolver.
+    Ok(subject.to_string())
+}
+
+fn map_invoke_error(err: AbilityInvokeError) -> ToolError {
+    // Surface the underlying error to stderr (captured by Claude Desktop's
+    // MCP log) so we can diagnose failures without losing detail to the
+    // wire-shape trace_id collapse.
+    eprintln!("mcp_v2 dailyos.read.account_status invoke failed: {err:?}");
+
+    let trace_id = match &err {
+        AbilityInvokeError::Surface(_) => "surface",
+        AbilityInvokeError::Ability(_) => "ability",
+        AbilityInvokeError::InvalidEnvelope => "invalid_envelope",
+        AbilityInvokeError::ProvenanceTooLarge => "provenance_too_large",
+        AbilityInvokeError::ProvenanceSerialize(_) => "provenance_serialize",
+    };
+    ToolError::Internal {
+        trace_id: trace_id.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, Scope, ScopedName,
+    };
+
+    fn stub_actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("test-client".to_string()),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv".to_string())),
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+            granted_scopes: vec![Scope::new("dailyos.read.account_status")],
+        }
+    }
+
+    #[test]
+    fn extract_subject_returns_trimmed_value() {
+        let params = serde_json::json!({ "subject": "  acme  " });
+        let subject = extract_subject(&params).unwrap();
+        assert_eq!(subject, "acme");
+    }
+
+    #[test]
+    fn extract_subject_rejects_missing() {
+        let params = serde_json::json!({});
+        let err = extract_subject(&params).unwrap_err();
+        match err {
+            ToolError::BadParams { detail } => assert!(detail.contains("subject")),
+            other => panic!("expected BadParams, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_subject_rejects_empty() {
+        let params = serde_json::json!({ "subject": "   " });
+        let err = extract_subject(&params).unwrap_err();
+        assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[test]
+    fn extract_subject_rejects_non_string() {
+        let params = serde_json::json!({ "subject": 42 });
+        let err = extract_subject(&params).unwrap_err();
+        assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[test]
+    fn stub_actor_smoke() {
+        // Ensures the actor projection compiles against the current
+        // McpActor enum shape (a tripwire if the variant fields change).
+        let actor = stub_actor();
+        match &actor {
+            McpActor::Client {
+                client_id,
+                tool_name,
+                granted_scopes,
+                ..
+            } => {
+                assert_eq!(client_id.as_str(), "test-client");
+                assert_eq!(tool_name.as_str(), "dailyos.read.account_status");
+                assert_eq!(granted_scopes.len(), 1);
+            }
+        }
+    }
+}

--- a/src-tauri/src/services/mcp_v2/mod.rs
+++ b/src-tauri/src/services/mcp_v2/mod.rs
@@ -1,24 +1,14 @@
 //! MCP v2 gateway: headless MCP head over the DailyOS abilities runtime.
 //!
-//! Per ADR-0128 — MCP as co-equal product surface — and the 2026-05-19
-//! amendment to ADR-0102 — Actor::McpClient actor variant + MCP client
-//! authentication + session contract — this module is the single ingress
-//! for MCP-originated invocations. Tool handlers never read the DB directly;
-//! every call flows through the gateway into services::* or the abilities
-//! runtime.
+//! Per ADR-0128 and the 2026-05-19 ADR-0102 amendment, this module is the
+//! single ingress for MCP-originated invocations. Tool handlers never read the
+//! DB directly; every call flows through the gateway into services::* or the
+//! abilities runtime.
 //!
-//! Submodules:
-//! - contracts — shared wire-shape types — ToolDescription, ScopedName,
-//!   Scope, McpActor, ToolError, Page, OpaqueConversationHandle envelope,
-//!   McpClientId envelope.
-//! - gateway — single entry-point dispatcher; loads scope manifest;
-//!   validates Actor::McpClient policy; emits audit + signals.
-//! - handlers — per-tool handler implementations — placeholder.
-//! - taxonomy — tool catalog and host-selection contract — placeholder.
-//! - actor_policy — scope/permission matrix for Actor::McpClient.
-//! - auth — pairing handshake; server-side scope manifest loading;
-//!   transport HMAC verification; conversation handle minting.
-//! - audit — audit log writer with keyed HMAC parameter/response hashes.
+//! The local MCP substrate enforces authorization and operational controls:
+//! server-side scope manifest, exposure tier, rate limits, conversation handle
+//! lifecycle, audit, and signals. Local transport ceremony is intentionally not
+//! part of this layer.
 
 pub mod actor_policy;
 pub mod audit;
@@ -27,3 +17,4 @@ pub mod contracts;
 pub mod gateway;
 pub mod handlers;
 pub mod taxonomy;
+pub mod transport;

--- a/src-tauri/src/services/mcp_v2/resources/tool_descriptions.yaml
+++ b/src-tauri/src/services/mcp_v2/resources/tool_descriptions.yaml
@@ -1,0 +1,769 @@
+[
+  {
+    "name": "dailyos.read.account_status",
+    "side": "Read",
+    "summary": "Returns the current state of an account the user works with.",
+    "when_to_call": "When the user asks about a specific account they work with.",
+    "when_NOT_to_call": "Do NOT call for broad enterprise or web corpus search.",
+    "scopesRequired": [
+      "dailyos.read.account_status"
+    ],
+    "parameters": [
+      {
+        "name": "subject",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Account name or handle"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Account status payload"
+    },
+    "examples": [
+      {
+        "prompt": "What's going on with Acme?",
+        "invocation": {
+          "name": "dailyos.read.account_status",
+          "arguments": {
+            "subject": "acme"
+          }
+        },
+        "expectedResponseShape": {
+          "account_id": "opaque",
+          "status": "enum",
+          "as_of": "iso8601"
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "What's going on with Acme?",
+          "expectedTool": "dailyos.read.account_status"
+        },
+        {
+          "prompt": "How are things looking with the Hooli deal?",
+          "expectedTool": "dailyos.read.account_status"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Search the web for SaaS pricing benchmarks",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "What's the company's vacation policy?",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "What did I write about the Q1 readout?",
+          "expectedTool": "dailyos.search.workspace_memory"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.read.daily_briefing",
+    "side": "Read",
+    "summary": "Returns the user's current-day briefing.",
+    "when_to_call": "When the user asks about today's priorities.",
+    "when_NOT_to_call": "Do NOT call for general news or weather.",
+    "scopesRequired": [
+      "dailyos.read.daily_briefing"
+    ],
+    "parameters": [],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Daily briefing payload"
+    },
+    "examples": [
+      {
+        "prompt": "What's on my plate today?",
+        "invocation": {
+          "name": "dailyos.read.daily_briefing",
+          "arguments": {}
+        },
+        "expectedResponseShape": {
+          "date": "iso8601",
+          "priorities": []
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "What's on my plate today?",
+          "expectedTool": "dailyos.read.daily_briefing"
+        },
+        {
+          "prompt": "Give me my morning rundown",
+          "expectedTool": "dailyos.read.daily_briefing"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "What's the weather today?",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Show me today's news headlines",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "What should I prep for my 2pm with Acme?",
+          "expectedTool": "dailyos.read.meeting_briefing"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.read.meeting_briefing",
+    "side": "Read",
+    "summary": "Returns the prep briefing for a specific meeting.",
+    "when_to_call": "When the user asks for prep notes on a specific meeting.",
+    "when_NOT_to_call": "Do NOT call for the user's overall day rundown.",
+    "scopesRequired": [
+      "dailyos.read.meeting_briefing"
+    ],
+    "parameters": [
+      {
+        "name": "meeting_id",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Opaque meeting identifier"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Meeting briefing payload"
+    },
+    "examples": [
+      {
+        "prompt": "What should I prep for my 2pm?",
+        "invocation": {
+          "name": "dailyos.read.meeting_briefing",
+          "arguments": {
+            "meeting_id": "opaque"
+          }
+        },
+        "expectedResponseShape": {
+          "meeting_id": "opaque",
+          "attendees": []
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "What should I prep for my 2pm with Acme?",
+          "expectedTool": "dailyos.read.meeting_briefing"
+        },
+        {
+          "prompt": "Brief me on my next call with Hooli",
+          "expectedTool": "dailyos.read.meeting_briefing"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Show me the company holiday calendar",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Search the web for meeting facilitation techniques",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "What's on my plate today overall?",
+          "expectedTool": "dailyos.read.daily_briefing"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.read.portfolio_attention",
+    "side": "Read",
+    "summary": "Returns accounts that currently need attention.",
+    "when_to_call": "When the user asks which accounts are at risk or need follow-up.",
+    "when_NOT_to_call": "Do NOT call for general account state of a specific named account.",
+    "scopesRequired": [
+      "dailyos.read.portfolio_attention"
+    ],
+    "parameters": [],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Ranked account attention list"
+    },
+    "examples": [
+      {
+        "prompt": "What accounts need my attention?",
+        "invocation": {
+          "name": "dailyos.read.portfolio_attention",
+          "arguments": {}
+        },
+        "expectedResponseShape": {
+          "accounts": []
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "What accounts need my attention?",
+          "expectedTool": "dailyos.read.portfolio_attention"
+        },
+        {
+          "prompt": "Where should I focus this week?",
+          "expectedTool": "dailyos.read.portfolio_attention"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Show me the Q3 sales report",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Search the web for customer churn benchmarks",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "What's going on with Acme specifically?",
+          "expectedTool": "dailyos.read.account_status"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.search.workspace_memory",
+    "side": "Read",
+    "summary": "Searches the user's working memory.",
+    "when_to_call": "When the user asks what they wrote, said, or noted about a topic.",
+    "when_NOT_to_call": "Do NOT call for general web search.",
+    "scopesRequired": [
+      "read.workspace_graph"
+    ],
+    "parameters": [
+      {
+        "name": "query",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Natural-language search query"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Workspace memory matches"
+    },
+    "examples": [
+      {
+        "prompt": "What did I write about the Q1 readout?",
+        "invocation": {
+          "name": "dailyos.search.workspace_memory",
+          "arguments": {
+            "query": "Q1 readout"
+          }
+        },
+        "expectedResponseShape": {
+          "matches": []
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "What did I write about the Q1 readout?",
+          "expectedTool": "dailyos.search.workspace_memory"
+        },
+        {
+          "prompt": "Find my notes on the Acme renewal",
+          "expectedTool": "dailyos.search.workspace_memory"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Search the web for Q1 readout templates",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Find company-wide Q1 reports in Glean",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "What's the current state of the Acme account?",
+          "expectedTool": "dailyos.read.account_status"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.read.workspace_source_provenance",
+    "side": "Read",
+    "summary": "Returns provenance metadata for a workspace memory entry.",
+    "when_to_call": "When the user asks where a specific memory entry came from.",
+    "when_NOT_to_call": "Do NOT call without a prior memory entry reference.",
+    "scopesRequired": [
+      "dailyos.read.workspace_source_provenance"
+    ],
+    "parameters": [
+      {
+        "name": "entry_id",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Opaque memory entry identifier"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "description": "Source attribution metadata"
+    },
+    "examples": [
+      {
+        "prompt": "Where did that note about Acme come from?",
+        "invocation": {
+          "name": "dailyos.read.workspace_source_provenance",
+          "arguments": {
+            "entry_id": "opaque"
+          }
+        },
+        "expectedResponseShape": {
+          "source": "string"
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "Where did that note about Acme come from?",
+          "expectedTool": "dailyos.read.workspace_source_provenance"
+        },
+        {
+          "prompt": "What's the source of this memory entry?",
+          "expectedTool": "dailyos.read.workspace_source_provenance"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Search the web for source attribution best practices",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Show me the org-wide data provenance policy",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "Find the actual note about Acme",
+          "expectedTool": "dailyos.search.workspace_memory"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.write.place_document",
+    "side": "Write",
+    "summary": "Places a document into working memory.",
+    "when_to_call": "When the user wants to save or file a document under a topic.",
+    "when_NOT_to_call": "Do NOT call for general file upload to shared drives.",
+    "scopesRequired": [
+      "write.workspace_place_document"
+    ],
+    "parameters": [
+      {
+        "name": "topic",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Topic"
+      },
+      {
+        "name": "content",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Document content"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "document_id": {
+            "type": "string"
+          },
+          "mutation_cursor": {
+            "type": "object"
+          }
+        }
+      },
+      "description": "New document identifier"
+    },
+    "examples": [
+      {
+        "prompt": "Save this Acme renewal context under the Acme topic",
+        "invocation": {
+          "name": "dailyos.write.place_document",
+          "arguments": {
+            "topic": "Acme",
+            "content": "opaque"
+          }
+        },
+        "expectedResponseShape": {
+          "document_id": "opaque",
+          "mutation_cursor": {
+            "document_id": "opaque"
+          }
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "Save this Acme renewal context under the Acme topic",
+          "expectedTool": "dailyos.write.place_document"
+        },
+        {
+          "prompt": "File this note under the Hooli deal",
+          "expectedTool": "dailyos.write.place_document"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Upload this file to Drive",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Save this to the company wiki",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "Add a quick note about Acme",
+          "expectedTool": "dailyos.submit.note"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.submit.note",
+    "side": "SubmitCorrection",
+    "summary": "Submits a free-form note.",
+    "when_to_call": "When the user wants to capture a quick thought or observation.",
+    "when_NOT_to_call": "Do NOT call for structured action items.",
+    "scopesRequired": [
+      "dailyos.submit.note"
+    ],
+    "parameters": [
+      {
+        "name": "text",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Note text"
+      },
+      {
+        "name": "subject",
+        "schema": {
+          "type": "string"
+        },
+        "required": false,
+        "description": "Optional subject"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "note_id": {
+            "type": "string"
+          },
+          "mutation_cursor": {
+            "type": "object"
+          }
+        }
+      },
+      "description": "New note identifier"
+    },
+    "examples": [
+      {
+        "prompt": "Note that Acme is concerned about pricing",
+        "invocation": {
+          "name": "dailyos.submit.note",
+          "arguments": {
+            "text": "Acme concerned about pricing",
+            "subject": "Acme"
+          }
+        },
+        "expectedResponseShape": {
+          "note_id": "opaque",
+          "mutation_cursor": {
+            "note_id": "opaque"
+          }
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "Note that Acme is concerned about pricing",
+          "expectedTool": "dailyos.submit.note"
+        },
+        {
+          "prompt": "Quick observation that Hooli champion is moving teams",
+          "expectedTool": "dailyos.submit.note"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Post this announcement to the company channel",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Send this note to the team via email",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "Save this full document under the Acme topic",
+          "expectedTool": "dailyos.write.place_document"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.submit.action",
+    "side": "SubmitCorrection",
+    "summary": "Submits a structured action item.",
+    "when_to_call": "When the user wants to capture a task or follow-up.",
+    "when_NOT_to_call": "Do NOT call for free-form notes.",
+    "scopesRequired": [
+      "dailyos.submit.action"
+    ],
+    "parameters": [
+      {
+        "name": "description",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Action description"
+      },
+      {
+        "name": "due_at",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "required": false,
+        "description": "Optional due time"
+      },
+      {
+        "name": "subject",
+        "schema": {
+          "type": "string"
+        },
+        "required": false,
+        "description": "Optional subject"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "action_id": {
+            "type": "string"
+          },
+          "mutation_cursor": {
+            "type": "object"
+          }
+        }
+      },
+      "description": "New action identifier"
+    },
+    "examples": [
+      {
+        "prompt": "Remind me to follow up with Acme next Tuesday",
+        "invocation": {
+          "name": "dailyos.submit.action",
+          "arguments": {
+            "description": "Follow up with Acme",
+            "due_at": "iso8601",
+            "subject": "Acme"
+          }
+        },
+        "expectedResponseShape": {
+          "action_id": "opaque",
+          "mutation_cursor": {
+            "action_id": "opaque"
+          }
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "Remind me to follow up with Acme next Tuesday",
+          "expectedTool": "dailyos.submit.action"
+        },
+        {
+          "prompt": "Add a task to send the Hooli proposal by Friday",
+          "expectedTool": "dailyos.submit.action"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Add this to the team's Jira backlog",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Create a calendar invite for the meeting",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "Note that Acme is concerned about pricing",
+          "expectedTool": "dailyos.submit.note"
+        }
+      ]
+    }
+  },
+  {
+    "name": "dailyos.submit.action_status",
+    "side": "SubmitCorrection",
+    "summary": "Updates the status of an existing action.",
+    "when_to_call": "When the user reports an action as done, deferred, or dropped.",
+    "when_NOT_to_call": "Do NOT call to create a new action.",
+    "scopesRequired": [
+      "dailyos.submit.action_status"
+    ],
+    "parameters": [
+      {
+        "name": "action_id",
+        "schema": {
+          "type": "string"
+        },
+        "required": true,
+        "description": "Opaque action identifier"
+      },
+      {
+        "name": "status",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "done",
+            "deferred",
+            "dropped"
+          ]
+        },
+        "required": true,
+        "description": "New status"
+      }
+    ],
+    "returns": {
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "action_id": {
+            "type": "string"
+          },
+          "mutation_cursor": {
+            "type": "object"
+          }
+        }
+      },
+      "description": "Updated action identifier"
+    },
+    "examples": [
+      {
+        "prompt": "I finished the Acme follow-up",
+        "invocation": {
+          "name": "dailyos.submit.action_status",
+          "arguments": {
+            "action_id": "opaque",
+            "status": "done"
+          }
+        },
+        "expectedResponseShape": {
+          "action_id": "opaque",
+          "mutation_cursor": {
+            "action_id": "opaque"
+          }
+        }
+      }
+    ],
+    "selectionFixtures": {
+      "positive": [
+        {
+          "prompt": "I finished the Acme follow-up",
+          "expectedTool": "dailyos.submit.action_status"
+        },
+        {
+          "prompt": "Mark the Hooli proposal task as dropped",
+          "expectedTool": "dailyos.submit.action_status"
+        }
+      ],
+      "negativeBroadCorpus": [
+        {
+          "prompt": "Mark this Jira ticket as done",
+          "expectedToolClass": "external"
+        },
+        {
+          "prompt": "Update the project status in the company wiki",
+          "expectedToolClass": "external"
+        }
+      ],
+      "negativeAdjacentTool": [
+        {
+          "prompt": "Add a new task to call Hooli tomorrow",
+          "expectedTool": "dailyos.submit.action"
+        }
+      ]
+    }
+  }
+]

--- a/src-tauri/src/services/mcp_v2/taxonomy.rs
+++ b/src-tauri/src/services/mcp_v2/taxonomy.rs
@@ -1,5 +1,684 @@
 //! MCP tool taxonomy + host-selection contract.
 //!
-//! The catalog of tool descriptions — the version-controlled product
-//! copy per ADR-0128 §3 — loads from a YAML file at runtime; this
-//! module defines the load + validation surface. Implementation pending.
+//! - [`TaxonomyCatalog`] trait — the abstract catalog interface the
+//!   gateway consumes at boot.
+//! - [`TaxonomyError`] — fail-fast variants with operator-readable
+//!   `Display`.
+//! - [`YamlTaxonomyCatalog`] — concrete YAML loader (W1-B / DOS-478)
+//!   implementing the trait. Production uses `load_embedded()` reading
+//!   the embedded `tool_descriptions` resource via `include_str!`. Dev uses
+//!   `load_from_path(env DAILYOS_MCP_TAXONOMY_PATH)` for catalog
+//!   iteration without rebuild.
+//!
+//! Handler bodies live in subsequent waves (W2 / W3 / W4) but must
+//! follow the handler-contract conventions documented on
+//! [`TaxonomyCatalog`] below.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use super::contracts::{
+    McpToolHandler, ParamSpec, ReturnSpec, Scope, ScopedName, Side, ToolDescription, ToolExample,
+};
+
+#[cfg(test)]
+#[allow(unused_imports)]
+use super::contracts::ToolDescription as _ToolDescriptionImported;
+
+// ---------------------------------------------------------------------------
+// TaxonomyError
+// ---------------------------------------------------------------------------
+
+/// Errors surfaced when the loaded tool catalog disagrees with the
+/// registered [`McpToolHandler`] implementations at startup, or when
+/// the YAML catalog itself fails to load / validate.
+///
+/// These are operator-facing — they indicate a mismatch between the
+/// version-controlled YAML catalog and the compiled handler registry.
+/// The gateway treats catalog load / validation failure as fatal at
+/// boot via `Gateway::seal()` returning `Err(...)`; no `panic!()`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaxonomyError {
+    /// A registered handler's `ScopedName` has no matching entry in
+    /// the loaded catalog, OR a catalog entry has no matching handler
+    /// (catalog-to-handler direction), OR the registered handler's
+    /// `Side` disagrees with the catalog entry's `Side`. The optional
+    /// `nearest_candidate` is the closest catalog name by Levenshtein
+    /// distance for typo DX.
+    HandlerCatalogMismatch {
+        handler: ScopedName,
+        catalog_entry: Option<ScopedName>,
+        nearest_candidate: Option<ScopedName>,
+    },
+
+    /// The catalog failed to parse (syntax error, unknown field on
+    /// `YamlToolEntry` / nested `SelectionFixtures` / `PromptFixture` /
+    /// `AdjacentFixture`, or missing required field).
+    ParseFailed { error: String },
+
+    /// An entry's `name` failed the canonical naming convention regex
+    /// `^dailyos\.(read|write|submit|search|list|get|prepare)\.[a-z][a-z0-9_]*$`.
+    InvalidName { name: String, reason: String },
+
+    /// An entry's `scopes_required` includes a scope not in the
+    /// allowlist (new `dailyos.<verb>.<noun>` or grandfathered v1.4.5).
+    InvalidScope { tool: ScopedName, scope: Scope },
+
+    /// Two YAML entries share the same `name`.
+    DuplicateName { name: ScopedName },
+
+    /// A registered handler's `Side` disagrees with the catalog entry's
+    /// `Side`.
+    SideMismatch {
+        handler: ScopedName,
+        expected: Side,
+        actual: Side,
+    },
+
+    /// An entry's `selectionFixtures` lacks the AC-5 coverage minimums
+    /// (≥ 2 positive, ≥ 2 negative_broad_corpus, ≥ 1 negative_adjacent_tool).
+    FixtureCoverage {
+        tool: ScopedName,
+        missing: &'static str,
+    },
+}
+
+impl std::fmt::Display for TaxonomyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HandlerCatalogMismatch {
+                handler,
+                catalog_entry,
+                nearest_candidate,
+            } => match (catalog_entry, nearest_candidate) {
+                (None, Some(near)) => write!(
+                    f,
+                    "mcp_v2 taxonomy: handler `{handler}` has no catalog entry. \
+                     Did you mean `{near}`? Fix the handler name or add an entry to \
+                     resources/mcp_v2/tool_descriptions.yaml.",
+                ),
+                (None, None) => write!(
+                    f,
+                    "mcp_v2 taxonomy: handler `{handler}` has no catalog entry. \
+                     Add an entry to resources/mcp_v2/tool_descriptions.yaml.",
+                ),
+                (Some(_), _) => write!(
+                    f,
+                    "mcp_v2 taxonomy: handler `{handler}` Side disagrees with catalog entry. \
+                     Verify the handler's description().side matches the catalog entry's side.",
+                ),
+            },
+            Self::ParseFailed { error } => write!(
+                f,
+                "mcp_v2 taxonomy: catalog parse failed: {error}. \
+                 Check resources/mcp_v2/tool_descriptions.yaml for syntax, unknown fields, \
+                 or missing required fields.",
+            ),
+            Self::InvalidName { name, reason } => write!(
+                f,
+                "mcp_v2 taxonomy: catalog entry name `{name}` is invalid: {reason}. \
+                 Names must match `dailyos.<verb>.<noun>` per ADR-0102 §E.",
+            ),
+            Self::InvalidScope { tool, scope } => write!(
+                f,
+                "mcp_v2 taxonomy: tool `{tool}` requires scope `{scope}` which is not in \
+                 the allowlist. New scopes use `dailyos.<verb>.<noun>` form; v1.4.5 \
+                 grandfathered scopes are listed in taxonomy.rs::GRANDFATHERED_SCOPES.",
+            ),
+            Self::DuplicateName { name } => write!(
+                f,
+                "mcp_v2 taxonomy: catalog has duplicate entry for `{name}`. \
+                 Remove the duplicate from resources/mcp_v2/tool_descriptions.yaml.",
+            ),
+            Self::SideMismatch {
+                handler,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "mcp_v2 taxonomy: handler `{handler}` side mismatch: \
+                 catalog says {expected:?} but handler advertises {actual:?}. \
+                 Fix the handler's description().side or update the catalog entry.",
+            ),
+            Self::FixtureCoverage { tool, missing } => write!(
+                f,
+                "mcp_v2 taxonomy: tool `{tool}` selectionFixtures missing required \
+                 coverage: {missing}. AC-5 requires ≥ 2 positive + ≥ 2 \
+                 negativeBroadCorpus + ≥ 1 negativeAdjacentTool.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TaxonomyError {}
+
+// ---------------------------------------------------------------------------
+// TaxonomyCatalog trait
+// ---------------------------------------------------------------------------
+
+/// The abstract catalog interface the gateway uses at boot. The
+/// concrete implementation is [`YamlTaxonomyCatalog`].
+///
+/// # Handler-contract conventions (read before writing a handler in W2 / W3 / W4)
+///
+/// Every concrete [`McpToolHandler`] in `services::mcp_v2::handlers::*`
+/// must obey the following rules. The gateway enforces them at
+/// dispatch time; failure to follow them produces operator-visible
+/// warnings or rejected calls.
+///
+/// ## Side::Read handlers
+///
+/// Read tools may return any JSON shape compatible with the
+/// `ToolDescription.returns.schema` advertised in the catalog. There
+/// is no `mutation_cursor` requirement.
+///
+/// ## Side::Write and Side::SubmitCorrection handlers — `mutation_cursor` field
+///
+/// Write and submit-correction tools must include a `mutation_cursor`
+/// field in their success payload. The gateway extracts it via JSON
+/// inspection and folds it into the audit detail JSON as forensic
+/// ordering material. Omitting it produces a `Suite-S` warning signal
+/// (`mcp_write_handler_missing_cursor`).
+///
+/// **Cursor shape: IDs only, no payload data.** Stable substrate IDs
+/// (UUIDs, integer primary keys, opaque hashes). Never embed user
+/// content, email addresses, names, or any PII-shaped string. The
+/// gateway caps the cursor at depth 4 and 2 KiB serialized; oversize
+/// cursors are replaced with `"truncated_oversize"` and a `Suite-S`
+/// warning (`mcp_write_handler_cursor_truncated`) is emitted.
+pub trait TaxonomyCatalog: Send + Sync {
+    /// Handler→catalog: verify every registered handler has a matching
+    /// catalog entry with matching `Side`. Production `Gateway::seal()`
+    /// uses this; mismatch = fatal at boot.
+    fn validate_against_handlers(
+        &self,
+        handlers: &[&dyn McpToolHandler],
+    ) -> Result<(), TaxonomyError>;
+
+    /// Catalog→handler: return the catalog entries that have no
+    /// matching handler. NOT an error in production — W2/W3/W4 land
+    /// handlers incrementally; the gateway logs the list as operator
+    /// info.
+    fn validate_catalog_against_handlers(
+        &self,
+        handlers: &[&dyn McpToolHandler],
+    ) -> Vec<ScopedName>;
+
+    /// Look up the catalog-declared [`Side`] tier for a tool by name.
+    fn side_for(&self, tool_name: &ScopedName) -> Option<Side>;
+
+    /// Look up the full `ToolDescription` for a tool by name. Used by
+    /// the v2 transport (W1.5) to compose `tools/list` descriptions
+    /// from `summary` + `when_to_call` + `when_NOT_to_call`.
+    fn description_for(&self, tool_name: &ScopedName) -> Option<&ToolDescription>;
+
+    /// Iterate every catalog entry's `ScopedName`. Used by transport
+    /// `tools/list` to enumerate handler candidates before filtering by
+    /// manifest grants.
+    fn iter_names(&self) -> Box<dyn Iterator<Item = &ScopedName> + '_>;
+}
+
+// ---------------------------------------------------------------------------
+// YAML DTOs
+// ---------------------------------------------------------------------------
+
+/// Wire-shape DTO for a single tool entry in the embedded tool catalog.
+/// Splits into `(ToolDescription, SelectionFixtures)` at load time via
+/// [`Self::into_description_and_fixtures`].
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct YamlToolEntry {
+    pub name: ScopedName,
+    pub side: Side,
+    pub summary: String,
+    #[serde(rename = "when_to_call")]
+    pub when_to_call: String,
+    #[serde(rename = "when_NOT_to_call")]
+    pub when_not_to_call: String,
+    pub scopes_required: Vec<Scope>,
+    pub parameters: Vec<ParamSpec>,
+    pub returns: ReturnSpec,
+    pub examples: Vec<ToolExample>,
+    pub selection_fixtures: SelectionFixtures,
+}
+
+impl YamlToolEntry {
+    pub fn into_description_and_fixtures(self) -> (ToolDescription, SelectionFixtures) {
+        let description = ToolDescription {
+            name: self.name,
+            summary: self.summary,
+            when_to_call: self.when_to_call,
+            when_not_to_call: self.when_not_to_call,
+            side: self.side,
+            parameters: self.parameters,
+            returns: self.returns,
+            examples: self.examples,
+            scopes_required: self.scopes_required,
+        };
+        (description, self.selection_fixtures)
+    }
+}
+
+/// Host-selection eval fixture stubs consumed by DOS-481 (W5-A).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct SelectionFixtures {
+    pub positive: Vec<PromptFixture>,
+    pub negative_broad_corpus: Vec<PromptFixture>,
+    pub negative_adjacent_tool: Vec<AdjacentFixture>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PromptFixture {
+    pub prompt: String,
+    #[serde(default)]
+    pub expected_tool: Option<ScopedName>,
+    #[serde(default)]
+    pub expected_tool_class: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct AdjacentFixture {
+    pub prompt: String,
+    pub expected_tool: ScopedName,
+}
+
+// ---------------------------------------------------------------------------
+// YamlTaxonomyCatalog
+// ---------------------------------------------------------------------------
+
+/// Embedded catalog compiled into the binary. Production uses
+/// [`YamlTaxonomyCatalog::load_embedded`]; dev can override via
+/// `DAILYOS_MCP_TAXONOMY_PATH` env var pointed at a local YAML file.
+const EMBEDDED_YAML: &str = include_str!("resources/tool_descriptions.yaml");
+
+/// Tool-name regex per AC-2 + ADR-0102 §E.
+const NAME_RE: &str = r"^dailyos\.(read|write|submit|search|list|get|prepare)\.[a-z][a-z0-9_]*$";
+
+/// v1.4.5 grandfathered scopes (per ADR-0102 §E + DOS-478 L0 §3): kept
+/// unprefixed verbatim to avoid breaking existing substrate.
+const GRANDFATHERED_SCOPES: &[&str] = &[
+    "write.workspace_place_document",
+    "read.workspace_graph",
+    "read.entity_names",
+    "submit.feedback",
+    "submit.correction",
+    "submit.dismissal",
+];
+
+#[derive(Debug)]
+pub struct YamlTaxonomyCatalog {
+    entries: HashMap<ScopedName, (ToolDescription, SelectionFixtures)>,
+}
+
+impl YamlTaxonomyCatalog {
+    /// Production loader — reads the embedded YAML resource.
+    pub fn load_embedded() -> Result<Self, TaxonomyError> {
+        Self::load_from_str(EMBEDDED_YAML)
+    }
+
+    /// Dev override — reads YAML from filesystem. Mirrors
+    /// `src/presets/loader.rs` precedent. Env-gate via
+    /// `DAILYOS_MCP_TAXONOMY_PATH` in callers; this function itself is
+    /// path-agnostic so tests can call directly.
+    pub fn load_from_path(path: &Path) -> Result<Self, TaxonomyError> {
+        let content = std::fs::read_to_string(path).map_err(|e| TaxonomyError::ParseFailed {
+            error: format!("read {path:?}: {e}"),
+        })?;
+        Self::load_from_str(&content)
+    }
+
+    pub fn load_from_str(yaml: &str) -> Result<Self, TaxonomyError> {
+        let raw: Vec<YamlToolEntry> =
+            serde_json::from_str(yaml).map_err(|e| TaxonomyError::ParseFailed {
+                error: e.to_string(),
+            })?;
+
+        let name_re = regex::Regex::new(NAME_RE).expect("static regex compiles");
+        let mut entries = HashMap::with_capacity(raw.len());
+
+        for entry in raw {
+            // Naming convention.
+            if !name_re.is_match(entry.name.as_str()) {
+                return Err(TaxonomyError::InvalidName {
+                    name: entry.name.as_str().to_string(),
+                    reason: format!("does not match `{NAME_RE}`"),
+                });
+            }
+
+            // Scope allowlist.
+            for scope in &entry.scopes_required {
+                if !scope_in_allowlist(scope) {
+                    return Err(TaxonomyError::InvalidScope {
+                        tool: entry.name.clone(),
+                        scope: scope.clone(),
+                    });
+                }
+            }
+
+            // Fixture coverage.
+            let (desc, fixtures) = entry.into_description_and_fixtures();
+            if fixtures.positive.len() < 2 {
+                return Err(TaxonomyError::FixtureCoverage {
+                    tool: desc.name.clone(),
+                    missing: "positive < 2",
+                });
+            }
+            if fixtures.negative_broad_corpus.len() < 2 {
+                return Err(TaxonomyError::FixtureCoverage {
+                    tool: desc.name.clone(),
+                    missing: "negativeBroadCorpus < 2",
+                });
+            }
+            if fixtures.negative_adjacent_tool.is_empty() {
+                return Err(TaxonomyError::FixtureCoverage {
+                    tool: desc.name.clone(),
+                    missing: "negativeAdjacentTool < 1",
+                });
+            }
+
+            // Duplicate name.
+            if entries.contains_key(&desc.name) {
+                return Err(TaxonomyError::DuplicateName {
+                    name: desc.name.clone(),
+                });
+            }
+            entries.insert(desc.name.clone(), (desc, fixtures));
+        }
+
+        Ok(Self { entries })
+    }
+
+    pub fn description_for(&self, name: &ScopedName) -> Option<&ToolDescription> {
+        self.entries.get(name).map(|(d, _)| d)
+    }
+
+    pub fn fixtures_for(&self, name: &ScopedName) -> Option<&SelectionFixtures> {
+        self.entries.get(name).map(|(_, f)| f)
+    }
+
+    pub fn entries_with_fixtures(
+        &self,
+    ) -> impl Iterator<Item = (&ScopedName, &ToolDescription, &SelectionFixtures)> {
+        self.entries.iter().map(|(n, (d, f))| (n, d, f))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl TaxonomyCatalog for YamlTaxonomyCatalog {
+    fn validate_against_handlers(
+        &self,
+        handlers: &[&dyn McpToolHandler],
+    ) -> Result<(), TaxonomyError> {
+        for handler in handlers {
+            let desc = handler.description();
+            match self.entries.get(&desc.name) {
+                None => {
+                    return Err(TaxonomyError::HandlerCatalogMismatch {
+                        handler: desc.name.clone(),
+                        catalog_entry: None,
+                        nearest_candidate: self.nearest_name(desc.name.as_str()),
+                    });
+                }
+                Some((catalog_desc, _)) => {
+                    if catalog_desc.side != desc.side {
+                        return Err(TaxonomyError::SideMismatch {
+                            handler: desc.name.clone(),
+                            expected: catalog_desc.side,
+                            actual: desc.side,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_catalog_against_handlers(
+        &self,
+        handlers: &[&dyn McpToolHandler],
+    ) -> Vec<ScopedName> {
+        let handler_names: std::collections::HashSet<&ScopedName> =
+            handlers.iter().map(|h| &h.description().name).collect();
+        self.entries
+            .keys()
+            .filter(|n| !handler_names.contains(n))
+            .cloned()
+            .collect()
+    }
+
+    fn side_for(&self, tool_name: &ScopedName) -> Option<Side> {
+        self.entries.get(tool_name).map(|(d, _)| d.side)
+    }
+
+    fn description_for(&self, tool_name: &ScopedName) -> Option<&ToolDescription> {
+        self.entries.get(tool_name).map(|(d, _)| d)
+    }
+
+    fn iter_names(&self) -> Box<dyn Iterator<Item = &ScopedName> + '_> {
+        Box::new(self.entries.keys())
+    }
+}
+
+impl YamlTaxonomyCatalog {
+    /// Nearest catalog name by simple prefix + Levenshtein-ish edit
+    /// distance for typo DX. Returns None if no entry is close enough.
+    fn nearest_name(&self, needle: &str) -> Option<ScopedName> {
+        self.entries
+            .keys()
+            .min_by_key(|name| levenshtein(name.as_str(), needle))
+            .cloned()
+    }
+}
+
+fn scope_in_allowlist(scope: &Scope) -> bool {
+    let s = scope.as_str();
+    if GRANDFATHERED_SCOPES.contains(&s) {
+        return true;
+    }
+    // dailyos.<verb>.<noun>
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 3 || parts[0] != "dailyos" {
+        return false;
+    }
+    matches!(
+        parts[1],
+        "read" | "write" | "submit" | "search" | "list" | "get" | "prepare"
+    ) && !parts[2].is_empty()
+        && parts[2]
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_lowercase())
+            .unwrap_or(false)
+        && parts[2]
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Minimal Levenshtein for nearest-candidate suggestion DX.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (m, n) = (a.len(), b.len());
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr = vec![0usize; n + 1];
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn catalog_json(entries: Vec<String>) -> String {
+        format!("[{}]", entries.join(","))
+    }
+
+    fn valid_entry_json(name: &str, scope: &str) -> String {
+        format!(
+            r#"{{
+                "name": "{name}",
+                "side": "Read",
+                "summary": "x",
+                "when_to_call": "y",
+                "when_NOT_to_call": "z",
+                "scopesRequired": ["{scope}"],
+                "parameters": [],
+                "returns": {{ "schema": {{}}, "description": "x" }},
+                "examples": [],
+                "selectionFixtures": {{
+                    "positive": [
+                        {{ "prompt": "a", "expectedTool": "dailyos.read.foo" }},
+                        {{ "prompt": "b", "expectedTool": "dailyos.read.foo" }}
+                    ],
+                    "negativeBroadCorpus": [
+                        {{ "prompt": "c", "expectedToolClass": "external" }},
+                        {{ "prompt": "d", "expectedToolClass": "external" }}
+                    ],
+                    "negativeAdjacentTool": [
+                        {{ "prompt": "e", "expectedTool": "dailyos.read.bar" }}
+                    ]
+                }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn embedded_catalog_loads_clean_with_ten_entries() {
+        let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
+        assert_eq!(catalog.len(), 10, "expected 10 tool entries per DOS-478 §5");
+    }
+
+    #[test]
+    fn embedded_catalog_contains_required_inventory() {
+        let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
+        for name in [
+            "dailyos.read.account_status",
+            "dailyos.read.daily_briefing",
+            "dailyos.read.meeting_briefing",
+            "dailyos.read.portfolio_attention",
+            "dailyos.search.workspace_memory",
+            "dailyos.read.workspace_source_provenance",
+            "dailyos.write.place_document",
+            "dailyos.submit.note",
+            "dailyos.submit.action",
+            "dailyos.submit.action_status",
+        ] {
+            assert!(
+                catalog.description_for(&ScopedName::new(name)).is_some(),
+                "missing required tool: {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_name_rejected() {
+        let catalog = catalog_json(vec![valid_entry_json(
+            "NotDailyos.read.foo",
+            "dailyos.read.foo",
+        )]);
+        match YamlTaxonomyCatalog::load_from_str(&catalog) {
+            Err(TaxonomyError::InvalidName { .. }) => {}
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_scope_rejected() {
+        let catalog = catalog_json(vec![valid_entry_json(
+            "dailyos.read.foo",
+            "some.random.scope",
+        )]);
+        match YamlTaxonomyCatalog::load_from_str(&catalog) {
+            Err(TaxonomyError::InvalidScope { .. }) => {}
+            other => panic!("expected InvalidScope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let catalog = catalog_json(vec![
+            valid_entry_json("dailyos.read.foo", "dailyos.read.foo"),
+            valid_entry_json("dailyos.read.foo", "dailyos.read.foo"),
+        ]);
+        match YamlTaxonomyCatalog::load_from_str(&catalog) {
+            Err(TaxonomyError::DuplicateName { .. }) => {}
+            other => panic!("expected DuplicateName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_top_level_field_rejected() {
+        let entry = valid_entry_json("dailyos.read.foo", "dailyos.read.foo").replace(
+            r#""selectionFixtures""#,
+            r#""unknownField": "oops", "selectionFixtures""#,
+        );
+        let catalog = catalog_json(vec![entry]);
+        match YamlTaxonomyCatalog::load_from_str(&catalog) {
+            Err(TaxonomyError::ParseFailed { .. }) => {}
+            other => panic!("expected ParseFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixture_coverage_enforced() {
+        let entry = valid_entry_json("dailyos.read.foo", "dailyos.read.foo").replace(
+            r#""positive": [
+                        { "prompt": "a", "expectedTool": "dailyos.read.foo" },
+                        { "prompt": "b", "expectedTool": "dailyos.read.foo" }
+                    ]"#,
+            r#""positive": [
+                        { "prompt": "a", "expectedTool": "dailyos.read.foo" }
+                    ]"#,
+        );
+        let catalog = catalog_json(vec![entry]);
+        match YamlTaxonomyCatalog::load_from_str(&catalog) {
+            Err(TaxonomyError::FixtureCoverage { missing, .. }) => {
+                assert!(missing.contains("positive"));
+            }
+            other => panic!("expected FixtureCoverage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nearest_candidate_returned_for_typo() {
+        let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
+        let near = catalog.nearest_name("dailyos.read.accont_status"); // typo
+        assert_eq!(
+            near,
+            Some(ScopedName::new("dailyos.read.account_status")),
+            "nearest should suggest the real name",
+        );
+    }
+
+    #[test]
+    fn levenshtein_basic() {
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("same", "same"), 0);
+    }
+}

--- a/src-tauri/src/services/mcp_v2/transport.rs
+++ b/src-tauri/src/services/mcp_v2/transport.rs
@@ -1,0 +1,408 @@
+//! MCP v2 transport ingress — rmcp::ServerHandler implementation.
+//!
+//! Bridges the official `rmcp` crate to the v2 Gateway so standard MCP
+//! clients (Claude Desktop, Cursor, custom local SDK) invoke v2 tools
+//! through the simplified local MCP v2 authorization contract.
+//!
+//! Architecture (per `.docs/plans/v1.4.7-w1-foundation/dos-mcp-transport-l0-plan.md`):
+//!
+//! - **Scope**: local-to-local same-machine only. Trust boundary is
+//!   "same user on this machine." No remote MCP transport in v1.4.7.
+//! - **Identity**: env-asserted at process startup (`DAILYOS_MCP_CLIENT_ID`).
+//!   The gateway treats the asserted id as scope/audit attribution in the
+//!   same-user local trust model.
+//! - **Per-call flow**: standard MCP clients send normal `{ name, arguments }`
+//!   shape; the transport builds a [`McpToolRequestEnvelope`] and calls
+//!   [`Gateway::handle_tool_call`]. `_dailyos_*` keys are NOT exposed in public
+//!   `tools/list` `input_schema`.
+//! - **Trust model**: local stdio is inside the OS-user boundary. Authorization
+//!   is the server-side manifest + exposure + rate-limit path in the gateway.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rmcp::model::{
+    CallToolRequestParam, CallToolResult, Content, ErrorCode, ErrorData, Implementation,
+    JsonObject, ListToolsResult, PaginatedRequestParam, ProtocolVersion, ServerCapabilities,
+    ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::{RoleServer, ServerHandler};
+use rusqlite::Connection;
+
+use super::auth;
+use super::contracts::{
+    McpClientId, McpToolRequestEnvelope, McpToolResponseEnvelope, McpToolResult, ScopedName,
+    ToolDescription, ToolError,
+};
+use super::gateway::Gateway;
+use super::taxonomy::TaxonomyCatalog;
+
+// ---------------------------------------------------------------------------
+// V2ServerHandler
+// ---------------------------------------------------------------------------
+
+/// Bridges `rmcp::ServerHandler` to the v2 `Gateway`. Constructed AFTER
+/// successful env-assertion + manifest lookup in `main.rs`. Construction
+/// failure exits the process before the rmcp service runs.
+///
+/// rmcp::ServerHandler requires Clone; all fields are Arc-wrapped so
+/// cloning is shallow.
+#[derive(Clone)]
+pub struct V2ServerHandler {
+    gateway: Arc<Gateway>,
+    catalog: Arc<dyn TaxonomyCatalog>,
+    conn: Arc<Mutex<Connection>>,
+    verified_client_id: McpClientId,
+}
+
+impl V2ServerHandler {
+    /// Construct after env-assertion + manifest lookup succeeds in `main.rs`.
+    pub fn from_verified_pairing(
+        gateway: Arc<Gateway>,
+        catalog: Arc<dyn TaxonomyCatalog>,
+        conn: Arc<Mutex<Connection>>,
+        verified_client_id: McpClientId,
+    ) -> Self {
+        Self {
+            gateway,
+            catalog,
+            conn,
+            verified_client_id,
+        }
+    }
+}
+
+/// Build a JSON Schema fragment from a `ToolDescription`'s parameter
+/// list. Per L0 AC-6, `_dailyos_*` keys are NOT advertised — clients
+/// send normal handler params only.
+fn build_input_schema(desc: &ToolDescription) -> JsonObject {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+    for param in &desc.parameters {
+        properties.insert(param.name.clone(), param.schema.0.clone());
+        if param.required {
+            required.push(serde_json::Value::String(param.name.clone()));
+        }
+    }
+    let mut schema = serde_json::Map::new();
+    schema.insert("type".into(), serde_json::Value::String("object".into()));
+    schema.insert("properties".into(), serde_json::Value::Object(properties));
+    schema.insert("required".into(), serde_json::Value::Array(required));
+    schema.insert(
+        "additionalProperties".into(),
+        serde_json::Value::Bool(false),
+    );
+    schema
+}
+
+fn tool_from_description(desc: &ToolDescription) -> Tool {
+    let description = format!(
+        "{}\n\nWhen to call:\n{}\n\nWhen NOT to call:\n{}",
+        desc.summary.trim(),
+        desc.when_to_call.trim(),
+        desc.when_not_to_call.trim(),
+    );
+    Tool {
+        name: desc.name.as_str().to_string().into(),
+        description: description.into(),
+        input_schema: Arc::new(build_input_schema(desc)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rmcp::ServerHandler impl
+// ---------------------------------------------------------------------------
+
+impl ServerHandler for V2ServerHandler {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: "dailyos-mcp-v2".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+            },
+            instructions: Some(
+                "DailyOS MCP v2. Personal working intelligence for the paired user — \
+                 accounts, briefings, attention, working memory, notes, actions. \
+                 Not for broad enterprise or web corpus search."
+                    .to_string(),
+            ),
+        }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: PaginatedRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        // Per L0 AC-6: filter by `mcp_tool_grant` rows for
+        // `verified_client_id` where exposure = Invocable.
+        let grants = {
+            let conn_guard = self.conn.lock();
+            auth::list_invocable_tool_grants(&conn_guard, &self.verified_client_id).map_err(
+                |e| ErrorData::internal_error(format!("mcp_v2 tool_grant lookup: {e}"), None),
+            )?
+        };
+
+        let mut tools = Vec::with_capacity(grants.len());
+        for grant_name in &grants {
+            if let Some(desc) = self.catalog.description_for(grant_name) {
+                tools.push(tool_from_description(desc));
+            }
+            // Catalog entries without a matching registered handler are
+            // silently absent — pending in catalog, not invocable yet.
+        }
+        Ok(ListToolsResult {
+            next_cursor: None,
+            tools,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        // Per L0 AC-2: receive normal MCP `{ name, arguments }` shape;
+        // transport builds the envelope consumed by the authorization gateway.
+        let tool_name = ScopedName::new(request.name.to_string());
+        let params = serde_json::Value::Object(request.arguments.unwrap_or_default());
+
+        let envelope = McpToolRequestEnvelope {
+            conversation_handle: None,
+            tool_name,
+            params,
+        };
+
+        // Call gateway. The simplified substrate loads the manifest,
+        // dispatches handler, audits, and signal-emits.
+        //
+        // Per DOS-175 cycle-2 §3.2: `handle_tool_call` is sync and the
+        // handler chain underneath it calls `runtime.block_on(...)` on a
+        // captured tokio handle to dispatch async abilities. Calling that
+        // directly from this async context would nested-runtime-panic, so
+        // we move dispatch onto a blocking-pool thread via
+        // `tokio::task::spawn_blocking`. Inside the blocking thread the
+        // handler's `block_on` is safe because we are not on a worker.
+        let gateway = self.gateway.clone();
+        let conn = self.conn.clone();
+        let client_id = self.verified_client_id.clone();
+        let response_envelope = tokio::task::spawn_blocking(move || {
+            let mut conn_guard = conn.lock();
+            gateway.handle_tool_call(&mut conn_guard, &client_id, envelope)
+        })
+        .await
+        .map_err(|join_err| {
+            ErrorData::internal_error(
+                format!("mcp_v2 dispatch task join failed: {join_err}"),
+                None,
+            )
+        })?;
+
+        unwrap_response(response_envelope)
+    }
+}
+
+/// Translate the gateway's response envelope into an rmcp result.
+fn unwrap_response(env: McpToolResponseEnvelope) -> Result<CallToolResult, ErrorData> {
+    match env.result {
+        McpToolResult::Ok { value } => {
+            let text = serde_json::to_string(&value).unwrap_or_else(|_| "{}".to_string());
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        }
+        McpToolResult::Error { error } => Err(tool_error_to_mcp_error(error)),
+    }
+}
+
+/// Per L0 AC-3 closed-matrix mapping from `ToolError` to `rmcp::ErrorData`.
+fn tool_error_to_mcp_error(err: ToolError) -> ErrorData {
+    use serde_json::json;
+    match err {
+        ToolError::Unauthorized { missing_scope } => ErrorData::invalid_request(
+            "tool requires scope your pairing lacks".to_string(),
+            Some(json!({
+                "kind": "unauthorized",
+                "missing_scope": missing_scope.as_str(),
+            })),
+        ),
+        ToolError::BadParams { detail: _ } => {
+            // detail intentionally NOT included in public payload per AC-3;
+            // logged server-side only by the gateway audit path.
+            ErrorData::invalid_params(
+                "tool params are malformed".to_string(),
+                Some(json!({
+                    "kind": "bad_params",
+                    "detail_logged_server_side": true,
+                })),
+            )
+        }
+        ToolError::RateLimited {
+            retry_after_seconds,
+        } => ErrorData::new(
+            ErrorCode(-32099),
+            "too many calls; retry later".to_string(),
+            Some(json!({
+                "kind": "rate_limited",
+                "retry_after_seconds": retry_after_seconds,
+            })),
+        ),
+        ToolError::ExposureForbidden { tool_name } => ErrorData::new(
+            ErrorCode::METHOD_NOT_FOUND,
+            "tool is not exposed to your pairing".to_string(),
+            Some(json!({
+                "kind": "exposure_forbidden",
+                "tool_name": tool_name.as_str(),
+            })),
+        ),
+        ToolError::PairingRevoked => ErrorData::invalid_request(
+            "pairing has been revoked".to_string(),
+            Some(json!({ "kind": "pairing_revoked" })),
+        ),
+        ToolError::ConversationRevoked => ErrorData::invalid_request(
+            "conversation has been revoked".to_string(),
+            Some(json!({ "kind": "conversation_revoked" })),
+        ),
+        ToolError::Internal { trace_id } => ErrorData::internal_error(
+            "internal error".to_string(),
+            Some(json!({
+                "kind": "internal",
+                "trace_id": trace_id,
+            })),
+        ),
+        ToolError::NotFound { resource } => ErrorData::new(
+            ErrorCode::METHOD_NOT_FOUND,
+            "requested resource not found".to_string(),
+            Some(json!({
+                "kind": "not_found",
+                // resource is an opaque ID per L0 AC-3 (never PII).
+                "resource": resource,
+            })),
+        ),
+        ToolError::UpstreamFailure { detail: _ } => {
+            // detail NOT included on wire per AC-3; logged server-side.
+            ErrorData::internal_error(
+                "upstream system failure; try again later".to_string(),
+                Some(json!({
+                    "kind": "upstream_failure",
+                    "detail_logged_server_side": true,
+                })),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::mcp_v2::contracts::{ParamSchema, ParamSpec, ReturnSpec, Scope, Side};
+
+    fn fake_desc(name: &str) -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new(name),
+            summary: "test summary".into(),
+            when_to_call: "test when".into(),
+            when_not_to_call: "test when not".into(),
+            side: Side::Read,
+            parameters: vec![ParamSpec {
+                name: "subject".into(),
+                schema: ParamSchema(serde_json::json!({ "type": "string" })),
+                required: true,
+                description: "an account name".into(),
+            }],
+            returns: ReturnSpec {
+                schema: ParamSchema(serde_json::json!({})),
+                description: "test return".into(),
+            },
+            examples: vec![],
+            scopes_required: vec![],
+        }
+    }
+
+    #[test]
+    fn input_schema_excludes_dailyos_keys_per_l0_ac6() {
+        let desc = fake_desc("dailyos.read.account_status");
+        let schema = build_input_schema(&desc);
+        let props = schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .expect("properties present");
+        assert!(props.contains_key("subject"), "handler params present");
+        assert!(
+            !props.keys().any(|k| k.starts_with("_dailyos_")),
+            "no `_dailyos_*` in public input_schema: keys={:?}",
+            props.keys().collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            schema.get("additionalProperties"),
+            Some(&serde_json::Value::Bool(false)),
+        );
+    }
+
+    #[test]
+    fn tool_description_composes_summary_when_to_call_when_not() {
+        let desc = fake_desc("dailyos.read.account_status");
+        let tool = tool_from_description(&desc);
+        let description = tool.description.to_string();
+        assert!(description.contains("test summary"));
+        assert!(description.contains("When to call:\ntest when"));
+        assert!(description.contains("When NOT to call:\ntest when not"));
+    }
+
+    #[test]
+    fn tool_error_unauthorized_maps_to_invalid_request_with_kind() {
+        let err = tool_error_to_mcp_error(ToolError::Unauthorized {
+            missing_scope: Scope::new("dailyos.read.account_status"),
+        });
+        assert_eq!(err.code, ErrorCode::INVALID_REQUEST);
+        let data = err.data.as_ref().expect("data present");
+        assert_eq!(data["kind"], "unauthorized");
+        assert_eq!(data["missing_scope"], "dailyos.read.account_status");
+    }
+
+    #[test]
+    fn tool_error_rate_limited_maps_with_retry_after() {
+        let err = tool_error_to_mcp_error(ToolError::RateLimited {
+            retry_after_seconds: 60,
+        });
+        assert_eq!(err.code, ErrorCode(-32099));
+        let data = err.data.as_ref().expect("data present");
+        assert_eq!(data["kind"], "rate_limited");
+        assert_eq!(data["retry_after_seconds"], 60);
+    }
+
+    #[test]
+    fn tool_error_exposure_forbidden_maps_to_method_not_found() {
+        let err = tool_error_to_mcp_error(ToolError::ExposureForbidden {
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+        });
+        assert_eq!(err.code, ErrorCode::METHOD_NOT_FOUND);
+        let data = err.data.as_ref().expect("data present");
+        assert_eq!(data["kind"], "exposure_forbidden");
+    }
+
+    #[test]
+    fn tool_error_bad_params_does_not_leak_detail() {
+        let err = tool_error_to_mcp_error(ToolError::BadParams {
+            detail: "secret-server-side-detail".into(),
+        });
+        let data_str = serde_json::to_string(&err.data).unwrap_or_default();
+        assert!(
+            !data_str.contains("secret-server-side-detail"),
+            "BadParams detail must NOT leak to wire per AC-3: data={data_str}",
+        );
+        assert!(data_str.contains("detail_logged_server_side"));
+    }
+
+    #[test]
+    fn tool_error_internal_includes_opaque_trace_id() {
+        let err = tool_error_to_mcp_error(ToolError::Internal {
+            trace_id: "trace-abc123".into(),
+        });
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        let data = err.data.as_ref().expect("data present");
+        assert_eq!(data["kind"], "internal");
+        assert_eq!(data["trace_id"], "trace-abc123");
+    }
+}

--- a/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
+++ b/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
@@ -1,0 +1,135 @@
+//! Smoke test for the v1.4.7 W1-A migrations (v255-v258 per dev-reconciliation
+//! renumber 2026-05-21; originally v241-v244 in L0 packet) per DOS-168.
+//!
+//! Runs the full migration chain against an in-memory SQLite and asserts the
+//! schema landed correctly: tables exist, expected columns are present, and
+//! the composite UNIQUE constraints + indexes from ADR-0102 §C.bis.schema are
+//! enforced.
+
+use dailyos_lib::migration_test_api::run_migrations;
+use rusqlite::Connection;
+
+#[test]
+fn dos168_v255_v258_migrations_land_canonical_schema() {
+    let conn = Connection::open_in_memory().expect("open in-memory database");
+    run_migrations(&conn).expect("migrations apply cleanly");
+
+    // ---- v255 mcp_client_manifest + mcp_tool_grant ----
+    let manifest_cols = table_columns(&conn, "mcp_client_manifest");
+    assert!(manifest_cols.contains(&"client_id".to_string()), "manifest missing client_id");
+    assert!(manifest_cols.contains(&"paired_at".to_string()), "manifest missing paired_at");
+    assert!(manifest_cols.contains(&"revoked_at".to_string()), "manifest missing revoked_at");
+    assert!(
+        manifest_cols.contains(&"transport_key_ref".to_string()),
+        "manifest missing transport_key_ref"
+    );
+
+    let grant_cols = table_columns(&conn, "mcp_tool_grant");
+    assert!(grant_cols.contains(&"client_id".to_string()), "grant missing client_id");
+    assert!(grant_cols.contains(&"tool_name".to_string()), "grant missing tool_name");
+    assert!(
+        grant_cols.contains(&"scopes_granted_json".to_string()),
+        "grant missing scopes_granted_json"
+    );
+    assert!(grant_cols.contains(&"exposure".to_string()), "grant missing exposure");
+    assert!(
+        grant_cols.contains(&"rate_limit_max".to_string()),
+        "grant missing rate_limit_max"
+    );
+    assert!(
+        grant_cols.contains(&"rate_limit_window_secs".to_string()),
+        "grant missing rate_limit_window_secs"
+    );
+    assert!(
+        has_index(&conn, "mcp_tool_grant", "idx_mcp_tool_grant_client_tool"),
+        "missing idx_mcp_tool_grant_client_tool index per L0 packet AC-2"
+    );
+
+    // ---- v256 mcp_conversation_handle (composite handle+client_id) ----
+    let handle_cols = table_columns(&conn, "mcp_conversation_handle");
+    assert!(handle_cols.contains(&"handle".to_string()));
+    assert!(handle_cols.contains(&"client_id".to_string()));
+    assert!(handle_cols.contains(&"mint_at".to_string()));
+    assert!(handle_cols.contains(&"last_touched_at".to_string()));
+    assert!(handle_cols.contains(&"revoked_at".to_string()));
+    // Cross-client binding per ADR-0102 §D.bis: composite UNIQUE on (handle, client_id).
+    let handle_indexes = indexes_for(&conn, "mcp_conversation_handle");
+    assert!(
+        handle_indexes.iter().any(|name| name.contains("handle")),
+        "missing handle index per ADR-0102 §D.bis"
+    );
+
+    // ---- DOS-168 amended: transport-ceremony rip verification ----
+    // Migration 257 (mcp_transport_nonce_ledger) was never introduced — the
+    // nonce-replay defense applied to a transport that doesn't have a wire to
+    // capture (stdio MCP / loopback). Proving its absence here keeps a future
+    // re-introduction loud.
+    let nonce_table_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type = 'table' AND name = 'mcp_transport_nonce_ledger'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(
+        nonce_table_exists, 0,
+        "mcp_transport_nonce_ledger reintroduced — transport-ceremony rip regressed"
+    );
+
+    // Seed a manifest row so subsequent assertions can reference a client_id.
+    // transport_key_ref retained for schema stability under DOS-758 but is
+    // always NULL post-rip (no transport key material in personal-tier model).
+    conn.execute(
+        "INSERT INTO mcp_client_manifest (client_id, paired_at, revoked_at, transport_key_ref) \
+         VALUES ('smoke-client', 1, NULL, NULL)",
+        [],
+    )
+    .expect("seed manifest row");
+
+    // ---- v258 mcp_tool_call_ledger + mcp_audit_outbox ----
+    let ledger_cols = table_columns(&conn, "mcp_tool_call_ledger");
+    assert!(ledger_cols.contains(&"client_id".to_string()));
+    assert!(ledger_cols.contains(&"tool_name".to_string()));
+    assert!(ledger_cols.contains(&"called_at".to_string()));
+
+    let outbox_cols = table_columns(&conn, "mcp_audit_outbox");
+    assert!(outbox_cols.contains(&"event".to_string()));
+    assert!(outbox_cols.contains(&"detail_json".to_string()));
+    assert!(outbox_cols.contains(&"actor_kind".to_string()));
+    assert!(outbox_cols.contains(&"created_at".to_string()));
+    assert!(
+        outbox_cols.contains(&"drained_at".to_string()),
+        "outbox missing drained_at for sweep cadence per §C.bis.sweep"
+    );
+
+    // Idempotency: re-running migrations is a no-op.
+    let second_run = run_migrations(&conn).expect("re-run is idempotent");
+    let _ = second_run; // count is implementation-specific; only the success matters.
+}
+
+// ---- helpers -------------------------------------------------------------
+
+fn table_columns(conn: &Connection, table: &str) -> Vec<String> {
+    conn.prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table_info")
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("execute table_info")
+        .filter_map(Result::ok)
+        .collect()
+}
+
+fn indexes_for(conn: &Connection, table: &str) -> Vec<String> {
+    conn.prepare(&format!("PRAGMA index_list({table})"))
+        .expect("prepare index_list")
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("execute index_list")
+        .filter_map(Result::ok)
+        .collect()
+}
+
+fn has_index(conn: &Connection, table: &str, index_name: &str) -> bool {
+    indexes_for(conn, table)
+        .iter()
+        .any(|name| name == index_name)
+}


### PR DESCRIPTION
## Summary

Ships the v1.4.7 W1-A MCP v2 gateway substrate at a simplified shape. Supersedes #347 — the original W1-A substrate was modeled on the wrong threat premise (transport-ceremony for local-stdio), inherited verbatim from v1.4.2 SurfaceClient pairing.

Per the L0 packet at [.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/L0-packet.md §3e](.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/L0-packet.md).

## What stays (authorization machinery)

- Pairing handshake, manifest load, scope resolution, exposure-tier check
- Conversation handle lifecycle, scope-subset enforcement
- Rate-limit reserve, plain audit emission, audit outbox
- `actor_policy`, `taxonomy`, `contracts` (types ecosystem minus nonce/HMAC fields)
- Migrations 255 / 256 / 258 (manifest, conversation handle, rate-limit + audit outbox)
- `Actor::McpClient` as distinct actor class — third-party agents need scope-distinct attribution from `Actor::User`
- DOS-624 sensitivity gating composes downstream of actor materialization
- PR #355's `McpHandlerContext` interface + CI gate (`check_mcp_v2_handlers_no_direct_db_open.sh`)
- Opaque resource IDs (v1.4.7 cycle 2 CSO MED #4)

## What goes (transport-ceremony — ~645 LOC of dead-weight defense)

- Migration 257 (transport nonce ledger): not created
- `verify_transport_hmac`, `verify_and_consume_and_preissue` (auth.rs): never introduced
- Transport key Keychain custody (Zeroize wrappers, persist/load): never introduced
- Keyed-HMAC audit hashes (`hmac_json`, `canonical_value`, audit key keychain): never introduced
- `TIMING_FLOOR_MILLIS` + `sleep_until_floor`: never introduced
- HMAC envelope signing in `transport.rs`: never introduced

## Threat model

Per packet §1: stdio MCP transports are OS pipes set up at process spawn — no in-flight tamper surface. In-process MCP hosting (DOS-647-C) makes "transport" a Rust function call. Audit content is protected by SQLCipher + Keychain; the user is the only auditor. Transport-ceremony was defending threats that don't exist in personal-tier local.

## Coordination

PR #347 (the original W1-A) closes superseded-by-this-PR. PR #355 lands independently — handler context is transport-agnostic.

Handler-to-masked-fields table for write-class tools at [.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/pr-c-masking-table.md](.docs/plans/v1.4.4-wp-surface-migration/L0-trust-topology-and-substrate-readers/pr-c-masking-table.md).

## Test plan

- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --lib services::mcp_v2` — 56 passed, 0 failed
- [ ] L4: connect a local stdio MCP client, observe `tools/list` filtered by manifest grants, invoke a read tool, receive result

🤖 Generated with [Claude Code](https://claude.com/claude-code)