### PR TITLE
MCP v2 account status runtime fixes

### DIFF
--- a/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/mod.rs
@@ -28,7 +28,7 @@ use crate::abilities::{AbilityContext, AbilityResult};
     category = Read,
     version = "0.1.0",
     schema_version = 1,
-    allowed_actors = [User, Agent, System, SurfaceClient],
+    allowed_actors = [User, Agent, System, SurfaceClient, McpClient],
     allowed_modes = [Live, Simulate, Evaluate],
     requires_confirmation = false,
     may_publish = false,

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
@@ -38,7 +38,9 @@ use crate::abilities::trust::types::TrustBand;
 use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
 };
-use crate::sensitivity::{renderable_claim_text_with_value, RenderActor, RenderSurface};
+use crate::sensitivity::{
+    renderable_claim_text_with_value, ClaimDismissalSurface, RenderActor, RenderSurface,
+};
 use crate::types::{claim_allowed_for_prompt_input, IntelligenceClaim};
 
 const ABILITY_NAME: &str = "get_entity_intelligence";
@@ -79,7 +81,7 @@ pub async fn build_entity_intelligence(
         Vec::new()
     };
     let render_actor = render_actor_for_context(ctx);
-    let render_surface = RenderSurface::TauriEntityDetail;
+    let render_surface = render_surface_for_context(ctx);
 
     let mut envelope_provenance = EnvelopeProvenance::empty();
 
