### PR TITLE
ci(l3): align L3 gate with ladder revision — suite firing by need + reviewer composition

### DIFF
--- a/.github/reviewer-prompts/l3-architect-reviewer.md
+++ b/.github/reviewer-prompts/l3-architect-reviewer.md
@@ -1,4 +1,11 @@
-You are running an architectural review of a completed unit-of-work's integrated state.
+<!-- Engineering-ladder.md (2026-05-23 revision) routes L3 architectural review
+     to ce-architecture-strategist. This prompt is the DailyOS-specific wrapper
+     that adds: topology framing (§0), Intelligence Loop check, ADR-0101
+     service-boundary discipline, and NAMING.md conventions. The agent invoked
+     via .github/actions/l3-reviewer-job applies the lens below against the
+     integrated wave diff. -->
+
+You are running an architectural review of a completed unit-of-work's integrated state, applying the `ce-architecture-strategist` lens with DailyOS-specific framing.
 
 ## §0 Threat-topology scoping (load-bearing)
 

--- a/.github/reviewer-prompts/matrix.yml
+++ b/.github/reviewer-prompts/matrix.yml
@@ -1,44 +1,104 @@
 # L2 reviewer matrix — maps changed-file path globs to which domain reviewer(s)
-# the L2 GitHub Action invokes for a given PR.
+# the L2 panel invokes for a given PR.
 #
-# Resolver: .github/scripts/resolve-reviewers.py
+# REVISION 2026-05-23: aligns with engineering-ladder.md reviewer-composition
+# revision. The ladder now composes installed agents (`ce-*` and
+# `pr-review-toolkit:*`) per concern rather than running every reviewer on
+# every change. This matrix documents that composition.
+#
+# What this file enforces (mechanical):
+#   - validate-pr-template.py reads `security-auditor.when_changed` and
+#     enforces `security_auditor_invoked: true` in PR body when any matching
+#     path is in the diff. That's the only field this file mechanically gates.
+#
+# What this file documents (informational, for local L2 panel orchestration):
+#   - L2 router-selected specialists keyed to diff content
+#   - L2 advisory-parallel reviewers that always run but never block merge
+#   - L0 planning reviewers (subset; the canonical list lives in
+#     engineering-ladder.md § L0 reviewer router)
+#
+# Resolver: `.github/scripts/validate-pr-template.py` (security-auditor only);
+# `.github/scripts/detect-l3-suite-firing.py` (suite-s + suite-p firing).
 # Loaded from BASE ref by the workflow (NOT the PR head — see workflow comment).
 #
 # An entry can declare:
 #   - reviewer: <name>
+#     advisory: true|false    # advisory means always-on, non-blocking, files to maintenance project
 #     always: true            # always invoked, regardless of changed files
 #     when_changed: [...]     # globs that trigger this reviewer
 #
 # Multiple matches are additive — a PR that touches services/ AND src/components/
-# pulls both security-auditor AND accessibility-tester.
+# pulls both ce-security-reviewer AND accessibility-tester.
 #
 # To add a new reviewer:
-#   1. Drop a `<name>.md` prompt in this directory (and `_common-preamble.md` is shared)
-#   2. Add an entry below
-#   3. Add a job block in .github/workflows/l2-review.yml referencing the prompt
+#   1. If it's a `ce-*` or `pr-review-toolkit:*` agent already installed, just add an entry here
+#   2. If it's a DailyOS-specific custom prompt, drop a `<name>.md` prompt in this directory
+#   3. Update engineering-ladder.md's router table if the new reviewer is part of the routed default
 #   4. Re-run configure-branch-protection.sh if the new reviewer should block merge
 #
-# Glob syntax (per resolve-reviewers.py): `**/` recursive, `*` non-slash, `?` single char.
+# Glob syntax (per validate-pr-template.py): `**/` recursive, `*` non-slash, `?` single char.
 
 reviewers:
-  - reviewer: code-reviewer
+  # ─── L2 default ──────────────────────────────────────────────────────────
+  - reviewer: l2-bounded-reviewer
     description: |
-      General code-quality reviewer. Always runs — every PR gets this slot.
+      Default L2 reviewer (2026-05-23 revision). Orchestrates /codex review
+      against the diff bounded by the ticket's acceptance criteria. Routes
+      theoretical findings to the Codebase Maintenance Linear project
+      (b8e6aea4-d47e-4f3a-b03d-a05bec914aeb). Always invoked.
     always: true
 
