### PR TITLE
Tighten hook gauntlet caching

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -38,10 +38,58 @@ append_error() {
   fi
 }
 
+GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null || true)"
+HOOK_STATE_DIR=""
+HOOK_GAUNTLET_CACHE=""
+if [ -n "$GIT_DIR_RESOLVED" ]; then
+  HOOK_STATE_DIR="${GIT_DIR_RESOLVED}/hooks-state"
+  HOOK_GAUNTLET_CACHE="${HOOK_STATE_DIR}/last-green-gauntlet-v2"
+fi
+
+cache_field() {
+  local key="$1"
+  [ -n "$HOOK_GAUNTLET_CACHE" ] && [ -f "$HOOK_GAUNTLET_CACHE" ] || return 0
+  grep -E "^${key}=" "$HOOK_GAUNTLET_CACHE" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+write_gauntlet_cache() {
+  local tree="$1"
+  local rust_passed="$2"
+  local frontend_passed="$3"
+  [ -n "$HOOK_STATE_DIR" ] && [ -n "$HOOK_GAUNTLET_CACHE" ] && [ -n "$tree" ] || return 0
+  mkdir -p "$HOOK_STATE_DIR" 2>/dev/null || true
+  {
+    printf 'version=2\n'
+    printf 'tree=%s\n' "$tree"
+    printf 'rust=%s\n' "$rust_passed"
+    printf 'frontend=%s\n' "$frontend_passed"
+  } > "$HOOK_GAUNTLET_CACHE" 2>/dev/null || true
+}
+
+run_silenced_check() {
+  local label="$1"
+  local exit_code="$2"
+  shift 2
+
+  local log_dir="${HOOK_STATE_DIR:-/tmp}"
+  mkdir -p "$log_dir" 2>/dev/null || true
+  local safe_label
+  safe_label="$(printf '%s' "$label" | tr -c '[:alnum:]_.-' '_')"
+  local log_file="${log_dir}/${safe_label}.log"
+
+  echo "pre-commit: ${label}" >&2
+  if ! "$@" >"$log_file" 2>&1; then
+    printf '🚫 Pre-commit gate FAILED. Fix before committing:\n❌ %s FAILED\n' "$label" >&2
+    printf '   Log: %s\n' "$log_file" >&2
+    tail -40 "$log_file" >&2 || true
+    exit "$exit_code"
+  fi
+}
+
 staged_added_lines() {
   git diff --cached -U0 -- "$1" 2>/dev/null \
-    | grep -E '^\+' \
-    | grep -v '^\+\+\+' \
+    | grep '^+' \
+    | grep -v '^+++' \
     || true
 }
 
@@ -65,35 +113,7 @@ if [ "${WIP:-0}" = "1" ]; then
   echo "pre-commit: WIP=1 set — skipping heavy checks (clippy/test/tsc). pre-push will catch them." >&2
 fi
 
-# 0. Ensure Tauri externalBin stub exists (required for cargo build/clippy/test).
-if [ -d "$BACKEND_DIR" ] && [ -f "${BACKEND_DIR}/scripts/build-mcp.sh" ]; then
-  if ! ls "${BACKEND_DIR}/binaries/"dailyos-mcp-* >/dev/null 2>&1; then
-    bash "${BACKEND_DIR}/scripts/build-mcp.sh" --stub >/dev/null 2>&1 || true
-  fi
-fi
-
-# 1. Clippy — only if Rust files staged AND not in WIP mode.
-if [ "$HAS_RUST" = true ] && [ "$WIP_MODE" = false ] && [ -d "$BACKEND_DIR" ]; then
-  if ! cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings >/dev/null 2>&1; then
-    append_error "❌ cargo clippy -- -D warnings FAILED"
-  fi
-fi
-
-# 2. Cargo test — only if Rust files staged AND not in WIP mode.
-if [ "$HAS_RUST" = true ] && [ "$WIP_MODE" = false ] && [ -d "$BACKEND_DIR" ]; then
-  if ! cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml" >/dev/null 2>&1; then
-    append_error "❌ cargo test --lib FAILED"
-  fi
-fi
-
-# 3. TypeScript type check — only if frontend files staged AND not in WIP mode.
-if [ "$HAS_FRONTEND" = true ] && [ "$WIP_MODE" = false ] && [ -f "${CWD}/package.json" ]; then
-  if ! pnpm tsc --noEmit >/dev/null 2>&1; then
-    append_error "❌ pnpm tsc --noEmit FAILED"
-  fi
-fi
-
-# 3a. lint-staged — fast eslint + stylelint on changed files only (DOS-533).
+# 1. lint-staged — fast eslint + stylelint on changed files only (DOS-533).
 # Runs even in WIP mode because it's fast (<5s) and only touches staged files.
 # Skip cleanly if lint-staged isn't installed yet (config rolling out gradually).
 # --concurrent true: eslint + stylelint can run in parallel on non-overlapping
@@ -225,9 +245,11 @@ done <<< "$STAGED_FILES"
 # per-file loop — same terms, same exclusions, same exit signal.
 PII_BLOCKLIST="${CWD}/.claude/pii-blocklist.txt"
 if [ -f "$PII_BLOCKLIST" ]; then
-  PII_TERMS="$(grep -v '^[[:space:]]*#' "$PII_BLOCKLIST" | grep -v '^[[:space:]]*$' | sed 's/[][(){}.*+?^$|\\]/\\&/g' | paste -sd '|' - || true)"
-  if [ -n "$PII_TERMS" ]; then
-    bad_paths="$(printf '%s\n' "$STAGED_FILES" | grep -iwE "$PII_TERMS" 2>/dev/null || true)"
+  PII_TERMS_FILE="${HOOK_STATE_DIR:-/tmp}/pii-blocklist-terms.$$"
+  mkdir -p "$(dirname "$PII_TERMS_FILE")" 2>/dev/null || true
+  grep -v '^[[:space:]]*#' "$PII_BLOCKLIST" | grep -v '^[[:space:]]*$' > "$PII_TERMS_FILE" 2>/dev/null || true
+  if [ -s "$PII_TERMS_FILE" ]; then
+    bad_paths="$(printf '%s\n' "$STAGED_FILES" | grep -iwFf "$PII_TERMS_FILE" 2>/dev/null || true)"
     if [ -n "$bad_paths" ]; then
       append_error "🔒 PII check: staged filename(s) match blocklist:"
       append_error "$(printf '%s\n' "$bad_paths" | sed 's/^/   /')"
@@ -240,7 +262,7 @@ if [ -f "$PII_BLOCKLIST" ]; then
       [ -z "$pii_current_file" ] && return 0
       [ "$pii_current_file" = ".claude/pii-blocklist.txt" ] && { pii_current_file=""; pii_current_added=""; return 0; }
       if [ -n "$pii_current_added" ]; then
-        bad_content="$(printf '%s\n' "$pii_current_added" | grep -iwE "$PII_TERMS" 2>/dev/null || true)"
+        bad_content="$(printf '%s\n' "$pii_current_added" | grep -iwFf "$PII_TERMS_FILE" 2>/dev/null || true)"
         if [ -n "$bad_content" ]; then
           append_error "🔒 PII check: staged diff in ${pii_current_file} contains blocklisted term(s):"
           append_error "$(printf '%s\n' "$bad_content" | head -5 | sed 's/^/   /')"
@@ -267,6 +289,7 @@ if [ -f "$PII_BLOCKLIST" ]; then
     done < <(git diff --cached -U0 --diff-filter=ACM 2>/dev/null || true)
     flush_pii_check
   fi
+  rm -f "$PII_TERMS_FILE"
 fi
 
 # 8. Reference fidelity gate (cheap unless audit script does heavy work)
@@ -281,7 +304,7 @@ if printf '%s\n' "$STAGED_FILES" | grep -qE '\.docs/design/reference/(surfaces|_
   fi
 fi
 
-# Block commit if any errors.
+# Block commit before prompt/cargo checks if cheap/path-local checks already failed.
 if [ -n "$ERRORS" ]; then
   printf '🚫 Pre-commit gate FAILED. Fix these before committing:\n%s\n' "$ERRORS" >&2
   exit 2
@@ -300,18 +323,55 @@ if [ "$HAS_PROMPT_RELEVANT_CHANGE" = true ]; then
   "$ROOT_DIR/scripts/check_prompt_fingerprint_boundary.sh"
 fi
 
-# Cache tree-SHA: lets pre-push short-circuit its duplicate gauntlet when
-# HEAD's tree hasn't drifted from what pre-commit just verified. Only write
-# the marker when the heavy gauntlet actually ran (not WIP mode) AND
-# everything passed. Pre-push compares HEAD's tree to this marker.
-# Use `git rev-parse --git-dir` so the marker is per-worktree (in worktrees
-# the path `.git` is a file pointing at `.git/worktrees/<name>/`).
-if [ "$WIP_MODE" = false ]; then
-  GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null)"
-  if [ -n "$GIT_DIR_RESOLVED" ]; then
-    mkdir -p "${GIT_DIR_RESOLVED}/hooks-state" 2>/dev/null || true
-    git write-tree > "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" 2>/dev/null || true
+# Heavy gauntlet cache: repeated commit attempts against the same index tree
+# should not re-run clippy/test/tsc after they have already passed once. The
+# cache records which tiers passed, so doc-only commits cannot accidentally mark
+# a Rust or frontend tree as verified.
+CURRENT_INDEX_TREE="$(git write-tree 2>/dev/null || echo "")"
+HEAVY_CACHE_HIT=false
+if [ "$WIP_MODE" = false ] && [ -n "$CURRENT_INDEX_TREE" ]; then
+  CACHED_TREE="$(cache_field tree)"
+  CACHED_RUST="$(cache_field rust)"
+  CACHED_FRONTEND="$(cache_field frontend)"
+  if [ "$CACHED_TREE" = "$CURRENT_INDEX_TREE" ]; then
+    RUST_COVERED=false
+    FRONTEND_COVERED=false
+    if [ "$HAS_RUST" = false ] || [ "$CACHED_RUST" = true ]; then
+      RUST_COVERED=true
+    fi
+    if [ "$HAS_FRONTEND" = false ] || [ "$CACHED_FRONTEND" = true ]; then
+      FRONTEND_COVERED=true
+    fi
+    if [ "$RUST_COVERED" = true ] && [ "$FRONTEND_COVERED" = true ]; then
+      HEAVY_CACHE_HIT=true
+      echo "pre-commit: index tree ${CURRENT_INDEX_TREE} already passed required heavy checks — skipping clippy/test/tsc" >&2
+    fi
   fi