@@ -252,13 +254,38 @@ async fn read_claims(
 }
 
 fn filter_claims_for_actor(actor: Actor, claims: Vec<IntelligenceClaim>) -> Vec<IntelligenceClaim> {
-    if matches!(actor, Actor::Agent) {
+    if matches!(actor, Actor::Agent | Actor::McpClient { .. }) {
         claims
             .into_iter()
             .filter(claim_allowed_for_prompt_input)
             .collect()
     } else {
         claims
+    }
+}
+
+fn render_surface_for_context(ctx: &AbilityContext<'_>) -> RenderSurface {
+    match ctx.entity_context_claim_surface() {
+        ClaimDismissalSurface::TauriEntityDetail => RenderSurface::TauriEntityDetail,
+        ClaimDismissalSurface::Briefing => RenderSurface::TauriBriefingPrep,
+        ClaimDismissalSurface::TauriMeetingDetail => RenderSurface::TauriMeetingDetail,
+        ClaimDismissalSurface::TauriEmailSummary => RenderSurface::TauriEmailSummary,
+        ClaimDismissalSurface::Action => RenderSurface::Action,
+        ClaimDismissalSurface::TauriProvenance => RenderSurface::TauriProvenance,
+        ClaimDismissalSurface::TauriReport => RenderSurface::TauriReport,
+        ClaimDismissalSurface::TauriChat => RenderSurface::TauriChat,
+        ClaimDismissalSurface::McpTool => RenderSurface::McpTool,
+        ClaimDismissalSurface::McpToolDetail => RenderSurface::McpToolDetail,
+        ClaimDismissalSurface::P2Publication => RenderSurface::P2Publication,
+        ClaimDismissalSurface::LogStructured => RenderSurface::LogStructured,
+        ClaimDismissalSurface::PushNotification => RenderSurface::PushNotification,
+        ClaimDismissalSurface::Worker | ClaimDismissalSurface::Eval => {
+            if matches!(&ctx.actor, Actor::Agent | Actor::McpClient { .. }) {
+                RenderSurface::McpTool
+            } else {
+                RenderSurface::TauriEntityDetail
+            }
+        }
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
@@ -69,7 +69,7 @@ pub struct OpenLoopSubject {
     category = Read,
     version = "1.0.0",
     schema_version = 1,
-    allowed_actors = [User, Agent, System, SurfaceClient],
+    allowed_actors = [User, Agent, System, SurfaceClient, McpClient],
     allowed_modes = [Live, Evaluate],
     requires_confirmation = false,
     may_publish = false,
@@ -296,7 +296,7 @@ fn render_surface_for_context(ctx: &AbilityContext<'_>) -> RenderSurface {
         ClaimDismissalSurface::LogStructured => RenderSurface::LogStructured,
         ClaimDismissalSurface::PushNotification => RenderSurface::PushNotification,
         ClaimDismissalSurface::Worker | ClaimDismissalSurface::Eval => {
-            if matches!(&ctx.actor, Actor::Agent) {
+            if matches!(&ctx.actor, Actor::Agent | Actor::McpClient { .. }) {
                 RenderSurface::McpTool
             } else {
                 RenderSurface::TauriEntityDetail
@@ -317,8 +317,11 @@ fn render_actor_for_context(ctx: &AbilityContext<'_>) -> RenderActor {
             actor: "system".to_string(),
             user_id: None,
         },
-        Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
-        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
+        Actor::SurfaceClient { .. } => RenderActor {
+            actor: "surface_client".to_string(),
+            user_id: None,
+        },
+        Actor::McpClient { .. } => RenderActor::agent("mcp_client"),
     }
 }
 
@@ -582,8 +585,13 @@ fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Actor {
         Actor::System => crate::abilities::provenance::Actor::System {
             component: "dailyos".to_string(),
         },
-        Actor::SurfaceClient { .. } => todo!("W1-B+ wiring for Actor::SurfaceClient"),
-        Actor::McpClient { .. } => todo!("McpClient invocation routing pending"),
+        Actor::SurfaceClient { .. } => crate::abilities::provenance::Actor::System {
+            component: "surface_client".to_string(),
+        },
+        Actor::McpClient { .. } => crate::abilities::provenance::Actor::Agent {
+            name: "mcp".to_string(),
+            version: "unknown".to_string(),
+        },
     }
 }
 

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1011,6 +1011,14 @@ const MIGRATIONS: &[Migration] = &[
         version: 258,
         sql: include_str!("migrations/258_mcp_rate_limit_and_audit_outbox.sql"),
     },
+    // v1.4.7 W1-A repair: some DBs reached v258 from the simplified MCP
+    // substrate line without recording/running v257. Re-create the nonce
+    // ledger idempotently at the next forward slot so pairing can seed
+    // transport nonces.
+    Migration::Sql {
+        version: 259,
+        sql: include_str!("migrations/259_mcp_transport_nonce_ledger_repair.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -2456,6 +2464,23 @@ fn verify_required_schema(conn: &Connection) -> Result<(), String> {
                 "Schema integrity check failed: missing column action_commitment_sources.source_key"
                     .to_string(),
             );
+        }
+    }
+
+    if version >= 258 {
+        for table in [
+            "mcp_client_manifest",
+            "mcp_tool_grant",
+            "mcp_conversation_handle",
+            "mcp_transport_nonce_ledger",
+            "mcp_tool_call_ledger",
+            "mcp_audit_outbox",
+        ] {
+            if !table_exists(conn, table)? {
+                return Err(format!(
+                    "Schema integrity check failed: missing required table '{table}'"
+                ));
+            }
         }
     }
 
@@ -4965,6 +4990,44 @@ mod tests {
     }
 
     #[test]
+    fn migration_259_repairs_missing_mcp_transport_nonce_ledger_after_v258() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "DROP TABLE mcp_transport_nonce_ledger;
+             DELETE FROM schema_version WHERE version = 259;",
+        )
+        .expect("simulate v258 DB that skipped nonce ledger migration");
+        assert_eq!(current_version(&conn).expect("current version"), 258);
+        assert!(
+            !table_exists(&conn, "mcp_transport_nonce_ledger").expect("table lookup"),
+            "test precondition: nonce ledger should be missing"
+        );
+
+        let applied = run_migrations(&conn).expect("repair migration should succeed");
+        assert_eq!(applied, 1, "only v259 repair should be pending");
+        assert!(
+            table_exists(&conn, "mcp_transport_nonce_ledger").expect("table lookup"),
+            "v259 should recreate the nonce ledger"
+        );
+    }
+
+    #[test]
+    fn verify_required_schema_rejects_missing_mcp_transport_nonce_ledger() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute("DROP TABLE mcp_transport_nonce_ledger", [])
+            .expect("drop nonce ledger");
+
+        let err = verify_required_schema(&conn)
+            .expect_err("missing MCP nonce ledger must fail startup schema verifier");
+        assert!(
+            err.contains("mcp_transport_nonce_ledger"),
+            "error should report missing MCP nonce ledger: {err}"
+        );
+    }
+
+    #[test]
     fn test_fresh_db_applies_baseline() {
         let conn = mem_db();
         let applied = run_migrations(&conn).expect("migrations should succeed");
@@ -6267,10 +6330,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("query sqlite_master for table");
-        assert_eq!(
-            table_count, 1,
-            "claim_feedback exists after v245 applies"
-        );
+        assert_eq!(table_count, 1, "claim_feedback exists after v245 applies");
 
         // Seed a parent intelligence_claims row so the FK from
         // claim_feedback.claim_id holds. Column shape mirrors the v140
@@ -6336,11 +6396,9 @@ mod tests {
         // This catches the case where the DROP succeeded but CREATE failed
         // mid-batch and left the view definition unparseable.
         let row_count: i64 = conn
-            .query_row(
-                "SELECT count(*) FROM meeting_prep_status_view",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT count(*) FROM meeting_prep_status_view", [], |row| {
+                row.get(0)
+            })
             .expect("query the view");
         assert!(row_count >= 0, "view is queryable");
 

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -995,7 +995,7 @@ const MIGRATIONS: &[Migration] = &[
         version: 254,
         sql: include_str!("migrations/254_document_entity_links.sql"),
     },
-    // DOS-168 amended (v1.4.7 W1-A MCP v2 substrate at simplified shape).
+    // MCP v2 substrate at the simplified local shape.
     // Migration 257 (mcp_transport_nonce_ledger) is intentionally absent —
     // the nonce ledger defended replay over a wire that doesn't exist for
     // stdio / loopback MCP. See L0 packet §3e.

--- a/src-tauri/src/migrations/255_mcp_client_manifest.sql
+++ b/src-tauri/src/migrations/255_mcp_client_manifest.sql
@@ -1,7 +1,6 @@
--- DOS-168 amended: transport_key_ref retained as nullable column for schema
--- stability (DOS-758's McpHandlerContext interface references the column
--- name); always NULL post-rip because the personal-tier model has no
--- transport key material to bind. See L0 packet §3e.
+-- transport_key_ref is retained as a nullable column for schema stability;
+-- it is always NULL post-rip because the personal-tier model has no
+-- transport key material to bind.
 CREATE TABLE IF NOT EXISTS mcp_client_manifest (
     client_id TEXT PRIMARY KEY,
     paired_at INTEGER NOT NULL,

--- a/src-tauri/src/migrations/259_mcp_transport_nonce_ledger_repair.sql
+++ b/src-tauri/src/migrations/259_mcp_transport_nonce_ledger_repair.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS mcp_transport_nonce_ledger (
+    nonce TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    issued_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    consumed_at INTEGER NULL,
+    UNIQUE (nonce, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_nonce_lookup
+    ON mcp_transport_nonce_ledger (client_id, nonce);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_nonce_consumed
+    ON mcp_transport_nonce_ledger (consumed_at);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_nonce_expires
+    ON mcp_transport_nonce_ledger (expires_at);

--- a/src-tauri/src/services/composition_render_orchestrator.rs
+++ b/src-tauri/src/services/composition_render_orchestrator.rs
@@ -86,12 +86,11 @@ impl CompositionRenderOrchestrator {
         composition_id: &str,
         composition_version: i64,
     ) -> Option<CacheKey> {
-        // DOS-761 codex P2: first-party loopback runs as Actor::User and
-        // needs the cache to function the same as Actor::SurfaceClient.
-        // Without an Actor::User branch the new /v1/local/project-composition
-        // route would re-run the producer on every render. Use a fixed
-        // "local_first_party" canonical id since first-party invocations
-        // share the full scope set.
+        // First-party loopback runs as Actor::User and needs the cache to
+        // function the same as Actor::SurfaceClient. Without an Actor::User
+        // branch the local composition route would re-run the producer on
+        // every render. Use a fixed "local_first_party" canonical id since
+        // first-party invocations share the full scope set.
         let scopes_canonical = match actor {
             Actor::SurfaceClient { scopes, .. } => scopes_canonical_id(scopes),
             Actor::User => "local_first_party".to_string(),

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -285,12 +285,11 @@ fn health_band_for_account(
 ) -> abilities_runtime::abilities::trust::types::TrustBand {
     use abilities_runtime::abilities::trust::types::TrustBand;
 
-    // DOS-762 P2 (codex review): the accounts table stores health as color
-    // strings — `green` / `yellow` / `red` — per the existing data layer, NOT
-    // the narrative strings the producer first guessed. Map both vocabularies
-    // so existing rows surface their actual band instead of silently
-    // defaulting to LikelyCurrent. Unknown / missing → Unscored (honest)
-    // instead of LikelyCurrent (optimistic).
+    // The accounts table stores health as color strings — `green` / `yellow`
+    // / `red` — per the existing data layer, not the narrative strings the
+    // producer first guessed. Map both vocabularies so existing rows surface
+    // their actual band instead of silently defaulting to LikelyCurrent.
+    // Unknown / missing maps to Unscored instead of an optimistic band.
     match health.map(|value| value.trim().to_ascii_lowercase()) {
         Some(value) if value == "healthy" || value == "good" || value == "green" => {
             TrustBand::LikelyCurrent

--- a/src-tauri/src/services/mcp_v2/gateway.rs
+++ b/src-tauri/src/services/mcp_v2/gateway.rs
@@ -7,9 +7,9 @@
 //! respectively via the [`SignalEmitter`] trait (W2+ wires a production
 //! emitter that calls `crate::signals::bus::emit_signal_and_propagate`).
 //!
-//! Per ADR-0102 §C authorization machinery and the DOS-168-amended local MCP
-//! trust model: authorization and operational controls live here; local
-//! transport ceremony does not.
+//! Per ADR-0102 §C authorization machinery and the local MCP trust model:
+//! authorization and operational controls live here; local transport ceremony
+//! does not.
 
 use rusqlite::{params, Connection};
 use serde_json::json;
@@ -187,7 +187,7 @@ impl Gateway {
 
     /// Seal the gateway after all handlers are registered. Validates
     /// every registered handler has a matching catalog entry with matching
-    /// `Side` (per DOS-478 L0 AC-7). Returns operator-readable error if
+    /// `Side` per the taxonomy seal contract. Returns operator-readable error if
     /// mismatch. Also returns catalog→handler pending-tool list as
     /// operator info; callers log it.
     ///
@@ -205,9 +205,8 @@ impl Gateway {
     }
 
     /// Handle a single MCP tool invocation. Full per-dispatch contract per
-    /// L0 packet §1 #1 after DOS-168-amended: local transport identity is the
-    /// asserted `McpClientId`; the gateway enforces manifest authorization and
-    /// operational controls.
+    /// Local transport identity is the asserted `McpClientId`; the gateway
+    /// enforces manifest authorization and operational controls.
     pub fn handle_tool_call(
         &self,
         conn: &mut Connection,

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -1,7 +1,8 @@
 //! `dailyos.read.account_status` MCP tool handler.
 //!
-//! Wraps the `dailyos/account-overview` ability from `abilities-runtime`,
-//! dispatched via the same `invoke_registry_json` path the Tauri UI uses.
+//! Wraps the claim-backed `get_entity_intelligence` ability from
+//! `abilities-runtime`, then projects the envelope into an MCP-friendly
+//! account briefing with prose plus compact provenance.
 //! Per DOS-175 cycle-2 §3: sync `McpToolHandler::invoke` is called from
 //! within `tokio::task::spawn_blocking` at the transport boundary, so
 //! `runtime.block_on(...)` on a captured handle is safe.
@@ -9,9 +10,11 @@
 //! See `.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md` for the L0
 //! contract.
 
+use std::collections::BTreeMap;
+
 use abilities_runtime::abilities::registry::{AbilityRegistry, McpExposure};
 use abilities_runtime::abilities::tracer::NOOP_ABILITY_TRACER;
-use serde_json::Value;
+use serde_json::{json, Map, Value};
 
 use crate::bridges::types::{
     invoke_registry_json_for_actor, AbilityInvokeError, RequestScopedInvocation,
@@ -28,11 +31,12 @@ use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescripti
 const ACTOR_LABEL: &str = concat!("agent:dailyos-mcp-v2:", env!("CARGO_PKG_VERSION"));
 
 /// Registered ability name in the abilities-runtime registry.
-/// Per `account_overview.rs:84` the registered name uses `/` (not `_`).
-const ABILITY_NAME: &str = "dailyos/account-overview";
+const ABILITY_NAME: &str = "get_entity_intelligence";
 
-/// `AccountOverviewInput` schema version pinned by `account_overview.rs:39`.
-const ACCOUNT_OVERVIEW_SCHEMA_VERSION: u32 = 1;
+/// `EntityIntelligenceInput` schema version pinned by the ability contract.
+const ENTITY_INTELLIGENCE_SCHEMA_VERSION: u32 = 1;
+const ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION: u32 = 1;
+const MAX_ASSESSMENT_ITEMS: usize = 8;
 
 pub struct AccountStatusHandler {
     description: ToolDescription,
@@ -98,12 +102,7 @@ impl McpToolHandler for AccountStatusHandler {
         let runtime_actor =
             project_actor(client_id, &synthetic_grant, conversation_handle.as_ref());
 
-        // The catalog gives us `subject` (string). Pre-read the current
-        // composition version for this account_id so the ability's
-        // optimistic-concurrency commit doesn't trip StaleComposition.
-        // Matches surface_runtime/mod.rs:2545 read-before-invoke pattern.
         let subject = extract_subject(&params)?;
-        let composition_id = format!("dailyos/account-overview:account:{subject}");
 
         self.runtime.block_on(async {
             let clock = SystemClock;
@@ -113,54 +112,20 @@ impl McpToolHandler for AccountStatusHandler {
                 ServiceContext::new_live(&clock, &rng, &external).with_actor(ACTOR_LABEL),
             );
 
-            // Pre-read current version. If the composition row does not
-            // exist yet, this returns 0; the ability will then commit at
-            // version 1.
-            let composition_id_for_read = composition_id.clone();
-            let current_version = tokio::task::spawn_blocking(move || {
-                let db =
-                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-                        .map_err(|err| {
-                            eprintln!("mcp_v2 account_status pre-read open_db failed: {err}");
-                            AbilityInvokeError::Surface(
-                                crate::bridges::BridgeSurfaceError::AbilityUnavailable,
-                            )
-                        })?;
-                let clock = SystemClock;
-                let rng = SystemRng;
-                let external = ExternalClients::default();
-                let ctx = ServiceContext::new_live(&clock, &rng, &external);
-                crate::services::compositions::current_composition_version_for_composition_id(
-                    &ctx,
-                    &db,
-                    &composition_id_for_read,
-                )
-                .map_err(|_| {
-                    AbilityInvokeError::Surface(
-                        crate::bridges::BridgeSurfaceError::AbilityUnavailable,
-                    )
-                })
-            })
-            .await
-            .map_err(|_| {
-                AbilityInvokeError::Surface(crate::bridges::BridgeSurfaceError::AbilityUnavailable)
-            })
-            .and_then(|inner| inner)
-            .map_err(map_invoke_error)?;
-
-            let resolved_input = serde_json::json!({
-                "schema_version": ACCOUNT_OVERVIEW_SCHEMA_VERSION,
-                "account_id": subject,
-                "expected_composition_version": current_version,
+            let resolved_input = json!({
+                "schemaVersion": ENTITY_INTELLIGENCE_SCHEMA_VERSION,
+                "entityType": "account",
+                "entityId": subject.clone(),
+                "depth": "standard",
+                "sections": ["facts", "open_loops", "touchpoints", "record"],
             });
 
             // Use the request-scoped dispatch path — V2 MCP needs to pass
             // the full `Actor::McpClient { client_id, conversation_handle }`
-            // variant through to the registry so account_overview's
-            // `allowed_actors = [User, SurfaceClient, McpClient]` matches.
+            // variant through to the registry so get_entity_intelligence's
+            // `allowed_actors` can apply the MCP render policy.
             // The legacy `invoke_registry_json` calls `BridgeActor::Agent
-            // .registry_actor()` which returns `Actor::Agent` — not in the
-            // allowed list, surface-rejected.
+            // .registry_actor()` which would erase the client identity.
             let invocation = RequestScopedInvocation {
                 registry_actor: runtime_actor,
                 response_actor: BridgeActor::McpClient,
@@ -178,7 +143,7 @@ impl McpToolHandler for AccountStatusHandler {
             )
             .await
             .map_err(map_invoke_error)?;
-            Ok(response.data)
+            Ok(present_account_status_response(&subject, response.data))
         })
     }
 }
@@ -200,6 +165,301 @@ fn extract_subject(params: &Value) -> Result<String, ToolError> {
     // DOS-175 §3.4. Phase-A.1 sub-ticket replaces this with a real
     // subject-to-account_id resolver.
     Ok(subject.to_string())
+}
+
+fn present_account_status_response(subject: &str, envelope: Value) -> Value {
+    let subject_value = envelope
+        .get("subject")
+        .cloned()
+        .unwrap_or_else(|| fallback_subject(subject));
+    let label = subject_value
+        .get("displayLabel")
+        .and_then(Value::as_str)
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| subject.to_string());
+
+    let (provenance, source_id_map) = build_provenance_summary(&envelope);
+    let facts = collect_fact_summaries(&envelope, &source_id_map);
+    let open_loops = collect_open_loop_summaries(&envelope, &source_id_map);
+    let answer = build_account_status_answer(&label, &facts, &open_loops, &envelope, &provenance);
+
+    json!({
+        "schemaVersion": ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION,
+        "surface": "dailyos.read.account_status",
+        "producer": ABILITY_NAME,
+        "subject": subject_value,
+        "answer": answer,
+        "assessment": {
+            "facts": facts,
+            "openLoops": open_loops,
+        },
+        "trust": envelope.get("trust").cloned().unwrap_or(Value::Null),
+        "sensitivity": envelope.get("sensitivity").cloned().unwrap_or(Value::Null),
+        "provenance": provenance,
+        "sections": envelope.get("sections").cloned().unwrap_or_else(|| json!({})),
+        "sourceEnvelope": {
+            "schemaVersion": envelope.get("schemaVersion").cloned().unwrap_or(Value::Null),
+            "rawEnvelopeIncluded": false,
+        },
+    })
+}
+
+fn fallback_subject(subject: &str) -> Value {
+    json!({
+        "kind": "account",
+        "id": subject,
+        "displayLabel": subject,
+    })
+}
+
+fn build_provenance_summary(envelope: &Value) -> (Value, BTreeMap<String, String>) {
+    let mut source_id_map = BTreeMap::new();
+    let mut sources = Vec::new();
+
+    if let Some(raw_sources) = envelope
+        .pointer("/provenance/sources")
+        .and_then(Value::as_array)
+    {
+        for (index, source) in raw_sources.iter().enumerate() {
+            let display_id = format!("source_{}", index + 1);
+            if let Some(raw_id) = source.get("id").and_then(Value::as_str) {
+                source_id_map.insert(raw_id.to_string(), display_id.clone());
+            }
+
+            let mut projected = Map::new();
+            projected.insert("id".to_string(), Value::String(display_id));
+            insert_string_or_clone(&mut projected, "label", source, "/label");
+            insert_string_or_clone(&mut projected, "sourceType", source, "/sourceType");
+            insert_string_or_clone(&mut projected, "asOf", source, "/asOf");
+            if let Some(redacted) = source.get("redacted").and_then(Value::as_bool) {
+                projected.insert("redacted".to_string(), Value::Bool(redacted));
+            }
+            sources.push(Value::Object(projected));
+        }
+    }
+
+    let redaction_applied = envelope
+        .pointer("/provenance/redactionApplied")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    (
+        json!({
+            "sources": sources,
+            "redactionApplied": redaction_applied,
+            "rawClaimIdsIncluded": false,
+        }),
+        source_id_map,
+    )
+}
+
+fn collect_fact_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/facts/items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| fact_summary(item, source_id_map))
+                .take(MAX_ASSESSMENT_ITEMS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn fact_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
+    let text = string_at(item, "/renderedText/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("text".to_string(), Value::String(text));
+    insert_string_or_clone(&mut summary, "fieldPath", item, "/fieldPath");
+    insert_string_or_clone(&mut summary, "claimType", item, "/claimType");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsof");
+    insert_string_or_clone(&mut summary, "sensitivity", item, "/sensitivity");
+    insert_string_or_clone(&mut summary, "lifecycleState", item, "/lifecycleState");
+    insert_string_or_clone(
+        &mut summary,
+        "verificationState",
+        item,
+        "/verificationState",
+    );
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn collect_open_loop_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/openLoops/items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| open_loop_summary(item, source_id_map))
+                .take(MAX_ASSESSMENT_ITEMS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn open_loop_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
+    let open_loop = item.get("openLoop").unwrap_or(item);
+    let description = string_at(open_loop, "/description")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("description".to_string(), Value::String(description));
+    insert_string_or_clone(&mut summary, "loopKind", open_loop, "/loop_kind");
+    insert_string_or_clone(&mut summary, "owner", open_loop, "/owner");
+    insert_string_or_clone(&mut summary, "dueDate", open_loop, "/due_date");
+    insert_string_or_clone(&mut summary, "status", open_loop, "/status");
+    insert_string_or_clone(&mut summary, "sourceAsOf", open_loop, "/source_asof");
+    insert_string_or_clone(&mut summary, "claimType", open_loop, "/claim_type");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn build_account_status_answer(
+    label: &str,
+    facts: &[Value],
+    open_loops: &[Value],
+    envelope: &Value,
+    provenance: &Value,
+) -> String {
+    if facts.is_empty() && open_loops.is_empty() {
+        return format!("DailyOS does not yet have claim-backed account intelligence for {label}.");
+    }
+
+    let mut lines = vec![format!("DailyOS account briefing for {label}.")];
+
+    if !facts.is_empty() {
+        lines.push(String::new());
+        lines.push("Assessment:".to_string());
+        for fact in facts.iter().take(5) {
+            if let Some(text) = string_at(fact, "/text") {
+                lines.push(format!("- {}{}", text, evidence_suffix(fact)));
+            }
+        }
+    }
+
+    if !open_loops.is_empty() {
+        lines.push(String::new());
+        lines.push("Open loops:".to_string());
+        for open_loop in open_loops.iter().take(5) {
+            if let Some(description) = string_at(open_loop, "/description") {
+                lines.push(format!("- {}{}", description, open_loop_suffix(open_loop)));
+            }
+        }
+    }
+
+    let source_count = provenance
+        .pointer("/sources")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let trust = string_at(envelope, "/trust/aggregateBand")
+        .map(humanize_token)
+        .unwrap_or_else(|| "unscored".to_string());
+    lines.push(String::new());
+    lines.push(format!(
+        "Provenance: {source_count} source(s) surfaced; trust posture {trust}."
+    ));
+    lines.join("\n")
+}
+
+fn evidence_suffix(item: &Value) -> String {
+    let mut parts = Vec::new();
+    push_humanized_part(&mut parts, "trust", item, "/trustBand");
+    push_humanized_part(&mut parts, "freshness", item, "/freshness");
+    if let Some(source_as_of) = string_at(item, "/sourceAsOf") {
+        parts.push(format!("as of {source_as_of}"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join("; "))
+    }
+}
+
+fn open_loop_suffix(item: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(status) = string_at(item, "/status") {
+        parts.push(format!("status: {}", humanize_token(status)));
+    }
+    if let Some(due_date) = string_at(item, "/dueDate") {
+        parts.push(format!("due {due_date}"));
+    }
+    push_humanized_part(&mut parts, "trust", item, "/trustBand");
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join("; "))
+    }
+}
+
+fn push_humanized_part(parts: &mut Vec<String>, label: &str, item: &Value, pointer: &str) {
+    if let Some(value) = string_at(item, pointer) {
+        parts.push(format!("{label}: {}", humanize_token(value)));
+    }
+}
+
+fn insert_string_or_clone(
+    target: &mut Map<String, Value>,
+    key: &str,
+    source: &Value,
+    pointer: &str,
+) {
+    if let Some(value) = source.pointer(pointer).filter(|value| !value.is_null()) {
+        target.insert(key.to_string(), value.clone());
+    }
+}
+
+fn insert_source_refs(
+    target: &mut Map<String, Value>,
+    item: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) {
+    let refs = item
+        .pointer("/provenance/sourceIds")
+        .and_then(Value::as_array)
+        .map(|source_ids| {
+            source_ids
+                .iter()
+                .filter_map(Value::as_str)
+                .filter_map(|raw_id| source_id_map.get(raw_id))
+                .cloned()
+                .map(Value::String)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !refs.is_empty() {
+        target.insert("sourceRefs".to_string(), Value::Array(refs));
+    }
+}
+
+fn string_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn compact_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn humanize_token(value: &str) -> String {
+    value.replace('_', " ")
 }
 
 fn map_invoke_error(err: AbilityInvokeError) -> ToolError {
@@ -265,6 +525,105 @@ mod tests {
         let params = serde_json::json!({ "subject": 42 });
         let err = extract_subject(&params).unwrap_err();
         assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[test]
+    fn account_status_presenter_returns_prose_and_display_provenance() {
+        let envelope = serde_json::json!({
+            "schemaVersion": 1,
+            "subject": {
+                "kind": "account",
+                "id": "acct-1",
+                "displayLabel": "account:acct-1"
+            },
+            "facts": {
+                "items": [{
+                    "claimId": "claim-1",
+                    "fieldPath": "/commercial/posture",
+                    "claimType": "account_status",
+                    "renderedText": {
+                        "text": "Renewal risk is elevated because procurement has not replied.",
+                        "policy": {}
+                    },
+                    "trustBand": "likely_current",
+                    "freshness": "current",
+                    "sourceAsof": "2026-05-22T15:00:00Z",
+                    "sensitivity": "internal",
+                    "lifecycleState": "active",
+                    "verificationState": "active",
+                    "provenance": {
+                        "sourceIds": ["claim_source:claim-1"]
+                    }
+                }]
+            },
+            "openLoops": {
+                "items": [{
+                    "openLoop": {
+                        "id": "claim-2",
+                        "subject": {
+                            "entity_type": "account",
+                            "entity_id": "acct-1"
+                        },
+                        "loop_kind": "renewal_follow_up",
+                        "description": "Confirm commercial owner before renewal review.",
+                        "status": "open",
+                        "due_date": "2026-05-30",
+                        "source_asof": "2026-05-22T15:00:00Z",
+                        "claim_type": "open_loop"
+                    },
+                    "trustBand": "unscored",
+                    "freshness": "unknown",
+                    "provenance": {
+                        "sourceIds": ["open_loop:claim-2"]
+                    }
+                }]
+            },
+            "trust": {
+                "aggregateBand": "likely_current",
+                "sectionCaveats": {}
+            },
+            "sensitivity": "internal",
+            "provenance": {
+                "sources": [
+                    {
+                        "id": "claim_source:claim-1",
+                        "label": "meeting",
+                        "sourceType": "meeting",
+                        "asOf": "2026-05-22T15:00:00Z",
+                        "redacted": false
+                    },
+                    {
+                        "id": "open_loop:claim-2",
+                        "label": "open_loop",
+                        "sourceType": "open_loop",
+                        "asOf": "2026-05-22T15:00:00Z",
+                        "redacted": false
+                    }
+                ],
+                "redactionApplied": false
+            },
+            "sections": {}
+        });
+
+        let payload = present_account_status_response("acct-1", envelope);
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("Renewal risk is elevated"));
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("Confirm commercial owner"));
+        assert_eq!(
+            payload["assessment"]["facts"][0]["sourceRefs"][0],
+            "source_1"
+        );
+        assert_eq!(payload["provenance"]["sources"][0]["id"], "source_1");
+        assert_eq!(payload["provenance"]["rawClaimIdsIncluded"], false);
+
+        let serialized = serde_json::to_string(&payload).unwrap();
+        assert!(!serialized.contains("claim_source:claim-1"));
+        assert!(!serialized.contains("\"claimId\""));
     }
 
     #[test]

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -3,8 +3,8 @@
 //! Wraps the claim-backed `get_entity_intelligence` ability from
 //! `abilities-runtime`, then projects the envelope into an MCP-friendly
 //! account briefing with prose plus compact provenance.
-//! Per DOS-175 cycle-2 §3: sync `McpToolHandler::invoke` is called from
-//! within `tokio::task::spawn_blocking` at the transport boundary, so
+//! Sync `McpToolHandler::invoke` is called from within
+//! `tokio::task::spawn_blocking` at the transport boundary, so
 //! `runtime.block_on(...)` on a captured handle is safe.
 //!
 //! See `.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md` for the L0
@@ -161,9 +161,8 @@ fn extract_subject(params: &Value) -> Result<String, ToolError> {
             detail: "'subject' must be a non-empty string".into(),
         });
     }
-    // Cycle-1 passthrough: treat `subject` as the account_id directly per
-    // DOS-175 §3.4. Phase-A.1 sub-ticket replaces this with a real
-    // subject-to-account_id resolver.
+    // Phase-A passthrough: treat `subject` as the account_id directly. The
+    // follow-on subject resolver replaces this with slug/account resolution.
     Ok(subject.to_string())
 }
 

--- a/src-tauri/src/services/mcp_v2/taxonomy.rs
+++ b/src-tauri/src/services/mcp_v2/taxonomy.rs
@@ -4,14 +4,13 @@
 //!   gateway consumes at boot.
 //! - [`TaxonomyError`] — fail-fast variants with operator-readable
 //!   `Display`.
-//! - [`YamlTaxonomyCatalog`] — concrete YAML loader (W1-B / DOS-478)
-//!   implementing the trait. Production uses `load_embedded()` reading
+//! - [`YamlTaxonomyCatalog`] — concrete YAML loader implementing the trait.
+//!   Production uses `load_embedded()` reading
 //!   the embedded `tool_descriptions` resource via `include_str!`. Dev uses
 //!   `load_from_path(env DAILYOS_MCP_TAXONOMY_PATH)` for catalog
 //!   iteration without rebuild.
 //!
-//! Handler bodies live in subsequent waves (W2 / W3 / W4) but must
-//! follow the handler-contract conventions documented on
+//! Handler bodies follow the handler-contract conventions documented on
 //! [`TaxonomyCatalog`] below.
 
 use std::collections::HashMap;
@@ -261,7 +260,7 @@ impl YamlToolEntry {
     }
 }
 
-/// Host-selection eval fixture stubs consumed by DOS-481 (W5-A).
+/// Host-selection eval fixture stubs consumed by the routing evaluator.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SelectionFixtures {
@@ -296,11 +295,11 @@ pub struct AdjacentFixture {
 /// `DAILYOS_MCP_TAXONOMY_PATH` env var pointed at a local YAML file.
 const EMBEDDED_YAML: &str = include_str!("resources/tool_descriptions.yaml");
 
-/// Tool-name regex per AC-2 + ADR-0102 §E.
+/// Tool-name regex per ADR-0102 §E.
 const NAME_RE: &str = r"^dailyos\.(read|write|submit|search|list|get|prepare)\.[a-z][a-z0-9_]*$";
 
-/// v1.4.5 grandfathered scopes (per ADR-0102 §E + DOS-478 L0 §3): kept
-/// unprefixed verbatim to avoid breaking existing substrate.
+/// Grandfathered scopes (per ADR-0102 §E): kept unprefixed verbatim to avoid
+/// breaking existing substrate.
 const GRANDFATHERED_SCOPES: &[&str] = &[
     "write.workspace_place_document",
     "read.workspace_graph",

--- a/src-tauri/src/services/mcp_v2/transport.rs
+++ b/src-tauri/src/services/mcp_v2/transport.rs
@@ -179,12 +179,11 @@ impl ServerHandler for V2ServerHandler {
         // Call gateway. The simplified substrate loads the manifest,
         // dispatches handler, audits, and signal-emits.
         //
-        // Per DOS-175 cycle-2 §3.2: `handle_tool_call` is sync and the
-        // handler chain underneath it calls `runtime.block_on(...)` on a
-        // captured tokio handle to dispatch async abilities. Calling that
-        // directly from this async context would nested-runtime-panic, so
-        // we move dispatch onto a blocking-pool thread via
-        // `tokio::task::spawn_blocking`. Inside the blocking thread the
+        // `handle_tool_call` is sync and the handler chain underneath it calls
+        // `runtime.block_on(...)` on a captured tokio handle to dispatch async
+        // abilities. Calling that directly from this async context would
+        // nested-runtime-panic, so we move dispatch onto a blocking-pool thread
+        // via `tokio::task::spawn_blocking`. Inside the blocking thread the
         // handler's `block_on` is safe because we are not on a worker.
         let gateway = self.gateway.clone();
         let conn = self.conn.clone();

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -3960,6 +3960,9 @@ fn bridge_surface_error_code(error: &BridgeSurfaceError) -> &'static str {
         BridgeSurfaceError::StaleVersion { .. } => "stale_watermark",
         BridgeSurfaceError::StaleComposition { .. } => "stale_composition",
         BridgeSurfaceError::CompositionVersionOverflow { .. } => "composition_version_overflow",
+        BridgeSurfaceError::ProducerUnavailable => "producer_unavailable",
+        BridgeSurfaceError::InputSchemaInvalid => "input_schema_invalid",
+        BridgeSurfaceError::InputReservedField => "input_reserved_field",
         BridgeSurfaceError::Validation(_) => "validation_error",
         BridgeSurfaceError::AbilityUnavailable | BridgeSurfaceError::Ownership(_) => {
             "ability_unavailable"

--- a/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
+++ b/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
@@ -1,5 +1,4 @@
-//! Smoke test for the v1.4.7 W1-A migrations (v255-v258 per dev-reconciliation
-//! renumber 2026-05-21; originally v241-v244 in L0 packet) per DOS-168.
+//! Smoke test for the MCP v2 migrations after dev-reconciliation renumbering.
 //!
 //! Runs the full migration chain against an in-memory SQLite and asserts the
 //! schema landed correctly: tables exist, expected columns are present, and
@@ -59,7 +58,7 @@ fn dos168_v255_v258_migrations_land_canonical_schema() {
         "missing handle index per ADR-0102 §D.bis"
     );
 
-    // ---- DOS-168 amended: transport-ceremony rip verification ----
+    // ---- Transport-ceremony rip verification ----
     // Migration 257 (mcp_transport_nonce_ledger) was never introduced — the
     // nonce-replay defense applied to a transport that doesn't have a wire to
     // capture (stdio MCP / loopback). Proving its absence here keeps a future
@@ -78,8 +77,8 @@ fn dos168_v255_v258_migrations_land_canonical_schema() {
     );
 
     // Seed a manifest row so subsequent assertions can reference a client_id.
-    // transport_key_ref retained for schema stability under DOS-758 but is
-    // always NULL post-rip (no transport key material in personal-tier model).
+    // transport_key_ref is retained for schema stability but is always NULL
+    // post-rip (no transport key material in the personal-tier model).
     conn.execute(
         "INSERT INTO mcp_client_manifest (client_id, paired_at, revoked_at, transport_key_ref) \
          VALUES ('smoke-client', 1, NULL, NULL)",

--- a/src-tauri/tests/dos567_fixture_variant_precedence.rs
+++ b/src-tauri/tests/dos567_fixture_variant_precedence.rs
@@ -33,6 +33,7 @@ fn precedence_rank(error: &BridgeSurfaceError) -> u8 {
         BridgeSurfaceError::StaleComposition { .. } => 6,
         BridgeSurfaceError::AbilityUnavailable
         | BridgeSurfaceError::InputSchemaInvalid
+        | BridgeSurfaceError::InputReservedField
         | BridgeSurfaceError::ProducerUnavailable
         | BridgeSurfaceError::Validation(_)
         | BridgeSurfaceError::Ownership(_) => 7,

--- a/src-tauri/tests/w5_b_list_open_loops_test.rs
+++ b/src-tauri/tests/w5_b_list_open_loops_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use dailyos_lib::abilities::feedback::ClaimVerificationState;
+use dailyos_lib::abilities::registry::McpClientId;
 use dailyos_lib::abilities::{AbilityContext, AbilityError, AbilityErrorKind, AbilityRegistry};
 use dailyos_lib::abilities::{Actor, NOOP_ABILITY_TRACER};
 use dailyos_lib::db::claims::{
@@ -150,6 +151,29 @@ async fn w5_b_list_open_loops_returns_empty_for_owned_entity_without_loops() {
 }
 
 #[tokio::test]
+async fn w5_b_list_open_loops_allows_mcp_actor_with_provenance() {
+    let value = invoke_list_open_loops_with_actor(
+        Actor::McpClient {
+            client_id: McpClientId::new("mcp-test"),
+            conversation_handle: None,
+        },
+        Some(("account", EMPTY_ACCOUNT_ID)),
+        fixture_claims(),
+        owned_subjects(),
+    )
+    .await
+    .expect("mcp actor list_open_loops succeeds");
+
+    assert!(loops(&value).is_empty());
+    assert!(
+        value["provenance"]["field_attributions"]
+            .get("/loops")
+            .is_some(),
+        "mcp actor output should carry provenance instead of panicking"
+    );
+}
+
+#[tokio::test]
 async fn w5_b_list_open_loops_rejects_cross_tenant_subject() {
     let err = invoke_list_open_loops(
         Some(("account", CROSS_TENANT_ACCOUNT_ID)),
@@ -188,6 +212,15 @@ async fn invoke_list_open_loops(
     claims: Vec<IntelligenceClaim>,
     owned_subjects: HashSet<SubjectKey>,
 ) -> Result<Value, AbilityError> {
+    invoke_list_open_loops_with_actor(Actor::User, entity_filter, claims, owned_subjects).await
+}
+
+async fn invoke_list_open_loops_with_actor(
+    actor: Actor,
+    entity_filter: Option<(&str, &str)>,
+    claims: Vec<IntelligenceClaim>,
+    owned_subjects: HashSet<SubjectKey>,
+) -> Result<Value, AbilityError> {
     let registry = AbilityRegistry::from_inventory_checked().expect("registry builds");
     let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 6, 12, 0, 0).unwrap());
     let rng = SeedableRng::new(221);
@@ -202,7 +235,7 @@ async fn invoke_list_open_loops(
         &services,
         &provider,
         &NOOP_ABILITY_TRACER,
-        Actor::User,
+        actor,
         None,
         ClaimDismissalSurface::Eval,
     );


### PR DESCRIPTION
## Linear ticket

DOS-175 / MCP v2 account status runtime path

## Summary

Routes MCP account status through the claim-backed entity intelligence runtime on current `dev`, repairs the missing MCP transport nonce ledger schema path, and keeps the rebuilt PR branch mergeable after the old foundation stack diverged.

## What changed

- `dailyos.read.account_status` now invokes `get_entity_intelligence` and projects prose, facts, open loops, trust, sensitivity, and display-safe provenance instead of raw claim/composition identifiers.
- `Actor::McpClient` is allowed through the account intelligence and open-loop runtime paths, including MCP render/provenance mappings and an open-loop provenance regression test.
- Added an idempotent v259 repair migration for the missing MCP transport nonce ledger and verifier coverage for required MCP transport/auth tables.
- Covered bridge surface audit reason codes for newer bridge error variants.
- Removed ticket-specific source comment references that blocked the durable-comment CI lint.

## Test plan

- [x] `cargo test --features mcp account_status_presenter_returns_prose_and_display_provenance`
- [x] `cargo test --features mcp mcp_transport_nonce_ledger`
- [x] `cargo test --features mcp w5_b_list_open_loops_allows_mcp_actor_with_provenance`
- [x] `cargo clippy --features mcp --lib -- -D warnings`
- [x] `./scripts/check_no_ephemeral_issue_refs_in_comments.sh`
- [x] `git diff --check FETCH_HEAD..HEAD`
- [ ] Full `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` not run locally in this session.

## Definition of Done

- [x] Account status MCP output is backed by the abilities runtime instead of the legacy account-overview path.
- [x] End-to-end MCP handler path renders human-readable prose and display-local provenance without exposing raw claim ids in the primary payload.
- [x] No stubs, TODOs, or deferrals introduced.
- [ ] Full repo validation deferred to CI plus the focused local checks above.

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: N/A

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

Focused security pass: the PR keeps MCP on the existing local, single-user client model; does not add remote authentication or broader scopes; routes through the existing ability registry and actor projection; keeps raw claim ids out of the primary MCP response; and the schema repair is additive/idempotent.

## Follow-ups

- Add a service-owned claim promotion/backfill path for structured account facts so schema facts and Glean-promoted facts become first-class claim substrate inputs for MCP/WP/Tauri surfaces.

## Notes for review

- The old PR branch contained a divergent foundation stack. This PR branch was rebuilt from current `dev` and now carries only the focused runtime fixes plus CI unblockers.
