### PR TITLE
Project runtime evidence for MCP account status

### DIFF
--- a/scripts/check_stakeholder_writer_emits_signal.sh
+++ b/scripts/check_stakeholder_writer_emits_signal.sh
@@ -267,7 +267,7 @@ while IFS= read -r -d '' file; do
         }
         stop = min(n, i + 30)
         fn_idx = enclosing_function(i)
-        if (allowlisted_writer || is_non_graph_update(i, stop) ||
+        if (in_cfg_test_line[i] || allowlisted_writer || is_non_graph_update(i, stop) ||
             has_write_level_stakeholder_signal(i, fn_idx)) {
           continue
         }

--- a/src-tauri/src/mcp/main.rs
+++ b/src-tauri/src/mcp/main.rs
@@ -27,7 +27,7 @@ use dailyos_lib::bridges::tauri::TauriAbilityBridge;
 use dailyos_lib::bridges::{BridgeSurfaceError, McpSessionId};
 use dailyos_lib::db::ActionDb;
 use dailyos_lib::embeddings::EmbeddingModel;
-use dailyos_lib::services::mcp_v2::handlers::tool_account_status::present_account_status_response_with_label;
+use dailyos_lib::services::mcp_v2::handlers::tool_account_status::present_account_status_response_with_context;
 use dailyos_lib::services::sensitivity::{
     render_mcp_static_json_for_surface, render_mcp_static_text_for_surface, McpStaticTextClass,
     RenderableMcpClaimText, RenderableMcpStaticText, RenderableMcpText,
@@ -413,10 +413,13 @@ impl DailyOsMcp {
                 None,
             )
             .await?;
-        Ok(present_account_status_response_with_label(
+        let invocation_id = response.invocation_id.0.to_string();
+        Ok(present_account_status_response_with_context(
             account_id,
             response.data,
             Some(account_label),
+            Some(&invocation_id),
+            Some("get_provenance"),
         ))
     }
 
@@ -1002,14 +1005,9 @@ fn get_provenance_invocation_id(request: &CallToolRequestParam) -> Result<Invoca
         ));
     };
 
-    if arguments.len() != 1 {
-        return Err(mcp_error_from_bridge_surface_error(
-            BridgeSurfaceError::AbilityUnavailable,
-        ));
-    }
-
     let Some(invocation_id) = arguments
         .get("invocation_id")