+fi
+
+RUST_GAUNTLET_PASSED=false
+FRONTEND_GAUNTLET_PASSED=false
+
+if [ "$WIP_MODE" = false ] && [ "$HEAVY_CACHE_HIT" = false ]; then
+  # Ensure Tauri externalBin stub exists (required for cargo build/clippy/test).
+  if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ] && [ -f "${BACKEND_DIR}/scripts/build-mcp.sh" ]; then
+    if ! ls "${BACKEND_DIR}/binaries/"dailyos-mcp-* >/dev/null 2>&1; then
+      bash "${BACKEND_DIR}/scripts/build-mcp.sh" --stub >/dev/null 2>&1 || true
+    fi
+  fi
+
+  if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ]; then
+    run_silenced_check "cargo clippy -- -D warnings" 2 cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings
+    run_silenced_check "cargo test --lib" 2 cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml"
+    RUST_GAUNTLET_PASSED=true
+  fi
+
+  if [ "$HAS_FRONTEND" = true ] && [ -f "${CWD}/package.json" ]; then
+    run_silenced_check "pnpm tsc --noEmit" 2 pnpm tsc --noEmit
+    FRONTEND_GAUNTLET_PASSED=true
+  fi
+
+  write_gauntlet_cache "$CURRENT_INDEX_TREE" "$RUST_GAUNTLET_PASSED" "$FRONTEND_GAUNTLET_PASSED"
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,13 +19,54 @@ cd "$CWD"
 
 BACKEND_DIR="${CWD}/src-tauri"
 ZERO_SHA="0000000000000000000000000000000000000000"
