### PR TITLE
fix(surface_runtime): drop duplicate BridgeSurfaceError match arms

### DIFF
--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -3990,9 +3990,6 @@ fn bridge_surface_error_code(error: &BridgeSurfaceError) -> &'static str {
         BridgeSurfaceError::InputReservedField => "input_reserved_field",
         BridgeSurfaceError::Validation(_) => "validation_error",
         BridgeSurfaceError::AbilityUnavailable => "ability_not_registered",
-        BridgeSurfaceError::ProducerUnavailable => "producer_unavailable",
-        BridgeSurfaceError::InputSchemaInvalid => "input_schema_invalid",
-        BridgeSurfaceError::InputReservedField => "input_reserved_field",
         BridgeSurfaceError::Ownership(_) => "ownership_denied",
     }
 }


### PR DESCRIPTION
<!-- protocol-doc: dailyos-pr-template -->

## Linear ticket

Drive-by maintenance — surfaced during PR #354 rebase.

## Summary

Three match arms in `bridge_surface_error_code()` were duplicated by the wp-surface-prep merge (PR #362). Rust flagged them as unreachable. Removing the dead duplicates; first occurrence already covers all values.

## What changed

- `src-tauri/src/surface_runtime/mod.rs`: removed 3 unreachable match arms (`ProducerUnavailable`, `InputSchemaInvalid`, `InputReservedField`).

## Test plan

- [x] `cargo check -p dailyos` — clean (no more unreachable-pattern warnings)
- [x] Behavior unchanged: the first occurrence of each variant always matched, so the dup was dead code.

## Definition of Done

- [x] Unreachable warnings resolved
- [x] No behavior change (dup never reached)
- [x] Single-file 3-line deletion, no test churn required

## §4 Security

`security_auditor_invoked: false`

**Exemption ID**: `EXEMPT-STYLE`

**Exemption rationale**: Dead-code removal in error-code mapping; identical match arms. No trust boundary, sensitivity, schema, prompt, MCP, or workflow change.

- [ ] All security trigger checkboxes: no

## Notes for review

Drop-in fix. Surfaced during PR #354 rebase when `cargo check` emitted the three unreachable-pattern warnings.

L2-status: not-run-acknowledged

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)