-  - reviewer: architect-reviewer
+  # ─── L2 advisory parallel (always-on, non-blocking) ─────────────────────
+  - reviewer: ce-maintainability-reviewer
     description: |
-      Architectural / structural reviewer. Always runs — every PR gets architect's
-      eyes on the design implications, even small ones.
+      Advisory (non-blocking). Reviews for premature abstraction, dead code,
+      coupling between unrelated modules, naming that obscures intent.
+      Findings file to maintenance project, never gate merge.
+    advisory: true
     always: true
 
+  - reviewer: ce-pattern-recognition-specialist
+    description: |
+      Advisory (non-blocking). DRY / duplication / anti-pattern detector
+      across files. Findings file to maintenance project.
+    advisory: true
+    always: true
+
+  - reviewer: ce-code-simplicity-reviewer
+    description: |
+      Advisory (non-blocking). YAGNI + simplification pass. Identifies
+      unnecessary complexity introduced by the diff. Findings file to
+      maintenance project.
+    advisory: true
+    always: true
+
+  - reviewer: ce-project-standards-reviewer
+    description: |
+      Advisory (non-blocking). Audits diff against CLAUDE.md + AGENTS.md
+      standards. Findings file to maintenance project.
+    advisory: true
+    always: true
+
+  - reviewer: ce-testing-reviewer
+    description: |
+      Advisory (non-blocking). Reviews for test coverage gaps, weak
+      assertions, brittle implementation-coupled tests, missing edge cases.
+      Findings file to maintenance project.
+    advisory: true
+    always: true
+
+  # ─── L2 router-selected (blocking when triggered) ───────────────────────
   - reviewer: security-auditor
     description: |