+        .or_else(|| arguments.get("invocationId"))
         .and_then(serde_json::Value::as_str)
     else {
         return Err(mcp_error_from_bridge_surface_error(
@@ -1379,6 +1377,9 @@ fn account_status_has_assessment_content(value: &serde_json::Value) -> bool {
         "/assessment/facts",
         "/assessment/openLoops",
         "/assessment/relationships",
+        "/assessment/touchpoints",
+        "/assessment/recordEntries",
+        "/assessment/priorities",
     ]
     .iter()
     .any(|pointer| {
@@ -1625,6 +1626,26 @@ mod tests {
                 "facts": [],
                 "openLoops": [],
                 "relationships": [{ "relationship": "Stakeholder" }]
+            }
+        });
+
+        assert_eq!(
+            account_intelligence_summary(&payload),
+            Some("DailyOS account briefing for Example Account.".to_string())
+        );
+    }
+
+    #[test]
+    fn account_intelligence_summary_uses_answer_for_touchpoint_only_content() {
+        let payload = json!({
+            "answer": "DailyOS account briefing for Example Account.",
+            "assessment": {
+                "facts": [],
+                "openLoops": [],
+                "relationships": [],
+                "touchpoints": [{ "kind": "meeting", "when": "2026-05-22T15:00:00Z" }],
+                "recordEntries": [],
+                "priorities": []
             }
         });
 
@@ -1980,6 +2001,21 @@ mod tests {
         assert_eq!(provenance_result.is_error, Some(false));
         assert_eq!(provenance_value["surface"], "mcp_tool_detail");
         assert_eq!(provenance_value["value"]["invocation_id"], invocation_id);
+
+        let camel_case_handle_result = invoke_mcp_get_provenance_tool(
+            &bridge,
+            session_id,
+            request(
+                "get_provenance",
+                json!({
+                    "invocationId": invocation_id,
+                    "detailAvailable": true,
+                    "detailTool": "get_provenance"
+                }),
+            ),
+        )
+        .unwrap();
+        assert_eq!(camel_case_handle_result.is_error, Some(false));
 
         let cross_session = invoke_mcp_get_provenance_tool(
             &bridge,

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1013,7 +1013,7 @@ const MIGRATIONS: &[Migration] = &[
     },
     // Migration 259 (mcp_transport_nonce_ledger repair) is intentionally
     // absent. It briefly reintroduced the remote transport nonce ledger after
-    // DOS-168 removed transport ceremony for local MCP.
+    // local MCP moved to OS/user trust instead of remote transport ceremony.
     // v1.4.4a W5 — email summary trust/source badges must be tied to the
     // enrichment pass that produced the summary, not computed from a later
     // entity-claim snapshot.

--- a/src-tauri/src/migrations/261_drop_mcp_transport_nonce_ledger.sql
+++ b/src-tauri/src/migrations/261_drop_mcp_transport_nonce_ledger.sql
@@ -1,4 +1,8 @@
 -- MCP v2 local transport-ceremony cleanup.
 -- The nonce ledger belongs to the removed HMAC transport layer; local MCP uses
 -- OS/user trust plus tool authorization scopes.
+BEGIN IMMEDIATE;
+
 DROP TABLE IF EXISTS mcp_transport_nonce_ledger;
+
+COMMIT;

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -10,11 +10,9 @@
 //! See `.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md` for the L0
 //! contract.
 
-use std::collections::BTreeMap;
-
 use abilities_runtime::abilities::registry::{AbilityRegistry, McpExposure};
 use abilities_runtime::abilities::tracer::NOOP_ABILITY_TRACER;
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 
 use crate::bridges::types::{
     invoke_registry_json_for_actor, AbilityInvokeError, RequestScopedInvocation,
@@ -27,16 +25,20 @@ use crate::services::context::{
 };
 use crate::services::mcp_v2::actor_policy::{project_actor, ToolGrant, ToolRateLimit};
 use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::runtime_projection::{
+    compact_text, evidence_suffix, humanize_token, open_loop_suffix, project_runtime_evidence,
+    string_at, RuntimeEvidenceProjection,
+};
 
 const ACTOR_LABEL: &str = concat!("agent:dailyos-mcp-v2:", env!("CARGO_PKG_VERSION"));
 
 /// Registered ability name in the abilities-runtime registry.
 const ABILITY_NAME: &str = "get_entity_intelligence";
+const TOOL_NAME: &str = "dailyos.read.account_status";
 
 /// `EntityIntelligenceInput` schema version pinned by the ability contract.
 const ENTITY_INTELLIGENCE_SCHEMA_VERSION: u32 = 2;
-const ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION: u32 = 1;
-const MAX_ASSESSMENT_ITEMS: usize = 8;
+const ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION: u32 = 2;
 
 pub struct AccountStatusHandler {
     description: ToolDescription,
@@ -143,7 +145,14 @@ impl McpToolHandler for AccountStatusHandler {
             )
             .await
             .map_err(map_invoke_error)?;
-            Ok(present_account_status_response(&subject, response.data))
+            let invocation_id = response.invocation_id.0.to_string();
+            Ok(present_account_status_response_with_context(
+                &subject,
+                response.data,
+                None,
+                Some(&invocation_id),
+                None,
+            ))
         })
     }
 }
@@ -167,13 +176,29 @@ fn extract_subject(params: &Value) -> Result<String, ToolError> {
 }
 
 pub fn present_account_status_response(subject: &str, envelope: Value) -> Value {
-    present_account_status_response_with_label(subject, envelope, None)
+    present_account_status_response_with_context(subject, envelope, None, None, None)
 }
 
 pub fn present_account_status_response_with_label(
     subject: &str,
     envelope: Value,
     display_label_override: Option<&str>,
+) -> Value {
+    present_account_status_response_with_context(
+        subject,
+        envelope,
+        display_label_override,
+        None,
+        None,
+    )
+}
+
+pub fn present_account_status_response_with_context(
+    subject: &str,
+    envelope: Value,
+    display_label_override: Option<&str>,
+    invocation_id: Option<&str>,
+    provenance_detail_tool: Option<&str>,
 ) -> Value {
     let subject_value = envelope
         .get("subject")
@@ -198,34 +223,45 @@ pub fn present_account_status_response_with_label(
         subject_value
     };
 
-    let (provenance, source_id_map) = build_provenance_summary(&envelope);
-    let facts = collect_fact_summaries(&envelope, &source_id_map);
-    let open_loops = collect_open_loop_summaries(&envelope, &source_id_map);
-    let relationships = collect_relationship_summaries(&envelope, &source_id_map);
-    let answer = build_account_status_answer(
-        &label,
-        &facts,
-        &open_loops,
-        &relationships,
-        &envelope,
-        &provenance,
-    );
+    let projection = project_runtime_evidence(&envelope);
+    let answer = build_account_status_answer(&label, &projection, &envelope);
+    let provenance_handle = invocation_id.map(|id| {
+        json!({
+            "invocationId": id,
+            "invocation_id": id,
+            "detailAvailable": provenance_detail_tool.is_some(),
+            "detailTool": provenance_detail_tool,
+            "detailParams": {
+                "invocation_id": id
+            }
+        })
+    });
 
     json!({
         "schemaVersion": ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION,
-        "surface": "dailyos.read.account_status",
+        "toolName": TOOL_NAME,
+        "surface": TOOL_NAME,
         "producer": ABILITY_NAME,
+        "status": projection.status,
+        "invocationId": invocation_id,
+        "provenanceHandle": provenance_handle,
         "subject": subject_value,
         "answer": answer,
         "assessment": {
-            "facts": facts,
-            "openLoops": open_loops,
-            "relationships": relationships,
+            "facts": projection.facts,
+            "openLoops": projection.open_loops,
+            "relationships": projection.relationships,
+            "touchpoints": projection.touchpoints,
+            "recordEntries": projection.record_entries,
+            "priorities": projection.priorities,
+            "caveats": projection.caveats,
         },
         "trust": envelope.get("trust").cloned().unwrap_or(Value::Null),
         "sensitivity": envelope.get("sensitivity").cloned().unwrap_or(Value::Null),
-        "provenance": provenance,
-        "sections": envelope.get("sections").cloned().unwrap_or_else(|| json!({})),
+        "provenance": projection.provenance,
+        "sectionStates": projection.section_states.clone(),
+        "sections": projection.section_states,
+        "truncation": projection.truncation,
         "sourceEnvelope": {
             "schemaVersion": envelope.get("schemaVersion").cloned().unwrap_or(Value::Null),
             "rawEnvelopeIncluded": false,
@@ -241,283 +277,20 @@ fn fallback_subject(subject: &str) -> Value {
     })
 }
 
-fn build_provenance_summary(envelope: &Value) -> (Value, BTreeMap<String, String>) {
-    let mut source_id_map = BTreeMap::new();
-    let mut sources = Vec::new();
-
-    if let Some(raw_sources) = envelope
-        .pointer("/provenance/sources")
-        .and_then(Value::as_array)
-    {
-        for (index, source) in raw_sources.iter().enumerate() {
-            let display_id = format!("source_{}", index + 1);
-            if let Some(raw_id) = source.get("id").and_then(Value::as_str) {
-                source_id_map.insert(raw_id.to_string(), display_id.clone());
-            }
-
-            let mut projected = Map::new();
-            projected.insert("id".to_string(), Value::String(display_id));
-            insert_string_or_clone(&mut projected, "label", source, "/label");
-            insert_string_or_clone(&mut projected, "sourceType", source, "/sourceType");
-            insert_string_or_clone(&mut projected, "asOf", source, "/asOf");
-            if let Some(redacted) = source.get("redacted").and_then(Value::as_bool) {
-                projected.insert("redacted".to_string(), Value::Bool(redacted));
-            }
-            sources.push(Value::Object(projected));
-        }
-    }
-
-    let redaction_applied = envelope
-        .pointer("/provenance/redactionApplied")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-
-    (
-        json!({
-            "sources": sources,
-            "redactionApplied": redaction_applied,
-            "rawClaimIdsIncluded": false,
-        }),
-        source_id_map,
-    )
-}
-
-fn collect_fact_summaries(
-    envelope: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) -> Vec<Value> {
-    envelope
-        .pointer("/facts/items")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| fact_summary(item, source_id_map))
-                .take(MAX_ASSESSMENT_ITEMS)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn fact_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
-    let text = string_at(item, "/renderedText/text")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())?;
-
-    let mut summary = Map::new();
-    summary.insert("text".to_string(), Value::String(text));
-    insert_string_or_clone(&mut summary, "fieldPath", item, "/fieldPath");
-    insert_string_or_clone(&mut summary, "claimType", item, "/claimType");
-    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
-    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
-    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsof");
-    insert_string_or_clone(&mut summary, "sensitivity", item, "/sensitivity");
-    insert_string_or_clone(&mut summary, "lifecycleState", item, "/lifecycleState");
-    insert_string_or_clone(
-        &mut summary,
-        "verificationState",
-        item,
-        "/verificationState",
-    );
-    insert_source_refs(&mut summary, item, source_id_map);
-    Some(Value::Object(summary))
-}
-
-fn collect_open_loop_summaries(
-    envelope: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) -> Vec<Value> {
-    envelope
-        .pointer("/openLoops/items")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| open_loop_summary(item, source_id_map))
-                .take(MAX_ASSESSMENT_ITEMS)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn collect_relationship_summaries(
-    envelope: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) -> Vec<Value> {
-    envelope
-        .pointer("/relationships/items")
-        .and_then(Value::as_array)
-        .map(|bundles| {
-            let mut summaries = Vec::new();
-            for bundle in bundles {
-                if let Some(participants) = bundle
-                    .pointer("/participants/items")
-                    .and_then(Value::as_array)
-                {
-                    summaries.extend(
-                        participants.iter().filter_map(|item| {
-                            relationship_participant_summary(item, source_id_map)
-                        }),
-                    );
-                }
-                if let Some(edges) = bundle.pointer("/edges/items").and_then(Value::as_array) {
-                    summaries.extend(
-                        edges
-                            .iter()
-                            .filter_map(|item| relationship_edge_summary(item, source_id_map)),
-                    );
-                }
-            }
-            summaries.truncate(MAX_ASSESSMENT_ITEMS);
-            summaries
-        })
-        .unwrap_or_default()
-}
-
-fn relationship_participant_summary(
-    item: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) -> Option<Value> {
-    let display_label = string_at(item, "/displayLabel/text")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())?;
-
-    let mut summary = Map::new();
-    summary.insert("kind".to_string(), Value::String("participant".to_string()));
-    summary.insert("displayLabel".to_string(), Value::String(display_label));
-    if let Some(role) = string_at(item, "/role/text")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())
-    {
-        summary.insert("role".to_string(), Value::String(role));
-    }
-    if let Some(relationship) = string_at(item, "/relationship/text")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())
-    {
-        summary.insert("relationship".to_string(), Value::String(relationship));
-    }
-    if let Some(count) = item
-        .get("normalizedTouchpointCount")
-        .and_then(Value::as_u64)
-    {
-        summary.insert(
-            "normalizedTouchpointCount".to_string(),
-            Value::Number(count.into()),
-        );
-    }
-    insert_string_or_clone(&mut summary, "lastSeenAt", item, "/lastSeenAt");
-    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
-    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
-    insert_source_refs(&mut summary, item, source_id_map);
-    Some(Value::Object(summary))
-}
-
-fn relationship_edge_summary(
-    item: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) -> Option<Value> {
-    let relationship = string_at(item, "/edgeType")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())
-        .map(|value| relationship_label_for_edge_type(&value))
-        .unwrap_or_else(|| "Relationship".to_string());
-    let mut summary = Map::new();
-    summary.insert("kind".to_string(), Value::String("edge".to_string()));
-    summary.insert("relationship".to_string(), Value::String(relationship));
-    if let Some(display_label) = string_at(item, "/relatedDisplayLabel/text")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())
-    {
-        summary.insert("displayLabel".to_string(), Value::String(display_label));
-    }
-    if let Some(related_entity_type) = relationship_subject_type(item.get("relatedSubjectRef")) {
-        summary.insert(
-            "relatedEntityType".to_string(),
-            Value::String(related_entity_type.to_string()),
-        );
-    }
-    insert_string_or_clone(&mut summary, "inclusionReason", item, "/inclusionReason");
-    insert_string_or_clone(&mut summary, "observedAt", item, "/observedAt");
-    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsof");
-    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
-    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
-    insert_source_refs(&mut summary, item, source_id_map);
-    Some(Value::Object(summary))
-}
-
-fn relationship_label_for_edge_type(edge_type: &str) -> String {
-    match edge_type {
-        "hierarchy_parent" => "Parent relationship",
-        "hierarchy_child" => "Child relationship",
-        "stakeholder" => "Stakeholder",
-        "member" => "Member",
-        "meeting_subject" => "Meeting subject",
-        "meeting_attendance" => "Meeting attendance",
-        "meeting_link" => "Meeting link",
-        "person_relationship" => "Person relationship",
-        _ => "Relationship",
-    }
-    .to_string()
-}
-
-fn relationship_subject_type(subject_ref: Option<&Value>) -> Option<&'static str> {
-    subject_ref.and_then(|value| {
-        if let Some(value) = value.as_str() {
-            return value
-                .split_once(':')
-                .map(|(entity_type, _)| entity_type)
-                .or(Some(value))
-                .and_then(known_entity_type);
-        }
-        value
-            .as_object()
-            .and_then(|object| object.keys().find_map(|key| known_entity_type(key)))
-    })
-}
-
-fn known_entity_type(entity_type: &str) -> Option<&'static str> {
-    match entity_type {
-        "account" => Some("account"),
-        "project" => Some("project"),
-        "person" => Some("person"),
-        "meeting" => Some("meeting"),
-        _ => None,
-    }
-}
-
-fn open_loop_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
-    let open_loop = item.get("openLoop").unwrap_or(item);
-    let description = string_at(open_loop, "/description")
-        .map(compact_text)
-        .filter(|value| !value.is_empty())?;
-
-    let mut summary = Map::new();
-    summary.insert("description".to_string(), Value::String(description));
-    insert_string_or_clone(&mut summary, "loopKind", open_loop, "/loop_kind");
-    insert_string_or_clone(&mut summary, "owner", open_loop, "/owner");
-    insert_string_or_clone(&mut summary, "dueDate", open_loop, "/due_date");
-    insert_string_or_clone(&mut summary, "status", open_loop, "/status");
-    insert_string_or_clone(&mut summary, "sourceAsOf", open_loop, "/source_asof");
-    insert_string_or_clone(&mut summary, "claimType", open_loop, "/claim_type");
-    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
-    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
-    insert_source_refs(&mut summary, item, source_id_map);
-    Some(Value::Object(summary))
-}
-
 fn build_account_status_answer(
     label: &str,
-    facts: &[Value],
-    open_loops: &[Value],
-    relationships: &[Value],
+    projection: &RuntimeEvidenceProjection,
     envelope: &Value,
-    provenance: &Value,
 ) -> String {
-    if facts.is_empty() && open_loops.is_empty() && relationships.is_empty() {
+    if projection.facts.is_empty()
+        && projection.open_loops.is_empty()
+        && projection.relationships.is_empty()
+        && projection.touchpoints.is_empty()
+        && projection.record_entries.is_empty()
+    {
         if let Some(advisory) = relationship_partial_failure_advisory(envelope) {
             return format!(
-                "DailyOS could not read relationship intelligence for {label}: {advisory}."
+                "DailyOS could not read requested intelligence for {label}: {advisory}."
             );
         }
         return format!("DailyOS does not yet have claim-backed account intelligence for {label}.");
@@ -525,28 +298,29 @@ fn build_account_status_answer(
 
     let mut lines = vec![format!("DailyOS account briefing for {label}.")];
 
-    if !facts.is_empty() {
+    if !projection.facts.is_empty() {
         lines.push(String::new());
         lines.push("Assessment:".to_string());
-        for fact in facts.iter().take(5) {
+        for fact in projection.facts.iter().take(5) {
             if let Some(text) = string_at(fact, "/text") {
                 lines.push(format!("- {}{}", text, evidence_suffix(fact)));
             }
         }
     }
 
-    if !open_loops.is_empty() {
+    if !projection.open_loops.is_empty() {
         lines.push(String::new());
         lines.push("Open loops:".to_string());
-        for open_loop in open_loops.iter().take(5) {
+        for open_loop in projection.open_loops.iter().take(5) {
             if let Some(description) = string_at(open_loop, "/description") {
                 lines.push(format!("- {}{}", description, open_loop_suffix(open_loop)));
             }
         }
     }
 
-    if !relationships.is_empty() {
-        let participants = relationships
+    if !projection.relationships.is_empty() {
+        let participants = projection
+            .relationships
             .iter()
             .filter(|item| string_at(item, "/kind") == Some("participant"))
             .take(3)
@@ -571,7 +345,8 @@ fn build_account_status_answer(
             }
         }
 
-        let edges = relationships
+        let edges = projection
+            .relationships
             .iter()
             .filter(|item| string_at(item, "/kind") == Some("edge"))
             .take(3)
@@ -590,7 +365,46 @@ fn build_account_status_answer(
         }
     }
 
-    let source_count = provenance
+    if !projection.touchpoints.is_empty() {
+        lines.push(String::new());
+        lines.push("Touchpoint evidence:".to_string());
+        for touchpoint in projection.touchpoints.iter().take(5) {
+            let timing = string_at(touchpoint, "/timing").unwrap_or("touchpoint");
+            let kind = string_at(touchpoint, "/kind")
+                .map(humanize_token)
+                .unwrap_or_else(|| "touchpoint".to_string());
+            if let Some(when) = string_at(touchpoint, "/when") {
+                lines.push(format!(
+                    "- {} {} on {}{}",
+                    humanize_token(timing),
+                    kind,
+                    when,
+                    evidence_suffix(touchpoint)
+                ));
+            }
+        }
+    }
+
+    if !projection.record_entries.is_empty() {
+        lines.push(String::new());
+        lines.push("Record evidence:".to_string());
+        for entry in projection.record_entries.iter().take(5) {
+            if let Some(text) = string_at(entry, "/text") {
+                let recorded_at = string_at(entry, "/recordedAt")
+                    .map(|value| format!(" recorded {value}"))
+                    .unwrap_or_default();
+                lines.push(format!(
+                    "- {}{}{}",
+                    text,
+                    recorded_at,
+                    evidence_suffix(entry)
+                ));
+            }
+        }
+    }
+
+    let source_count = projection
+        .provenance
         .pointer("/sources")
         .and_then(Value::as_array)
         .map(Vec::len)
@@ -606,102 +420,26 @@ fn build_account_status_answer(
 }
 
 fn relationship_partial_failure_advisory(envelope: &Value) -> Option<String> {
-    envelope
-        .pointer("/relationships/items")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .find_map(|bundle| {
-            bundle
-                .get("emptyReason")
-                .and_then(|reason| reason.get("partial_failure"))
-                .and_then(|failure| failure.get("advisory"))
-                .and_then(Value::as_str)
-                .map(compact_text)
-                .filter(|value| !value.is_empty())
-        })
-}
-
-fn evidence_suffix(item: &Value) -> String {
-    let mut parts = Vec::new();
-    push_humanized_part(&mut parts, "trust", item, "/trustBand");
-    push_humanized_part(&mut parts, "freshness", item, "/freshness");
-    if let Some(source_as_of) = string_at(item, "/sourceAsOf") {
-        parts.push(format!("as of {source_as_of}"));
+    match envelope {
+        Value::Object(object) => {
+            for key in ["partial_failure", "partialFailure"] {
+                if let Some(advisory) = object
+                    .get(key)
+                    .and_then(|failure| failure.get("advisory"))
+                    .and_then(Value::as_str)
+                    .map(compact_text)
+                    .filter(|value| !value.is_empty())
+                {
+                    return Some(advisory);
+                }
+            }
+            object
+                .values()
+                .find_map(relationship_partial_failure_advisory)
+        }
+        Value::Array(items) => items.iter().find_map(relationship_partial_failure_advisory),
+        _ => None,
     }
-    if parts.is_empty() {
-        String::new()
-    } else {
-        format!(" ({})", parts.join("; "))
-    }
-}
-
-fn open_loop_suffix(item: &Value) -> String {
-    let mut parts = Vec::new();
-    if let Some(status) = string_at(item, "/status") {
-        parts.push(format!("status: {}", humanize_token(status)));
-    }
-    if let Some(due_date) = string_at(item, "/dueDate") {
-        parts.push(format!("due {due_date}"));
-    }
-    push_humanized_part(&mut parts, "trust", item, "/trustBand");
-    if parts.is_empty() {
-        String::new()
-    } else {
-        format!(" ({})", parts.join("; "))
-    }
-}
-
-fn push_humanized_part(parts: &mut Vec<String>, label: &str, item: &Value, pointer: &str) {
-    if let Some(value) = string_at(item, pointer) {
-        parts.push(format!("{label}: {}", humanize_token(value)));
-    }
-}
-
-fn insert_string_or_clone(
-    target: &mut Map<String, Value>,
-    key: &str,
-    source: &Value,
-    pointer: &str,
-) {
-    if let Some(value) = source.pointer(pointer).filter(|value| !value.is_null()) {
-        target.insert(key.to_string(), value.clone());
-    }
-}
-
-fn insert_source_refs(
-    target: &mut Map<String, Value>,
-    item: &Value,
-    source_id_map: &BTreeMap<String, String>,
-) {
-    let refs = item
-        .pointer("/provenance/sourceIds")
-        .and_then(Value::as_array)
-        .map(|source_ids| {
-            source_ids
-                .iter()
-                .filter_map(Value::as_str)
-                .filter_map(|raw_id| source_id_map.get(raw_id))
-                .cloned()
-                .map(Value::String)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    if !refs.is_empty() {
-        target.insert("sourceRefs".to_string(), Value::Array(refs));
-    }
-}
-
-fn string_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
-    value.pointer(pointer).and_then(Value::as_str)
-}
-
-fn compact_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn humanize_token(value: &str) -> String {
-    value.replace('_', " ")
 }
 
 fn map_invoke_error(err: AbilityInvokeError) -> ToolError {
@@ -867,6 +605,40 @@ mod tests {
                     }
                 }]
             },
+            "touchpoints": {
+                "items": [{
+                    "upcoming": { "items": [] },
+                    "recent": {
+                        "items": [{
+                            "meetingId": "meeting-1",
+                            "kind": "meeting",
+                            "when": "2026-05-22T15:00:00Z",
+                            "inclusionReason": "attendee_match",
+                            "trustBand": "unscored",
+                            "freshness": "current",
+                            "provenance": {
+                                "sourceIds": ["touchpoint:meeting-1"]
+                            }
+                        }]
+                    }
+                }]
+            },
+            "recordEntries": {
+                "items": [{
+                    "claimId": "claim-3",
+                    "claimType": "account_priority",
+                    "recordedAt": "2026-05-22T15:00:00Z",
+                    "renderedText": {
+                        "text": "Prioritize the reliability recap before the next renewal review.",
+                        "policy": {}
+                    },
+                    "trustBand": "likely_current",
+                    "sensitivity": "internal",
+                    "provenance": {
+                        "sourceIds": ["record_source:claim-3"]
+                    }
+                }]
+            },
             "trust": {
                 "aggregateBand": "likely_current",
                 "sectionCaveats": {}
@@ -901,6 +673,20 @@ mod tests {
                         "sourceType": "account_stakeholders",
                         "asOf": "2026-05-22T15:00:00Z",
                         "redacted": false
+                    },
+                    {
+                        "id": "touchpoint:meeting-1",
+                        "label": "Meeting (redacted)",
+                        "sourceType": "meeting",
+                        "asOf": "2026-05-22T15:00:00Z",
+                        "redacted": true
+                    },
+                    {
+                        "id": "record_source:claim-3",
+                        "label": "claim",
+                        "sourceType": "claim",
+                        "asOf": "2026-05-22T15:00:00Z",
+                        "redacted": false
                     }
                 ],
                 "redactionApplied": false
@@ -925,6 +711,17 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Commercial Sponsor"));
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("Touchpoint evidence"));
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("Prioritize the reliability recap"));
+        assert_eq!(payload["schemaVersion"], 2);
+        assert_eq!(payload["toolName"], "dailyos.read.account_status");
+        assert_eq!(payload["status"], "ok");
         assert_eq!(
             payload["assessment"]["facts"][0]["sourceRefs"][0],
             "source_1"
@@ -933,15 +730,31 @@ mod tests {
             payload["assessment"]["relationships"][0]["sourceRefs"][0],
             "source_3"
         );
+        assert_eq!(
+            payload["assessment"]["touchpoints"][0]["sourceRefs"][0],
+            "source_5"
+        );
+        assert_eq!(
+            payload["assessment"]["recordEntries"][0]["sourceRefs"][0],
+            "source_6"
+        );
+        assert_eq!(
+            payload["assessment"]["priorities"][0]["text"],
+            "Prioritize the reliability recap before the next renewal review."
+        );
         assert_eq!(payload["provenance"]["sources"][0]["id"], "source_1");
         assert_eq!(payload["provenance"]["rawClaimIdsIncluded"], false);
+        assert_eq!(payload["truncation"]["recordEntries"]["renderedCount"], 1);
 
         let serialized = serde_json::to_string(&payload).unwrap();
         assert!(!serialized.contains("claim_source:claim-1"));
         assert!(!serialized.contains("relationship_source:person-1"));
         assert!(!serialized.contains("relationship_source:edge-1"));
+        assert!(!serialized.contains("touchpoint:meeting-1"));
+        assert!(!serialized.contains("record_source:claim-3"));
         assert!(!serialized.contains("raw-edge-source"));
         assert!(!serialized.contains("meeting-1"));
+        assert!(!serialized.contains("claim-3"));
         assert!(!serialized.contains("\"claimId\""));
     }
 
@@ -994,8 +807,13 @@ mod tests {
             "sections": {}
         });
 
-        let payload =
-            present_account_status_response_with_label("acct-1", envelope, Some("Example Account"));
+        let payload = present_account_status_response_with_context(
+            "acct-1",
+            envelope,
+            Some("Example Account"),
+            Some("00000000-0000-0000-0000-000000000001"),
+            Some("get_provenance"),
+        );
 
         assert!(payload["answer"]
             .as_str()
@@ -1010,11 +828,111 @@ mod tests {
             payload["assessment"]["relationships"][0]["sourceRefs"][0],
             "source_1"
         );
+        assert_eq!(
+            payload["provenanceHandle"]["invocationId"],
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(
+            payload["provenanceHandle"]["invocation_id"],
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(payload["provenanceHandle"]["detailAvailable"], true);
+        assert_eq!(payload["provenanceHandle"]["detailTool"], "get_provenance");
+        assert_eq!(
+            payload["provenanceHandle"]["detailParams"]["invocation_id"],
+            "00000000-0000-0000-0000-000000000001"
+        );
 
         let serialized = serde_json::to_string(&payload).unwrap();
         assert!(!serialized.contains("relationship_source:edge-1"));
         assert!(!serialized.contains("raw-source"));
         assert!(!serialized.contains("person-1"));
+    }
+
+    #[test]
+    fn account_status_presenter_reports_presenter_truncation() {
+        let facts = (0..9)
+            .map(|index| {
+                json!({
+                    "claimId": format!("claim-{index}"),
+                    "claimType": "account_status",
+                    "renderedText": {
+                        "text": format!("Runtime fact {index}."),
+                        "policy": {}
+                    },
+                    "trustBand": "likely_current",
+                    "freshness": "current",
+                    "provenance": { "sourceIds": [] }
+                })
+            })
+            .collect::<Vec<_>>();
+        let envelope = json!({
+            "schemaVersion": 2,
+            "subject": {
+                "kind": "account",
+                "id": "acct-1",
+                "displayLabel": "Example Account"
+            },
+            "facts": { "items": facts },
+            "openLoops": { "items": [] },
+            "relationships": { "items": [] },
+            "touchpoints": { "items": [] },
+            "recordEntries": { "items": [] },
+            "trust": {
+                "aggregateBand": "likely_current",
+                "sectionCaveats": {}
+            },
+            "sensitivity": "internal",
+            "provenance": {
+                "sources": [],
+                "redactionApplied": false
+            },
+            "sections": {}
+        });
+
+        let payload = present_account_status_response("acct-1", envelope);
+
+        assert_eq!(payload["assessment"]["facts"].as_array().unwrap().len(), 8);
+        assert_eq!(payload["truncation"]["facts"]["renderedCount"], 8);
+        assert_eq!(payload["truncation"]["facts"]["rawCount"], 9);
+        assert_eq!(payload["truncation"]["facts"]["omittedCount"], 1);
+        assert_eq!(payload["truncation"]["facts"]["projectionTruncated"], true);
+        assert_eq!(payload["truncation"]["facts"]["presenterTruncated"], true);
+    }
+
+    #[test]
+    fn account_status_presenter_uses_documented_status_for_empty_response() {
+        let envelope = json!({
+            "schemaVersion": 2,
+            "subject": {
+                "kind": "account",
+                "id": "acct-1",
+                "displayLabel": "Example Account"
+            },
+            "facts": { "items": [] },
+            "openLoops": { "items": [] },
+            "relationships": { "items": [] },
+            "touchpoints": { "items": [] },
+            "recordEntries": { "items": [] },
+            "trust": {
+                "aggregateBand": "unscored",
+                "sectionCaveats": {}
+            },
+            "sensitivity": "internal",
+            "provenance": {
+                "sources": [],
+                "redactionApplied": false
+            },
+            "sections": {}
+        });
+
+        let payload = present_account_status_response("acct-1", envelope);
+
+        assert_eq!(payload["status"], "not_found");
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("does not yet have claim-backed account intelligence"));
     }
 
     #[test]
@@ -1067,11 +985,70 @@ mod tests {
         assert!(payload["answer"]
             .as_str()
             .unwrap()
-            .contains("could not read relationship intelligence"));
+            .contains("could not read requested intelligence"));
         assert!(!payload["answer"]
             .as_str()
             .unwrap()
             .contains("does not yet have claim-backed account intelligence"));
+        assert_eq!(payload["status"], "unavailable");
+        assert_eq!(
+            payload["assessment"]["caveats"][0]["text"],
+            "relationships reader unavailable"
+        );
+    }
+
+    #[test]
+    fn account_status_presenter_marks_touchpoint_partial_failure() {
+        let envelope = json!({
+            "schemaVersion": 2,
+            "subject": {
+                "kind": "account",
+                "id": "acct-1",
+                "displayLabel": "Example Account"
+            },
+            "facts": { "items": [] },
+            "openLoops": { "items": [] },
+            "relationships": { "items": [] },
+            "touchpoints": {
+                "items": [{
+                    "upcoming": { "items": [] },
+                    "recent": { "items": [] },
+                    "emptyReason": {
+                        "partial_failure": {
+                            "advisory": "touchpoints reader unavailable"
+                        }
+                    }
+                }]
+            },
+            "recordEntries": { "items": [] },
+            "trust": {
+                "aggregateBand": "unscored",
+                "sectionCaveats": {}
+            },
+            "sensitivity": "internal",
+            "provenance": {
+                "sources": [],
+                "redactionApplied": false
+            },
+            "sections": {
+                "touchpoints": {
+                    "kind": "empty",
+                    "reason": "no_relevant_touchpoints"
+                }
+            }
+        });
+
+        let payload = present_account_status_response("acct-1", envelope);
+
+        assert_eq!(payload["status"], "unavailable");
+        assert!(payload["answer"]
+            .as_str()
+            .unwrap()
+            .contains("touchpoints reader unavailable"));
+        assert_eq!(
+            payload["assessment"]["caveats"][0]["text"],
+            "touchpoints reader unavailable"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/mcp_v2/mod.rs
+++ b/src-tauri/src/services/mcp_v2/mod.rs
@@ -16,5 +16,6 @@ pub mod auth;
 pub mod contracts;
 pub mod gateway;
 pub mod handlers;
+pub mod runtime_projection;
 pub mod taxonomy;
 pub mod transport;

--- a/src-tauri/src/services/mcp_v2/runtime_projection.rs
+++ b/src-tauri/src/services/mcp_v2/runtime_projection.rs
@@ -1,0 +1,835 @@
+//! Shared MCP projection over abilities-runtime entity intelligence envelopes.
+//!
+//! This is a surface adapter, not an authority source: it only projects
+//! rendered, policy-filtered values already present in the runtime envelope.
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Map, Value};
+
+const MAX_ASSESSMENT_ITEMS: usize = 8;
+
+pub(crate) struct RuntimeEvidenceProjection {
+    pub(crate) provenance: Value,
+    pub(crate) facts: Vec<Value>,
+    pub(crate) open_loops: Vec<Value>,
+    pub(crate) relationships: Vec<Value>,
+    pub(crate) touchpoints: Vec<Value>,
+    pub(crate) record_entries: Vec<Value>,
+    pub(crate) priorities: Vec<Value>,
+    pub(crate) caveats: Vec<Value>,
+    pub(crate) section_states: Value,
+    pub(crate) truncation: Value,
+    pub(crate) status: &'static str,
+}
+
+pub(crate) fn project_runtime_evidence(envelope: &Value) -> RuntimeEvidenceProjection {
+    let (provenance, source_id_map) = build_provenance_summary(envelope);
+    let facts = collect_fact_summaries(envelope, &source_id_map);
+    let open_loops = collect_open_loop_summaries(envelope, &source_id_map);
+    let relationships = collect_relationship_summaries(envelope, &source_id_map);
+    let touchpoints = collect_touchpoint_summaries(envelope, &source_id_map);
+    let record_entries = collect_record_entry_summaries(envelope, &source_id_map);
+    let priorities = collect_priority_summaries(&facts, &open_loops, &record_entries);
+    let mut caveats = collect_caveats(envelope);
+    if priorities.is_empty() {
+        caveats.push(json!({
+            "section": "priorities",
+            "text": "No explicit priority claims were present; use facts, open loops, touchpoints, and record entries as evidence candidates."
+        }));
+    }
+    let section_states = envelope
+        .get("sections")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let truncation = build_truncation_summary(
+        envelope,
+        &facts,
+        &open_loops,
+        &relationships,
+        &touchpoints,
+        &record_entries,
+    );
+    let status = response_status(
+        &facts,
+        &open_loops,
+        &relationships,
+        &touchpoints,
+        &record_entries,
+        envelope,
+    );
+
+    RuntimeEvidenceProjection {
+        provenance,
+        facts,
+        open_loops,
+        relationships,
+        touchpoints,
+        record_entries,
+        priorities,
+        caveats,
+        section_states,
+        truncation,
+        status,
+    }
+}
+
+fn build_provenance_summary(envelope: &Value) -> (Value, BTreeMap<String, String>) {
+    let mut source_id_map = BTreeMap::new();
+    let mut sources = Vec::new();
+
+    if let Some(raw_sources) = envelope
+        .pointer("/provenance/sources")
+        .and_then(Value::as_array)
+    {
+        for (index, source) in raw_sources.iter().enumerate() {
+            let display_id = format!("source_{}", index + 1);
+            if let Some(raw_id) = source.get("id").and_then(Value::as_str) {
+                source_id_map.insert(raw_id.to_string(), display_id.clone());
+            }
+
+            let mut projected = Map::new();
+            projected.insert("id".to_string(), Value::String(display_id));
+            insert_string_or_clone(&mut projected, "label", source, "/label");
+            insert_string_or_clone(&mut projected, "sourceType", source, "/sourceType");
+            insert_string_or_clone(&mut projected, "asOf", source, "/asOf");
+            if let Some(redacted) = source.get("redacted").and_then(Value::as_bool) {
+                projected.insert("redacted".to_string(), Value::Bool(redacted));
+            }
+            sources.push(Value::Object(projected));
+        }
+    }
+
+    let redaction_applied = envelope
+        .pointer("/provenance/redactionApplied")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    (
+        json!({
+            "sources": sources,
+            "redactionApplied": redaction_applied,
+            "rawClaimIdsIncluded": false,
+        }),
+        source_id_map,
+    )
+}
+
+fn collect_fact_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/facts/items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| fact_summary(item, source_id_map))
+                .take(MAX_ASSESSMENT_ITEMS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn fact_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
+    let text = string_at(item, "/renderedText/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("text".to_string(), Value::String(text));
+    insert_string_or_clone(&mut summary, "fieldPath", item, "/fieldPath");
+    insert_string_or_clone(&mut summary, "claimType", item, "/claimType");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsof");
+    insert_string_or_clone(&mut summary, "sensitivity", item, "/sensitivity");
+    insert_string_or_clone(&mut summary, "lifecycleState", item, "/lifecycleState");
+    insert_string_or_clone(
+        &mut summary,
+        "verificationState",
+        item,
+        "/verificationState",
+    );
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn collect_open_loop_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/openLoops/items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| open_loop_summary(item, source_id_map))
+                .take(MAX_ASSESSMENT_ITEMS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn open_loop_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
+    let open_loop = item.get("openLoop").unwrap_or(item);
+    let description = string_at(open_loop, "/description")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("description".to_string(), Value::String(description));
+    insert_string_or_clone(&mut summary, "loopKind", open_loop, "/loop_kind");
+    insert_string_or_clone(&mut summary, "owner", open_loop, "/owner");
+    insert_string_or_clone(&mut summary, "dueDate", open_loop, "/due_date");
+    insert_string_or_clone(&mut summary, "status", open_loop, "/status");
+    insert_string_or_clone(&mut summary, "sourceAsOf", open_loop, "/source_asof");
+    insert_string_or_clone(&mut summary, "claimType", open_loop, "/claim_type");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn collect_relationship_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/relationships/items")
+        .and_then(Value::as_array)
+        .map(|bundles| {
+            let mut summaries = Vec::new();
+            for bundle in bundles {
+                if let Some(participants) = bundle
+                    .pointer("/participants/items")
+                    .and_then(Value::as_array)
+                {
+                    summaries.extend(
+                        participants.iter().filter_map(|item| {
+                            relationship_participant_summary(item, source_id_map)
+                        }),
+                    );
+                }
+                if let Some(edges) = bundle.pointer("/edges/items").and_then(Value::as_array) {
+                    summaries.extend(
+                        edges
+                            .iter()
+                            .filter_map(|item| relationship_edge_summary(item, source_id_map)),
+                    );
+                }
+            }
+            summaries.truncate(MAX_ASSESSMENT_ITEMS);
+            summaries
+        })
+        .unwrap_or_default()
+}
+
+fn relationship_participant_summary(
+    item: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Option<Value> {
+    let display_label = string_at(item, "/displayLabel/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("kind".to_string(), Value::String("participant".to_string()));
+    summary.insert("displayLabel".to_string(), Value::String(display_label));
+    if let Some(role) = string_at(item, "/role/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+    {
+        summary.insert("role".to_string(), Value::String(role));
+    }
+    if let Some(relationship) = string_at(item, "/relationship/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+    {
+        summary.insert("relationship".to_string(), Value::String(relationship));
+    }
+    if let Some(count) = item
+        .get("normalizedTouchpointCount")
+        .and_then(Value::as_u64)
+    {
+        summary.insert(
+            "normalizedTouchpointCount".to_string(),
+            Value::Number(count.into()),
+        );
+    }
+    insert_string_or_clone(&mut summary, "lastSeenAt", item, "/lastSeenAt");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn relationship_edge_summary(
+    item: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Option<Value> {
+    let relationship = string_at(item, "/edgeType")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+        .map(|value| relationship_label_for_edge_type(&value))
+        .unwrap_or_else(|| "Relationship".to_string());
+    let mut summary = Map::new();
+    summary.insert("kind".to_string(), Value::String("edge".to_string()));
+    summary.insert("relationship".to_string(), Value::String(relationship));
+    if let Some(display_label) = string_at(item, "/relatedDisplayLabel/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+    {
+        summary.insert("displayLabel".to_string(), Value::String(display_label));
+    }
+    if let Some(related_entity_type) = relationship_subject_type(item.get("relatedSubjectRef")) {
+        summary.insert(
+            "relatedEntityType".to_string(),
+            Value::String(related_entity_type.to_string()),
+        );
+    }
+    insert_string_or_clone(&mut summary, "inclusionReason", item, "/inclusionReason");
+    insert_string_or_clone(&mut summary, "observedAt", item, "/observedAt");
+    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsof");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn relationship_label_for_edge_type(edge_type: &str) -> String {
+    match edge_type {
+        "hierarchy_parent" => "Parent relationship",
+        "hierarchy_child" => "Child relationship",
+        "stakeholder" => "Stakeholder",
+        "member" => "Member",
+        "meeting_subject" => "Meeting subject",
+        "meeting_attendance" => "Meeting attendance",
+        "meeting_link" => "Meeting link",
+        "person_relationship" => "Person relationship",
+        _ => "Relationship",
+    }
+    .to_string()
+}
+
+fn relationship_subject_type(subject_ref: Option<&Value>) -> Option<&'static str> {
+    subject_ref.and_then(|value| {
+        if let Some(value) = value.as_str() {
+            return value
+                .split_once(':')
+                .map(|(entity_type, _)| entity_type)
+                .or(Some(value))
+                .and_then(known_entity_type);
+        }
+        value
+            .as_object()
+            .and_then(|object| object.keys().find_map(|key| known_entity_type(key)))
+    })
+}
+
+fn known_entity_type(entity_type: &str) -> Option<&'static str> {
+    match entity_type {
+        "account" => Some("account"),
+        "project" => Some("project"),
+        "person" => Some("person"),
+        "meeting" => Some("meeting"),
+        _ => None,
+    }
+}
+
+fn collect_touchpoint_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    let mut summaries = Vec::new();
+    if let Some(bundles) = envelope
+        .pointer("/touchpoints/items")
+        .and_then(Value::as_array)
+    {
+        for bundle in bundles {
+            summaries.extend(collect_touchpoint_side(
+                bundle,
+                "upcoming",
+                "/upcoming/items",
+                source_id_map,
+            ));
+            summaries.extend(collect_touchpoint_side(
+                bundle,
+                "recent",
+                "/recent/items",
+                source_id_map,
+            ));
+        }
+    }
+    summaries.truncate(MAX_ASSESSMENT_ITEMS);
+    summaries
+}
+
+fn collect_touchpoint_side(
+    bundle: &Value,
+    timing: &str,
+    pointer: &str,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    bundle
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| touchpoint_summary(item, timing, source_id_map))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn touchpoint_summary(
+    item: &Value,
+    timing: &str,
+    source_id_map: &BTreeMap<String, String>,
+) -> Option<Value> {
+    let when = string_at(item, "/when")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+    let mut summary = Map::new();
+    summary.insert("timing".to_string(), Value::String(timing.to_string()));
+    summary.insert("when".to_string(), Value::String(when));
+    insert_string_or_clone(&mut summary, "kind", item, "/kind");
+    insert_string_or_clone(&mut summary, "inclusionReason", item, "/inclusionReason");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn collect_record_entry_summaries(
+    envelope: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) -> Vec<Value> {
+    envelope
+        .pointer("/recordEntries/items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| record_entry_summary(item, source_id_map))
+                .take(MAX_ASSESSMENT_ITEMS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn record_entry_summary(item: &Value, source_id_map: &BTreeMap<String, String>) -> Option<Value> {
+    let text = string_at(item, "/renderedText/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+
+    let mut summary = Map::new();
+    summary.insert("text".to_string(), Value::String(text));
+    insert_string_or_clone(&mut summary, "claimType", item, "/claimType");
+    insert_string_or_clone(&mut summary, "recordedAt", item, "/recordedAt");
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "sensitivity", item, "/sensitivity");
+    insert_source_refs(&mut summary, item, source_id_map);
+    Some(Value::Object(summary))
+}
+
+fn collect_priority_summaries(
+    facts: &[Value],
+    open_loops: &[Value],
+    record_entries: &[Value],
+) -> Vec<Value> {
+    let mut priorities = facts
+        .iter()
+        .filter(|item| is_priority_like(item))
+        .filter_map(|item| priority_from_text_item(item, "/text", "claim"))
+        .chain(
+            record_entries
+                .iter()
+                .filter(|item| is_priority_like(item))
+                .filter_map(|item| priority_from_text_item(item, "/text", "record_entry")),
+        )
+        .collect::<Vec<_>>();
+
+    if priorities.is_empty() {
+        priorities.extend(
+            open_loops
+                .iter()
+                .filter_map(|item| priority_from_text_item(item, "/description", "open_loop"))
+                .take(3),
+        );
+    }
+
+    priorities.truncate(3);
+    priorities
+}
+
+fn is_priority_like(item: &Value) -> bool {
+    ["/claimType", "/fieldPath", "/text"]
+        .into_iter()
+        .filter_map(|pointer| string_at(item, pointer))
+        .any(|value| {
+            let normalized = value.to_ascii_lowercase();
+            normalized.contains("priority")
+                || normalized.contains("next step")
+                || normalized.contains("focus")
+                || normalized.contains("recommend")
+        })
+}
+
+fn priority_from_text_item(item: &Value, text_pointer: &str, basis: &str) -> Option<Value> {
+    let text = string_at(item, text_pointer)
+        .map(compact_text)
+        .filter(|value| !value.is_empty())?;
+    let mut summary = Map::new();
+    summary.insert("text".to_string(), Value::String(text));
+    summary.insert("basis".to_string(), Value::String(basis.to_string()));
+    insert_string_or_clone(&mut summary, "trustBand", item, "/trustBand");
+    insert_string_or_clone(&mut summary, "freshness", item, "/freshness");
+    insert_string_or_clone(&mut summary, "sourceAsOf", item, "/sourceAsOf");
+    if let Some(source_refs) = item.get("sourceRefs").filter(|value| !value.is_null()) {
+        summary.insert("sourceRefs".to_string(), source_refs.clone());
+    }
+    Some(Value::Object(summary))
+}
+
+fn collect_caveats(envelope: &Value) -> Vec<Value> {
+    let mut caveats = Vec::new();
+    if let Some(section_caveats) = envelope
+        .pointer("/trust/sectionCaveats")
+        .and_then(Value::as_object)
+    {
+        for (section, value) in section_caveats {
+            if let Some(text) = value
+                .as_str()
+                .map(compact_text)
+                .filter(|text| !text.is_empty())
+            {
+                push_unique_caveat(&mut caveats, section, text);
+            }
+        }
+    }
+
+    if let Some(sections) = envelope.get("sections").and_then(Value::as_object) {
+        for (section, state) in sections {
+            if let Some(advisory) = partial_failure_advisory(state) {
+                push_unique_caveat(&mut caveats, section, advisory);
+            }
+        }
+    }
+
+    push_bundle_partial_failure_caveats(
+        &mut caveats,
+        envelope,
+        "relationships",
+        "/relationships/items",
+    );
+    push_bundle_partial_failure_caveats(
+        &mut caveats,
+        envelope,
+        "touchpoints",
+        "/touchpoints/items",
+    );
+
+    if envelope
+        .pointer("/provenance/redactionApplied")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        push_unique_caveat(
+            &mut caveats,
+            "provenance",
+            "Some source details were redacted for this surface.".to_string(),
+        );
+    }
+    caveats
+}
+
+fn push_bundle_partial_failure_caveats(
+    caveats: &mut Vec<Value>,
+    envelope: &Value,
+    section: &str,
+    pointer: &str,
+) {
+    if let Some(items) = envelope.pointer(pointer).and_then(Value::as_array) {
+        for item in items {
+            if let Some(advisory) = item.get("emptyReason").and_then(partial_failure_advisory) {
+                push_unique_caveat(caveats, section, advisory);
+            }
+        }
+    }
+}
+
+fn push_unique_caveat(caveats: &mut Vec<Value>, section: &str, text: String) {
+    let exists = caveats.iter().any(|caveat| {
+        string_at(caveat, "/section") == Some(section) && string_at(caveat, "/text") == Some(&text)
+    });
+    if !exists {
+        caveats.push(json!({
+            "section": section,
+            "text": text,
+        }));
+    }
+}
+
+fn partial_failure_advisory(state: &Value) -> Option<String> {
+    state
+        .pointer("/partial_failure/advisory")
+        .or_else(|| state.pointer("/partialFailure/advisory"))
+        .or_else(|| state.pointer("/reason/partial_failure/advisory"))
+        .or_else(|| state.pointer("/empty/partial_failure/advisory"))
+        .or_else(|| state.pointer("/reason/partialFailure/advisory"))
+        .and_then(Value::as_str)
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+}
+
+fn build_truncation_summary(
+    envelope: &Value,
+    facts: &[Value],
+    open_loops: &[Value],
+    relationships: &[Value],
+    touchpoints: &[Value],
+    record_entries: &[Value],
+) -> Value {
+    json!({
+        "facts": paginated_summary(envelope.pointer("/facts"), facts.len()),
+        "openLoops": paginated_summary(envelope.pointer("/openLoops"), open_loops.len()),
+        "relationships": relationships_truncation_summary(envelope, relationships.len()),
+        "touchpoints": touchpoints_truncation_summary(envelope, touchpoints.len()),
+        "recordEntries": paginated_summary(envelope.pointer("/recordEntries"), record_entries.len()),
+    })
+}
+
+fn paginated_summary(value: Option<&Value>, rendered_count: usize) -> Value {
+    let raw_count = value
+        .and_then(|value| value.pointer("/items"))
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let omitted_count = raw_count.saturating_sub(rendered_count);
+    json!({
+        "renderedCount": rendered_count,
+        "rawCount": raw_count,
+        "omittedCount": omitted_count,
+        "projectionTruncated": omitted_count > 0,
+        "presenterTruncated": raw_count > rendered_count,
+        "sourcePage": source_page_summary(value),
+    })
+}
+
+fn source_page_summary(value: Option<&Value>) -> Value {
+    json!({
+        "totalHint": value
+            .and_then(|value| value.get("totalHint"))
+            .cloned()
+            .unwrap_or(Value::Null),
+        "nextCursorPresent": value
+            .and_then(|value| value.get("nextCursor"))
+            .is_some_and(|cursor| !cursor.is_null()),
+        "cursorState": value
+            .and_then(|value| value.get("cursorState"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    })
+}
+
+fn relationships_truncation_summary(envelope: &Value, rendered_count: usize) -> Value {
+    let bundles = envelope
+        .pointer("/relationships/items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let edge_count = bundles
+        .iter()
+        .filter_map(|bundle| bundle.pointer("/edges/items").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    let participant_count = bundles
+        .iter()
+        .filter_map(|bundle| {
+            bundle
+                .pointer("/participants/items")
+                .and_then(Value::as_array)
+        })
+        .map(Vec::len)
+        .sum::<usize>();
+    let edges_truncated = bundles.iter().any(|bundle| {
+        bundle
+            .pointer("/truncation/edgesTruncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    });
+    let participants_truncated = bundles.iter().any(|bundle| {
+        bundle
+            .pointer("/truncation/participantsTruncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    });
+    let raw_summary_count = edge_count + participant_count;
+    let omitted_count = raw_summary_count.saturating_sub(rendered_count);
+
+    json!({
+        "renderedBundleCount": bundles.len(),
+        "renderedCount": rendered_count,
+        "edgeCount": edge_count,
+        "participantCount": participant_count,
+        "rawSummaryCount": raw_summary_count,
+        "omittedCount": omitted_count,
+        "projectionTruncated": omitted_count > 0,
+        "presenterTruncated": raw_summary_count > rendered_count,
+        "edgesTruncated": edges_truncated,
+        "participantsTruncated": participants_truncated,
+        "page": paginated_summary(envelope.pointer("/relationships"), bundles.len()),
+    })
+}
+
+fn touchpoints_truncation_summary(envelope: &Value, rendered_count: usize) -> Value {
+    let bundles = envelope
+        .pointer("/touchpoints/items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let upcoming_count = bundles
+        .iter()
+        .filter_map(|bundle| bundle.pointer("/upcoming/items").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    let recent_count = bundles
+        .iter()
+        .filter_map(|bundle| bundle.pointer("/recent/items").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    let raw_summary_count = upcoming_count + recent_count;
+    let omitted_count = raw_summary_count.saturating_sub(rendered_count);
+    json!({
+        "renderedBundleCount": bundles.len(),
+        "renderedCount": rendered_count,
+        "upcomingCount": upcoming_count,
+        "recentCount": recent_count,
+        "rawSummaryCount": raw_summary_count,
+        "omittedCount": omitted_count,
+        "projectionTruncated": omitted_count > 0,
+        "presenterTruncated": raw_summary_count > rendered_count,
+        "page": paginated_summary(envelope.pointer("/touchpoints"), bundles.len()),
+    })
+}
+
+fn response_status(
+    facts: &[Value],
+    open_loops: &[Value],
+    relationships: &[Value],
+    touchpoints: &[Value],
+    record_entries: &[Value],
+    envelope: &Value,
+) -> &'static str {
+    let has_content = !(facts.is_empty()
+        && open_loops.is_empty()
+        && relationships.is_empty()
+        && touchpoints.is_empty()
+        && record_entries.is_empty());
+    if contains_partial_failure(envelope) {
+        return if has_content { "ok" } else { "unavailable" };
+    }
+    if has_content {
+        "ok"
+    } else {
+        "not_found"
+    }
+}
+
+fn contains_partial_failure(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            object.contains_key("partial_failure")
+                || object.contains_key("partialFailure")
+                || object.values().any(contains_partial_failure)
+        }
+        Value::Array(items) => items.iter().any(contains_partial_failure),
+        _ => false,
+    }
+}
+
+fn insert_string_or_clone(
+    target: &mut Map<String, Value>,
+    key: &str,
+    source: &Value,
+    pointer: &str,
+) {
+    if let Some(value) = source.pointer(pointer).filter(|value| !value.is_null()) {
+        target.insert(key.to_string(), value.clone());
+    }
+}
+
+fn insert_source_refs(
+    target: &mut Map<String, Value>,
+    item: &Value,
+    source_id_map: &BTreeMap<String, String>,
+) {
+    let refs = item
+        .pointer("/provenance/sourceIds")
+        .and_then(Value::as_array)
+        .map(|source_ids| {
+            source_ids
+                .iter()
+                .filter_map(Value::as_str)
+                .filter_map(|raw_id| source_id_map.get(raw_id))
+                .cloned()
+                .map(Value::String)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !refs.is_empty() {
+        target.insert("sourceRefs".to_string(), Value::Array(refs));
+    }
+}
+
+pub(crate) fn evidence_suffix(item: &Value) -> String {
+    let mut parts = Vec::new();
+    push_humanized_part(&mut parts, "trust", item, "/trustBand");
+    push_humanized_part(&mut parts, "freshness", item, "/freshness");
+    if let Some(source_as_of) = string_at(item, "/sourceAsOf") {
+        parts.push(format!("as of {source_as_of}"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join("; "))
+    }
+}
+
+pub(crate) fn open_loop_suffix(item: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(status) = string_at(item, "/status") {
+        parts.push(format!("status: {}", humanize_token(status)));
+    }
+    if let Some(due_date) = string_at(item, "/dueDate") {
+        parts.push(format!("due {due_date}"));
+    }
+    push_humanized_part(&mut parts, "trust", item, "/trustBand");
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join("; "))
+    }
+}
+
+fn push_humanized_part(parts: &mut Vec<String>, label: &str, item: &Value, pointer: &str) {
+    if let Some(value) = string_at(item, pointer) {
+        parts.push(format!("{label}: {}", humanize_token(value)));
+    }
+}
+
+pub(crate) fn string_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+pub(crate) fn compact_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub(crate) fn humanize_token(value: &str) -> String {
+    value.replace('_', " ")
+}

--- a/src/services/entity-intelligence/invoke.test.ts
+++ b/src/services/entity-intelligence/invoke.test.ts
@@ -38,7 +38,7 @@ describe("invokeEntityIntelligenceAbility", () => {
     expect(invokeMock).toHaveBeenCalledWith("invoke_ability", {
       abilityName: "get_entity_intelligence",
       inputJson: {
-        schemaVersion: 1,
+        schemaVersion: 2,
         entityType: "meeting",
         entityId: "meeting-1",
         depth: "standard",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,6 @@
 # Lessons
 
+- 2026-05-24: When multiple wave plans are active, anchor status and commit work to the user-named plan/worktree before inferring from nearby W6/Wave labels. Do not treat a similarly named release-gate worktree as the active plan without re-reading the referenced plan path.
 - 2026-05-23: Treat workspace JSON/MD artifacts as write-only projections unless a migration/backfill/import path explicitly says otherwise. Runtime, MCP, prompt-input, and surface reads must use DB/runtime services first, with regression gates to stop `intelligence.json`, `dashboard.json`, or derived markdown from becoming authority again.
 - 2026-05-22: When a surface starts rendering claim-backed rows, treat opaque claim ids as machine metadata only. Visible block copy must come from rendered claim text or a surface-specific assessment composer, and class-wide row renderer sweeps need a regression gate so one fixed block does not leave sibling blocks leaking ids.
 - 2026-05-22: Do not assume another agent session still owns dirty branch state after a handoff. Re-check the worktree and commit the active branch state directly when the user confirms no peer session is running.


### PR DESCRIPTION
## Linear ticket
DOS-764 / abilities-runtime producer remediation plan

## Summary
Add a shared MCP runtime projection over `get_entity_intelligence` envelopes so MCP account-status output exposes runtime-backed evidence instead of a thin account-shaped subset.

## What changed
- Adds a shared MCP projection for facts, open loops, relationships, touchpoints, record entries, priorities, caveats, section states, truncation, and display-safe provenance.
- Routes MCP v2 account status and legacy MCP `query_entity` account intelligence through the same runtime-backed projection.
- Preserves `get_provenance` follow-up compatibility where the legacy MCP bridge has invocation detail.
- Aligns the entity-intelligence invoke test with schema v2 and keeps stakeholder signal lint focused on production writes rather than cfg-test fixture SQL.
- Wraps the local MCP transport cleanup migration in an explicit transaction for multi-process reader safety.

## Test plan
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --features mcp -- -D warnings` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::mcp_v2::handlers::tool_account_status -- --nocapture` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features mcp --bin dailyos-mcp account_intelligence_summary -- --nocapture` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --features mcp --bin dailyos-mcp mcp_call_tool_routes_get_provenance_to_bridge_session_scoped_lookup -- --nocapture` passes
- [x] `pnpm test -- src/services/entity-intelligence/invoke.test.ts` passes
- [x] `scripts/check_stakeholder_writer_emits_signal.sh` passes
- [x] `bash src-tauri/scripts/check_migrations_transactional.sh` passes
- [x] local PR-template validator passes
- [ ] Manual verification: W2/W3 L4 Claude Desktop comparison prompt still pending after merge to `dev`

## Definition of Done
- [x] Acceptance criteria from the Linear ticket are validated with fixture/runtime tests
- [ ] End-to-end flow works through to rendered surfaces; W2/W3 L4 prompt pass pending on merged `dev`
- [x] No stubs, TODOs, or deferred implementation introduced by this PR
- [ ] Full combined gate `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` not rerun after the CI-only follow-up

## §4 Security
security_auditor_invoked: true

**Exemption ID**: _none_

**Exemption rationale**: N/A; security reviewer was invoked during L2 and found no blocking issues.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups
- W2/W3 L4 Claude Desktop comparison prompt against merged `dev`.
- Route-level Suite P benchmarks remain out of scope for this PR.

## Notes for review
- Raw claim/source/meeting IDs remain out of the MCP projection; provenance uses display-safe source refs.
- Production MCP paths still go through runtime/bridge rendering before projection.
- The migration follow-up only adds transaction boundaries around an existing cleanup migration; it does not add schema shape.

L2-status: passed