-ERRORS=""
 
-append_error() {
-  if [ -z "$ERRORS" ]; then
-    ERRORS="$1"
-  else
-    ERRORS="${ERRORS}"$'\n'"$1"
+GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null || true)"
+HOOK_STATE_DIR=""
+HOOK_GAUNTLET_CACHE=""
+if [ -n "$GIT_DIR_RESOLVED" ]; then
+  HOOK_STATE_DIR="${GIT_DIR_RESOLVED}/hooks-state"
+  HOOK_GAUNTLET_CACHE="${HOOK_STATE_DIR}/last-green-gauntlet-v2"
+fi
+
+cache_field() {
+  local key="$1"
+  [ -n "$HOOK_GAUNTLET_CACHE" ] && [ -f "$HOOK_GAUNTLET_CACHE" ] || return 0
+  grep -E "^${key}=" "$HOOK_GAUNTLET_CACHE" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+write_gauntlet_cache() {
+  local tree="$1"
+  local rust_passed="$2"
+  local frontend_passed="$3"
+  [ -n "$HOOK_STATE_DIR" ] && [ -n "$HOOK_GAUNTLET_CACHE" ] && [ -n "$tree" ] || return 0
+  mkdir -p "$HOOK_STATE_DIR" 2>/dev/null || true
+  {
+    printf 'version=2\n'
+    printf 'tree=%s\n' "$tree"
+    printf 'rust=%s\n' "$rust_passed"
+    printf 'frontend=%s\n' "$frontend_passed"
+  } > "$HOOK_GAUNTLET_CACHE" 2>/dev/null || true
+}
+
+run_silenced_check() {
+  local label="$1"
+  local exit_code="$2"
+  shift 2
+
+  local log_dir="${HOOK_STATE_DIR:-/tmp}"
+  mkdir -p "$log_dir" 2>/dev/null || true
+  local safe_label
+  safe_label="$(printf '%s' "$label" | tr -c '[:alnum:]_.-' '_')"
+  local log_file="${log_dir}/${safe_label}.log"
+
+  echo "pre-push: ${label}" >&2
+  if ! "$@" >"$log_file" 2>&1; then
+    printf '🚫 Pre-push gate FAILED. Fix before pushing:\n❌ %s FAILED\n' "$label" >&2
+    printf '   Log: %s\n' "$log_file" >&2
+    tail -40 "$log_file" >&2 || true
+    echo "" >&2
+    echo "If you really need to push (rare), bypass with: git push --no-verify" >&2
+    exit "$exit_code"
   fi
 }
 
@@ -79,45 +120,43 @@ if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ] && [ -f "${BACKEND_DIR}/scrip
   fi
 fi
 
-# Cache check: if pre-commit just ran the gauntlet against the same tree
-# that's now at HEAD, skip the duplicate run. Pre-commit writes the tree
-# SHA to <git-dir>/hooks-state/last-green-tree after a clean gauntlet
-# pass. Pushing an unmodified commit takes pre-push to ~0s; WIP=1 commits
-# and amended trees still pay the full gauntlet cost. Use --git-dir so
-# the marker is per-worktree.
-GIT_DIR_RESOLVED="$(git rev-parse --git-dir 2>/dev/null)"
-LAST_GREEN_TREE=""
-if [ -n "$GIT_DIR_RESOLVED" ] && [ -f "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" ]; then
-  LAST_GREEN_TREE="$(tr -d '[:space:]' < "${GIT_DIR_RESOLVED}/hooks-state/last-green-tree" 2>/dev/null || echo "")"
-fi
+# Cache check: if pre-commit or an earlier pre-push ran the required gauntlet
+# against the same HEAD tree, skip the duplicate run. The cache records which
+# tiers passed so a frontend-only pass cannot bless a Rust-touching push.
 CURRENT_TREE="$(git rev-parse HEAD^{tree} 2>/dev/null || echo "")"
-if [ -n "$LAST_GREEN_TREE" ] && [ -n "$CURRENT_TREE" ] && [ "$LAST_GREEN_TREE" = "$CURRENT_TREE" ]; then
-  echo "pre-push: HEAD tree ${CURRENT_TREE} already passed pre-commit gauntlet — skipping clippy/test/tsc" >&2
-  exit 0
+if [ -n "$CURRENT_TREE" ] && [ "$(cache_field tree)" = "$CURRENT_TREE" ]; then
+  CACHED_RUST="$(cache_field rust)"
+  CACHED_FRONTEND="$(cache_field frontend)"
+  RUST_COVERED=false
+  FRONTEND_COVERED=false
+  if [ "$HAS_RUST" = false ] || [ "$CACHED_RUST" = true ]; then
+    RUST_COVERED=true
+  fi
+  if [ "$HAS_FRONTEND" = false ] || [ "$CACHED_FRONTEND" = true ]; then
+    FRONTEND_COVERED=true
+  fi
+  if [ "$RUST_COVERED" = true ] && [ "$FRONTEND_COVERED" = true ]; then
+    echo "pre-push: HEAD tree ${CURRENT_TREE} already passed required gauntlet — skipping clippy/test/tsc" >&2
+    exit 0
+  fi
 fi
+
+RUST_GAUNTLET_PASSED=false
+FRONTEND_GAUNTLET_PASSED=false
 
 if [ "$HAS_RUST" = true ] && [ -d "$BACKEND_DIR" ]; then
   # Silence cargo output. When git push wraps the hook, ~2500 lines of
   # cargo test stdout streamed through git push's stdio caused git push
-  # to die with SIGPIPE (exit 141) before reaching the transmit phase,
-  # even though the hook itself returned 0 standalone. Matches the
-  # pattern pre-commit already uses for the same reason.
-  echo "pre-push: cargo clippy -- -D warnings" >&2
-  if ! cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings >/dev/null 2>&1; then
-    append_error "❌ cargo clippy -- -D warnings FAILED"
-  fi
-
-  echo "pre-push: cargo test --lib" >&2
-  if ! cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml" >/dev/null 2>&1; then
-    append_error "❌ cargo test --lib FAILED"
-  fi
+  # to die with SIGPIPE (exit 141) before reaching the transmit phase.
+  # Failure tails are still printed from the per-check log.
+  run_silenced_check "cargo clippy -- -D warnings" 1 cargo clippy --manifest-path "$BACKEND_DIR/Cargo.toml" -- -D warnings
+  run_silenced_check "cargo test --lib" 1 cargo test --lib --manifest-path "$BACKEND_DIR/Cargo.toml"
+  RUST_GAUNTLET_PASSED=true
 fi
 
 if [ "$HAS_FRONTEND" = true ] && [ -f "${CWD}/package.json" ]; then
-  echo "pre-push: pnpm tsc --noEmit" >&2
-  if ! pnpm tsc --noEmit >/dev/null 2>&1; then
-    append_error "❌ pnpm tsc --noEmit FAILED"
-  fi
+  run_silenced_check "pnpm tsc --noEmit" 1 pnpm tsc --noEmit
+  FRONTEND_GAUNTLET_PASSED=true
 fi
 
 # When neither tier is touched, the push is metadata-only (docs, hooks, etc.) — no gauntlet.
@@ -125,11 +164,8 @@ if [ "$HAS_RUST" = false ] && [ "$HAS_FRONTEND" = false ]; then
   echo "pre-push: no Rust or frontend files in push diff — skipping gauntlet" >&2
 fi
 
-if [ -n "$ERRORS" ]; then
-  printf '🚫 Pre-push gate FAILED. Fix before pushing:\n%s\n' "$ERRORS" >&2
-  echo "" >&2
-  echo "If you really need to push (rare), bypass with: git push --no-verify" >&2
-  exit 1
+if [ -n "$CURRENT_TREE" ]; then
+  write_gauntlet_cache "$CURRENT_TREE" "$RUST_GAUNTLET_PASSED" "$FRONTEND_GAUNTLET_PASSED"
 fi
 
 exit 0

--- a/docs/solutions/test-failures/repeated-full-migration-test-fixtures-2026-05-24.md
+++ b/docs/solutions/test-failures/repeated-full-migration-test-fixtures-2026-05-24.md
@@ -1,0 +1,77 @@
+---
+title: "Repeated full-migration test fixtures make cargo test --lib look hung"
+problem_type: test_failure
+track: bug
+module: src-tauri/src/migrations.rs, src-tauri/src/db/core.rs test utilities
+tags: [cargo-test, test-performance, migrations, sqlite, fixtures, pre-push]
+date: 2026-05-24
+---
+
+## Problem
+
+Rust unit tests that need a current SQLite schema were opening a fresh in-memory or temporary database and replaying every registered migration inside each test fixture helper. As the migration list grew, this made `cargo test --lib` spend minutes rebuilding identical empty schemas.
+
+## Symptoms
+
+- `cargo test --lib` appears stuck while test binaries consume several CPU cores.
+- Stack samples show tests inside `migrations::run_migrations` and SQLite schema parsing.
+- Module filters with many DB fixtures take tens of seconds or time out even though individual assertions are simple.
+- Pre-commit and pre-push feel disproportionately expensive for small Rust diffs.
+
+## What Didn't Work
+
+- Retrying the hook. That repeats the same migration replay work.
+- Treating one sampled test as the only culprit. The sampled test may pass in isolation; the class issue is the repeated fixture setup.
+- Running multiple full suites in parallel worktrees. That amplifies CPU and target-dir contention.
+
+## Solution
+
+Use a test-only migrated in-memory template and clone it for isolated DB fixtures:
+
+```rust
+#[cfg(test)]
+pub(crate) fn migrated_in_memory_for_tests() -> Connection {
+    static TEMPLATE: std::sync::OnceLock<std::sync::Mutex<Connection>> =
+        std::sync::OnceLock::new();
+
+    let template = TEMPLATE.get_or_init(|| {
+        let conn = Connection::open_in_memory().expect("open migrated test template");
+        run_migrations(&conn).expect("migrate test template");
+        std::sync::Mutex::new(conn)
+    });
+
+    let template = template
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut conn = Connection::open_in_memory().expect("open test db clone");
+    {
+        let backup =
+            rusqlite::backup::Backup::new(&template, &mut conn).expect("start test db clone");
+        backup.step(-1).expect("clone migrated test db");
+    }
+    conn
+}
+```
+
+Then have schema-current fixture helpers call `crate::migrations::migrated_in_memory_for_tests()` instead of replaying `run_migrations(&conn)` themselves.
+
+## Why This Works
+
+The template still runs the real migration stack once per test binary process, so tests exercise the current schema. SQLite backup creates a fresh isolated database per test, so mutations do not leak across tests. The expensive migration replay is no longer multiplied by every fixture.
+
+Observed during the fix:
+
+- `db::core` filter: timed out after 120s before finishing; after template cloning, 185 tests finished in 1.80s.
+- `db::intelligence_feedback` filter: 27.65s to 0.65s.
+- `services::surface_pairing` filter: 30.22s to 3.23s.
+- `services::trust_extraction` filter: 10.23s to 0.54s.
+- `services::claims_backfill` filter: 15.63s to 3.17s.
+
+## Prevention
+
+When adding unit-test helpers that need the current schema:
+
+1. Use `migrated_in_memory_for_tests()` for an empty current-schema DB.
+2. Replay `run_migrations` directly only when the test is about migration behavior itself.
+3. Avoid file-backed DBs unless the test asserts path, WAL, backup, permissions, or reopen behavior.
+4. Before adding another full-schema fixture helper, time the module filter and compare against the template helper.

--- a/docs/solutions/tooling-decisions/pre-push-hook-duration-vs-ssh-idle-timeout-2026-05-19.md
+++ b/docs/solutions/tooling-decisions/pre-push-hook-duration-vs-ssh-idle-timeout-2026-05-19.md
@@ -7,12 +7,12 @@ component: development_workflow
 severity: medium
 tags: [pre-push, ssh, github, cargo-test, idle-timeout, rebase, pipestatus]
 date: 2026-05-19
-last_updated: 2026-05-19
+last_updated: 2026-05-24
 related_linear: DOS-713
 applies_when:
   - "Pushing a Rust-touching branch that triggers the full pre-push gauntlet"
   - "Cargo target/ is cold or partially cold (rebuild time is long)"
-  - "Pushing immediately after a rebase (rebased commits never trigger pre-commit, so the last-green-tree cache is always cold)"
+  - "Pushing immediately after a rebase before the tier-aware gauntlet cache has been warmed for the rebased tree"
   - "Multiple parallel sessions are running pre-push gauntlets simultaneously (resource contention)"
 ---
 
@@ -20,7 +20,7 @@ applies_when:
 
 Surfaced during the 2026-05-19 parallel-session fan-out. Session 4 hit this on PR #320 push attempts — deterministic failure, 3 retries on the same commit, identical symptom each time. Session 2 corroborated on PR #323 — same pattern, ~60 min lost across 3 attempts before authorizing the `--no-verify` workaround. The repeatability across independent sessions on the same day is strong evidence this is a structural hook + transport interaction, not a flaky network.
 
-**Why the cache always misses on rebase-then-push.** The pre-push hook reads `<git-dir>/hooks-state/last-green-tree` and skips the gauntlet when HEAD's tree matches. That cache file is written only by **pre-commit**, not by pre-push. A `git rebase` replays commits without invoking pre-commit, so even though the file contents are byte-identical to the pre-rebase commit, the new commit object's tree-SHA hasn't been recorded in the cache. Every post-rebase push pays the full gauntlet cost.
+**Historical rebase cache miss.** The old pre-push hook read `<git-dir>/hooks-state/last-green-tree`, which was written only by **pre-commit**. A `git rebase` replays commits without invoking pre-commit, so even byte-identical content was not recorded under the rebased tree SHA. As of 2026-05-24, pre-push writes the shared tier-aware cache after a successful gauntlet, so the first post-rebase push may still pay the cost but same-tree retries do not.
 
 The pre-push hook (`.githooks/pre-push`) on Rust-touching pushes runs:
 
@@ -34,7 +34,7 @@ Total: 7–15+ minutes of local work **before** git invokes the SSH transport.
 
 **Don't rely on the SSH connection staying alive through the full gauntlet.** Three mitigations, in increasing cost:
 
-1. **Trust the tree-SHA cache.** The hook already prints `pre-push: HEAD tree <sha> already passed pre-commit gauntlet — skipping clippy/test/tsc` when the same tree was pre-commit-validated earlier. Retry the push without changing anything — if the cache fires, the gauntlet skips and the push lands. If it doesn't fire on retry (e.g., after a rebase changed the tree SHA), investigate why before assuming the network is at fault.
+1. **Trust the tier-aware tree cache.** The hook prints `pre-push: HEAD tree <sha> already passed required gauntlet — skipping clippy/test/tsc` when the same tree already passed the required Rust/frontend tier. Retry the push without changing anything — if the cache fires, the gauntlet skips and the push lands. If it doesn't fire on retry, investigate why before assuming the network is at fault.
 2. **Pre-validate the gauntlet locally, then push with `--no-verify`** when you've already manually run clippy + test + tsc and have explicit authorization (per CLAUDE.md "Never skip hooks unless the user explicitly requests it"). The hook is duplicating work you've already done.
 3. **Configure SSH keepalive** for the `github.com` host (`ServerAliveInterval 60` in `~/.ssh/config`). Lower-friction long-term fix.
 
@@ -53,7 +53,7 @@ The hook gates aren't catching anything — `ssh -T git@github.com` in isolation
 
 ## When to apply
 
-- **Always**: prefer the tree-SHA cache path. If you already ran clippy + test + tsc locally, the hook should skip them on push.
+- **Always**: prefer the tier-aware tree-cache path. If the required Rust/frontend tiers already passed on the same tree, the hook should skip them on push.
 - **As a fallback** when the cache misses and you've manually validated: `--no-verify` is justified, but only after surfacing the call to the user per CLAUDE.md.
 - **Long-term**: file a Maintenance ticket to investigate either the cache-miss path or SSH keepalive. DOS-713 covers both.
 
@@ -111,11 +111,7 @@ grep -E "ssh.*disconnect|broken pipe|EOF|closed by remote" /tmp/push.log
 
 ## Tracking
 
-- DOS-713 — investigate tree-SHA cache miss on retry path; optionally configure SSH keepalive for github.com.
-- **Structural fix candidate**: teach `.githooks/pre-push` to write `<git-dir>/hooks-state/last-green-tree` on its own successful gauntlet pass, not just pre-commit. That closes the rebase-then-push cache gap permanently — after one expensive gauntlet run on the rebased tree, subsequent pushes from the same tree (e.g., retry, force-push of identical content) short-circuit in <1s instead of re-running the 17-min suite. Approximate one-liner to append to the hook's success path:
-  ```bash
-  git_dir="$(git rev-parse --git-dir)"
-  mkdir -p "$git_dir/hooks-state"
-  git rev-parse HEAD^{tree} > "$git_dir/hooks-state/last-green-tree"
-  ```
+- DOS-713 — originally tracked the tree-cache miss on retry path and optional SSH keepalive for github.com.
+- **Resolved 2026-05-24:** `.githooks/pre-commit` and `.githooks/pre-push` now share `<git-dir>/hooks-state/last-green-gauntlet-v2`. The marker records the tree plus which tiers passed (`rust`, `frontend`), so repeated commit attempts and pre-push retries skip duplicate clippy/test/tsc only when the required tier has already passed for that exact tree. Pre-push writes the marker after its own successful gauntlet, closing the rebase-then-retry cache gap without letting doc-only commits bless Rust or frontend changes.
+- Related pre-commit improvement: cheap/path-local gates now run before clippy/test/tsc, and heavy checks fail fast with a log path and tail output. A cheap PII/stub/schema/boundary failure should return before the Rust gauntlet starts.
 - Related: long pre-push duration is exacerbated when parallel worktrees both invoke the gauntlet at the same time (cargo target/ contention). Coordinate pushes serially across sessions if running the parallel-session protocol.

--- a/docs/solutions/tooling-decisions/wip-and-no-verify-escape-hatches-under-memory-pressure-2026-05-20.md
+++ b/docs/solutions/tooling-decisions/wip-and-no-verify-escape-hatches-under-memory-pressure-2026-05-20.md
@@ -5,6 +5,7 @@ track: knowledge
 module: .githooks/pre-commit + .githooks/pre-push (escape-hatch policy)
 tags: [pre-commit, pre-push, cargo-test, memory-pressure, disk-pressure, wip-flag, no-verify, ship-velocity]
 date: 2026-05-20
+last_updated: 2026-05-24
 related_linear: DOS-741, DOS-742, DOS-743, DOS-576, DOS-577
 related_memories: [feedback_disk_pressure_from_worktree_targets, feedback_5min_heartbeat_for_long_jobs]
 ---
@@ -44,7 +45,7 @@ From `.githooks/pre-push` header:
 # Bypass: git push --no-verify (use sparingly; surface to user).
 ```
 
-Pre-push has a tree-SHA cache: if pre-commit ran the gauntlet on the same tree SHA, pre-push skips. Under WIP=1, the cache is empty, so pre-push runs cargo test from scratch.
+Pre-push has a tier-aware tree cache: if pre-commit or an earlier pre-push ran the required gauntlet on the same tree SHA, pre-push skips. Under `WIP=1`, the first pre-push still pays the gauntlet cost, but a successful pre-push now records the tree so retries skip instead of rerunning cargo from scratch.
 
 When pre-push itself hangs under memory pressure, `--no-verify` is the documented bypass — but only when manual `cargo test --lib` has already passed clean on the same tree.
 

--- a/scripts/check_prompt_fingerprint_boundary.sh
+++ b/scripts/check_prompt_fingerprint_boundary.sh
@@ -45,7 +45,7 @@ check_line() {
 while IFS= read -r line; do
   check_line "$line"
 done < <(
-  grep -RInE '\bcanonical_prompt_hash[[:space:]]*\(|\bCanonicalPromptRequest[[:space:]]*\{|\bPromptFingerprint[[:space:]]*\{' \
+  grep -RInE 'canonical_prompt_hash[[:space:]]*\(|CanonicalPromptRequest[[:space:]]*[{]|PromptFingerprint[[:space:]]*[{]' \
     "$ROOT_DIR/src-tauri/src" \
     "$ROOT_DIR/src-tauri/abilities-runtime/src" 2>/dev/null || true
 )

--- a/src-tauri/src/bridges/tauri.rs
+++ b/src-tauri/src/bridges/tauri.rs
@@ -1104,7 +1104,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(err, BridgeSurfaceError::InputReservedField);
+        assert_eq!(err, BridgeSurfaceError::AbilityUnavailable);
     }
 
     #[tokio::test]

--- a/src-tauri/src/bridges/tauri.rs
+++ b/src-tauri/src/bridges/tauri.rs
@@ -1104,7 +1104,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(err, BridgeSurfaceError::AbilityUnavailable);
+        assert_eq!(err, BridgeSurfaceError::InputReservedField);
     }
 
     #[tokio::test]

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -740,16 +740,13 @@ impl ActionDb {
 pub mod test_utils {
     use super::ActionDb;
 
-    /// Create a temporary database for testing.
+    /// Create an isolated migrated in-memory database for testing.
     ///
-    /// We leak the `TempDir` so the directory persists for the duration of the test.
-    /// Test temp dirs are cleaned up by the OS. FK enforcement is disabled so that
-    /// unit tests can insert rows without satisfying every foreign key constraint.
+    /// FK enforcement is disabled so unit tests can insert rows without satisfying
+    /// every foreign key constraint.
     pub fn test_db() -> ActionDb {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let path = dir.path().join("test.db");
-        std::mem::forget(dir);
-        let db = ActionDb::open_at_unencrypted(path).expect("Failed to open test database");
+        let db =
+            ActionDb::from_connection_for_tests(crate::migrations::migrated_in_memory_for_tests());
         db.conn_ref()
             .execute_batch("PRAGMA foreign_keys = OFF;")
             .expect("disable FK for tests");

--- a/src-tauri/src/db/intelligence_feedback.rs
+++ b/src-tauri/src/db/intelligence_feedback.rs
@@ -732,8 +732,7 @@ mod tests {
     }
 
     fn setup_pair_db() -> Connection {
-        let conn = Connection::open_in_memory().expect("in-memory db");
-        crate::migrations::run_migrations(&conn).expect("apply migrations");
+        let conn = crate::migrations::migrated_in_memory_for_tests();
         conn.execute_batch("PRAGMA foreign_keys = OFF;")
             .expect("disable FK for tests");
         conn

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -3600,6 +3600,28 @@ pub fn run_migrations(conn: &Connection) -> Result<usize, String> {
     run_migrations_with_key(conn, None)
 }
 
+#[cfg(test)]
+pub(crate) fn migrated_in_memory_for_tests() -> Connection {
+    static TEMPLATE: std::sync::OnceLock<std::sync::Mutex<Connection>> = std::sync::OnceLock::new();
+
+    let template = TEMPLATE.get_or_init(|| {
+        let conn = Connection::open_in_memory().expect("open migrated test template");
+        run_migrations(&conn).expect("migrate test template");
+        std::sync::Mutex::new(conn)
+    });
+
+    let template = template
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut conn = Connection::open_in_memory().expect("open test db clone");
+    {
+        let backup =
+            rusqlite::backup::Backup::new(&template, &mut conn).expect("start test db clone");
+        backup.step(-1).expect("clone migrated test db");
+    }
+    conn
+}
+
 pub(crate) fn run_migrations_with_key(
     conn: &Connection,
     encryption_key: Option<&crate::db::EncryptionKey>,

--- a/src-tauri/src/services/claims_backfill.rs
+++ b/src-tauri/src/services/claims_backfill.rs
@@ -3333,9 +3333,7 @@ mod tests {
     // ---------------------------------------------------------------------
 
     fn fresh_full_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        crate::migrations::run_migrations(&conn).unwrap();
-        conn
+        crate::migrations::migrated_in_memory_for_tests()
     }
 
     #[test]

--- a/src-tauri/src/services/claims_backfill/structural_canonical_id_tests.rs
+++ b/src-tauri/src/services/claims_backfill/structural_canonical_id_tests.rs
@@ -17,9 +17,7 @@ fn fixture_ctx<'a>(
 }
 
 fn fresh_full_db() -> Connection {
-    let conn = Connection::open_in_memory().unwrap();
-    crate::migrations::run_migrations(&conn).unwrap();
-    conn
+    crate::migrations::migrated_in_memory_for_tests()
 }
 
 fn expected_structural_id(values: [&str; 4]) -> String {

--- a/src-tauri/src/services/surface_pairing.rs
+++ b/src-tauri/src/services/surface_pairing.rs
@@ -2811,13 +2811,11 @@ mod tests {
         load_session_master_key, set_keychain_for_tests, MockKeychain, SessionKeyLookup,
     };
     use abilities_runtime::abilities::registry::ScopeSet;
-    use rusqlite::Connection;
     use std::sync::Arc;
     use std::time::{Duration as StdDuration, Instant};
 
     fn db() -> ActionDb {
-        let conn = Connection::open_in_memory().unwrap();
-        crate::migrations::run_migrations(&conn).unwrap();
+        let conn = crate::migrations::migrated_in_memory_for_tests();
         ActionDb::from_connection_for_tests(conn)
     }
 

--- a/src-tauri/src/services/trust_extraction.rs
+++ b/src-tauri/src/services/trust_extraction.rs
@@ -446,9 +446,7 @@ mod tests {
     use rusqlite::Connection;
 
     fn fresh_db() -> Connection {
-        let conn = Connection::open_in_memory().expect("open in-memory db");
-        crate::migrations::run_migrations(&conn).expect("apply migrations");
-        conn
+        crate::migrations::migrated_in_memory_for_tests()
     }
 
     fn db_view(conn: &Connection) -> &ActionDb {


### PR DESCRIPTION
## Summary
- add a tier-aware hook cache shared by pre-commit and pre-push so same-tree retries skip already-passed cargo/tsc tiers
- move cheap/path-local gates ahead of the heavy Rust/frontend gauntlet and make heavy failures fail fast with log tails
- fix BSD grep portability in hook-adjacent checks
- add a test-only migrated in-memory SQLite template and switch hot current-schema fixtures to clone it instead of replaying all migrations per test
- document the migration-fixture performance pattern in `docs/solutions/test-failures/`

## Why
Small Rust edits were repeatedly paying the full clippy/test/tsc gauntlet, including after cheap failures and after SSH idle disconnects during push. The hook cache fixes duplicate same-tree retries, and the migrated test DB template removes a major class of repeated setup work inside `cargo test --lib` itself.

## Measured Impact
- `db::core` filter: timed out after 120s before finishing; now 185 tests finish in 1.80s
- `db::intelligence_feedback` filter: 27.65s → 0.65s
- `services::surface_pairing` filter: 30.22s → 3.23s
- `services::trust_extraction` filter: 10.23s → 0.54s
- `services::claims_backfill` filter: 15.63s → 3.17s
- full `cargo test --lib`: passed in 179s locally, under leftover system contention
- normal `git push` pre-push hook completed successfully and pushed the branch

## Validation
- `bash -n .githooks/pre-commit`
- `bash -n .githooks/pre-push`
- `bash -n scripts/check_prompt_fingerprint_boundary.sh`
- `scripts/check_prompt_template_registry.sh`
- `scripts/check_prompt_fingerprint_boundary.sh`
- `git diff --check`
- simulated pre-commit WIP path with intended staged files
- simulated pre-commit same-index cache skip
- simulated pre-push same-HEAD cache skip
- targeted Rust test: `cargo test --lib --manifest-path src-tauri/Cargo.toml bridges::tauri::tests::invoke_ability_rejects_actor_override_in_input_json -- --exact --nocapture`
- targeted Rust test: `cargo test --lib --manifest-path src-tauri/Cargo.toml bridges::tauri::tests::tauri_bridge_rejects_locked_app -- --exact --nocapture`
- `cargo test --lib --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- normal `git push public codex/hook-gauntlet-cache` passed pre-push clippy + `cargo test --lib`

L2-status: not-run-acknowledged