-      Mandatory for plans/PRs touching trust boundaries, claim substrate,
-      privileged actions, schema, orchestration system itself, or governance.
-      Per Amendment 3 of v1.4.0-waves-amendments.md, plus paths surfaced in
-      L2 cycle-1 review of Phase 2 (release_gate.rs, build.rs, .github/scripts/**,
-      pull_request_template.md).
+      Blocking. Triggered for PRs touching trust boundaries, claim
+      substrate, privileged actions, schema, orchestration system itself,
+      or governance. Per Amendment 3 of v1.4.0-waves-amendments.md.
+
+      Routes to /cso (DailyOS-specific) and/or ce-security-reviewer.
+      Matrix key kept as `security-auditor` for validate-pr-template.py
+      compat — that script reads `security-auditor.when_changed` as SSOT
+      for the `security_auditor_invoked: true` PR-body field, and
+      detect-l3-suite-firing.py reads the same key for Suite S firing.
     when_changed:
       # Backend privileged paths
       - "src-tauri/src/services/**"
@@ -84,14 +144,20 @@ reviewers:
 
   - reviewer: performance-engineer
     description: |
-      Triggered when the diff touches performance-budgeted hot paths,
-      DB query layers, IPC boundaries, or async orchestration.
+      Blocking. Triggered when the diff touches performance-budgeted hot
+      paths, DB query layers, IPC boundaries, or async orchestration.
+
+      Routes to ce-performance-reviewer (diff scope) and/or
+      ce-performance-oracle (deep scope). detect-l3-suite-firing.py reads
+      this entry's when_changed to gate Suite P firing.
     when_changed:
       - "src-tauri/src/services/**"
       - "src-tauri/src/intelligence/**"
       - "src-tauri/src/db/**"
       - "src-tauri/src/commands/**"
       - "src-tauri/src/abilities/**"
+      - "src-tauri/src/migrations.rs"
+      - "src-tauri/migrations/**"
       - "src/hooks/**"
       - "src/components/**/*.tsx"
       - "src/pages/**/*.tsx"
@@ -100,7 +166,8 @@ reviewers:
     description: |
       Triggered for any user-facing surface change. Broad globs over `src/**`
       catch global layout, routing, providers, and root-level styles in
-      addition to components/pages — all of which can affect a11y.
+      addition to components/pages — all of which can affect a11y. Used at
+      L4 hands-on validation (not blocking at L2).
     when_changed:
       - "src/**/*.tsx"
       - "src/**/*.ts"
@@ -108,6 +175,18 @@ reviewers:
       - "src/**/*.module.css"
       - "src/**/*.html"
       - "index.html"
+
+  # ─── L2 router-selected diff-content reviewers (informational) ──────────
+  # Per engineering-ladder.md § L2 reviewer router. These are invoked locally
+  # by the L2 orchestrator based on diff content; not currently gated by CI.
+  #
+  # - pr-review-toolkit:type-design-analyzer → new types/structs/enums
+  # - pr-review-toolkit:silent-failure-hunter → error handling / fallbacks
+  # - ce-data-migrations-reviewer → migrations / schema / backfills
+  # - ce-api-contract-reviewer → API routes / request-response types
+  # - ce-reliability-reviewer → retries / circuit breakers / timeouts / background jobs
+  # - ce-kieran-typescript-reviewer → high-risk TypeScript diffs
+  # - ce-data-integrity-guardian → migration safety + data integrity together
 
 # Notes:
 #
@@ -121,6 +200,8 @@ reviewers:
 #   matrix changes themselves go through a manual-review path; the matrix
 #   doesn't review its own modifications.
 #
-# - matrix.yml is the single source of truth for security-auditor trigger
-#   paths. validate-pr-template.py reads `security-auditor.when_changed`
-#   from this file at runtime — no parallel list to maintain.
+# - matrix.yml is the single source of truth for:
+#   1. security-auditor trigger paths (validate-pr-template.py reads at runtime)
+#   2. L3 Suite S firing (detect-l3-suite-firing.py reads at runtime)
+#   3. L3 Suite P firing (detect-l3-suite-firing.py reads performance-engineer key)
+#   No parallel path lists to maintain.

--- a/.github/scripts/detect-l3-suite-firing.py
+++ b/.github/scripts/detect-l3-suite-firing.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Detect which L3 suites (S, P, E) should fire for a given integrated diff.
+
+Engineering-ladder.md (2026-05-23 revision) moves Suite S/P/E firing from
+"all three always at L3" to "fire by need":
+  - Suite S fires when the diff touches any path in matrix.yml's
+    `security-auditor.when_changed` (Amendment 3 paths)
+  - Suite P fires when the diff touches any path in matrix.yml's
+    `performance-engineer.when_changed`
+  - Suite E always fires (cheap; catches the long tail)
+
+This script reads the matrix from a path passed as argv[1], reads the changed
+files from stdin (one per line), and prints GitHub Actions outputs:
+
+    needs-s=true|false
+    needs-p=true|false
+
+Usage (in CI):
+    git diff --name-only "$BASE_SHA..$HEAD_SHA" \\
+      | python3 .github/scripts/detect-l3-suite-firing.py \\
+          .github/reviewer-prompts/matrix.yml \\
+          >> "$GITHUB_OUTPUT"
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Mirror of the glob compiler in validate-pr-template.py for parity."""
+    tokens: list[str] = []
+    i = 0
+    while i < len(pattern):
+        if pattern.startswith("**/", i):
+            tokens.append(r"(?:.*/)?")
+            i += 3
+        elif pattern.startswith("**", i):
+            tokens.append(r".*")
+            i += 2
+        elif pattern[i] == "*":
+            tokens.append(r"[^/]*")
+            i += 1
+        elif pattern[i] == "?":
+            tokens.append(r"[^/]")
+            i += 1
+        else:
+            tokens.append(re.escape(pattern[i]))
+            i += 1
+    return re.compile("^" + "".join(tokens) + "$")
+
+
+def matches_any(path: str, patterns: list[re.Pattern[str]]) -> bool:
+    return any(p.match(path) for p in patterns)
+
+
+def load_when_changed(matrix_path: Path, reviewer: str) -> list[re.Pattern[str]]:
+    """Load `when_changed` glob list for `reviewer` and compile to regex.
+
+    Fails closed: if the reviewer entry is missing or its `when_changed` list
+    is empty, raises ValueError. This gate is load-bearing for the L3 release
+    review — a corrupted or trimmed matrix.yml must not silently produce
+    `needs-{s,p}=false` for every diff.
+    """
+    with matrix_path.open() as fh:
+        data = yaml.safe_load(fh)
+    for entry in data.get("reviewers", []):
+        if entry.get("reviewer") == reviewer:
+            globs = entry.get("when_changed", []) or []
+            if not globs:
+                raise ValueError(
+                    f"matrix.yml reviewer '{reviewer}' has empty `when_changed` — "
+                    f"L3 suite firing cannot be computed safely. Refusing to fail open."
+                )
+            return [glob_to_regex(g) for g in globs]
+    raise ValueError(
+        f"matrix.yml has no reviewer entry named '{reviewer}' — "
+        f"L3 suite firing cannot be computed safely. Refusing to fail open."
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: detect-l3-suite-firing.py <matrix.yml>", file=sys.stderr)
+        return 2
+
+    matrix_path = Path(argv[1])
+    if not matrix_path.exists():
+        print(f"matrix not found: {matrix_path}", file=sys.stderr)
+        return 2
+
+    s_patterns = load_when_changed(matrix_path, "security-auditor")
+    p_patterns = load_when_changed(matrix_path, "performance-engineer")
+
+    changed = [line.strip() for line in sys.stdin if line.strip()]
+
+    needs_s = any(matches_any(path, s_patterns) for path in changed)
+    needs_p = any(matches_any(path, p_patterns) for path in changed)
+
+    # Write to GITHUB_OUTPUT if available; otherwise stdout for local testing.
+    out_lines = [
+        f"needs-s={'true' if needs_s else 'false'}",
+        f"needs-p={'true' if needs_p else 'false'}",
+    ]
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a") as fh:
+            for line in out_lines:
+                fh.write(line + "\n")
+    for line in out_lines:
+        print(line)
+
+    # Diagnostic to stderr.
+    print(
+        f"detect-l3-suite-firing: {len(changed)} changed paths; "
+        f"Suite S needed={needs_s}; Suite P needed={needs_p}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/l3-review.yml
+++ b/.github/workflows/l3-review.yml
@@ -159,6 +159,32 @@ jobs:
 
           echo "config-fence: no L3 gate-config paths in the integrated range"
 
+  # ─── Suite firing detection (2026-05-23: gate Suite S/P by need) ─────
+  # Per engineering-ladder.md revision: Suite S fires only when the integrated
+  # diff touches paths in matrix.yml's security-auditor.when_changed; Suite P
+  # fires only when it touches performance-engineer.when_changed. Suite E
+  # always fires.
+  detect-suite-firing:
+    name: L3 / detect-suite-firing
+    needs: gate
+    runs-on: ubuntu-latest
+    outputs:
+      needs-s: ${{ steps.detect.outputs.needs-s }}
+      needs-p: ${{ steps.detect.outputs.needs-p }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - run: pip install 'pyyaml==6.0.1'
+      - id: detect
+        env:
+          RANGE: ${{ needs.gate.outputs.range }}
+        run: |
+          set -euo pipefail
+          git diff --name-only $RANGE \
+            | python3 .github/scripts/detect-l3-suite-firing.py \
+                .github/reviewer-prompts/matrix.yml
+
   panel-codex:
     name: L3 / panel / codex-challenge
     needs: gate
@@ -205,7 +231,8 @@ jobs:
 
   suite-s:
     name: L3 / suite-s
-    needs: gate
+    needs: [gate, detect-suite-firing]
+    if: needs.detect-suite-firing.outputs.needs-s == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -219,7 +246,8 @@ jobs:
 
   suite-p:
     name: L3 / suite-p
-    needs: gate
+    needs: [gate, detect-suite-firing]
+    if: needs.detect-suite-firing.outputs.needs-p == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -260,7 +288,7 @@ jobs:
 
   aggregate:
     name: L3 / aggregate
-    needs: [gate, panel-codex, panel-architect, suite-s, suite-p, suite-e]
+    needs: [gate, detect-suite-firing, panel-codex, panel-architect, suite-s, suite-p, suite-e]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -270,23 +298,59 @@ jobs:
 
       - id: verdict
         env:
+          DETECT_RESULT: ${{ needs.detect-suite-firing.result }}
           CODEX_RESULT: ${{ needs.panel-codex.result }}
           ARCH_RESULT: ${{ needs.panel-architect.result }}
           S_RESULT: ${{ needs.suite-s.result }}
           P_RESULT: ${{ needs.suite-p.result }}
           E_RESULT: ${{ needs.suite-e.result }}
+          NEEDS_S: ${{ needs.detect-suite-firing.outputs.needs-s }}
+          NEEDS_P: ${{ needs.detect-suite-firing.outputs.needs-p }}
         run: |
           set -euo pipefail
-          if [[ "$CODEX_RESULT" == "success" \
-             && "$ARCH_RESULT"  == "success" \
-             && "$S_RESULT"     == "success" \
-             && "$P_RESULT"     == "success" \
-             && "$E_RESULT"     == "success" ]]; then
+          # Suites S and P now fire by need (2026-05-23 ladder revision).
+          # 'skipped' is a valid pass state when the suite was not needed.
+
+          # Fail-closed guard: the detector itself must have succeeded AND
+          # produced a definite true/false for each suite. If the detector
+          # failed (NEEDS_S/NEEDS_P empty), treating skipped + "" as pass
+          # would let a needed-but-skipped suite slip through. Refuse.
+          if [[ "$DETECT_RESULT" != "success" ]]; then
+            echo "::error::detect-suite-firing result=$DETECT_RESULT — cannot determine suite need; failing closed"
+            echo "verdict=fail" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          for var in NEEDS_S NEEDS_P; do
+            val="${!var}"
+            if [[ "$val" != "true" && "$val" != "false" ]]; then
+              echo "::error::$var='$val' (expected exactly 'true' or 'false'); failing closed"
+              echo "verdict=fail" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          # Treat as success ⇔ result is 'success' OR (result is 'skipped' AND that suite wasn't needed).
+          check() {
+            local result="$1"; local needed="$2"; local label="$3"
+            if [[ "$result" == "success" ]]; then return 0; fi
+            if [[ "$result" == "skipped" && "$needed" == "false" ]]; then return 0; fi
+            echo "::error::$label result=$result (needed=$needed) — not a pass state"
+            return 1
+          }
+
+          ok=1
+          [[ "$CODEX_RESULT" == "success" ]] || { echo "::error::codex result=$CODEX_RESULT"; ok=0; }
+          [[ "$ARCH_RESULT"  == "success" ]] || { echo "::error::architect result=$ARCH_RESULT"; ok=0; }
+          check "$S_RESULT" "$NEEDS_S" "Suite S" || ok=0
+          check "$P_RESULT" "$NEEDS_P" "Suite P" || ok=0
+          [[ "$E_RESULT"     == "success" ]] || { echo "::error::Suite E result=$E_RESULT (always required)"; ok=0; }
+
+          if [[ "$ok" == "1" ]]; then
             echo "verdict=pass" >> "$GITHUB_OUTPUT"
           else
             echo "verdict=fail" >> "$GITHUB_OUTPUT"
           fi
-          echo "results: codex=$CODEX_RESULT arch=$ARCH_RESULT S=$S_RESULT P=$P_RESULT E=$E_RESULT"
+          echo "results: detect=$DETECT_RESULT codex=$CODEX_RESULT arch=$ARCH_RESULT S=$S_RESULT (needed=$NEEDS_S) P=$P_RESULT (needed=$NEEDS_P) E=$E_RESULT"
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:


### PR DESCRIPTION
## Linear ticket

None — process/protocol work. Follows on from #368 (engineering-ladder reviewer composition revision).

## Summary

CI-side changes that were config-fenced out of PR #368. Aligns the L3 release-review workflow with the ladder revision: Suites S/P fire only when the integrated diff warrants them, instead of running unconditionally. Documents the new L2 composition in `matrix.yml`. Adds a one-line preamble to `l3-architect-reviewer.md` noting alignment with `ce-architecture-strategist`.

**Admin merge required** — touches `.github/workflows/`, `.github/scripts/`, and `.github/reviewer-prompts/`, all of which are config-fenced by L2's `config-fence` job (the L2 gate can't review its own config without defeating the trust boundary).

## What changed

- **`.github/workflows/l3-review.yml`** — new `detect-suite-firing` job runs after `gate`; reads matrix.yml patterns and the integrated diff to emit `needs-s` / `needs-p` outputs. `suite-s` and `suite-p` jobs get `if:` conditions on those outputs. `aggregate` verdict rewritten to treat `skipped` as pass only when the corresponding suite wasn't needed.
- **`.github/scripts/detect-l3-suite-firing.py`** (new) — reads `security-auditor.when_changed` + `performance-engineer.when_changed` from matrix.yml, matches against stdin file list, writes outputs. Mirrors `validate-pr-template.py`'s `glob_to_regex` for parity.
- **`.github/reviewer-prompts/matrix.yml`** — rewritten to document the new L2 composition. `l2-bounded-reviewer` as default (always: true), advisory-parallel reviewers marked `advisory: true / always: true` (non-blocking), `security-auditor` + `performance-engineer` matrix keys preserved for validator + detector compat, router-selected diff-content reviewers documented as comments.
- **`.github/reviewer-prompts/l3-architect-reviewer.md`** — one-line preamble noting alignment with `ce-architecture-strategist`. Prompt body unchanged.

## Fail-closed posture

Two fail-open paths surfaced by L2 codex review on first dispatch and addressed before second-pass APPROVE:

1. **`l3-review.yml:283`** — `aggregate` now hard-checks `needs.detect-suite-firing.result == success` AND that `NEEDS_S`/`NEEDS_P` are exactly `'true'` or `'false'`. Empty values (from detector failure) now fail closed instead of letting a needed-but-skipped suite slip through.
2. **`detect-l3-suite-firing.py:61`** — `load_when_changed` now raises `ValueError` + exits 1 when the reviewer key is missing or its `when_changed` list is empty. A trimmed/corrupted matrix.yml can no longer silently produce `needs-{s,p}=false` for every diff.

## Test plan

- [x] YAML lint clean on `l3-review.yml` and `matrix.yml`
- [x] Detector smoke-tested both directions (services/ path → fires both S and P; docs-only → fires neither)
- [x] Fail-closed verified with synthetic bad-matrix (no security-auditor key → ValueError + exit 1)
- [x] L2 codex review: BLOCK on first pass (2 fail-open findings) → addressed → APPROVE on second pass
- [ ] First post-merge L3 release fire will be the real integration test — watch for verdict aggregation behavior on a diff that doesn't touch Amendment 3 paths (expect Suite S to skip cleanly + verdict still resolve)

## Definition of Done

- [x] Acceptance: Suites S/P gate-by-need per ladder revision; verdict aggregation handles all (success/skipped/failure) × (needed/not-needed) combinations correctly
- [x] End-to-end: matrix.yml is the SSOT for both validate-pr-template.py AND detect-l3-suite-firing.py
- [x] No stubs / TODOs / Phase 2 deferrals
- [x] Tests: detector + fail-closed paths verified; full L3 integration verified on next release fire (this is the gate itself; can't dry-run from inside it)

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (if `security_auditor_invoked: false`): _none — declared true_

**Exemption rationale**: n/a

L2 codex review dispatched against the staged diff with explicit focus on logic correctness of the verdict aggregation + detector edge cases. First pass returned BLOCK with two fail-open findings (`aggregate` not gating on detector result; `load_when_changed` returning `[]` on missing key). Both fixed; re-review returned APPROVE. The new fail-closed guards strengthen the gate's trust boundary rather than weakening it — the gate now refuses to issue a pass verdict when the detector itself failed, where previously a detector failure could mask a needed-but-skipped Suite S/P. Topology: this PR modifies a privileged-action surface (the release gate), so the security review is load-bearing — not a doc-only exemption.

- [ ] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action — modifies the L3 release-review gate's decision logic
- [x] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

None for this PR. The ladder-revision sweep is complete with PR #368 + this one. Maintenance-tracked items from the original audit (delete pre-push hook duplicate-layer, add 3 quality-metric trends to retros) are filed separately for the maintenance project, not gated on this PR.

## Notes for review

- This PR is admin-merge because all touched paths are config-fenced. The L2 panel cannot review its own configuration — that's a deliberate trust-boundary property of the gate, not a workflow bug. Resolution: merge with admin override; the new configuration becomes the base for subsequent reviews.
- The first post-merge L3 release fire is the integration test for this change. Watch the workflow log for the `detect-suite-firing` job emitting `needs-s` / `needs-p` and the `aggregate` step's `results: ...` echo to confirm gating logic works end-to-end.
- `matrix.yml`'s advisory-parallel reviewers section is documentation-only — the L2 CI workflow doesn't dispatch reviewers (per existing design); the local L2 panel reads this matrix to know which reviewers to invoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)