### PR TITLE
feat: add v1.4.4a W6 release gate

### DIFF
--- a/.docs/perf/baselines/scope-v1.4.4a-W6.json
+++ b/.docs/perf/baselines/scope-v1.4.4a-W6.json
@@ -1,0 +1,29 @@
+{
+  "baseline_version": "suite_p_baseline_v1",
+  "suite": "suite_p",
+  "lane": "DOS-348",
+  "scope": "v1.4.4a-W6",
+  "run_id": "v1.4.4a-w6-published",
+  "generated_at": "2026-05-24T20:37:01Z",
+  "threshold_pct": 10,
+  "benchmarks": [
+    {
+      "bench": "context_mode_atomic_local_snapshot",
+      "mean_ns": 52.01133734954785,
+      "median_ns": 51.69016277515381,
+      "std_dev_ns": 0.8878184897512243
+    },
+    {
+      "bench": "fenced_write_intelligence_json",
+      "mean_ns": 161358.82420696266,
+      "median_ns": 159902.45692567568,
+      "std_dev_ns": 4692.295503392031
+    },
+    {
+      "bench": "mutation_gate_mode_check",
+      "mean_ns": 47.57418581115251,
+      "median_ns": 47.571148073756,
+      "std_dev_ns": 0.39795167691043065
+    }
+  ]
+}

--- a/.docs/perf/baselines/scope-v1.4.4a-W6.json
+++ b/.docs/perf/baselines/scope-v1.4.4a-W6.json
@@ -4,26 +4,26 @@
   "lane": "DOS-348",
   "scope": "v1.4.4a-W6",
   "run_id": "v1.4.4a-w6-published",
-  "generated_at": "2026-05-24T20:37:01Z",
+  "generated_at": "2026-05-24T21:14:09Z",
   "threshold_pct": 10,
   "benchmarks": [
     {
       "bench": "context_mode_atomic_local_snapshot",
-      "mean_ns": 52.01133734954785,
-      "median_ns": 51.69016277515381,
-      "std_dev_ns": 0.8878184897512243
+      "mean_ns": 49.33288338771727,
+      "median_ns": 49.14595364126424,
+      "std_dev_ns": 0.9589084152528821
     },
     {
       "bench": "fenced_write_intelligence_json",
-      "mean_ns": 161358.82420696266,
-      "median_ns": 159902.45692567568,
-      "std_dev_ns": 4692.295503392031
+      "mean_ns": 154279.16688111136,
+      "median_ns": 155094.5896381579,
+      "std_dev_ns": 8460.544782008425
     },
     {
       "bench": "mutation_gate_mode_check",
-      "mean_ns": 47.57418581115251,
-      "median_ns": 47.571148073756,
-      "std_dev_ns": 0.39795167691043065
+      "mean_ns": 46.52128059982657,
+      "median_ns": 46.6757123514723,
+      "std_dev_ns": 0.47846211662694027
     }
   ]
 }

--- a/.docs/perf/runs/v1.4.4a-w6-published/bench-summary.json
+++ b/.docs/perf/runs/v1.4.4a-w6-published/bench-summary.json
@@ -4,7 +4,7 @@
   "mode": "published",
   "scope": "v1.4.4a-W6",
   "run_id": "v1.4.4a-w6-published",
-  "generated_at": "2026-05-24T20:37:01Z",
+  "generated_at": "2026-05-24T21:14:09Z",
   "criterion_baseline": "v1.4.4a-w6-published",
   "prior_baseline": ".docs/perf/baselines/scope-v1.4.1-W8.json",
   "threshold_pct": 10,
@@ -20,21 +20,21 @@
   "benchmarks": [
     {
       "bench": "context_mode_atomic_local_snapshot",
-      "mean_ns": 52.01133734954785,
-      "median_ns": 51.69016277515381,
-      "std_dev_ns": 0.8878184897512243
+      "mean_ns": 49.33288338771727,
+      "median_ns": 49.14595364126424,
+      "std_dev_ns": 0.9589084152528821
     },
     {
       "bench": "fenced_write_intelligence_json",
-      "mean_ns": 161358.82420696266,
-      "median_ns": 159902.45692567568,
-      "std_dev_ns": 4692.295503392031
+      "mean_ns": 154279.16688111136,
+      "median_ns": 155094.5896381579,
+      "std_dev_ns": 8460.544782008425
     },
     {
       "bench": "mutation_gate_mode_check",
-      "mean_ns": 47.57418581115251,
-      "median_ns": 47.571148073756,
-      "std_dev_ns": 0.39795167691043065
+      "mean_ns": 46.52128059982657,
+      "median_ns": 46.6757123514723,
+      "std_dev_ns": 0.47846211662694027
     }
   ],
   "missing_benches": [],

--- a/.docs/perf/runs/v1.4.4a-w6-published/bench-summary.json
+++ b/.docs/perf/runs/v1.4.4a-w6-published/bench-summary.json
@@ -1,0 +1,51 @@
+{
+  "suite": "suite_p",
+  "lane": "DOS-348",
+  "mode": "published",
+  "scope": "v1.4.4a-W6",
+  "run_id": "v1.4.4a-w6-published",
+  "generated_at": "2026-05-24T20:37:01Z",
+  "criterion_baseline": "v1.4.4a-w6-published",
+  "prior_baseline": ".docs/perf/baselines/scope-v1.4.1-W8.json",
+  "threshold_pct": 10,
+  "manifest_benches": [
+    "context_mode_atomic_local_snapshot",
+    "fenced_write_intelligence_json",
+    "mutation_gate_mode_check"
+  ],
+  "bench_count": 3,
+  "missing_bench_count": 0,
+  "extra_bench_count": 0,
+  "regression_count": 0,
+  "benchmarks": [
+    {
+      "bench": "context_mode_atomic_local_snapshot",
+      "mean_ns": 52.01133734954785,
+      "median_ns": 51.69016277515381,
+      "std_dev_ns": 0.8878184897512243
+    },
+    {
+      "bench": "fenced_write_intelligence_json",
+      "mean_ns": 161358.82420696266,
+      "median_ns": 159902.45692567568,
+      "std_dev_ns": 4692.295503392031
+    },
+    {
+      "bench": "mutation_gate_mode_check",
+      "mean_ns": 47.57418581115251,
+      "median_ns": 47.571148073756,
+      "std_dev_ns": 0.39795167691043065
+    }
+  ],
+  "missing_benches": [],
+  "extra_benches": [],
+  "current_invalid_numeric_bench_count": 0,
+  "current_invalid_numeric_benches": [],
+  "prior_missing_bench_count": 0,
+  "prior_extra_bench_count": 0,
+  "prior_missing_benches": [],
+  "prior_extra_benches": [],
+  "prior_invalid_numeric_bench_count": 0,
+  "prior_invalid_numeric_benches": [],
+  "regressions": []
+}

--- a/.docs/perf/runs/v1.4.4a-w6-published/record.json
+++ b/.docs/perf/runs/v1.4.4a-w6-published/record.json
@@ -1,0 +1,265 @@
+{
+  "schema_version": "evaluation_evidence_record_v1",
+  "suite": "suite_p",
+  "lane": "DOS-348",
+  "mode": "published",
+  "scope": "v1.4.4a-W6",
+  "run_id": "v1.4.4a-w6-published",
+  "commit": "943ff92829e6f3873e8ec3174efc9b780b742e39",
+  "branch": "codex/v1.4.4a-w6-release-gate",
+  "dirty": false,
+  "command": "pnpm suite:p -- --mode published --scope v1.4.4a-W6 --run-id v1.4.4a-w6-published --out .docs/perf/runs/v1.4.4a-w6-published/record.json --baseline .docs/perf/baselines/scope-v1.4.1-W8.json",
+  "started_at": "2026-05-24T20:26:30Z",
+  "finished_at": "2026-05-24T20:37:01Z",
+  "environment": {
+    "os": "Darwin 25.5.0",
+    "arch": "arm64",
+    "node": "v24.12.0",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "runner": "scripts/suite-p.sh"
+  },
+  "input_hashes": {
+    "schema": "sha256:f83ae06b4eda04bd638c6a98bd8127d526cd01997527a89b41e5dad8662f6127",
+    "bench_manifest": "sha256:33677f6f8f0c0cc441d14313ab748897902bbbb3005446cb71bb7ae6ac9f8bab",
+    "bench_config": "sha256:574a4ed45b17786ccd0d1f59e065c6ea31234b88c714ee58aba59cba932612f4",
+    "baseline": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+    "prior_baseline": "sha256:f44d1be9846b6d75a2f98ffc192ed2b3ff65d72ac82d262e5a6d4de611334f1b"
+  },
+  "metric_definitions": [
+    {
+      "namespace": "performance_regression",
+      "name": "bench_count",
+      "description": "Number of Criterion benchmarks with collected estimate data.",
+      "unit": "count",
+      "higher_is_better": true
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "missing_bench_count",
+      "description": "Number of manifest-declared Criterion benchmarks missing from the current published run.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "extra_bench_count",
+      "description": "Number of Criterion benchmark estimates not declared in the Suite P manifest.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "regression_count",
+      "description": "Number of benchmarks regressing more than 10% against the bound baseline when available.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "current_invalid_numeric_bench_count",
+      "description": "Number of manifest-declared current benchmarks missing a positive numeric mean estimate.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_missing_bench_count",
+      "description": "Number of manifest-declared Criterion benchmarks missing from the comparator baseline.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_extra_bench_count",
+      "description": "Number of comparator baseline benchmark estimates not declared in the Suite P manifest.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_invalid_numeric_bench_count",
+      "description": "Number of manifest-declared comparator benchmarks missing a positive numeric mean estimate.",
+      "unit": "count",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_context_mode_atomic_local_snapshot",
+      "description": "Criterion mean point estimate for context_mode_atomic_local_snapshot.",
+      "unit": "ns",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_fenced_write_intelligence_json",
+      "description": "Criterion mean point estimate for fenced_write_intelligence_json.",
+      "unit": "ns",
+      "higher_is_better": false
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_mutation_gate_mode_check",
+      "description": "Criterion mean point estimate for mutation_gate_mode_check.",
+      "unit": "ns",
+      "higher_is_better": false
+    }
+  ],
+  "metrics": [
+    {
+      "namespace": "performance_regression",
+      "name": "bench_count",
+      "value": 3,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "missing_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "extra_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "regression_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "current_invalid_numeric_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_missing_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_extra_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "prior_invalid_numeric_bench_count",
+      "value": 0,
+      "unit": "count",
+      "status": "pass"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_context_mode_atomic_local_snapshot",
+      "value": 52.01133734954785,
+      "unit": "ns",
+      "status": "info"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_fenced_write_intelligence_json",
+      "value": 161358.82420696266,
+      "unit": "ns",
+      "status": "info"
+    },
+    {
+      "namespace": "performance_regression",
+      "name": "criterion_mean_ns_mutation_gate_mode_check",
+      "value": 47.57418581115251,
+      "unit": "ns",
+      "status": "info"
+    }
+  ],
+  "thresholds": {
+    "requires_baseline": true,
+    "bench_count": {
+      "operator": "eq",
+      "value": 3
+    },
+    "missing_bench_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "extra_bench_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "regression_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "current_invalid_numeric_bench_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "prior_missing_bench_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "prior_extra_bench_count": {
+      "operator": "eq",
+      "value": 0
+    },
+    "prior_invalid_numeric_bench_count": {
+      "operator": "eq",
+      "value": 0
+    }
+  },
+  "result": "pass",
+  "artifact_paths": [
+    {
+      "path": ".docs/perf/runs/v1.4.4a-w6-published/bench-summary.json",
+      "kind": "suite-p-summary",
+      "sha256": "sha256:5d29e8a10561ce18dabd8b463babb2dee60c7c2913dce43ce18136563d44b853",
+      "privacy_class": "public",
+      "publishable": true,
+      "redaction_status": "synthetic"
+    },
+    {
+      "path": ".docs/perf/suite-p-bench-manifest.json",
+      "kind": "suite-p-bench-manifest",
+      "sha256": "sha256:33677f6f8f0c0cc441d14313ab748897902bbbb3005446cb71bb7ae6ac9f8bab",
+      "privacy_class": "public",
+      "publishable": true,
+      "redaction_status": "synthetic"
+    },
+    {
+      "path": ".docs/perf/baselines/scope-v1.4.4a-W6.json",
+      "kind": "suite-p-baseline",
+      "sha256": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+      "privacy_class": "public",
+      "publishable": true,
+      "redaction_status": "synthetic"
+    }
+  ],
+  "privacy_class": "public",
+  "publishable": true,
+  "dataset_source": "DailyOS synthetic Criterion hot-path benchmarks",
+  "dataset_license": "DailyOS synthetic/public",
+  "dataset_hash": "sha256:33677f6f8f0c0cc441d14313ab748897902bbbb3005446cb71bb7ae6ac9f8bab",
+  "redaction_status": "synthetic",
+  "notes": "Published Suite P Criterion evidence for synthetic v1.4.x hot-path benchmarks.",
+  "extensions": {
+    "evidence_counts": {
+      "bench_count": 3
+    },
+    "baseline_binding": {
+      "baseline_hash": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+      "prior_baseline_hash": "sha256:f44d1be9846b6d75a2f98ffc192ed2b3ff65d72ac82d262e5a6d4de611334f1b"
+    }
+  }
+}

--- a/.docs/perf/runs/v1.4.4a-w6-published/record.json
+++ b/.docs/perf/runs/v1.4.4a-w6-published/record.json
@@ -5,12 +5,12 @@
   "mode": "published",
   "scope": "v1.4.4a-W6",
   "run_id": "v1.4.4a-w6-published",
-  "commit": "943ff92829e6f3873e8ec3174efc9b780b742e39",
+  "commit": "07cd4dfe21050720dd9b3f7ff237d5177d1d901f",
   "branch": "codex/v1.4.4a-w6-release-gate",
   "dirty": false,
   "command": "pnpm suite:p -- --mode published --scope v1.4.4a-W6 --run-id v1.4.4a-w6-published --out .docs/perf/runs/v1.4.4a-w6-published/record.json --baseline .docs/perf/baselines/scope-v1.4.1-W8.json",
-  "started_at": "2026-05-24T20:26:30Z",
-  "finished_at": "2026-05-24T20:37:01Z",
+  "started_at": "2026-05-24T21:04:27Z",
+  "finished_at": "2026-05-24T21:14:09Z",
   "environment": {
     "os": "Darwin 25.5.0",
     "arch": "arm64",
@@ -23,7 +23,7 @@
     "schema": "sha256:f83ae06b4eda04bd638c6a98bd8127d526cd01997527a89b41e5dad8662f6127",
     "bench_manifest": "sha256:33677f6f8f0c0cc441d14313ab748897902bbbb3005446cb71bb7ae6ac9f8bab",
     "bench_config": "sha256:574a4ed45b17786ccd0d1f59e065c6ea31234b88c714ee58aba59cba932612f4",
-    "baseline": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+    "baseline": "sha256:ac5f8382ddc6aed2e13ab3c3c6022763f992e3f92c6ca10ec85b35369a84c086",
     "prior_baseline": "sha256:f44d1be9846b6d75a2f98ffc192ed2b3ff65d72ac82d262e5a6d4de611334f1b"
   },
   "metric_definitions": [
@@ -165,21 +165,21 @@
     {
       "namespace": "performance_regression",
       "name": "criterion_mean_ns_context_mode_atomic_local_snapshot",
-      "value": 52.01133734954785,
+      "value": 49.33288338771727,
       "unit": "ns",
       "status": "info"
     },
     {
       "namespace": "performance_regression",
       "name": "criterion_mean_ns_fenced_write_intelligence_json",
-      "value": 161358.82420696266,
+      "value": 154279.16688111136,
       "unit": "ns",
       "status": "info"
     },
     {
       "namespace": "performance_regression",
       "name": "criterion_mean_ns_mutation_gate_mode_check",
-      "value": 47.57418581115251,
+      "value": 46.52128059982657,
       "unit": "ns",
       "status": "info"
     }
@@ -224,7 +224,7 @@
     {
       "path": ".docs/perf/runs/v1.4.4a-w6-published/bench-summary.json",
       "kind": "suite-p-summary",
-      "sha256": "sha256:5d29e8a10561ce18dabd8b463babb2dee60c7c2913dce43ce18136563d44b853",
+      "sha256": "sha256:8f6eca8d1d8be2b59cae495bcb289b5e353791e6f292308175892ead1826c0c3",
       "privacy_class": "public",
       "publishable": true,
       "redaction_status": "synthetic"
@@ -240,7 +240,7 @@
     {
       "path": ".docs/perf/baselines/scope-v1.4.4a-W6.json",
       "kind": "suite-p-baseline",
-      "sha256": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+      "sha256": "sha256:ac5f8382ddc6aed2e13ab3c3c6022763f992e3f92c6ca10ec85b35369a84c086",
       "privacy_class": "public",
       "publishable": true,
       "redaction_status": "synthetic"
@@ -258,7 +258,7 @@
       "bench_count": 3
     },
     "baseline_binding": {
-      "baseline_hash": "sha256:5b9c7a8dec49d7133b3091f050e2830ade577ad6a3e01588f50e760320b1ee76",
+      "baseline_hash": "sha256:ac5f8382ddc6aed2e13ab3c3c6022763f992e3f92c6ca10ec85b35369a84c086",
       "prior_baseline_hash": "sha256:f44d1be9846b6d75a2f98ffc192ed2b3ff65d72ac82d262e5a6d4de611334f1b"
     }
   }

--- a/.docs/plans/l3-reviews/v1.4.4a-W6/l3-suite-e-attest.md
+++ b/.docs/plans/l3-reviews/v1.4.4a-W6/l3-suite-e-attest.md
@@ -1,0 +1,20 @@
+# v1.4.4a W6 Suite E Attestation
+
+L3-suite-e-attest: passed
+
+Date: 2026-05-24
+Scope: v1.4.4a-W6
+
+Surface evidence:
+
+- `scripts/release-gate/run-v144a-w6-fixtures.sh` passed.
+- `pnpm tsc --noEmit` passed.
+- `pnpm test` passed through the fixture runner.
+- Daily Briefing, Meeting Briefing, entity detail, suggested actions, work surface, and email-ranking frontend tests were included in the W6 fixture scope.
+- `src-tauri/tests/entity_fixture_harness.rs` passed, including no-bypass assertions for claim-bound rendered text.
+- `src-tauri/tests/foreground_db_contention_regression.rs` passed.
+
+Notes:
+
+- This attestation is for release-gate evidence on the local Tauri surfaces in v1.4.4a.
+- No visual redesign or browser-driven UI change is introduced by W6; this gate validates claim-backed reader behavior, no-bypass fixtures, and foreground contention regressions.

--- a/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence-waves.html
+++ b/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence-waves.html
@@ -1,0 +1,611 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>v1.4.4a Tauri Briefing Entity Intelligence - DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body data-tint="sage">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS - Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="v1.4.4a-tauri-briefing-entity-intelligence-waves.html" data-active="true">Tauri Briefing Cutover</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS - v1.4.4a - Parallel Wave Plan</p>
+  <h1 class="plans-title">Tauri briefings consume scored entity intelligence.</h1>
+  <p class="plans-kicker">Start with Daily Briefing and Meeting Briefing, then roll the same substrate-backed read contract into entity detail, actions, and email.</p>
+  <p class="plans-lede">
+    This plan turns the app surfaces into consumers of the abilities runtime instead of parallel readers of legacy intelligence projections.
+    The first proof is not WordPress or MCP: it is the shipped Tauri experience.
+    Daily Briefing and Meeting Briefing become the first two surfaces that read scored claims, provenance, trust bands, source-as-of dates, and sensitivity policy through runtime envelopes.
+  </p>
+  <div class="plans-meta">
+    <span>Target: v1.4.4a parallel app-surface lane</span>
+    <span>Current revision: V1.2 L0 approved</span>
+    <span>Waves: 7 (W0 gate + W1-W6)</span>
+    <span>Parallel agents: 3 peak</span>
+    <span>Source: Linear v1.4.4 project</span>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="source-and-scope">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Source and scope</p>
+    <h2 id="source-and-scope" class="plans-section-title">This is the consumer half of the substrate repair.</h2>
+    <p class="plans-section-lede">
+      A parallel producer-remediation plan is making <code>get_entity_intelligence</code> richer.
+      This plan makes the app consume that envelope for claim-backed briefing content, without replacing operational shell data or inventing a cache database.
+    </p>
+  </header>
+  <ul class="plans-related">
+    <li><strong>Problem:</strong> app surfaces and PTY prompt builders still mix raw detail commands, cached prep blobs, legacy <code>db.get_entity_intelligence</code>, and page-local composition as sources for claim-backed intelligence.</li>
+    <li><strong>First surfaces:</strong> Daily Briefing at <code>src/components/dashboard/DailyBriefing.tsx</code> and Meeting Briefing through <code>prepare_meeting</code>, <code>refresh_meeting_briefing_full</code>, and <code>src/pages/MeetingDetailPage.tsx</code>.</li>
+    <li><strong>Next surfaces:</strong> Account, Project, and Person detail pages. After that, Actions and Email.</li>
+    <li><strong>Lane authority:</strong> v1.4.4a is a W0-approved exception/amendment to the v1.4.4 WordPress Surface Migration Tauri-freeze rule. It may touch existing Tauri React surfaces only to change claim-backed data sourcing, trust/provenance rendering, and prompt-input plumbing; no new routes, visual patterns, or UI features. W0 records the exception in Linear and mirrors it into the main v1.4.4 wave packet before W1 starts.</li>
+    <li><strong>Upstream dependency:</strong> producer remediation for <code>get_entity_intelligence</code> fills the envelope with neighborhood, touchpoints, relationships, health, threads, metadata proposals, and section caveats.</li>
+    <li><strong>Non-goal:</strong> no WordPress migration, no remote processing, no new read-cache database, no wholesale rewrite of dashboard shell data, and no prompt-template redesign beyond the minimum needed for substrate-fed inputs.</li>
+    <li><strong>Threat topology:</strong> local-to-local single-user. No new loopback endpoint, remote endpoint, MCP exposure, or SurfaceClient pairing scope ships in this lane. Prompt channels, sensitivity gates, source hygiene, provenance rendering, and log redaction still apply.</li>
+    <li><strong>Authority surfaces:</strong> Linear remains canonical for issue approval and reviewer verdicts. Durable review artifacts live under <code>.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/reviews/</code>.</li>
+    <li><strong>WordPress boundary:</strong> v1.4.4a may consume v1.4.4 W1 substrate, but it does not satisfy, replace, or change any W2-W6 WordPress migration acceptance criteria. Any cross-surface contract change reopens or amends the v1.4.4 master/sub-L0 packet before code starts.</li>
+    <li><strong>Composition boundary:</strong> this lane is a temporary envelope-rendered Tauri consumer exception, not a new composition-producing wave. If implementation creates substrate-authored composed page output, it must use ADR-0130 <code>Composition</code>; otherwise W6 records whether a later ReactBlockRenderer-over-Composition cutover is required.</li>
+    <li><strong>K-in:</strong> <code>docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md</code>, ADR-0093, ADR-0102, ADR-0106, ADR-0108, ADR-0111, ADR-0125, ADR-0130.</li>
+  </ul>
+</section>
+
+<section class="plans-section" aria-labelledby="l0-status">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">L0 status</p>
+    <h2 id="l0-status" class="plans-section-title">Cycle-1 review folds are part of the approved plan.</h2>
+    <p class="plans-section-lede">
+      Final L0 status: approved after cycle-1 folds on 2026-05-23.
+      The fold-ins are not optional notes; they are W0/W1 gates so later waves do not have to guess.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Fold</th>
+        <th>Decision</th>
+        <th>Where enforced</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Minimum producer gate</td>
+        <td>W2/W3 may start before all producer remediation is done only if their required envelope fields are present or explicitly degraded.</td>
+        <td>W0, W1, W2, W3</td>
+      </tr>
+      <tr>
+        <td>Tauri-freeze exception</td>
+        <td>This lane is an explicit v1.4.4 exception for data sourcing, trust/provenance rendering, and prompt plumbing only; no new Tauri UI scope.</td>
+        <td>W0, main v1.4.4 packet</td>
+      </tr>
+      <tr>
+        <td>Cache vs authority</td>
+        <td><code>prep_context_json</code> and <code>prep_frozen_json</code> remain valid cached read models for already-rendered meeting prep, but not authoritative prompt input for new claim-backed analysis.</td>
+        <td>Operating principles, W3, CI invariants</td>
+      </tr>
+      <tr>
+        <td>Daily split</td>
+        <td>W0 freezes which dashboard fields are shell data and which are claim-backed sections before W2 starts.</td>
+        <td>W0, W2</td>
+      </tr>
+      <tr>
+        <td>Actor and surface policy</td>
+        <td>The shipped Tauri app invokes through <code>invoke_ability</code> as <code>Actor::User</code>; render surfaces are <code>tauri_briefing_prep</code>, <code>tauri_meeting_detail</code>, and <code>tauri_entity_detail</code>. Existing MCP/SurfaceClient exposure is frozen and regression-tested.</td>
+        <td>W1-W4, Suite S</td>
+      </tr>
+      <tr>
+        <td>Prompt fingerprints</td>
+        <td>Any meeting prompt-input shape change bumps <code>prepare_meeting_prep</code> template version and records canonical JSON / fingerprint drift per ADR-0106.</td>
+        <td>W3, Suite S/E</td>
+      </tr>
+      <tr>
+        <td>Prompt-safe projection</td>
+        <td>Only a Rust projection built from <code>EntityIntelligenceEnvelope</code> after the centralized prompt-channel sensitivity gate may enter canonical prompt JSON.</td>
+        <td>W1, W3</td>
+      </tr>
+      <tr>
+        <td>Live Daily Briefing path</td>
+        <td>W1 proves populated Tauri <code>invoke_ability("get_daily_briefing")</code> works with the live daily-readiness reader and complete outer provenance attribution.</td>
+        <td>W1, W2</td>
+      </tr>
+      <tr>
+        <td>Rendered provenance boundary</td>
+        <td>UI renders trust/provenance from <code>AbilityResponseJson.rendered_provenance</code>; DTO-local provenance is for refs, source counts, and diagnostics only unless explicitly actor-rendered.</td>
+        <td>W1-W4</td>
+      </tr>
+      <tr>
+        <td><code>prepare_meeting</code> composition</td>
+        <td>W3 must update descriptor/provenance/prompt fixtures so <code>get_entity_intelligence</code> is the claim-backed composed source; remaining raw reads are allowlisted shell/cache reads only.</td>
+        <td>W3</td>
+      </tr>
+      <tr>
+        <td>Performance budgets</td>
+        <td>W0 captures root-route and Meeting Detail baseline plus cardinality caps; W2/W3 fail if the ability path adds visible render delay, exceeds fan-out caps, or regresses the measured baseline by more than 10% without an L6 call.</td>
+        <td>Suite P, W6</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="actor-exposure-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Actor and exposure matrix</p>
+    <h2 id="actor-exposure-matrix" class="plans-section-title">Tauri is the target, but other heads already exist.</h2>
+    <p class="plans-section-lede">
+      The lane must not treat "no new exposure" as sufficient.
+      W0 freezes the current descriptor shape for every touched ability, then W1-W4 add regressions so Tauri output changes do not leak through MCP, SurfaceClient, diagnostics, or audit sinks.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Ability</th>
+        <th>Current actor/exposure contract</th>
+        <th>v1.4.4a rule</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>get_entity_intelligence</code></td>
+        <td><code>User</code>, <code>Agent</code>, <code>System</code>, <code>SurfaceClient</code>, <code>McpClient</code>; scope <code>read.entity_intelligence</code>; <code>mcp_exposure = Invocable</code>; <code>client_side_executable</code> frozen from descriptor.</td>
+        <td>Any output-shape change needs User/MCP/SurfaceClient golden fixtures for data, rendered text, provenance redaction, diagnostics omission, and source-id masking.</td>
+      </tr>
+      <tr>
+        <td><code>get_daily_briefing</code></td>
+        <td>v1.4.4a target authority is <code>User</code> only; scope <code>read.daily_briefing</code>; <code>mcp_exposure = None</code>; <code>client_side_executable = false</code> unless the main W3/sub-L0 packet separately approves SurfaceClient execution.</td>
+        <td>W0 resolves any descriptor drift before W1: either narrow runtime metadata to User-only for this lane, or amend the main W3/sub-L0 with explicit SurfaceClient scope/render/audit policy. Tauri proof cannot count as WordPress block proof.</td>
+      </tr>
+      <tr>
+        <td><code>prepare_meeting</code></td>
+        <td><code>User</code>, <code>Agent</code>, <code>System</code>; Transform ability with prompt input and provider output; no SurfaceClient or MCP descriptor exposure in this lane.</td>
+        <td>Prompt-input changes require ADR-0093/0106 fixtures plus Agent-vs-User response checks; no SurfaceClient or MCP exposure is added in this lane.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="principles">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Operating principles</p>
+    <h2 id="principles" class="plans-section-title">Consume the substrate; keep the shell pragmatic.</h2>
+  </header>
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">Claim-backed means ability-backed</h3>
+      <p class="callout-prose">Facts, risks, open loops, touchpoints, relationship context, trust summaries, and provenance must come from <code>get_entity_intelligence</code> or abilities that compose it. Legacy detail commands may still provide names, navigation, timestamps, meetings, and explicit mutation affordances.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Prompt input is a trust boundary</h3>
+      <p class="callout-prose">Meeting briefing PTY inputs must use a prompt-safe Rust projection of entity intelligence. The projection applies the centralized <code>services::claims</code> prompt-channel sensitivity gate, a subject allowlist, structural sanitization or equivalent JSON-boundary defense, length/invisible-character handling, prompt-version bumping, and canonical fingerprint fixtures. Derived prior intelligence is treated as untrusted input under ADR-0093.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Prompt authority is Rust-only</h3>
+      <p class="callout-prose">Only the prompt-safe projection built from <code>EntityIntelligenceEnvelope</code> may enter canonical prompt JSON. Tauri React components, <code>get_dashboard_data</code>, cached <code>prep_*</code> blobs, and page-local composers are never prompt authorities.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">No silent bypasses</h3>
+      <p class="callout-prose">If a briefing section renders claim-backed intelligence, tests and lint must fail when it sources that section from raw SQL, <code>db.get_entity_intelligence</code>, page-local composers, or legacy AI JSON. Cached meeting output may still render as a read model; it cannot become the source of truth for newly generated claim-backed prompt input.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Cache means stale display, not authority</h3>
+      <p class="callout-prose">Current ability envelopes are authoritative for new prompt input and new claim-backed rendering. <code>prep_context_json</code> and <code>prep_frozen_json</code> may keep a previous briefing visible during rebuild only when rendered as stale and bound to the envelope or claim ids that produced it. An unresolved cached claim id is a stale-render failure; a claim-substantive string with no current-or-stale claim binding is a bypass.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Render actor-filtered provenance</h3>
+      <p class="callout-prose">Tauri UI uses <code>AbilityResponseJson.rendered_provenance</code> for user-visible provenance and trust treatment. DTO-local <code>data.provenance</code> and per-fact provenance refs can drive counts, bindings, and detail fetches, but cannot be rendered as raw provenance unless passed through the actor/surface renderer.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Actor and surface stay narrow</h3>
+      <p class="callout-prose">The Tauri app path uses <code>invoke_ability</code> as <code>Actor::User</code>. This lane does not broaden <code>Agent</code>, <code>McpClient</code>, or <code>SurfaceClient</code> exposure for briefing abilities. Any exposure change needs a fresh <code>/cso</code> pass.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Producers can degrade, not disappear</h3>
+      <p class="callout-prose">When a producer slice is unavailable, the envelope must return typed empty, stale, or caveated state with trust and provenance context. A missing producer cannot silently fall back to legacy projections for a claim-backed section.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="wave-overview">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave shape</p>
+    <h2 id="wave-overview" class="plans-section-title">7 waves: W0 gate plus W1-W6 implementation and release.</h2>
+    <p class="plans-section-lede">
+      W0 freezes the boundary. W1 builds the shared consumer seam. W2 and W3 prove it on Daily Briefing and Meeting Briefing.
+      W4 applies the same pattern to entity detail. W5 applies it to actions and email. W6 closes drift and performance.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Wave</th>
+        <th>Issues</th>
+        <th>Parallel agents</th>
+        <th>Target</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>W0 - Boundary and inventory</td>
+        <td>surface inventory, prompt-channel matrix, no-bypass contract</td>
+        <td>1</td>
+        <td>L0-ready packet</td>
+      </tr>
+      <tr>
+        <td>W1 - Shared consumer seam</td>
+        <td>frontend hook, Rust prompt projection, test fixtures, lint gates</td>
+        <td>3</td>
+        <td>shared contract merged</td>
+      </tr>
+      <tr>
+        <td>W2 - Daily Briefing</td>
+        <td>Tauri dashboard consumes <code>get_daily_briefing</code> / entity envelopes for claim-backed sections</td>
+        <td>2</td>
+        <td>first rendered app proof</td>
+      </tr>
+      <tr>
+        <td>W3 - Meeting Briefing</td>
+        <td><code>prepare_meeting</code> prompt input and meeting-detail render cutover</td>
+        <td>3</td>
+        <td>first PTY prompt proof</td>
+      </tr>
+      <tr>
+        <td>W4 - Entity Detail</td>
+        <td>Account, Project, Person detail pages consume the envelope</td>
+        <td>3</td>
+        <td>legacy detail split complete</td>
+      </tr>
+      <tr>
+        <td>W5 - Actions and Email</td>
+        <td>action surfaces and email summaries consume scored claims</td>
+        <td>2</td>
+        <td>downstream surfaces aligned</td>
+      </tr>
+      <tr>
+        <td>W6 - Release gate</td>
+        <td>drift, performance, no-bypass sweep, proof bundle</td>
+        <td>1</td>
+        <td>ship-ready cutover</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="reviewer-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reviewer matrix</p>
+    <h2 id="reviewer-matrix" class="plans-section-title">Prompt and privacy scope make security non-optional.</h2>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Agent profile</th>
+        <th>L0 domain reviewer</th>
+        <th>L2 domain reviewer</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Ability runtime / envelope contract</td>
+        <td><code>/plan-eng-review</code></td>
+        <td><code>architect-reviewer</code></td>
+      </tr>
+      <tr>
+        <td>Prompt-channel / PTY input</td>
+        <td><code>/cso</code></td>
+        <td><code>/cso</code> + <code>code-reviewer</code></td>
+      </tr>
+      <tr>
+        <td>Tauri user-facing render</td>
+        <td><code>/plan-design-review</code></td>
+        <td><code>accessibility-tester</code></td>
+      </tr>
+      <tr>
+        <td>Performance-sensitive read path</td>
+        <td><code>/plan-eng-review</code> with Suite P focus</td>
+        <td><code>performance-engineer</code></td>
+      </tr>
+      <tr>
+        <td>No-bypass / fixture gates</td>
+        <td><code>qa-expert</code></td>
+        <td><code>qa-expert</code></td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="suites">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Test suites</p>
+    <h2 id="suites" class="plans-section-title">S, P, and E feed L3 and W6.</h2>
+  </header>
+
+  <div class="suite-grid">
+    <article class="suite-card" data-suite="s">
+      <span class="suite-letter">S</span>
+      <h3 class="suite-name">Security</h3>
+      <p class="suite-prose">Prompt-input sensitivity, source-subject allowlists, ADR-0093 injection fixtures, provenance redaction, actor/exposure golden fixtures, and no raw prompt/output/claim text in app logs, MCP audit rows, SurfaceClient/local-loopback audit, PTY errors, diagnostics, or structured telemetry. Audit payloads are allowlisted to invocation ids, hashes, counts, byte sizes, enum states, source classes, and redaction flags.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>/cso</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> zero Critical/High</p>
+    </article>
+    <article class="suite-card" data-suite="p">
+      <span class="suite-letter">P</span>
+      <h3 class="suite-name">Performance</h3>
+      <p class="suite-prose">Daily Briefing and Meeting Detail render latency budgets, DB lock hold-time checks, explicit meeting/entity cardinality caps before pagination, maximum frontend ability calls per route refresh, ability envelope fan-out caps, and no repeated per-card/per-row ability calls.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>performance-engineer</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> no regression vs baseline</p>
+    </article>
+    <article class="suite-card" data-suite="e">
+      <span class="suite-letter">E</span>
+      <h3 class="suite-name">Edge cases</h3>
+      <p class="suite-prose">Empty envelopes, stale claims, superseded claims, revoked sources, partial producer availability, prompt drift, unlinked meetings, and cross-entity subject bleed.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>qa-expert</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> fixtures + no-bypass checks green</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="wave-details">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave details</p>
+    <h2 id="wave-details" class="plans-section-title">Acceptance criteria by wave.</h2>
+  </header>
+
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">W0 - Boundary and inventory</h3>
+      <p class="callout-prose">Inventory every Daily Briefing, Meeting Briefing, entity-detail, action, and email path that currently reads claim-backed intelligence. Classify each read as shell data, rendered claim-backed intelligence, prompt input, cached output, mutation, or operational telemetry.</p>
+      <p class="callout-prose"><strong>Pass:</strong> Linear issues exist for W1-W6; the main v1.4.4 packet records this Tauri-freeze exception; the no-bypass allowlist distinguishes shell/cache reads, stale bound snapshots, and claim-backed authority; prompt-channel matrix enumerates every channel touched by W1-W5 and cites the gate function plus fixture/lint for each; actor/exposure matrix freezes <code>allowed_actors</code>, <code>required_scopes</code>, <code>mcp_exposure</code>, and <code>client_side_executable</code> descriptor values; Daily Briefing shell-vs-claim split is frozen; W2/W3 minimum producer fields and degraded-state behavior are named; composition exception is recorded; root-route and Meeting Detail baselines plus Suite P cardinality caps are captured.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence-waves.html</code>, Linear issue bodies, and optional L0 packets under <code>.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/</code>.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W1 - Shared consumer seam</h3>
+      <p class="callout-prose">Create a small shared app-side consumer contract: a frontend ability hook for briefing/entity envelopes, a Rust prompt-safe projection from <code>EntityIntelligenceEnvelope</code>, and lint/tests that keep claim-backed briefing sections off legacy projection reads.</p>
+      <p class="callout-prose"><strong>Pass:</strong> <code>invoke_ability</code> can fetch briefing/entity envelopes for Tauri surfaces as <code>Actor::User</code>; a populated live <code>invoke_ability("get_daily_briefing", renderSurface="tauri_briefing_prep")</code> fixture succeeds with the daily-readiness reader registered and complete outer provenance attribution; prompt-safe projection contains scored facts, open loops, touchpoints, trust, caveats, sensitivity, and provenance refs; high-sensitivity claims are absent from prompt JSON through the centralized sensitivity gate; any abilities-runtime mirror of the gate has a parity test against <code>services::claims</code>; projection applies subject allowlist, wrapping/sanitization or equivalent JSON-boundary defense, length and invisible-character controls; no-bypass test fails red against at least one known legacy source before implementation makes it green; no <code>Agent</code>, <code>McpClient</code>, or new <code>SurfaceClient</code> exposure is introduced; existing MCP/SurfaceClient reachable abilities get golden response/redaction regressions.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>src/hooks/useEntityIntelligence.ts</code>, <code>src/services/entity-intelligence/contracts.ts</code>, <code>src/services/daily-briefing/contracts.ts</code>, <code>src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/*</code>, <code>src-tauri/abilities-runtime/src/abilities/prepare_meeting/*</code>, <code>src-tauri/src/services/context.rs</code>, and new scoped lint/tests.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W2 - Daily Briefing</h3>
+      <p class="callout-prose">Move claim-backed Daily Briefing intelligence to runtime envelopes while keeping dashboard shell data in the existing fast dashboard service. The dashboard may still load schedule, actions, emails, and UI shell through <code>get_dashboard_data</code>; claim-backed attention, trust, source-as-of, watch proposals, and linked-entity readiness come from the ability path.</p>
+      <p class="callout-prose"><strong>Pass:</strong> <code>DailyBriefing.tsx</code> renders ability-backed briefing state/trust/provenance for the W0-frozen claim-backed sections using <code>rendered_provenance</code> for user-visible provenance; existing dashboard tests cover empty/loading/stale states; new tests prove the rendered intelligence does not come from legacy AI JSON or legacy DB entity-intelligence projection; root-route render does not regress beyond the W0 budget; Suite P fails per-card ability fan-out in <code>DailyBriefing</code> or <code>BriefingMeetingCard</code>; missing producer fields show typed degraded state instead of empty confidence.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>src/hooks/useDashboardData.ts</code>, <code>src/components/dashboard/DailyBriefing.tsx</code>, <code>src/components/dashboard/BriefingMeetingCard.tsx</code>, <code>src-tauri/src/services/dashboard.rs</code>, <code>src-tauri/abilities-runtime/src/abilities/get_daily_briefing/*</code>, and daily-briefing golden tests.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W3 - Meeting Briefing</h3>
+      <p class="callout-prose">Feed <code>prepare_meeting</code> from scored entity-intelligence envelopes instead of raw claim/context assemblers where the content is claim-backed. Preserve <code>prep_context_json</code> and <code>prep_frozen_json</code> as cached output/read models, not as authoritative prompt input. Bump prompt template versions when prompt input shape changes. W3 chooses one Meeting Detail render seam before coding: extend <code>get_meeting_intelligence</code> with a meeting/entity envelope adjunct, or add a separate <code>useMeetingEntityIntelligence(meetingId)</code> hook.</p>
+      <p class="callout-prose"><strong>Pass:</strong> <code>prepare_meeting</code> descriptor, provenance, and prompt fixtures prove <code>get_entity_intelligence</code> or a named projection ability is the claim-backed composed source; any remaining direct <code>get_entity_context</code> or raw claim reads are explicitly allowlisted as shell/cache reads; meeting briefing generation includes prompt-safe entity intelligence in canonical prompt JSON; <code>prepare_meeting_prep</code> template version and fingerprint drift are updated per ADR-0106; existing prompt sensitivity fixtures still pass; new fixtures prove revoked/private/adjacent-subject claims are excluded; Meeting Detail render uses <code>rendered_provenance</code> for claim-backed briefing sections; the chosen render seam names merge precedence with <code>prep_context_json</code>/<code>prep_frozen_json</code> and partial/failure behavior keeps the prior briefing visible while rebuilding.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>src-tauri/abilities-runtime/src/abilities/prepare_meeting/synthesis.rs</code>, <code>src-tauri/abilities-runtime/src/abilities/prepare_meeting/prompts.rs</code>, <code>src-tauri/src/services/meetings.rs</code>, <code>src-tauri/src/meeting_prep_queue.rs</code>, <code>src/pages/MeetingDetailPage.tsx</code>, and prepare-meeting fixtures.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W4 - Entity Detail</h3>
+      <p class="callout-prose">Apply the same split to Account, Project, and Person detail pages: operational detail commands remain for shell/navigation/mutations; claim-backed intelligence sections consume <code>get_entity_intelligence</code> through the shared frontend hook.</p>
+      <p class="callout-prose"><strong>Pass:</strong> Account, Project, and Person detail pages render facts, open loops, touchpoints, health/relationship sections, trust, and provenance from the envelope; no-bypass tests reject legacy detail command intelligence as the rendered source; existing editor/mutation workflows keep working.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>src/hooks/useAccountDetail.ts</code>, <code>src/hooks/useProjectDetail.ts</code>, <code>src/hooks/usePersonDetail.ts</code>, <code>src/pages/AccountDetailPage.tsx</code>, <code>src/pages/ProjectDetailEditorial.tsx</code>, <code>src/pages/PersonDetailEditorial.tsx</code>, and entity-intelligence contract tests.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W5 - Actions and Email</h3>
+      <p class="callout-prose">Move action and email surfaces to the same scored-claim read policy for suggestions, summaries, and claim receipts. Keep action/email operational rows and mutations in their existing services, but route claim-backed analysis through runtime envelopes or dedicated abilities that compose them.</p>
+      <p class="callout-prose"><strong>Pass:</strong> action suggestions and email summaries show trust/provenance where they depend on claims; correction/dismissal feedback carries surface context; prompt-input email enrichment does not reintroduce raw entity-intelligence projection reads.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> <code>src/pages/ActionsPage.tsx</code>, <code>src/pages/EmailsPage.tsx</code>, <code>src-tauri/src/prepare/email_enrich.rs</code>, <code>src-tauri/src/commands/actions_calendar.rs</code>, <code>src-tauri/src/services/claim_receipt/*</code>, and action/email surface tests.</p>
+    </article>
+
+    <article class="callout">
+      <h3 class="callout-title">W6 - Release gate</h3>
+      <p class="callout-prose">Run the integrated no-bypass, prompt-safety, performance, and drift sweeps. Capture proof that the two kickstart surfaces and the downstream surfaces agree on the same scored claims rather than diverging projections.</p>
+      <p class="callout-prose"><strong>Pass:</strong> <code>cargo clippy -- -D warnings</code>, <code>cargo test</code>, <code>pnpm tsc --noEmit</code>, briefing surface QA, Suite S/P/E, L5 drift, and proof bundle all pass. Any Path-alpha findings move to maintenance instead of blocking once acceptance criteria are met.</p>
+      <p class="callout-prose"><strong>Likely files:</strong> proof bundle and retro under <code>.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/</code>, plus any CI lint scripts created in W1.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="invariants">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">CI invariants</p>
+    <h2 id="invariants" class="plans-section-title">The plan needs structural gates, not reviewer memory.</h2>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Invariant</th>
+        <th>Mechanism</th>
+        <th>Activated by</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Prompt input uses centralized sensitivity policy</td>
+        <td>Rust tests over canonical prompt JSON plus scoped grep/lint for new prompt assemblers using <code>prompt_input_sensitivity_allowed</code> and <code>prompt_input_sensitivity_name_allowed</code></td>
+        <td>W1</td>
+      </tr>
+      <tr>
+        <td>Existing non-Tauri exposure does not regress</td>
+        <td>Actor/exposure matrix fixture for User, Agent/MCP, and SurfaceClient paths; asserts actor-filtered response shape, diagnostics omission, source-id masking, and provenance redaction</td>
+        <td>W1-W4</td>
+      </tr>
+      <tr>
+        <td>Audit sinks never persist prompt or raw rendered intelligence</td>
+        <td>Fixture scans app logs, MCP audit rows, SurfaceClient/local-loopback audit, PTY errors, diagnostics, and structured telemetry. Allowed payload: invocation ids, hashes, counts, byte sizes, enum states, source classes, redaction flags. Forbidden payload: raw prompt JSON, provider output, raw ability data, raw source ids, raw provenance labels, and claim text outside intentional actor-filtered render.</td>
+        <td>W1, W3, W6</td>
+      </tr>
+      <tr>
+        <td>Daily Briefing claim-backed sections do not source legacy projections</td>
+        <td>Frontend tests + scoped no-bypass script covering dashboard and daily briefing paths</td>
+        <td>W2</td>
+      </tr>
+      <tr>
+        <td>Meeting Briefing prompt inputs include scored envelope context</td>
+        <td>Prepare-meeting descriptor/provenance/prompt fixture asserts <code>get_entity_intelligence</code> composition, prompt canonical JSON shape, prompt-template version/fingerprint drift, and redaction behavior</td>
+        <td>W3</td>
+      </tr>
+      <tr>
+        <td>Entity detail pages consume envelope for intelligence sections</td>
+        <td>Hook/component tests and no-bypass script for Account, Project, and Person paths</td>
+        <td>W4</td>
+      </tr>
+      <tr>
+        <td>Actions/email do not bypass claim substrate for analysis text</td>
+        <td>Scoped lint over action/email prompt builders and render selectors</td>
+        <td>W5</td>
+      </tr>
+      <tr>
+        <td>Surface render latency does not regress</td>
+        <td>Suite P baseline for root route and meeting detail before/after cutover; fail on &gt;10% regression or visible ability-path delay without L6 decision</td>
+        <td>W2, W3, W6</td>
+      </tr>
+      <tr>
+        <td>Daily Briefing avoids fan-out regression</td>
+        <td>Suite P fixture pins maximum meetings/entities processed before pagination, maximum frontend ability calls per root-route refresh, DB lock hold threshold, and representative fixture size</td>
+        <td>W0, W1, W2</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section plans-section-callouts">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">Pacing</h3>
+      <p class="callout-prose">W2 and W3 can run in parallel after W1 only if the prompt-safe projection contract, no-bypass allowlist, Daily split, and minimum producer gates are frozen. W4 does not start until Daily and Meeting proof both pass L2.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Bounding</h3>
+      <p class="callout-prose">The first PRs should not chase every PTY caller. They prove two surfaces and add the shared seam. Reports, entity detail, actions, and email follow in named waves.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Migration slots</h3>
+      <p class="callout-prose">None expected. If W1 discovers a needed schema or cache table, pause for a W0 amendment and claim slots from the active v1.4.4 migration block before coding.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="review-ladder">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Review ladder</p>
+    <h2 id="review-ladder" class="plans-section-title">L0 through L6 for this train.</h2>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Level</th>
+        <th>Applies</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>L0 Prep</td>
+        <td>Every wave packet</td>
+        <td><code>/plan-eng-review</code> default; add <code>/cso</code> for prompt/input/privacy waves and <code>/plan-design-review</code> for rendered surface changes.</td>
+      </tr>
+      <tr>
+        <td>L0 Plan</td>
+        <td>Every issue</td>
+        <td>Codex challenge + domain reviewer + Codex consult. <code>/cso</code> required for W1, W3, W5 and any wave that changes render policy or prompt inputs.</td>
+      </tr>
+      <tr>
+        <td>L1 Self</td>
+        <td>Every issue</td>
+        <td>Implementer proves acceptance with real fixtures. Passing clippy/tsc/tests is necessary but not sufficient.</td>
+      </tr>
+      <tr>
+        <td>L2 Diff</td>
+        <td>Every wave PR</td>
+        <td>Run locally before push. Codex review + code-reviewer + domain reviewer. Security re-review for prompt/privacy diffs.</td>
+      </tr>
+      <tr>
+        <td>L3 Wave</td>
+        <td>W1, W2+W3 integrated, W6</td>
+        <td>Codex challenge + architect-reviewer + Suite S/P/E. W2 and W3 may share an integrated L3 because the proof surfaces interlock.</td>
+      </tr>
+      <tr>
+        <td>L4 Surface</td>
+        <td>W2, W3, W4, W5</td>
+        <td><code>/qa-only</code> first, then <code>/qa</code> if remediation needed. Browser proof required for Daily Briefing and Meeting Detail.</td>
+      </tr>
+      <tr>
+        <td>L5 Drift</td>
+        <td>W6 close</td>
+        <td>Compare integrated state to this wave plan and the producer-remediation dependency list.</td>
+      </tr>
+      <tr>
+        <td>L6 Human</td>
+        <td>If escalated</td>
+        <td>James decides scope tradeoffs if prompt quality, latency, or surface completeness conflict.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="open-questions">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Open questions</p>
+    <h2 id="open-questions" class="plans-section-title">Resolve at W0, not during implementation.</h2>
+  </header>
+  <ul class="plans-related">
+    <li><strong>Linear topology:</strong> W0 should decide whether this lands as new v1.4.4a issues/milestones, as an amendment to existing W1/W3/W6 issues, or as a named parallel lane under the current v1.4.4 project. It is part of the v1.4.4 build window either way.</li>
+    <li><strong>Producer dependency gate:</strong> W0 must declare minimum producer fields for W2/W3 and the visible degraded state for each absent field.</li>
+    <li><strong>Prompt quality drift:</strong> W3 must decide whether meeting-briefing output parity means exact section parity or improved output with documented prompt-version drift and replay-fixture classification.</li>
+    <li><strong>Daily Briefing data split:</strong> W0 must pin which dashboard fields remain shell data from <code>get_dashboard_data</code> and which become ability-backed claim intelligence.</li>
+    <li><strong>No-bypass scope:</strong> W0 must freeze the exact file/path allowlist for legacy reads so legitimate shell/cache reads do not get blocked by overbroad grep tests.</li>
+    <li><strong>Workspace-memory adjacency:</strong> v1.4.5 file-ingestion substrate is adjacent producer work, not owned by this lane. If W2/W3 chooses file-derived claims as required inputs, W0 names that as a producer dependency instead of editing the v1.4.5 plan.</li>
+  </ul>
+</section>
+
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">Cross-references.</h2>
+  </header>
+  <ul class="plans-related">
+    <li><strong><code>engineering-ladder.html</code></strong> L0-L6 + K-channel + review matrix.</li>
+    <li><strong><code>src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/</code></strong> runtime envelope consumed by this plan.</li>
+    <li><strong><code>src-tauri/abilities-runtime/src/abilities/get_daily_briefing/</code></strong> existing daily briefing ability.</li>
+    <li><strong><code>src-tauri/abilities-runtime/src/abilities/prepare_meeting/</code></strong> meeting briefing transform ability and prompt fixtures.</li>
+    <li><strong><code>docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md</code></strong> required K-in for new prompt channels.</li>
+    <li><strong><code>v1.4.4a-tauri-briefing-entity-intelligence/reviews/L0-cycle1-summary.md</code></strong> L0 reviewer verdicts, folds, and final approval trail.</li>
+  </ul>
+</section>
+
+<div class="finis">
+  <div class="finis-mark">W0 - W1 - W2 - W3 - W4 - W5 - W6</div>
+  <div class="finis-date">v1.4.4a Tauri Briefing Entity Intelligence - 2026-05-23</div>
+  <div class="finis-caption">The substrate only matters if the app reads from it.</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/W6-proof-bundle.md
+++ b/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/W6-proof-bundle.md
@@ -1,0 +1,94 @@
+# v1.4.4a W6 Proof Bundle
+
+**Wave:** W6 release gate for claim-backed briefing and entity-intelligence surfaces
+**Status:** Local gate passed; pre-push L2 passed
+**Date:** 2026-05-24
+**Branch:** `codex/v1.4.4a-w6-release-gate`
+**Base:** `public/dev` after W5/W6 rebase (`4f3337df`)
+
+## Scope
+
+W6 is the release-gate pass for v1.4.4a. The goal is not a new surface; the goal is proving the claim-backed read path is safe, bounded, and usable across the surfaces touched by W1-W5:
+
+- Daily Briefing
+- Meeting Briefing
+- entity detail pages
+- suggested actions and work/email-adjacent reads
+- release-gate fixtures for foreground DB contention and no-bypass claim rendering
+
+## Subagent Findings Closed
+
+| Reviewer | Finding | Disposition |
+|---|---|---|
+| Security | Action-derived synthetic open-loop claims could become MCP-visible without a backing claim sensitivity decision. | Closed by suppressing synthetic action open-loop claim synthesis for MCP surfaces unless the item already has backing claim semantics. Added regression coverage. |
+| Security | `noise_reason` logging could persist raw model rationale text. | Closed by logging only the boolean `is_noise` decision and whether a reason was present. |
+| Performance | Daily Briefing expanded every meeting before pagination, creating avoidable claim/prep reads. | Closed by expanding only the current meeting, next meeting, and the requested upcoming page. Added bounded expansion regression. |
+| Performance | Entity intelligence loaded all active context claims before applying a display cap. | Closed by adding a limited claim reader, a SQL anti-join dismissal path, and a v263 SubjectRef expression index so the service reads bounded rows. Added capped-reader and query-plan regressions. |
+| Performance / Adversarial | The limited entity-context reader still applied the cap once per related subject, then globally truncated in memory. | Closed by routing limited related-subject reads through one batched SQL query with a single global `ORDER BY created_at DESC LIMIT`. Added a regression with multiple child subjects. |
+| Adversarial | Agent/MCP prompt-safe claims could disappear when non-prompt-safe claims filled the SQL page before actor filtering. | Closed by adding a prompt-safe limited reader that applies sensitivity filtering before the cap for Agent/MCP reads. Added regression coverage with newer confidential claims ahead of an older internal claim. |
+| Performance | Email refresh events could stack overlapping foreground reloads. | Closed by adding in-flight coalescing and debounced silent refresh. |
+| Testing | The W6 fixture script still pointed at an old WordPress-era gate. | Closed by wiring the release gate to `scripts/release-gate/run-v144a-w6-fixtures.sh` and the v1.4.4a fixture catalog. |
+| Testing | Prompt-safe-before-cap producer wiring covered MCP but not plain Agent. | Closed by parameterizing the producer regression across `Actor::Agent` and `Actor::McpClient`, and including that test in fixture 04. |
+| Security | Cargo-filtered fixture commands could pass while running zero tests. | Closed by adding a filtered-test helper that fails closed when a fixture filter does not resolve to a real test. |
+| Testing | Suite P evidence was smoke-only. | Closed by running published Suite P against `.docs/perf/baselines/scope-v1.4.1-W8.json`; 3/3 manifest benches passed with zero regressions. |
+
+## Implementation Evidence
+
+- `scripts/release-gate/run-v144a-w6-fixtures.sh` runs the v1.4.4a W6 local gate.
+- `scripts/suite-s.sh` now builds the MCP stub before clippy, runs the active writer-path lint, and invokes `cargo audit` against `src-tauri/Cargo.lock`.
+- Daily Briefing now sorts meetings once and bounds expensive expansion to visible/current records.
+- `get_entity_intelligence` now calls bounded claim readers, including prompt-safe pre-cap reads for Agent/MCP actors.
+- The live claims service uses globally bounded related-subject surface reads, anti-joins `claim_surface_dismissals`, and filters prompt-unsafe sensitivities before Agent/MCP page caps.
+- v263 adds an expression index for semantic SubjectRef lookups and skips cleanly for legacy partial schemas that do not yet have the full claims table shape.
+- MCP action rows no longer synthesize public prompt-visible claim text without a backing claim.
+- Email refresh events are debounced and coalesced while a load is already in flight.
+- The legacy DOS-412 render-policy migration fixture now includes the minimal `emails` table needed by later migrations.
+
+## Validation
+
+All commands below passed locally from the W6 worktree:
+
+```bash
+cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_expansion_ids_are_bounded_to_visible_page_current_and_next
+cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_producer_expands_only_current_next_and_requested_page
+cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_entity_sections_omit_open_loops_for_aggregate_pass
+cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib upcoming_meetings_cursor_roundtrip
+cargo test --manifest-path src-tauri/Cargo.toml --lib action_open_loop_synthesis_is_not_mcp_visible_without_claim_sensitivity
+cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_surface_limited_reader_caps_visible_claims
+cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_surface_limited_reader_applies_global_cap_across_related_subjects
+cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_prompt_claim_reader_filters_sensitivity_before_cap
+cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_subject_lookup_uses_expression_index
+cargo test --manifest-path src-tauri/Cargo.toml --lib migration_263_adds_claim_subject_lookup_index
+cargo test --manifest-path src-tauri/Cargo.toml --lib mcp_action_db_reader_filters_prompt_unsafe_claims_before_page_cap
+cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib agent_and_mcp_producer_read_prompt_safe_claims_before_page_cap
+cargo test --manifest-path src-tauri/Cargo.toml --features release-gate --test release_gate_hermetic_test
+cargo test --manifest-path src-tauri/Cargo.toml --test dos412_render_policy_test
+cargo test --manifest-path src-tauri/Cargo.toml --test dos168_mcp_v2_migration_smoke_test
+pnpm tsc --noEmit
+pnpm test -- src/pages/EmailsPage.test.tsx src/services/entity-intelligence/invoke.test.ts
+scripts/release-gate/run-v144a-w6-fixtures.sh
+scripts/suite-s.sh --scope v1.4.4a-W6 --out src-tauri/target/release-gate/v1.4.4a-suite-s.json
+scripts/suite-e.sh --scope v1.4.4a-W6 --out src-tauri/target/release-gate/v1.4.4a-suite-e.json
+scripts/suite-p.sh --mode published --scope v1.4.4a-W6 --run-id v1.4.4a-w6-published --out .docs/perf/runs/v1.4.4a-w6-published/record.json --baseline .docs/perf/baselines/scope-v1.4.1-W8.json
+cargo test --manifest-path src-tauri/Cargo.toml --lib -- --test-threads=1
+```
+
+Suite notes:
+
+- Suite S: passed.
+- Suite E: passed.
+- Suite P: published mode passed; bench count 3, missing 0, regressions 0, comparator `.docs/perf/baselines/scope-v1.4.1-W8.json`.
+- Pre-push L2: migration, security, performance, adversarial, and testing reviewers passed after the final global-cap and Agent/MCP producer-test fixes.
+- Rust lib suite: passed single-threaded after the DOS-412 legacy fixture drift fix (`2846 passed`, `11 ignored`). A normal full `cargo test --manifest-path src-tauri/Cargo.toml` attempt terminated with SIGBUS during the lib harness before reporting a deterministic assertion failure; the lib suite was rerun single-threaded to completion, and the focused release-gate integration test passed.
+- Post-rebase pre-commit surfaced parallel-test interference in key-rotation/global DB-service tests; fixed with a test-only rotation lock. Targeted parallel rotation cluster passed with `cargo test --manifest-path src-tauri/Cargo.toml --lib rotation -- --test-threads=8`.
+
+## Release-Gate Verdict
+
+W6 closes the known local release-gate gaps for v1.4.4a:
+
+- The main claim-backed surfaces render through bounded readers.
+- MCP prompt exposure does not get synthetic action text without backing claim sensitivity.
+- The foreground email refresh path avoids overlapping reload storms.
+- The release-gate fixtures now validate the v1.4.4a surfaces rather than stale WordPress setup work.
+
+Residual maintenance item: add route-level Suite P benchmarks for claim-backed Tauri surfaces beyond the current substrate benchmark manifest.

--- a/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/retro-W6.md
+++ b/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/retro-W6.md
@@ -1,0 +1,44 @@
+# v1.4.4a W6 Retro
+
+**Wave:** W6 release gate
+**Date:** 2026-05-24
+**Author:** Codex
+
+## What Went Right
+
+- The review agents found the right classes of issues before PR: security on MCP exposure/logging, performance on over-broad reads and reload storms, and testing on stale release-gate fixtures.
+- The fixes stayed close to the existing substrate instead of inventing a cache layer: bound the readers, avoid unnecessary expansion, and keep sensitivity decisions on claim-backed data.
+- Full `cargo test --manifest-path src-tauri/Cargo.toml` caught a real migration-fixture drift in the DOS-412 render-policy tests. The focused test had passed, but the full chain found that the old v143 fixture needed a minimal `emails` table for later migrations.
+- The published Suite P run replaced the earlier smoke-only evidence and compared the current bench manifest against the v1.4.1 W8 baseline with zero regressions.
+
+## What Went Wrong
+
+- The first W6 fixture script shape was inherited from the old WordPress setup work. That would have created false confidence for v1.4.4a because it did not exercise the briefing/entity surfaces.
+- Daily Briefing had a classic hidden cost: the displayed page was small, but the producer was expanding every meeting before pagination. That is the kind of issue that looks correct functionally and only shows up under realistic data volume.
+- Entity detail had the same shape: apply a cap after the full read. The correct fix was to push the limit into the service reader.
+- The first bounded related-subject implementation still capped per subject. Review caught that a parent with many children could still materialize too many rows, so the final fix uses one global SQL-bounded related-subject read.
+- The first claim-subject index migration was too optimistic for legacy partial schemas. The DOS-412 drift fixture forced the right shape: guard the migration by actual columns, then create the index only when the full claim table exists.
+- The first post-L2 bounded claim reader still filtered Agent/MCP prompt safety after the page cap. That could hide older safe claims behind newer confidential ones, so the final shape pushes prompt-safe filtering into the service query before limiting.
+
+## Decisions
+
+- Do not add a separate read cache database in W6. The immediate bottleneck was unbounded local reads and redundant expansion, not a missing architecture layer.
+- Do not expose synthetic action open-loop claim text to MCP without backing claim sensitivity. Tauri can show useful local action rows, but MCP/tool contexts need explicit claim/provenance semantics.
+- Treat route-level Suite P benchmarks as maintenance hardening after W6. The published substrate suite passes and the W6 regressions are covered, but route baselines should be added as their own bounded task.
+
+## Follow-Up
+
+- File maintenance work for route-level Suite P benchmarks across Daily Briefing, Meeting Briefing, entity detail, actions, and emails.
+- Keep the W6 fixture runner current as W7 or follow-up work extends more surfaces.
+
+## Final State
+
+- W6 local release gate: passed.
+- Suite S: passed.
+- Suite E: passed.
+- Suite P published: passed.
+- TypeScript check: passed.
+- Rust lib suite: passed single-threaded (`2846 passed`, `11 ignored`).
+- Release-gate integration test: passed.
+- Pre-push L2: passed after global-cap and Agent/MCP producer-test fixes.
+- Post-rebase rotation-test parallelism drift: fixed with a test-only lock; targeted rotation cluster passed under parallel test threads.

--- a/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/reviews/L0-cycle1-summary.md
+++ b/.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence/reviews/L0-cycle1-summary.md
@@ -1,0 +1,48 @@
+# v1.4.4a Tauri Briefing Entity Intelligence - L0 Cycle 1 Summary
+
+Date: 2026-05-23
+Plan: `.docs/plans/v1.4.4a-tauri-briefing-entity-intelligence-waves.html`
+Final status: APPROVED after cycle-1 folds
+
+## Panel
+
+| Lane | Initial verdict | Post-fold verdict |
+|---|---:|---:|
+| Adversarial document review | APPROVE-WITH-CONDITIONS | APPROVE |
+| Engineering feasibility | APPROVE-WITH-CONDITIONS | APPROVE |
+| Security lens | APPROVE-WITH-CONDITIONS | APPROVE |
+| Coherence / consult | BLOCK | APPROVE |
+
+## K-in
+
+Reviewed prior substrate and security decisions before scoring:
+
+- `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md`
+- ADR-0093 prompt-injection hardening
+- ADR-0106 prompt fingerprinting
+- ADR-0108 provenance rendering and privacy
+- ADR-0111 surface-independent ability invocation
+- ADR-0130 surface-independent composition contract
+- v1.4.4 master wave packet and W1 substrate context
+- Current source anchors for `get_entity_intelligence`, `get_daily_briefing`, `prepare_meeting`, Tauri `invoke_ability`, and dashboard/meeting render paths
+
+## Required Folds Landed
+
+1. Tauri-freeze exception: v1.4.4a is a scoped exception for existing Tauri surfaces, limited to data sourcing, actor-filtered trust/provenance rendering, and prompt-input plumbing. No new Tauri routes, visual patterns, UI features, or reskinning.
+2. Main v1.4.4 packet amendment: the Tauri-freeze exception is mirrored into `.docs/plans/v1.4.4-wp-surface-migration/L0-packet-wave-plan.md` and summarized in `.docs/plans/v1.4.4-waves.md`.
+3. Cache authority: `prep_context_json` and `prep_frozen_json` are cached display snapshots only. Current envelopes are authoritative for new prompt input and new claim-backed rendering.
+4. Prompt authority: only the Rust prompt-safe projection built from `EntityIntelligenceEnvelope` after the centralized `services::claims` prompt-channel sensitivity gate may enter canonical prompt JSON.
+5. Actor/exposure matrix: W0 freezes `allowed_actors`, `required_scopes`, `mcp_exposure`, and `client_side_executable` for touched abilities. `get_daily_briefing` target authority is User-only unless main W3/sub-L0 separately approves SurfaceClient execution.
+6. Existing non-Tauri exposure: `get_entity_intelligence` output changes require User/MCP/SurfaceClient golden fixtures for data shape, rendered text, provenance redaction, diagnostics omission, and source-id masking.
+7. Audit redaction: Suite S now covers app logs, MCP audit rows, SurfaceClient/local-loopback audit, PTY errors, diagnostics, and structured telemetry. Allowed audit payloads are only invocation ids, hashes, counts, byte sizes, enum states, source classes, and redaction flags.
+8. `prepare_meeting` composition: W3 must update descriptor, provenance, and prompt fixtures so `get_entity_intelligence` or a named projection ability is the claim-backed composed source.
+9. Rendered provenance boundary: Tauri UI must render user-visible trust/provenance from `AbilityResponseJson.rendered_provenance`; DTO-local provenance is refs/counts/bindings unless passed through actor/surface rendering.
+10. ADR-0130 boundary: this is a temporary envelope-rendered Tauri consumer exception. New substrate-authored composed output must use `Composition`.
+11. Live Daily Briefing gate: W1 must prove a populated live Tauri `invoke_ability("get_daily_briefing", renderSurface="tauri_briefing_prep")` fixture with the daily-readiness reader registered and complete outer provenance attribution.
+12. Suite P caps: W0/W1 must freeze route latency budgets, DB lock hold threshold, maximum meetings/entities processed before pagination, maximum frontend ability calls per route refresh, and representative fixture size.
+13. Meeting Detail seam: W3 must choose either a `get_meeting_intelligence` envelope adjunct or a separate `useMeetingEntityIntelligence(meetingId)` hook, with merge precedence and failure behavior named.
+14. Workspace-memory adjacency: v1.4.5 file-ingestion substrate is adjacent producer work, not owned by this lane.
+
+## Final Verdict
+
+L0 is approved for W0 issue authoring and implementation planning. W1 cannot start until W0 records the Tauri-freeze exception in Linear, resolves `get_daily_briefing` actor descriptor drift, freezes no-bypass/prompt/actor/performance matrices, and captures the required route baselines.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -190,14 +190,11 @@ while IFS= read -r file; do
   [ -z "$file" ] && continue
   case "$file" in
     src-tauri/src/migrations/*.sql)
-      added_lines="$(staged_added_lines "$file")"
-      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE[[:space:]]+TABLE|ALTER[[:space:]]+TABLE|DROP[[:space:]]+TABLE|ADD[[:space:]]+COLUMN|DROP[[:space:]]+COLUMN'; then
-        HAS_SCHEMA_CHANGE=true
-      fi
+      HAS_SCHEMA_CHANGE=true
       ;;
     src-tauri/src/db/*.rs|src-tauri/src/types.rs|src-tauri/src/intelligence/io.rs)
       added_lines="$(staged_added_lines "$file")"
-      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN|^\+[[:space:]]*pub (struct|enum) |INSERT (INTO|OR)|UPDATE [a-zA-Z_]+ SET|DELETE FROM'; then
+      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN|CREATE INDEX|DROP INDEX|^\+[[:space:]]*pub (struct|enum) |INSERT (INTO|OR)|UPDATE [a-zA-Z_]+ SET|DELETE FROM'; then
         HAS_SCHEMA_CHANGE=true
       fi
       ;;

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -190,11 +190,14 @@ while IFS= read -r file; do
   [ -z "$file" ] && continue
   case "$file" in
     src-tauri/src/migrations/*.sql)
-      HAS_SCHEMA_CHANGE=true
+      added_lines="$(staged_added_lines "$file")"
+      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE[[:space:]]+TABLE|ALTER[[:space:]]+TABLE|DROP[[:space:]]+TABLE|ADD[[:space:]]+COLUMN|DROP[[:space:]]+COLUMN'; then
+        HAS_SCHEMA_CHANGE=true
+      fi
       ;;
     src-tauri/src/db/*.rs|src-tauri/src/types.rs|src-tauri/src/intelligence/io.rs)
       added_lines="$(staged_added_lines "$file")"
-      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN|CREATE INDEX|DROP INDEX|^\+[[:space:]]*pub (struct|enum) |INSERT (INTO|OR)|UPDATE [a-zA-Z_]+ SET|DELETE FROM'; then
+      if printf '%s\n' "$added_lines" | grep -qiE 'CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN|^\+[[:space:]]*pub (struct|enum) |INSERT (INTO|OR)|UPDATE [a-zA-Z_]+ SET|DELETE FROM'; then
         HAS_SCHEMA_CHANGE=true
       fi
       ;;

--- a/scripts/release-gate/run-v144a-w6-fixtures.sh
+++ b/scripts/release-gate/run-v144a-w6-fixtures.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+ROOT_DIR="${V144A_W6_FIXTURE_ROOT:-${W6_FIXTURE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}}"
+OUTPUT_DIR="${V144A_W6_FIXTURE_OUTPUT_DIR:-${W6_FIXTURE_OUTPUT_DIR:-$ROOT_DIR/src-tauri/target/release-gate}}"
+REPORT_PATH="${V144A_W6_FIXTURE_REPORT:-${W6_FIXTURE_REPORT:-$OUTPUT_DIR/v144a-w6-fixtures.json}}"
+GIT_SHA="${V144A_W6_FIXTURE_GIT_SHA:-${W6_FIXTURE_GIT_SHA:-$(cd "$ROOT_DIR" && git rev-parse HEAD 2>/dev/null || printf unknown)}}"
+FIXTURES_HASH="${V144A_W6_FIXTURE_FIXTURES_HASH:-${W6_FIXTURE_FIXTURES_HASH:-unknown}}"
+
+mkdir -p "$OUTPUT_DIR"
+RESULTS_TSV="$(mktemp)"
+trap 'rm -f "$RESULTS_TSV"' EXIT
+
+cargo_filtered_test() {
+  local expected_test="$1"
+  shift
+  local list_output
+
+  if ! list_output=$("$@" -- --list 2>&1); then
+    printf '%s\n' "$list_output" >&2
+    return 1
+  fi
+  if ! printf '%s\n' "$list_output" | grep -F -- "$expected_test" >/dev/null; then
+    printf 'FAIL: expected cargo test filter not listed: %s\n' "$expected_test" >&2
+    printf '%s\n' "$list_output" >&2
+    return 1
+  fi
+
+  "$@"
+}
+
+run_fixture() {
+  local id="$1"
+  local owner_issue="$2"
+  local expected="$3"
+  local command="$4"
+  local status="pass"
+
+  printf 'v1.4.4a W6 fixture %s: %s\n' "$id" "$expected"
+  mkdir -p "$OUTPUT_DIR" "$ROOT_DIR/src-tauri/target/debug/deps"
+  if (cd "$ROOT_DIR" && eval "$command"); then
+    status="pass"
+  else
+    status="fail"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\n' "$id" "$owner_issue" "$expected" "$command" "$status" >>"$RESULTS_TSV"
+}
+
+run_fixture "v144a-w6-01-frontend-surface-contracts" "DOS-514" "Daily, meeting, entity, actions, and email-adjacent surface tests pass against claim-backed readers" \
+  "pnpm test -- src/components/dashboard/DailyBriefing.test.tsx src/hooks/useDailyBriefingAbility.test.tsx src/hooks/useMeetingEntityIntelligence.test.tsx src/hooks/useEntityDetailIntelligence.test.tsx src/services/entity-intelligence/entity-detail-mapper.test.ts src/components/shared/SuggestedActionRow.test.tsx src/components/work/WorkSurface.test.tsx src/lib/email-ranking.test.ts"
+
+run_fixture "v144a-w6-02-daily-briefing-bounded-expansion" "DOS-514" "Daily Briefing expands current, next, and visible upcoming meetings only" \
+  "cargo_filtered_test daily_briefing_expansion_ids_are_bounded_to_visible_page_current_and_next cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_expansion_ids_are_bounded_to_visible_page_current_and_next && cargo_filtered_test daily_briefing_producer_expands_only_current_next_and_requested_page cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_producer_expands_only_current_next_and_requested_page && cargo_filtered_test daily_briefing_entity_sections_omit_open_loops_for_aggregate_pass cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib daily_briefing_entity_sections_omit_open_loops_for_aggregate_pass"
+
+run_fixture "v144a-w6-03-daily-briefing-cursor" "DOS-514" "Daily Briefing upcoming cursor remains stable after bounded expansion" \
+  "cargo_filtered_test upcoming_meetings_cursor_roundtrip cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib upcoming_meetings_cursor_roundtrip"
+
+run_fixture "v144a-w6-04-entity-claim-read-cap" "DOS-514" "Entity intelligence claim reader applies prompt-safe filtering, subject indexes, and a page cap before rendering" \
+  "cargo_filtered_test entity_context_surface_limited_reader_caps_visible_claims cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_surface_limited_reader_caps_visible_claims && cargo_filtered_test entity_context_surface_limited_reader_applies_global_cap_across_related_subjects cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_surface_limited_reader_applies_global_cap_across_related_subjects && cargo_filtered_test entity_context_subject_lookup_uses_expression_index cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_subject_lookup_uses_expression_index && cargo_filtered_test entity_context_prompt_claim_reader_filters_sensitivity_before_cap cargo test --manifest-path src-tauri/Cargo.toml --lib entity_context_prompt_claim_reader_filters_sensitivity_before_cap && cargo_filtered_test agent_and_mcp_producer_read_prompt_safe_claims_before_page_cap cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml --lib agent_and_mcp_producer_read_prompt_safe_claims_before_page_cap && cargo_filtered_test migration_262_adds_claim_subject_lookup_index cargo test --manifest-path src-tauri/Cargo.toml --lib migration_262_adds_claim_subject_lookup_index"
+
+run_fixture "v144a-w6-05-mcp-action-redaction" "DOS-514" "Action-derived open-loop claims are not synthesized into MCP prompt context without claim sensitivity" \
+  "cargo_filtered_test action_open_loop_synthesis_is_not_mcp_visible_without_claim_sensitivity cargo test --manifest-path src-tauri/Cargo.toml --lib action_open_loop_synthesis_is_not_mcp_visible_without_claim_sensitivity && cargo_filtered_test mcp_action_db_reader_filters_prompt_unsafe_claims_before_page_cap cargo test --manifest-path src-tauri/Cargo.toml --lib mcp_action_db_reader_filters_prompt_unsafe_claims_before_page_cap"
+
+run_fixture "v144a-w6-06-entity-fixture-harness" "DOS-514" "Entity fixture harness still passes after claim-reader routing changes" \
+  "cargo test --manifest-path src-tauri/Cargo.toml --test entity_fixture_harness"
+
+run_fixture "v144a-w6-07-foreground-contention" "DOS-514" "Foreground DB contention regression harness stays green" \
+  "cargo test --manifest-path src-tauri/Cargo.toml --test foreground_db_contention_regression"
+
+run_fixture "v144a-w6-08-email-refresh-coalescing" "DOS-514" "Email refresh events coalesce so foreground reads do not stampede after background updates" \
+  "pnpm test -- src/pages/EmailsPage.test.tsx"
+
+run_fixture "v144a-w6-09-dos412-render-policy-drift" "DOS-514" "Legacy render-policy migration fixture remains compatible with current surface rules" \
+  "cargo test --manifest-path src-tauri/Cargo.toml --test dos412_render_policy_test"
+
+run_fixture "v144a-w6-10-dos168-mcp-migration-drift" "DOS-514" "Legacy MCP v2 migration smoke test remains compatible with current nonce cleanup rules" \
+  "cargo_filtered_test dos168_v255_v261_migrations_land_canonical_schema cargo test --manifest-path src-tauri/Cargo.toml --test dos168_mcp_v2_migration_smoke_test"
+
+python3 - "$RESULTS_TSV" "$REPORT_PATH" "$GIT_SHA" "$FIXTURES_HASH" <<'PY'
+import csv
+import json
+import os
+import sys
+
+tsv_path, report_path, git_sha, fixtures_hash = sys.argv[1:5]
+fixtures = []
+with open(tsv_path, newline="", encoding="utf-8") as handle:
+    for row in csv.reader(handle, delimiter="\t"):
+        if not row:
+            continue
+        fixture_id, owner_issue, expected, command, status = row
+        fixtures.append(
+            {
+                "id": fixture_id,
+                "owner_issue": owner_issue,
+                "expected": expected,
+                "proof_command": command,
+                "status": status,
+            }
+        )
+
+failed = [fixture for fixture in fixtures if fixture["status"] != "pass"]
+report = {
+    "schema_version": "v144a_w6_fixture_results_v1",
+    "status": "pass" if not failed else "fail",
+    "git_sha": git_sha,
+    "fixtures_hash": fixtures_hash,
+    "total": len(fixtures),
+    "passed": len(fixtures) - len(failed),
+    "failed": len(failed),
+    "skipped": 0,
+    "fixtures": fixtures,
+}
+
+os.makedirs(os.path.dirname(report_path), exist_ok=True)
+with open(report_path, "w", encoding="utf-8") as handle:
+    json.dump(report, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+sys.exit(1 if failed else 0)
+PY
+report_status=$?
+
+if [ "$report_status" -ne 0 ]; then
+  echo "FAIL: one or more v1.4.4a W6 fixtures failed; see $REPORT_PATH" >&2
+  exit 1
+fi
+
+echo "PASS: v1.4.4a W6 fixtures passed; report at $REPORT_PATH"

--- a/scripts/suite-s.sh
+++ b/scripts/suite-s.sh
@@ -32,15 +32,15 @@ trap 'rm -f "$OAUTH_SECRET_SCAN_SCRIPT"' EXIT
 # Each entry: "label::command"
 CHECKS=(
   "service-layer-boundary::./scripts/check_service_layer_boundary.sh"
-  "no-let-underscore::./scripts/check_no_let_underscore_feedback.sh"
+  "no-let-underscore::bash src-tauri/scripts/check_no_let_underscore_in_writer_paths.sh"
   "write-fence-usage::./scripts/check_write_fence_usage.sh"
   "ability-surface-drift::bash src-tauri/scripts/check_ability_surface_drift.sh"
   "no-live-external-clients::bash src-tauri/scripts/check_no_live_external_clients_in_eval.sh"
   "fixture-anonymization::bash src-tauri/scripts/check_fixture_anonymization.sh"
   "durable-source-comments::./scripts/check_no_ephemeral_issue_refs_in_comments.sh"
   "oauth-secret-scan::bash \"$OAUTH_SECRET_SCAN_SCRIPT\""
-  "clippy-deny-warnings::cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-features --lib --bins -- -D warnings"
-  "cargo-audit::cd src-tauri && cargo audit --file audit.toml"
+  "clippy-deny-warnings::bash src-tauri/scripts/build-mcp.sh --stub && cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-features --lib --bins -- -D warnings"
+  "cargo-audit::cargo audit --file src-tauri/Cargo.lock"
 )
 
 # Inline OAuth secret scan (matches CI policy step)
@@ -61,19 +61,19 @@ first=1
 for entry in "${CHECKS[@]}"; do
   label="${entry%%::*}"
   cmd="${entry#*::}"
+  log_path="/tmp/suite-s-${label}.log"
   total=$((total + 1))
 
   echo "─── Suite S: $label ───" >&2
-  if eval "$cmd" >/tmp/suite-s-${label}.log 2>&1; then
+  if (cd "$REPO_ROOT" && eval "$cmd") >"$log_path" 2>&1; then
     status="pass"
   else
     status="fail"
     failed=$((failed + 1))
-    cat /tmp/suite-s-${label}.log >&2 || true
+    cat "$log_path" >&2 || true
   fi
 
   if [[ $first -eq 1 ]]; then first=0; else results_json+=","; fi
-  log_path="/tmp/suite-s-${label}.log"
   results_json+="{\"check\":\"$label\",\"status\":\"$status\",\"log\":\"$log_path\"}"
 done
 

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
@@ -1,8 +1,8 @@
+use crate::abilities::provenance::trust::claim_trust_band_from_score;
 use crate::abilities::provenance::{
     AbilityExecutionMode, AbilityVersion, FieldAttribution, FieldPath, ProvenanceBuilder,
     ProvenanceBuilderConfig, SchemaVersion, SubjectAttribution, SubjectRef,
 };
-use crate::abilities::provenance::trust::claim_trust_band_from_score;
 use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
 };
@@ -22,7 +22,12 @@ pub async fn entity_intake(
     let receipt = ctx
         .services()
         .workspace_intake()
-        .ok_or_else(|| hard_error("WorkspaceIntakeUnavailable", "workspace intake service unavailable"))?
+        .ok_or_else(|| {
+            hard_error(
+                "WorkspaceIntakeUnavailable",
+                "workspace intake service unavailable",
+            )
+        })?
         .ingest(
             ctx,
             WorkspaceIntakeRequest {
@@ -101,7 +106,10 @@ async fn read_claims_for_block_render(
         .collect())
 }
 
-fn project_claim(claim: IntelligenceClaim, render_actor: &RenderActor) -> Option<EntityIntakeClaim> {
+fn project_claim(
+    claim: IntelligenceClaim,
+    render_actor: &RenderActor,
+) -> Option<EntityIntakeClaim> {
     let rendered = renderable_claim_text_with_value(
         &claim,
         &claim.text,
@@ -149,7 +157,9 @@ fn workspace_intake_error(error: WorkspaceIntakeError) -> AbilityError {
         WorkspaceIntakeError::InvalidEntityTypeSlug(value) => {
             hard_error("InvalidEntityType", value)
         }
-        WorkspaceIntakeError::InvalidEntityId => hard_error("InvalidEntityId", "entity_id is invalid"),
+        WorkspaceIntakeError::InvalidEntityId => {
+            hard_error("InvalidEntityId", "entity_id is invalid")
+        }
         WorkspaceIntakeError::EntityNotFound => hard_error("EntityNotFound", "entity not found"),
         WorkspaceIntakeError::InvalidCategorySlug(value) => {
             hard_error("InvalidCategorySlug", value)

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
@@ -16,7 +16,7 @@
 //! `call_graph_lint::briefing_producer_contains_no_mutations` test below
 //! (AC-507.7).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::contracts::{
     AmbiguityPair, BriefingAdvisory, BriefingAvailability, BriefingEmptyReason, BriefingFreshness,
@@ -84,18 +84,37 @@ pub async fn build_daily_briefing(
         }
     };
 
-    let meetings: Vec<&DailyReadinessMeetingSnapshot> = readiness.meetings.iter().collect();
+    let mut meetings: Vec<&DailyReadinessMeetingSnapshot> = readiness.meetings.iter().collect();
+    sort_meeting_snapshots(&mut meetings);
 
     if meetings.is_empty() {
         return empty_no_meetings(&input, workspace_id).into_envelope(ctx, input.schema_version);
     }
+
+    // Daily Briefing may run on unusually dense calendar days. Keep the
+    // authoritative meeting list for cursor totals, but only expand prep
+    // status and entity envelopes for what this invocation can render:
+    // current + next + the requested upcoming page.
+    let now = ctx.services().clock.now();
+    let (current_meeting_seed, next_meeting_seed) =
+        pick_current_and_next_snapshots(&meetings, &now);
+    let upcoming_meeting_seeds =
+        paginate_upcoming_snapshots(&meetings, input.upcoming_meetings_cursor.as_ref());
+    let expansion_ids = collect_expansion_meeting_ids(
+        current_meeting_seed.as_ref(),
+        next_meeting_seed.as_ref(),
+        &upcoming_meeting_seeds.items,
+    );
 
     // ---- compose: per-meeting prep status ---------------------------------
     let mut prep_snapshots: BTreeMap<String, MeetingPrepStatusSnapshot> = BTreeMap::new();
     let mut prep_read_failures: Vec<String> = Vec::new();
     let mut needs_prep_meeting_ids: Vec<String> = Vec::new();
 
-    for meeting in &meetings {
+    for meeting in meetings
+        .iter()
+        .filter(|meeting| expansion_ids.contains(&meeting.id))
+    {
         match ctx
             .services()
             .read_meeting_prep_status(meeting.id.clone())
@@ -120,20 +139,18 @@ pub async fn build_daily_briefing(
     }
 
     // ---- compose: meeting brief refs --------------------------------------
-    let mut meeting_refs: Vec<MeetingBriefRef> = meetings
-        .iter()
-        .map(|meeting| project_meeting_brief(meeting, prep_snapshots.get(&meeting.id)))
-        .collect();
-    // Sort by starts_at with undated meetings (None) sorted AFTER dated
-    // ones (cycle-2 fix for codex P3 — `Option::cmp` defaults to None < Some
-    // which pushed undated meetings to the FRONT of the cursor, contradicting
-    // the comment + AC-507.6 stable-cursor expectation).
-    meeting_refs.sort_by(|a, b| match (a.starts_at.as_ref(), b.starts_at.as_ref()) {
-        (Some(left), Some(right)) => left.cmp(right),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => std::cmp::Ordering::Equal,
-    });
+    let current_meeting = current_meeting_seed
+        .as_ref()
+        .map(|meeting| project_meeting_brief(meeting, prep_snapshots.get(&meeting.id)));
+    let next_meeting = next_meeting_seed
+        .as_ref()
+        .map(|meeting| project_meeting_brief(meeting, prep_snapshots.get(&meeting.id)));
+    let upcoming_meetings = project_upcoming_meetings(upcoming_meeting_seeds, &prep_snapshots);
+    let expanded_meeting_refs = collect_expanded_meeting_refs(
+        current_meeting.as_ref(),
+        next_meeting.as_ref(),
+        &upcoming_meetings.items,
+    );
 
     // ---- compose: per-linked-entity envelopes -----------------------------
     // The L0 contract calls for per-subject `get_entity_intelligence`
@@ -141,7 +158,7 @@ pub async fn build_daily_briefing(
     // of building the integrity + trust summary; they do not need to be
     // emitted back through this envelope verbatim because the W3 briefing
     // block re-invokes `get_entity_intelligence` for any deeper drill-in.
-    let linked_entities = collect_linked_entities(&meeting_refs);
+    let linked_entities = collect_linked_entities(&expanded_meeting_refs);
     let mut envelope_provenance = EnvelopeProvenance::empty();
     let mut superseded_claim_ids: Vec<String> = Vec::new();
     let mut aggregate_sensitivity = ClaimSensitivity::Public;
@@ -157,7 +174,7 @@ pub async fn build_daily_briefing(
             entity_type: entity_type.clone(),
             entity_id: entity_id.clone(),
             depth: ContextDepth::Shallow,
-            sections: Some(vec![EnvelopeSection::Facts, EnvelopeSection::OpenLoops]),
+            sections: Some(daily_briefing_entity_sections()),
         };
         match build_entity_intelligence(ctx, env_input).await {
             Ok(envelope_output) => {
@@ -184,19 +201,11 @@ pub async fn build_daily_briefing(
         }
     }
 
-    // ---- compose: current + next meeting ----------------------------------
-    let now = ctx.services().clock.now();
-    let (current_meeting, next_meeting) = pick_current_and_next(&meeting_refs, &now);
-
-    // ---- compose: pagination over upcoming meetings (AC-507.10) ----------
-    let upcoming_meetings =
-        paginate_upcoming(&meeting_refs, input.upcoming_meetings_cursor.as_ref());
-
     // ---- compose: candidate set -------------------------------------------
     let candidate_set = build_candidate_set(&readiness);
 
     // ---- compose: state (4-tuple) -----------------------------------------
-    let availability = if matches!(meeting_refs.len(), 0) {
+    let availability = if matches!(meetings.len(), 0) {
         BriefingAvailability::Empty {
             reason: BriefingEmptyReason::NoMeetings,
         }
@@ -208,7 +217,7 @@ pub async fn build_daily_briefing(
     let integrity = derive_integrity(&superseded_claim_ids);
     let advisories = derive_advisories(
         &readiness,
-        &meeting_refs,
+        &expanded_meeting_refs,
         &prep_read_failures,
         &envelope_failures,
     );
@@ -339,6 +348,49 @@ fn project_meeting_brief(
     }
 }
 
+fn sort_meeting_snapshots(meetings: &mut Vec<&DailyReadinessMeetingSnapshot>) {
+    // Sort by starts_at with undated meetings (None) sorted AFTER dated ones.
+    // `Option::cmp` defaults to None < Some, which would push undated
+    // meetings to the front and make the cursor unstable.
+    meetings.sort_by(|a, b| match (a.starts_at.as_ref(), b.starts_at.as_ref()) {
+        (Some(left), Some(right)) => left.cmp(right),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+}
+
+fn collect_expansion_meeting_ids(
+    current: Option<&DailyReadinessMeetingSnapshot>,
+    next: Option<&DailyReadinessMeetingSnapshot>,
+    upcoming: &[DailyReadinessMeetingSnapshot],
+) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    if let Some(meeting) = current {
+        ids.insert(meeting.id.clone());
+    }
+    if let Some(meeting) = next {
+        ids.insert(meeting.id.clone());
+    }
+    ids.extend(upcoming.iter().map(|meeting| meeting.id.clone()));
+    ids
+}
+
+fn collect_expanded_meeting_refs(
+    current: Option<&MeetingBriefRef>,
+    next: Option<&MeetingBriefRef>,
+    upcoming: &[MeetingBriefRef],
+) -> Vec<MeetingBriefRef> {
+    let mut seen = BTreeSet::new();
+    let mut refs = Vec::new();
+    for meeting in current.into_iter().chain(next).chain(upcoming.iter()) {
+        if seen.insert(meeting.meeting_id.clone()) {
+            refs.push(meeting.clone());
+        }
+    }
+    refs
+}
+
 fn collect_linked_entities(meetings: &[MeetingBriefRef]) -> Vec<(EntityKind, String)> {
     let mut seen = std::collections::BTreeSet::new();
     let mut out = Vec::new();
@@ -367,6 +419,10 @@ fn parse_entity_kind(kind: &str) -> Option<EntityKind> {
         "person" => Some(EntityKind::Person),
         _ => None,
     }
+}
+
+fn daily_briefing_entity_sections() -> Vec<EnvelopeSection> {
+    vec![EnvelopeSection::Facts]
 }
 
 fn prep_status_is_needs_preparation(status: &str) -> bool {
@@ -448,12 +504,15 @@ fn rank_sensitivity(sensitivity: &ClaimSensitivity) -> u8 {
     }
 }
 
-fn pick_current_and_next(
-    meetings: &[MeetingBriefRef],
+fn pick_current_and_next_snapshots(
+    meetings: &[&DailyReadinessMeetingSnapshot],
     now: &chrono::DateTime<chrono::Utc>,
-) -> (Option<MeetingBriefRef>, Option<MeetingBriefRef>) {
-    let mut current: Option<MeetingBriefRef> = None;
-    let mut next: Option<MeetingBriefRef> = None;
+) -> (
+    Option<DailyReadinessMeetingSnapshot>,
+    Option<DailyReadinessMeetingSnapshot>,
+) {
+    let mut current: Option<DailyReadinessMeetingSnapshot> = None;
+    let mut next: Option<DailyReadinessMeetingSnapshot> = None;
     for meeting in meetings {
         let Some(starts_at) = meeting.starts_at.as_deref() else {
             continue;
@@ -470,21 +529,21 @@ fn pick_current_and_next(
 
         if let Some(end) = ends_at_utc {
             if starts_at_utc <= *now && *now < end && current.is_none() {
-                current = Some(meeting.clone());
+                current = Some((*meeting).clone());
                 continue;
             }
         }
         if starts_at_utc > *now && next.is_none() {
-            next = Some(meeting.clone());
+            next = Some((*meeting).clone());
         }
     }
     (current, next)
 }
 
-fn paginate_upcoming(
-    meetings: &[MeetingBriefRef],
+fn paginate_upcoming_snapshots(
+    meetings: &[&DailyReadinessMeetingSnapshot],
     cursor: Option<&Cursor>,
-) -> Paginated<MeetingBriefRef> {
+) -> Paginated<DailyReadinessMeetingSnapshot> {
     let offset = cursor
         .and_then(|c| parse_cursor_offset(c.as_str()))
         .unwrap_or(0);
@@ -493,7 +552,7 @@ fn paginate_upcoming(
         .iter()
         .skip(offset)
         .take(UPCOMING_MEETINGS_PAGE_SIZE)
-        .cloned()
+        .map(|meeting| (*meeting).clone())
         .collect::<Vec<_>>();
     let consumed = offset + slice.len();
     let next_cursor = if consumed < meetings.len() {
@@ -506,6 +565,22 @@ fn paginate_upcoming(
         next_cursor,
         total_hint: Some(total),
         cursor_state: CursorState::Stable,
+    }
+}
+
+fn project_upcoming_meetings(
+    page: Paginated<DailyReadinessMeetingSnapshot>,
+    prep_snapshots: &BTreeMap<String, MeetingPrepStatusSnapshot>,
+) -> Paginated<MeetingBriefRef> {
+    Paginated {
+        items: page
+            .items
+            .iter()
+            .map(|meeting| project_meeting_brief(meeting, prep_snapshots.get(&meeting.id)))
+            .collect(),
+        next_cursor: page.next_cursor,
+        total_hint: page.total_hint,
+        cursor_state: page.cursor_state,
     }
 }
 
@@ -733,6 +808,12 @@ fn finalize_with_provenance(
     let subject_attr = SubjectAttribution::direct_confident(SubjectRef::Unknown);
     builder.set_subject(subject_attr.clone());
     builder
+        .attribute_subtree(
+            FieldPath::root(),
+            FieldAttribution::constant(subject_attr.clone()),
+        )
+        .map_err(provenance_error)?;
+    builder
         .attribute(
             FieldPath::new("/schemaVersion").map_err(field_error)?,
             FieldAttribution::constant(subject_attr),
@@ -865,19 +946,120 @@ mod state_matrix_fixtures {
     //! anyone collapsing it back to a flat enum.
 
     use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
-    fn empty_meeting_brief() -> MeetingBriefRef {
-        MeetingBriefRef {
-            meeting_id: "m-1".into(),
-            title: Some("Meeting 1".into()),
-            starts_at: None,
+    use crate::abilities::NOOP_ABILITY_TRACER;
+    use crate::intelligence::provider::ReplayProvider;
+    use crate::services::context::{
+        ClaimDismissalSurface, DailyReadinessContextReadFuture, DailyReadinessContextReadHandle,
+        EntityContextClaimReadFuture, EntityContextClaimReadHandle, ExternalClients, FixedClock,
+        MeetingPrepStatusReadFuture, MeetingPrepStatusReadHandle, SeedableRng, ServiceContext,
+    };
+    use crate::types::IntelligenceClaim;
+    use chrono::TimeZone;
+
+    #[derive(Clone)]
+    struct FixtureDailyReadinessReader {
+        snapshot: DailyReadinessContextSnapshot,
+    }
+
+    impl DailyReadinessContextReadHandle for FixtureDailyReadinessReader {
+        fn read_daily_readiness_context<'a>(
+            &'a self,
+            _workspace_scope: String,
+            _date: String,
+        ) -> DailyReadinessContextReadFuture<'a> {
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move { Ok(snapshot) })
+        }
+    }
+
+    struct RecordingPrepReader {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl MeetingPrepStatusReadHandle for RecordingPrepReader {
+        fn read_meeting_prep_status<'a>(
+            &'a self,
+            meeting_id: String,
+        ) -> MeetingPrepStatusReadFuture<'a> {
+            self.seen
+                .lock()
+                .expect("record prep read")
+                .push(meeting_id.clone());
+            Box::pin(async move {
+                Ok(MeetingPrepStatusSnapshot {
+                    meeting_id: meeting_id.clone(),
+                    event_id: Some(format!("event-{meeting_id}")),
+                    linked_entity_type: Some("account".to_string()),
+                    linked_entity_id: Some(format!("acct-{meeting_id}")),
+                    status: "ready".to_string(),
+                    blocking_reason: None,
+                    stale_reason: None,
+                    last_prepared_at: Some("2026-05-20T09:00:00Z".to_string()),
+                    source_asof_inputs: Vec::new(),
+                })
+            })
+        }
+    }
+
+    struct RecordingClaimReader {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl EntityContextClaimReadHandle for RecordingClaimReader {
+        fn read_entity_context_claims<'a>(
+            &'a self,
+            _entity_type: String,
+            entity_id: String,
+            _surface: ClaimDismissalSurface,
+            _depth: usize,
+        ) -> EntityContextClaimReadFuture<'a> {
+            self.seen
+                .lock()
+                .expect("record entity claim read")
+                .push(entity_id);
+            Box::pin(async move { Ok(Vec::<IntelligenceClaim>::new()) })
+        }
+
+        fn read_entity_context_claims_limited<'a>(
+            &'a self,
+            _entity_type: String,
+            entity_id: String,
+            _surface: ClaimDismissalSurface,
+            _depth: usize,
+            _limit: usize,
+        ) -> EntityContextClaimReadFuture<'a> {
+            self.seen
+                .lock()
+                .expect("record limited entity claim read")
+                .push(entity_id);
+            Box::pin(async move { Ok(Vec::<IntelligenceClaim>::new()) })
+        }
+    }
+
+    fn daily_meeting(id: &str, starts_at: Option<String>) -> DailyReadinessMeetingSnapshot {
+        DailyReadinessMeetingSnapshot {
+            id: id.to_string(),
+            title: id.to_string(),
+            starts_at,
             ends_at: None,
-            linked_entity_type: None,
-            linked_entity_id: None,
-            prep_status: "ready".into(),
-            blocking_reason: None,
-            stale_reason: None,
-            last_prepared_at: None,
+            workspace_scope: "local".to_string(),
+        }
+    }
+
+    fn daily_meeting_with_end(
+        id: &str,
+        starts_at: &str,
+        ends_at: Option<&str>,
+    ) -> DailyReadinessMeetingSnapshot {
+        DailyReadinessMeetingSnapshot {
+            id: id.to_string(),
+            title: id.to_string(),
+            starts_at: Some(starts_at.to_string()),
+            ends_at: ends_at.map(str::to_string),
+            workspace_scope: "local".to_string(),
         }
     }
 
@@ -1035,18 +1217,166 @@ mod state_matrix_fixtures {
     fn upcoming_meetings_cursor_roundtrip() {
         let meetings = (0..30)
             .map(|i| {
-                let mut m = empty_meeting_brief();
-                m.meeting_id = format!("m-{i}");
-                m.starts_at = Some(format!("2026-05-20T{:02}:00:00Z", i % 24));
-                m
+                daily_meeting(
+                    &format!("m-{i}"),
+                    Some(format!("2026-05-20T{:02}:00:00Z", i % 24)),
+                )
             })
             .collect::<Vec<_>>();
-        let page_one = paginate_upcoming(&meetings, None);
+        let meeting_refs = meetings.iter().collect::<Vec<_>>();
+        let page_one = paginate_upcoming_snapshots(&meeting_refs, None);
         assert_eq!(page_one.items.len(), UPCOMING_MEETINGS_PAGE_SIZE);
         let next = page_one.next_cursor.clone().expect("cursor present");
-        let page_two = paginate_upcoming(&meetings, Some(&next));
+        let page_two = paginate_upcoming_snapshots(&meeting_refs, Some(&next));
         assert_eq!(page_two.items.len(), 30 - UPCOMING_MEETINGS_PAGE_SIZE);
         assert!(page_two.next_cursor.is_none());
+    }
+
+    #[test]
+    fn daily_briefing_expansion_ids_are_bounded_to_visible_page_current_and_next() {
+        let mut meetings = vec![
+            daily_meeting_with_end(
+                "current",
+                "2026-05-20T10:00:00Z",
+                Some("2026-05-20T11:00:00Z"),
+            ),
+            daily_meeting("next", Some("2026-05-20T11:30:00Z".to_string())),
+        ];
+        meetings.extend((0..80).map(|i| {
+            daily_meeting(
+                &format!("future-{i:02}"),
+                Some(format!("2026-05-20T12:{:02}:00Z", i % 60)),
+            )
+        }));
+        let mut refs = meetings.iter().collect::<Vec<_>>();
+        sort_meeting_snapshots(&mut refs);
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-20T10:30:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let (current, next) = pick_current_and_next_snapshots(&refs, &now);
+        let page = paginate_upcoming_snapshots(&refs, None);
+        let expansion_ids =
+            collect_expansion_meeting_ids(current.as_ref(), next.as_ref(), &page.items);
+
+        assert!(expansion_ids.len() <= UPCOMING_MEETINGS_PAGE_SIZE + 2);
+        assert!(expansion_ids.contains("current"));
+        assert!(expansion_ids.contains("next"));
+    }
+
+    #[tokio::test]
+    async fn daily_briefing_producer_expands_only_current_next_and_requested_page() {
+        let mut meetings = vec![
+            daily_meeting_with_end(
+                "current",
+                "2026-05-20T10:00:00Z",
+                Some("2026-05-20T11:00:00Z"),
+            ),
+            daily_meeting("next", Some("2026-05-20T11:30:00Z".to_string())),
+        ];
+        meetings.extend((0..80).map(|i| {
+            daily_meeting(
+                &format!("future-{i:02}"),
+                Some(format!("2026-05-20T12:{:02}:00Z", i % 60)),
+            )
+        }));
+        let snapshot = DailyReadinessContextSnapshot {
+            workspace_scope: "local".to_string(),
+            date: "2026-05-20".to_string(),
+            meetings,
+            tracked_subjects: Vec::new(),
+            overnight_changes: Vec::new(),
+            risk_shifts: Vec::new(),
+            open_loops: Vec::new(),
+            coverage_warnings: Vec::new(),
+        };
+        let prep_seen = Arc::new(Mutex::new(Vec::new()));
+        let entity_seen = Arc::new(Mutex::new(Vec::new()));
+        let clock = FixedClock::new(
+            chrono::Utc
+                .with_ymd_and_hms(2026, 5, 20, 10, 30, 0)
+                .unwrap(),
+        );
+        let rng = SeedableRng::new(507);
+        let external = ExternalClients::default();
+        let services = ServiceContext::test_live(&clock, &rng, &external)
+            .with_daily_readiness_context_reader(Arc::new(FixtureDailyReadinessReader { snapshot }))
+            .with_meeting_prep_status_reader(Arc::new(RecordingPrepReader {
+                seen: prep_seen.clone(),
+            }))
+            .with_entity_context_claim_reader(Arc::new(RecordingClaimReader {
+                seen: entity_seen.clone(),
+            }));
+        let provider = ReplayProvider::new(HashMap::new());
+        let ctx = AbilityContext::new(
+            &services,
+            &provider,
+            &NOOP_ABILITY_TRACER,
+            Actor::User,
+            None,
+            ClaimDismissalSurface::TauriEntityDetail,
+        );
+
+        let output = build_daily_briefing(
+            &ctx,
+            DailyBriefingInput {
+                schema_version: BRIEFING_SCHEMA_VERSION,
+                date: chrono::NaiveDate::from_ymd_opt(2026, 5, 20).unwrap(),
+                workspace_id: "local".to_string(),
+                sections: None,
+                upcoming_meetings_cursor: Some(Cursor::new("upcoming_meetings:offset=25")),
+            },
+        )
+        .await
+        .expect("daily briefing builds")
+        .into_data();
+
+        let mut expected_meeting_ids = BTreeSet::new();
+        expected_meeting_ids.insert(output.current_meeting.as_ref().unwrap().meeting_id.clone());
+        expected_meeting_ids.insert(output.next_meeting.as_ref().unwrap().meeting_id.clone());
+        expected_meeting_ids.extend(
+            output
+                .upcoming_meetings
+                .items
+                .iter()
+                .map(|meeting| meeting.meeting_id.clone()),
+        );
+        let actual_prep_ids = prep_seen
+            .lock()
+            .expect("prep reads")
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let actual_entity_ids = entity_seen
+            .lock()
+            .expect("entity reads")
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let expected_entity_ids = expected_meeting_ids
+            .iter()
+            .map(|meeting_id| format!("acct-{meeting_id}"))
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            output.upcoming_meetings.items.len(),
+            UPCOMING_MEETINGS_PAGE_SIZE
+        );
+        assert_eq!(
+            actual_prep_ids, expected_meeting_ids,
+            "producer must not read prep for meetings outside current, next, and the requested page"
+        );
+        assert_eq!(
+            actual_entity_ids, expected_entity_ids,
+            "producer must not compose entity intelligence for meetings outside the bounded expansion set"
+        );
+    }
+
+    #[test]
+    fn daily_briefing_entity_sections_omit_open_loops_for_aggregate_pass() {
+        assert_eq!(
+            daily_briefing_entity_sections(),
+            vec![EnvelopeSection::Facts]
+        );
     }
 
     #[test]

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/mod.rs
@@ -14,9 +14,9 @@ pub use contracts::{
     EntityIntelligenceEnvelope, EntityIntelligenceInput, EntityKind, EnvelopeProvenance,
     EnvelopeProvenanceSource, EnvelopeSection, EnvelopeTrustSummary, ExclusionReason, Freshness,
     HealthStory, HealthStoryRow, InclusionReason, MetadataProposal, NormalizedSubject,
-    OpenLoopWithReceipt, Paginated, ProvenanceRef, ReceiptTargetRef, RecordEntry,
-    RelationshipEdge, RelationshipParticipant, RelationshipTruncation, RelationshipsBundle,
-    SectionState, SubjectScope, ThreadSummary, Touchpoint, TouchpointBundle, TouchpointKind,
+    OpenLoopWithReceipt, Paginated, ProvenanceRef, ReceiptTargetRef, RecordEntry, RelationshipEdge,
+    RelationshipParticipant, RelationshipTruncation, RelationshipsBundle, SectionState,
+    SubjectScope, ThreadSummary, Touchpoint, TouchpointBundle, TouchpointKind,
     ENVELOPE_SCHEMA_VERSION, ENVELOPE_SCHEMA_VERSION_V1, ENVELOPE_SCHEMA_VERSION_V2,
 };
 

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
@@ -362,16 +362,28 @@ async fn read_claims(
         crate::abilities::get_entity_context::ContextDepth::Standard => 2,
         crate::abilities::get_entity_context::ContextDepth::Deep => 3,
     };
-    let claims = ctx
-        .services()
-        .read_entity_context_claims(
-            entity_type.to_string(),
-            entity_id.to_string(),
-            ctx.entity_context_claim_surface(),
-            levels,
-        )
-        .await
-        .map_err(|error| hard_error("entity_intelligence_claim_read_failed", error))?;
+    let claims = if matches!(ctx.actor, Actor::Agent | Actor::McpClient { .. }) {
+        ctx.services()
+            .read_entity_context_prompt_claims_limited(
+                entity_type.to_string(),
+                entity_id.to_string(),
+                ctx.entity_context_claim_surface(),
+                levels,
+                DEFAULT_PAGE_SIZE + 1,
+            )
+            .await
+    } else {
+        ctx.services()
+            .read_entity_context_claims_limited(
+                entity_type.to_string(),
+                entity_id.to_string(),
+                ctx.entity_context_claim_surface(),
+                levels,
+                DEFAULT_PAGE_SIZE + 1,
+            )
+            .await
+    }
+    .map_err(|error| hard_error("entity_intelligence_claim_read_failed", error))?;
     Ok(filter_claims_for_actor(ctx.actor.clone(), claims))
 }
 
@@ -1186,12 +1198,7 @@ fn project_relationship_participant(
         .relationship
         .as_deref()
         .and_then(|relationship| {
-            renderable_evidence_text(
-                relationship,
-                &raw.sensitivity,
-                render_surface,
-                render_actor,
-            )
+            renderable_evidence_text(relationship, &raw.sensitivity, render_surface, render_actor)
         })
         .or_else(|| {
             if raw.relationship.is_some() {
@@ -1837,7 +1844,7 @@ mod tests {
     use chrono::TimeZone;
 
     use super::super::contracts::{ExclusionReason, InclusionReason, Touchpoint, TouchpointKind};
-    use crate::abilities::registry::AbilityContext;
+    use crate::abilities::registry::{AbilityContext, McpClientId};
     use crate::abilities::{Actor, NOOP_ABILITY_TRACER};
     use crate::intelligence::provider::ReplayProvider;
     use crate::sensitivity::ClaimVerificationState;
@@ -1863,6 +1870,36 @@ mod tests {
             _depth: usize,
         ) -> EntityContextClaimReadFuture<'a> {
             Box::pin(async { Ok(Vec::<IntelligenceClaim>::new()) })
+        }
+    }
+
+    struct PromptSafeBeforeCapClaimReader;
+
+    impl EntityContextClaimReadHandle for PromptSafeBeforeCapClaimReader {
+        fn read_entity_context_claims<'a>(
+            &'a self,
+            _entity_type: String,
+            _entity_id: String,
+            _surface: ClaimDismissalSurface,
+            _depth: usize,
+        ) -> EntityContextClaimReadFuture<'a> {
+            Box::pin(async { Ok(prompt_safe_before_cap_claims()) })
+        }
+
+        fn read_entity_context_prompt_claims_limited<'a>(
+            &'a self,
+            _entity_type: String,
+            _entity_id: String,
+            _surface: ClaimDismissalSurface,
+            _depth: usize,
+            limit: usize,
+        ) -> EntityContextClaimReadFuture<'a> {
+            Box::pin(async move {
+                let mut claims = prompt_safe_before_cap_claims();
+                claims.retain(crate::types::claim_allowed_for_prompt_input);
+                claims.truncate(limit);
+                Ok(claims)
+            })
         }
     }
 
@@ -2031,6 +2068,32 @@ mod tests {
         }
     }
 
+    fn prompt_safe_before_cap_claims() -> Vec<IntelligenceClaim> {
+        let mut claims = Vec::new();
+        for index in 0..=DEFAULT_PAGE_SIZE {
+            let mut claim = claim_fixture(
+                &format!("claim-confidential-newer-{index}"),
+                "account",
+                "acct-test-001",
+                &format!("Confidential claim {index}"),
+            );
+            claim.sensitivity = ClaimSensitivity::Confidential;
+            claim.created_at = format!("2026-05-23T11:{index:02}:00Z");
+            claims.push(claim);
+        }
+
+        let mut safe_claim = claim_fixture(
+            "claim-internal-older",
+            "account",
+            "acct-test-001",
+            "Older prompt-safe claim should survive the MCP bounded read.",
+        );
+        safe_claim.sensitivity = ClaimSensitivity::Internal;
+        safe_claim.created_at = "2026-05-23T10:00:00Z".to_string();
+        claims.push(safe_claim);
+        claims
+    }
+
     #[test]
     fn sections_map_enumerates_all_variants_when_no_filter() {
         let map = build_sections_map(ENVELOPE_SCHEMA_VERSION_V1, &None, fill(0, 0));
@@ -2071,6 +2134,58 @@ mod tests {
 
         assert_eq!(output.data().subject.id, "acct-test-001");
         assert!(output.data().facts.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_and_mcp_producer_read_prompt_safe_claims_before_page_cap() {
+        for actor in [
+            Actor::Agent,
+            Actor::McpClient {
+                client_id: McpClientId::new("mcp-test"),
+                conversation_handle: None,
+            },
+        ] {
+            let actor_label = format!("{actor:?}");
+            let clock =
+                FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+            let rng = SystemRng;
+            let services = ServiceContext::new_evaluate_default(&clock, &rng)
+                .with_entity_context_claim_reader(Arc::new(PromptSafeBeforeCapClaimReader));
+            let provider = ReplayProvider::new(std::collections::HashMap::new());
+            let ctx = AbilityContext::new(
+                &services,
+                &provider,
+                &NOOP_ABILITY_TRACER,
+                actor,
+                None,
+                ClaimDismissalSurface::McpTool,
+            );
+
+            let output = build_entity_intelligence(
+                &ctx,
+                EntityIntelligenceInput {
+                    schema_version: ENVELOPE_SCHEMA_VERSION_V2,
+                    entity_type: EntityKind::Account,
+                    entity_id: "acct-test-001".to_string(),
+                    depth: EnvelopeContextDepth::Standard,
+                    sections: Some(vec![EnvelopeSection::Facts]),
+                },
+            )
+            .await
+            .expect("prompt actors should preserve prompt-safe claims behind confidential rows");
+
+            assert_eq!(
+                output
+                    .data()
+                    .facts
+                    .items
+                    .iter()
+                    .map(|fact| fact.claim_id.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["claim-internal-older"],
+                "{actor_label} entity intelligence must call the prompt-safe reader before applying the page cap"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -55,8 +55,8 @@ use crate::services::external_replay::{
 };
 use crate::services::workspace_intake::WorkspaceIntakeService;
 use crate::types::{
-    subject_ref_from_json, ClaimSensitivity, ClaimSubjectRef, EntityContextEntry, EntityContextText,
-    IntelligenceClaim,
+    subject_ref_from_json, ClaimSensitivity, ClaimSubjectRef, EntityContextEntry,
+    EntityContextText, IntelligenceClaim,
 };
 
 const DEFAULT_EVALUATE_AUTH_SCOPE_ID: &str = "test-tenant-default";
@@ -884,6 +884,47 @@ pub trait EntityContextClaimReadHandle: Send + Sync {
         surface: ClaimDismissalSurface,
         depth: usize,
     ) -> EntityContextClaimReadFuture<'a>;
+
+    /// Read at most `limit` active entity-context claims. Implementations that
+    /// can push the limit into their backing store should override this; the
+    /// default preserves compatibility for test readers.
+    fn read_entity_context_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async move {
+            let mut claims = self
+                .read_entity_context_claims(entity_type, entity_id, surface, depth)
+                .await?;
+            claims.truncate(limit);
+            Ok(claims)
+        })
+    }
+
+    /// Read prompt-safe claims before applying the render page cap. Agent and
+    /// MCP paths use this so confidential/user-only rows cannot occupy the
+    /// bounded window and hide older prompt-safe claims.
+    fn read_entity_context_prompt_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async move {
+            let mut claims = self
+                .read_entity_context_claims(entity_type, entity_id, surface, depth)
+                .await?;
+            claims.retain(crate::types::claim_allowed_for_prompt_input);
+            claims.truncate(limit);
+            Ok(claims)
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2128,6 +2169,46 @@ impl<'a> ServiceContext<'a> {
         if let Some(reader) = &self.entity_context_claim_reader {
             return reader
                 .read_entity_context_claims(entity_type, entity_id, surface, depth)
+                .await;
+        }
+
+        Err(self.missing_reader_error("entity_context_claim_reader"))
+    }
+
+    pub async fn read_entity_context_claims_limited(
+        &self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> Result<Vec<IntelligenceClaim>, String> {
+        if let Some(reader) = &self.entity_context_claim_reader {
+            return reader
+                .read_entity_context_claims_limited(entity_type, entity_id, surface, depth, limit)
+                .await;
+        }
+
+        Err(self.missing_reader_error("entity_context_claim_reader"))
+    }
+
+    pub async fn read_entity_context_prompt_claims_limited(
+        &self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> Result<Vec<IntelligenceClaim>, String> {
+        if let Some(reader) = &self.entity_context_claim_reader {
+            return reader
+                .read_entity_context_prompt_claims_limited(
+                    entity_type,
+                    entity_id,
+                    surface,
+                    depth,
+                    limit,
+                )
                 .await;
         }
 

--- a/src-tauri/src/bridges/mcp.rs
+++ b/src-tauri/src/bridges/mcp.rs
@@ -130,6 +130,52 @@ impl EntityContextClaimReadHandle for McpActionDbWorkspaceReader {
         };
         Box::pin(std::future::ready(result))
     }
+
+    fn read_entity_context_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: crate::services::context::ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        let result = {
+            let db = self.db.lock();
+            crate::services::claims::load_entity_context_claims_active_for_surface_limited(
+                &db,
+                &entity_type,
+                &entity_id,
+                depth,
+                surface.as_str(),
+                limit,
+            )
+            .map_err(|error| format!("Entity context claim read failed: {error}"))
+        };
+        Box::pin(std::future::ready(result))
+    }
+
+    fn read_entity_context_prompt_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: crate::services::context::ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        let result = {
+            let db = self.db.lock();
+            crate::services::claims::load_entity_context_prompt_claims_active_for_surface_limited(
+                &db,
+                &entity_type,
+                &entity_id,
+                depth,
+                surface.as_str(),
+                limit,
+            )
+            .map_err(|error| format!("Entity context claim read failed: {error}"))
+        };
+        Box::pin(std::future::ready(result))
+    }
 }
 
 impl EntityTouchpointsReadHandle for McpActionDbWorkspaceReader {
@@ -647,7 +693,7 @@ mod tests {
     use std::sync::Arc;
 
     use chrono::{TimeZone, Utc};
-    use rusqlite::Connection;
+    use rusqlite::{params, Connection};
     use serde_json::json;
 
     use super::*;
@@ -679,6 +725,8 @@ mod tests {
         include_str!("../migrations/135_dos_294_typed_feedback_schema.sql");
     const CLAIM_SURFACE_DISMISSALS_SQL: &str =
         include_str!("../migrations/154_claim_surface_dismissals.sql");
+    const CLAIM_SUBJECT_LOOKUP_SQL: &str =
+        include_str!("../migrations/263_claim_subject_lookup_index.sql");
     const MINIMAL_ENTITY_SCHEMA_SQL: &str = r#"
 CREATE TABLE accounts (
     id TEXT PRIMARY KEY,
@@ -923,10 +971,28 @@ CREATE TABLE accounts (
             .expect("apply projection status schema");
         conn.execute_batch(CLAIM_SURFACE_DISMISSALS_SQL)
             .expect("apply claim surface dismissals schema");
+        conn.execute_batch(CLAIM_SUBJECT_LOOKUP_SQL)
+            .expect("apply claim subject lookup indexes");
         ActionDb::from_connection_for_tests(conn)
     }
 
     fn seed_mcp_entity_context_claim(db: &ActionDb) -> String {
+        seed_mcp_entity_context_claim_with(
+            db,
+            "claim-mcp-dismissed-context",
+            "MCP-visible context that must be hidden after dismissal",
+            ClaimSensitivity::Internal,
+            "2026-05-09T12:00:00Z",
+        )
+    }
+
+    fn seed_mcp_entity_context_claim_with(
+        db: &ActionDb,
+        claim_id: &str,
+        text: &str,
+        sensitivity: ClaimSensitivity,
+        created_at: &str,
+    ) -> String {
         let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 9, 12, 0, 0).unwrap());
         let rng = SeedableRng::new(309);
         let external = ExternalClients::default();
@@ -940,33 +1006,40 @@ CREATE TABLE accounts (
             })
             .to_string(),
             claim_type: "entity_summary".to_string(),
-            field_path: Some("context.summary".to_string()),
+            field_path: Some(format!("context.{claim_id}")),
             topic_key: None,
-            text: "MCP-visible context that must be hidden after dismissal".to_string(),
+            text: text.to_string(),
             actor: "agent:test".to_string(),
             data_source: "user".to_string(),
-            source_ref: Some("fixture:mcp-dismissed-context".to_string()),
-            source_asof: Some("2026-05-09T12:00:00Z".to_string()),
-            observed_at: "2026-05-09T12:00:00Z".to_string(),
+            source_ref: Some(format!("fixture:{claim_id}")),
+            source_asof: Some(created_at.to_string()),
+            observed_at: created_at.to_string(),
             provenance_json: json!({ "source": "mcp-dismissal-regression" }).to_string(),
             metadata_json: None,
             thread_id: None,
             temporal_scope: Some(TemporalScope::State),
-            sensitivity: Some(ClaimSensitivity::Internal),
+            sensitivity: Some(sensitivity),
             supersedes: None,
             tombstone: None,
         };
         let committed = commit_claim(
             &ctx,
             db,
-            DeterministicInsertProposal::new("claim-mcp-dismissed-context".to_string(), proposal),
+            DeterministicInsertProposal::new(claim_id.to_string(), proposal),
         )
         .expect("commit MCP entity context claim");
 
-        match committed {
+        let claim_id = match committed {
             CommittedClaim::Inserted { claim } => claim.id,
             other => panic!("expected inserted claim, got {other:?}"),
-        }
+        };
+        db.conn_ref()
+            .execute(
+                "UPDATE intelligence_claims SET created_at = ?1 WHERE id = ?2",
+                params![created_at, claim_id.as_str()],
+            )
+            .expect("pin MCP fixture claim created_at");
+        claim_id
     }
 
     fn dismiss_claim_on_surface(db: &ActionDb, claim_id: &str, surface: &str) {
@@ -1498,6 +1571,49 @@ CREATE TABLE accounts (
         assert!(
             entries.is_empty(),
             "mcp_tool dismissal must hide claim-backed entity context entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_action_db_reader_filters_prompt_unsafe_claims_before_page_cap() {
+        let db = fresh_mcp_claims_db();
+        for index in 0..51 {
+            seed_mcp_entity_context_claim_with(
+                &db,
+                &format!("claim-mcp-confidential-newer-{index}"),
+                &format!("Confidential MCP context fixture {index}"),
+                ClaimSensitivity::Confidential,
+                &format!("2026-05-09T12:{index:02}:00Z"),
+            );
+        }
+        seed_mcp_entity_context_claim_with(
+            &db,
+            "claim-mcp-internal-older",
+            "Older internal MCP context must remain visible after prompt-safe filtering.",
+            ClaimSensitivity::Internal,
+            "2026-05-09T11:00:00Z",
+        );
+
+        let reader = McpActionDbWorkspaceReader {
+            db: Arc::new(ParkingMutex::new(db)),
+        };
+        let claim_ids = reader
+            .read_entity_context_prompt_claims_limited(
+                "account".to_string(),
+                MCP_ENTITY_ID.to_string(),
+                crate::services::context::ClaimDismissalSurface::McpTool,
+                1,
+                51,
+            )
+            .await
+            .expect("MCP entity context prompt-safe claim read")
+            .into_iter()
+            .map(|claim| claim.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            claim_ids,
+            vec!["claim-mcp-internal-older".to_string()],
+            "MCP entity context readers must filter confidential/user-only claims before the page cap"
         );
     }
 

--- a/src-tauri/src/db/key_provider.rs
+++ b/src-tauri/src/db/key_provider.rs
@@ -50,6 +50,16 @@ static ROTATION_LOCK: RwLock<()> = parking_lot::const_rwlock(());
 /// allowed to replace the cached value.
 static CACHED_KEY: OnceLock<RwLock<Option<EncryptionKey>>> = OnceLock::new();
 
+#[cfg(test)]
+static ROTATION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn rotation_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    ROTATION_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 pub(crate) fn rotation_lock_read() -> parking_lot::RwLockReadGuard<'static, ()> {
     ROTATION_LOCK.read()
 }
@@ -1256,6 +1266,7 @@ mod tests {
 
     #[test]
     fn get_or_create_waits_for_in_flight_rotation() {
+        let _rotation_test_guard = rotation_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("blocked_rotation.db");
         let old_key = fixed_key("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
@@ -1276,7 +1287,7 @@ mod tests {
         let rotate_handle = thread::spawn(move || rotate_provider.rotate_key(&rotate_user));
 
         primary_started_rx
-            .recv_timeout(Duration::from_secs(2))
+            .recv_timeout(Duration::from_secs(30))
             .expect("rotation reached blocked primary upsert");
 
         let get_provider = LocalKeychain::with_keychain_for_tests(keychain.clone());
@@ -1341,6 +1352,7 @@ mod tests {
 
     #[test]
     fn startup_recovers_crash_after_rekey_before_primary_key_update() {
+        let _rotation_test_guard = rotation_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("rotation_recovery.db");
         let old_key = fixed_key("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
@@ -1379,6 +1391,7 @@ mod tests {
 
     #[test]
     fn startup_recovers_crash_after_primary_key_update_before_rekey() {
+        let _rotation_test_guard = rotation_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("primary_first_rotation_recovery.db");
         let old_key = fixed_key("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
@@ -1421,6 +1434,7 @@ mod tests {
 
     #[test]
     fn verify_existing_key_preserves_staged_entry_while_rotation_flag_is_set() {
+        let _rotation_test_guard = rotation_test_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("preserve_staged_during_rotation.db");
         let old_key = fixed_key("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");

--- a/src-tauri/src/db_service.rs
+++ b/src-tauri/src/db_service.rs
@@ -1036,13 +1036,16 @@ mod tests {
             .await
             .expect("writer call before rotation");
 
-        install_global(svc.clone());
-        let _global_guard = GlobalServiceGuard;
-        let rotated = provider
-            .rotate_key(&UserIdentity::local(path.clone()))
-            .expect("rotate through global DbService");
-        assert_eq!(rotated, EncryptionKey::from_hex(new_key.to_string()));
-        uninstall_global();
+        {
+            let _rotation_test_guard = crate::db::key_provider::rotation_test_guard();
+            install_global(svc.clone());
+            let _global_guard = GlobalServiceGuard;
+            let rotated = provider
+                .rotate_key(&UserIdentity::local(path.clone()))
+                .expect("rotate through global DbService");
+            assert_eq!(rotated, EncryptionKey::from_hex(new_key.to_string()));
+            uninstall_global();
+        }
 
         let email = sample_email("em-rotate-after", "acc-after");
         svc.writer()
@@ -1084,59 +1087,62 @@ mod tests {
             .await
             .expect("open svc");
 
-        install_global(svc);
-        let _global_guard = GlobalServiceGuard;
+        {
+            let _rotation_test_guard = crate::db::key_provider::rotation_test_guard();
+            install_global(svc);
+            let _global_guard = GlobalServiceGuard;
 
-        let (key_fetched_tx, key_fetched_rx) = mpsc::channel();
-        let (release_get_tx, release_get_rx) = mpsc::channel();
-        provider.block_next_get(key_fetched_tx, release_get_rx);
+            let (key_fetched_tx, key_fetched_rx) = mpsc::channel();
+            let (release_get_tx, release_get_rx) = mpsc::channel();
+            provider.block_next_get(key_fetched_tx, release_get_rx);
 
-        let open_provider = provider.clone();
-        let open_path = path.clone();
-        let open_handle = std::thread::spawn(move || {
-            let db = ActionDb::open_resolved_path_for_tests(open_path, open_provider)?;
-            drop(db);
-            Ok::<(), DbError>(())
-        });
+            let open_provider = provider.clone();
+            let open_path = path.clone();
+            let open_handle = std::thread::spawn(move || {
+                let db = ActionDb::open_resolved_path_for_tests(open_path, open_provider)?;
+                drop(db);
+                Ok::<(), DbError>(())
+            });
 
-        key_fetched_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("open fetched key before rotation attempt");
+            key_fetched_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("open fetched key before rotation attempt");
 
-        let rotate_provider = provider.clone();
-        let rotate_user = UserIdentity::local(path.clone());
-        let (rotation_started_tx, rotation_started_rx) = mpsc::channel();
-        let (rotation_done_tx, rotation_done_rx) = mpsc::channel();
-        let rotate_handle = std::thread::spawn(move || {
-            rotation_started_tx
-                .send(())
-                .expect("signal rotation started");
-            let result = rotate_provider.rotate_key(&rotate_user);
-            rotation_done_tx.send(()).expect("signal rotation done");
-            result
-        });
+            let rotate_provider = provider.clone();
+            let rotate_user = UserIdentity::local(path.clone());
+            let (rotation_started_tx, rotation_started_rx) = mpsc::channel();
+            let (rotation_done_tx, rotation_done_rx) = mpsc::channel();
+            let rotate_handle = std::thread::spawn(move || {
+                rotation_started_tx
+                    .send(())
+                    .expect("signal rotation started");
+                let result = rotate_provider.rotate_key(&rotate_user);
+                rotation_done_tx.send(()).expect("signal rotation done");
+                result
+            });
 
-        rotation_started_rx
-            .recv_timeout(Duration::from_secs(2))
-            .expect("rotation thread started");
-        assert!(
-            rotation_done_rx
-                .recv_timeout(Duration::from_millis(100))
-                .is_err(),
-            "rotation completed while ActionDb::open held a fetched key"
-        );
+            rotation_started_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("rotation thread started");
+            assert!(
+                rotation_done_rx
+                    .recv_timeout(Duration::from_millis(100))
+                    .is_err(),
+                "rotation completed while ActionDb::open held a fetched key"
+            );
 
-        release_get_tx.send(()).expect("release blocked key fetch");
-        open_handle
-            .join()
-            .expect("open thread joined")
-            .expect("open should complete with the pre-rotation key");
+            release_get_tx.send(()).expect("release blocked key fetch");
+            open_handle
+                .join()
+                .expect("open thread joined")
+                .expect("open should complete with the pre-rotation key");
 
-        let rotated = rotate_handle
-            .join()
-            .expect("rotation thread joined")
-            .expect("rotation completed after open connection acquisition");
-        assert_eq!(rotated, EncryptionKey::from_hex(new_key.to_string()));
+            let rotated = rotate_handle
+                .join()
+                .expect("rotation thread joined")
+                .expect("rotation completed after open connection acquisition");
+            assert_eq!(rotated, EncryptionKey::from_hex(new_key.to_string()));
+        }
         assert!(!encrypted_db_can_read(
             &path,
             &EncryptionKey::from_hex(old_key.to_string())

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1032,6 +1032,13 @@ const MIGRATIONS: &[Migration] = &[
         version: 262,
         sql: include_str!("migrations/262_workspace_placement_idempotency.sql"),
     },
+    // v1.4.4a W6 — claim-backed surface readers query SubjectRef by semantic
+    // kind/id instead of exact JSON text, so support the json_extract lookup
+    // path with an expression index.
+    Migration::Fn {
+        version: 263,
+        apply: migrate_v263_claim_subject_lookup_index,
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -2806,6 +2813,30 @@ fn migrate_v260_email_summary_context_evidence(conn: &Connection) -> Result<(), 
         conn,
         include_str!("migrations/260_email_summary_context_evidence.sql"),
         "v1.4.4a W5 email summary context evidence",
+    )
+}
+
+fn migrate_v263_claim_subject_lookup_index(conn: &Connection) -> Result<(), MigrationError> {
+    if !table_exists(conn, "intelligence_claims")? {
+        return Ok(());
+    }
+
+    let columns = table_columns(conn, "intelligence_claims")?;
+    let required = [
+        "subject_ref",
+        "claim_state",
+        "surfacing_state",
+        "claim_type",
+        "created_at",
+    ];
+    if required.iter().any(|column| !columns.contains(*column)) {
+        return Ok(());
+    }
+
+    apply_idempotent_sql_migration(
+        conn,
+        include_str!("migrations/263_claim_subject_lookup_index.sql"),
+        "v1.4.4a W6 claim subject lookup index",
     )
 }
 
@@ -6497,6 +6528,36 @@ mod tests {
         assert!(
             current_version(&conn).expect("current version") >= 244,
             "schema version is at least v244"
+        );
+    }
+
+    #[test]
+    fn migration_263_adds_claim_subject_lookup_index() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+
+        for index_name in [
+            "idx_claims_subject_kind_id_lifecycle_created",
+            "idx_claims_subject_kind_id_lifecycle_untyped_created",
+        ] {
+            let index_count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master \
+                     WHERE type = 'index' \
+                       AND name = ?1",
+                    [index_name],
+                    |row| row.get(0),
+                )
+                .expect("query sqlite_master for claim subject lookup index");
+            assert_eq!(
+                index_count, 1,
+                "claim-backed surface reads have indexed subject lookup path {index_name}"
+            );
+        }
+
+        assert!(
+            current_version(&conn).expect("current version") >= 263,
+            "schema version is at least v263"
         );
     }
 }

--- a/src-tauri/src/migrations/263_claim_subject_lookup_index.sql
+++ b/src-tauri/src/migrations/263_claim_subject_lookup_index.sql
@@ -1,0 +1,25 @@
+-- v1.4.4a W6: keep claim-backed surface reads bounded by subject.
+--
+-- Readers intentionally match SubjectRef semantics instead of exact JSON text:
+-- key order and kind casing can differ across producers. This expression
+-- index supports the json_extract lookup shape used by the surface readers.
+CREATE INDEX IF NOT EXISTS idx_claims_subject_kind_id_lifecycle_created
+ON intelligence_claims (
+    lower(json_extract(subject_ref, '$.kind')),
+    json_extract(subject_ref, '$.id'),
+    claim_state,
+    surfacing_state,
+    claim_type,
+    created_at DESC
+)
+WHERE json_valid(subject_ref) = 1;
+
+CREATE INDEX IF NOT EXISTS idx_claims_subject_kind_id_lifecycle_untyped_created
+ON intelligence_claims (
+    lower(json_extract(subject_ref, '$.kind')),
+    json_extract(subject_ref, '$.id'),
+    claim_state,
+    surfacing_state,
+    created_at DESC
+)
+WHERE json_valid(subject_ref) = 1;

--- a/src-tauri/src/prepare/email_enrich.rs
+++ b/src-tauri/src/prepare/email_enrich.rs
@@ -415,8 +415,12 @@ fn parse_enrichment_response(
         .map(|s| s.to_string());
     // AI noise verdict. Optional — older responses won't have it.
     let is_noise = parsed.get("is_noise").and_then(|v| v.as_bool());
-    if let Some(reason) = parsed.get("noise_reason").and_then(|v| v.as_str()) {
-        log::debug!("email_enrich: AI is_noise={is_noise:?} reason={reason}");
+    if parsed
+        .get("noise_reason")
+        .and_then(|v| v.as_str())
+        .is_some()
+    {
+        log::debug!("email_enrich: AI is_noise={is_noise:?} reason_present=true");
     }
 
     (summary, sentiment, urgency, is_noise)

--- a/src-tauri/src/release_gate.rs
+++ b/src-tauri/src/release_gate.rs
@@ -68,7 +68,7 @@ const DOS288_SELECTORS: &[&str] = &[
 const DOS288_OUTPUT_CAPTURE_CAP_BYTES: usize = 64 * 1024;
 const DOS288_OUTPUT_CAPTURE_EDGE_BYTES: usize = DOS288_OUTPUT_CAPTURE_CAP_BYTES / 2;
 const DOS288_SELECTOR_TIMEOUT_SUMMARY: &str = "dos288-selector-timeout-exceeded";
-const W6_FIXTURE_REPORT_NAME: &str = "w6-fixtures.json";
+const W6_FIXTURE_REPORT_NAME: &str = "v144a-w6-fixtures.json";
 
 const SUBSTRATE_ONLY_BUNDLES: &[&str] = &[
     "bundle-14",
@@ -131,64 +131,44 @@ const BUNDLE_INVARIANT_SPECS: &[BundleInvariantSpec] = &[
 
 const W6_FIXTURE_SPECS: &[W6FixtureSpec] = &[
     W6FixtureSpec {
-        id: "w6-01-default-wp-mcp-no-dailyos",
-        surface: "wp_mcp",
+        id: "v144a-w6-01-frontend-surface-contracts",
+        surface: "frontend_surfaces",
     },
     W6FixtureSpec {
-        id: "w6-02-mcp-exposure-none-hidden",
-        surface: "wp_mcp",
+        id: "v144a-w6-02-daily-briefing-bounded-expansion",
+        surface: "daily_briefing",
     },
     W6FixtureSpec {
-        id: "w6-03-frontend-js-no-dailyos-secrets",
-        surface: "frontend_js",
+        id: "v144a-w6-03-daily-briefing-cursor",
+        surface: "daily_briefing",
     },
     W6FixtureSpec {
-        id: "w6-04-gutenberg-rejects-raw-runtime-payloads",
-        surface: "gutenberg_save",
+        id: "v144a-w6-04-entity-claim-read-cap",
+        surface: "entity_intelligence",
     },
     W6FixtureSpec {
-        id: "w6-05-projection-tampered-typed-error",
-        surface: "projection_bridge",
+        id: "v144a-w6-05-mcp-action-redaction",
+        surface: "mcp_actions",
     },
     W6FixtureSpec {
-        id: "w6-06-stale-claim-version-feedback-409",
-        surface: "presence_nonce",
+        id: "v144a-w6-06-entity-fixture-harness",
+        surface: "entity_fixture_harness",
     },
     W6FixtureSpec {
-        id: "w6-07-cross-user-presence-nonce",
-        surface: "presence_nonce",
+        id: "v144a-w6-07-foreground-contention",
+        surface: "foreground_contention",
     },
     W6FixtureSpec {
-        id: "w6-08-presence-nonce-replay-rejected",
-        surface: "presence_nonce",
+        id: "v144a-w6-08-email-refresh-coalescing",
+        surface: "email_surface",
     },
     W6FixtureSpec {
-        id: "w6-09-phase3-budget-charge-fail-closed",
-        surface: "feedback_budget",
+        id: "v144a-w6-09-dos412-render-policy-drift",
+        surface: "render_policy",
     },
     W6FixtureSpec {
-        id: "w6-10-direct-plugin-claim-table-write-lint",
-        surface: "plugin_storage",
-    },
-    W6FixtureSpec {
-        id: "w6-11-payload-json-redaction",
-        surface: "presence_nonce",
-    },
-    W6FixtureSpec {
-        id: "w6-12-stock-theme-account-overview-render",
-        surface: "wp_theme_render",
-    },
-    W6FixtureSpec {
-        id: "w6-13-cold-start-stale-marker-notice",
-        surface: "runtime_lifecycle",
-    },
-    W6FixtureSpec {
-        id: "w6-14-hot-tauri-restart-sentinel-discovery",
-        surface: "runtime_lifecycle",
-    },
-    W6FixtureSpec {
-        id: "w6-15-hot-studio-restart-first-render",
-        surface: "studio_lifecycle",
+        id: "v144a-w6-10-dos168-mcp-migration-drift",
+        surface: "mcp_migration",
     },
 ];
 
@@ -1238,11 +1218,18 @@ struct W6FixtureGateResult {
     invariants: Vec<InvariantResult>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct W6FixtureRunnerInvocation {
+    script: PathBuf,
+    current_dir: PathBuf,
+    env: Vec<(&'static str, OsString)>,
+}
+
 fn w6_fixture_results(config: &GateConfig, binding: &EvidenceBinding) -> W6FixtureGateResult {
     let started = Instant::now();
     let path = config.output_dir.join(W6_FIXTURE_REPORT_NAME);
     let command_or_report = if config.run_tests {
-        "bash scripts/release-gate/run-w6-fixtures.sh".to_string()
+        "bash scripts/release-gate/run-v144a-w6-fixtures.sh".to_string()
     } else {
         path.display().to_string()
     };
@@ -1302,11 +1289,11 @@ fn run_w6_fixture_runner(
     binding: &EvidenceBinding,
     path: &Path,
 ) -> Result<bool, GateError> {
-    let script = repo_root().join("scripts/release-gate/run-w6-fixtures.sh");
-    if !script.is_file() {
+    let invocation = w6_fixture_runner_invocation(config, binding, path);
+    if !invocation.script.is_file() {
         return Err(GateError::infra(format!(
             "w6-fixture-runner-missing:{}",
-            script.display()
+            invocation.script.display()
         )));
     }
     if let Some(parent) = path.parent() {
@@ -1317,12 +1304,13 @@ fn run_w6_fixture_runner(
             ))
         })?;
     }
-    let output = Command::new("bash")
-        .current_dir(repo_root())
-        .arg(&script)
-        .env("W6_FIXTURE_OUTPUT_DIR", &config.output_dir)
-        .env("W6_FIXTURE_GIT_SHA", &binding.git_sha)
-        .env("W6_FIXTURE_FIXTURES_HASH", &binding.fixtures_hash)
+    let mut command = Command::new("bash");
+    command.current_dir(&invocation.current_dir);
+    command.arg(&invocation.script);
+    for (key, value) in invocation.env {
+        command.env(key, value);
+    }
+    let output = command
         .output()
         .map_err(|error| GateError::infra(format!("w6-fixture-runner-spawn:{error}")))?;
 
@@ -1335,6 +1323,33 @@ fn run_w6_fixture_runner(
         output.status.code().unwrap_or(-1),
         hash_prefix(&String::from_utf8_lossy(&output.stderr))
     )))
+}
+
+fn w6_fixture_runner_invocation(
+    config: &GateConfig,
+    binding: &EvidenceBinding,
+    path: &Path,
+) -> W6FixtureRunnerInvocation {
+    let root = repo_root();
+    W6FixtureRunnerInvocation {
+        script: root.join("scripts/release-gate/run-v144a-w6-fixtures.sh"),
+        current_dir: root,
+        env: vec![
+            (
+                "V144A_W6_FIXTURE_OUTPUT_DIR",
+                config.output_dir.as_os_str().to_os_string(),
+            ),
+            ("V144A_W6_FIXTURE_REPORT", path.as_os_str().to_os_string()),
+            (
+                "V144A_W6_FIXTURE_GIT_SHA",
+                OsString::from(binding.git_sha.clone()),
+            ),
+            (
+                "V144A_W6_FIXTURE_FIXTURES_HASH",
+                OsString::from(binding.fixtures_hash.clone()),
+            ),
+        ],
+    }
 }
 
 fn read_w6_fixture_report(
@@ -2330,6 +2345,55 @@ mod tests {
             dos288_selector_command("dos288_bleed_detection_test"),
             "cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features release-gate --test dos288_bleed_detection_test -- --nocapture --test-threads=1"
         );
+    }
+
+    #[test]
+    fn release_gate_w6_runner_invocation_uses_v144a_script_and_env() {
+        let temp = tempdir().unwrap();
+        let config = GateConfig {
+            mode: GateMode::Hermetic,
+            bundle_filters: Vec::new(),
+            mandatory_bundles: DEFAULT_MANDATORY_BUNDLES
+                .iter()
+                .map(|bundle| (*bundle).to_string())
+                .collect(),
+            tracked_bundles: DEFAULT_TRACKED_BUNDLES
+                .iter()
+                .map(|bundle| (*bundle).to_string())
+                .collect(),
+            output_dir: temp.path().join("out"),
+            harness_report: None,
+            db_path: None,
+            manual_evidence: None,
+            run_tests: true,
+            git_sha: "abc123".to_string(),
+            dos288_timeout_secs: DEFAULT_DOS288_TIMEOUT_SECS,
+        };
+        let binding = EvidenceBinding {
+            git_sha: "abc123".to_string(),
+            fixtures_hash: "fixturehash".to_string(),
+        };
+        let report_path = temp.path().join("out").join(W6_FIXTURE_REPORT_NAME);
+
+        let invocation = w6_fixture_runner_invocation(&config, &binding, &report_path);
+        let env = invocation.env.iter().cloned().collect::<Vec<_>>();
+
+        assert!(invocation
+            .script
+            .ends_with("scripts/release-gate/run-v144a-w6-fixtures.sh"));
+        assert!(env.contains(&(
+            "V144A_W6_FIXTURE_OUTPUT_DIR",
+            config.output_dir.as_os_str().to_os_string()
+        )));
+        assert!(env.contains(&(
+            "V144A_W6_FIXTURE_REPORT",
+            report_path.as_os_str().to_os_string()
+        )));
+        assert!(env.contains(&("V144A_W6_FIXTURE_GIT_SHA", OsString::from("abc123"))));
+        assert!(env.contains(&(
+            "V144A_W6_FIXTURE_FIXTURES_HASH",
+            OsString::from("fixturehash")
+        )));
     }
 
     #[test]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -5070,6 +5070,10 @@ fn load_claims_where(
     claim_type: Option<&str>,
     lifecycle_where: &str,
 ) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    load_claims_where_limited(db, subject_ref, claim_type, lifecycle_where, None)
+}
+
+fn claim_subject_lookup_parts(subject_ref: &str) -> Result<Option<(String, String)>, ClaimError> {
     // L2 cycle-13 fix #2: parse the caller's subject_ref into the
     // typed SubjectRef and query by json_extract on $.kind+$.id
     // (with json_valid guard) so the reader matches the same
@@ -5085,24 +5089,200 @@ fn load_claims_where(
         // Multi/Global readers aren't supported through this path —
         // they're a future addition (matching commit_claim's
         // behavior, which also returns no PRE-GATE match for them).
-        return Ok(Vec::new());
+        return Ok(None);
     };
     let Some(id) = subject_id_for_lookup(&subject) else {
+        return Ok(None);
+    };
+    Ok(Some((kind.to_string(), id.to_string())))
+}
+
+fn load_claims_where_limited(
+    db: &ActionDb,
+    subject_ref: &str,
+    claim_type: Option<&str>,
+    lifecycle_where: &str,
+    limit: Option<usize>,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    let Some((kind, id)) = claim_subject_lookup_parts(subject_ref)? else {
         return Ok(Vec::new());
     };
     let surface_columns = claim_surface_shadow_columns(db.conn_ref(), "current_claim")?;
+    let claim_type_filter = if claim_type.is_some() {
+        "AND claim_type = ?3"
+    } else {
+        ""
+    };
+    let limit_clause = match (claim_type, limit) {
+        (Some(_), Some(_)) => " LIMIT ?4",
+        (None, Some(_)) => " LIMIT ?3",
+        _ => "",
+    };
     let sql = format!(
         "SELECT {CLAIM_COLUMNS}, {surface_columns}
          FROM intelligence_claims current_claim
          WHERE json_valid(subject_ref) = 1
            AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
            AND json_extract(subject_ref, '$.id') = ?2
-           AND (?3 IS NULL OR claim_type = ?3)
+           {claim_type_filter}
            AND {lifecycle_where}
-         ORDER BY created_at DESC"
+         ORDER BY created_at DESC{limit_clause}"
     );
     let mut stmt = db.conn_ref().prepare(&sql)?;
-    let mut rows = stmt.query(params![kind, id, claim_type])?;
+    let mut rows = match (claim_type, limit) {
+        (Some(claim_type), Some(limit)) => {
+            stmt.query(params![kind, id, claim_type, limit as i64])?
+        }
+        (Some(claim_type), None) => stmt.query(params![kind, id, claim_type])?,
+        (None, Some(limit)) => stmt.query(params![kind, id, limit as i64])?,
+        (None, None) => stmt.query(params![kind, id])?,
+    };
+    let mut claims = Vec::new();
+    while let Some(row) = rows.next()? {
+        claims.push(read_claim_row_with_surface_shadow_state(row)?);
+    }
+    Ok(claims)
+}
+
+fn load_claims_where_for_surface_limited(
+    db: &ActionDb,
+    subject_ref: &str,
+    claim_type: Option<&str>,
+    lifecycle_where: &str,
+    surface: &str,
+    limit: Option<usize>,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    load_claims_where_for_surface_limited_filtered(
+        db,
+        subject_ref,
+        claim_type,
+        lifecycle_where,
+        surface,
+        limit,
+        false,
+    )
+}
+
+fn load_claims_where_for_surface_limited_filtered(
+    db: &ActionDb,
+    subject_ref: &str,
+    claim_type: Option<&str>,
+    lifecycle_where: &str,
+    surface: &str,
+    limit: Option<usize>,
+    prompt_safe_only: bool,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    let surface = normalize_claim_surface(surface)?;
+    if !table_exists_sqlite(db.conn_ref(), "claim_surface_dismissals")? {
+        if prompt_safe_only {
+            return load_claims_where_limited_prompt_safe(
+                db,
+                subject_ref,
+                claim_type,
+                lifecycle_where,
+                limit,
+            );
+        }
+        return load_claims_where_limited(db, subject_ref, claim_type, lifecycle_where, limit);
+    }
+    let Some((kind, id)) = claim_subject_lookup_parts(subject_ref)? else {
+        return Ok(Vec::new());
+    };
+    let surface_columns = claim_surface_shadow_columns(db.conn_ref(), "current_claim")?;
+    let claim_type_filter = if claim_type.is_some() {
+        "AND claim_type = ?3"
+    } else {
+        ""
+    };
+    let prompt_safe_filter = if prompt_safe_only {
+        "AND sensitivity IN ('public', 'internal')"
+    } else {
+        ""
+    };
+    let surface_placeholder = if claim_type.is_some() { "?4" } else { "?3" };
+    let limit_clause = match (claim_type, limit) {
+        (Some(_), Some(_)) => " LIMIT ?5",
+        (None, Some(_)) => " LIMIT ?4",
+        _ => "",
+    };
+    let sql = format!(
+        "SELECT {CLAIM_COLUMNS}, {surface_columns}
+         FROM intelligence_claims current_claim
+         WHERE json_valid(subject_ref) = 1
+           AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
+           AND json_extract(subject_ref, '$.id') = ?2
+           {claim_type_filter}
+           AND {lifecycle_where}
+           {prompt_safe_filter}
+           AND NOT EXISTS (
+               SELECT 1
+               FROM claim_surface_dismissals dismissal
+               WHERE dismissal.claim_id = current_claim.id
+                 AND dismissal.surface = {surface_placeholder}
+           )
+         ORDER BY created_at DESC{limit_clause}"
+    );
+    let mut stmt = db.conn_ref().prepare(&sql)?;
+    let mut rows = match (claim_type, limit) {
+        (Some(claim_type), Some(limit)) => stmt.query(params![
+            kind,
+            id,
+            claim_type,
+            surface.as_str(),
+            limit as i64
+        ])?,
+        (Some(claim_type), None) => stmt.query(params![kind, id, claim_type, surface.as_str()])?,
+        (None, Some(limit)) => stmt.query(params![kind, id, surface.as_str(), limit as i64])?,
+        (None, None) => stmt.query(params![kind, id, surface.as_str()])?,
+    };
+    let mut claims = Vec::new();
+    while let Some(row) = rows.next()? {
+        claims.push(read_claim_row_with_surface_shadow_state(row)?);
+    }
+    Ok(claims)
+}
+
+fn load_claims_where_limited_prompt_safe(
+    db: &ActionDb,
+    subject_ref: &str,
+    claim_type: Option<&str>,
+    lifecycle_where: &str,
+    limit: Option<usize>,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    let Some((kind, id)) = claim_subject_lookup_parts(subject_ref)? else {
+        return Ok(Vec::new());
+    };
+    let surface_columns = claim_surface_shadow_columns(db.conn_ref(), "current_claim")?;
+    let claim_type_filter = if claim_type.is_some() {
+        "AND claim_type = ?3"
+    } else {
+        ""
+    };
+    let limit_clause = match (claim_type, limit) {
+        (Some(_), Some(_)) => " LIMIT ?4",
+        (None, Some(_)) => " LIMIT ?3",
+        _ => "",
+    };
+    let sql = format!(
+        "SELECT {CLAIM_COLUMNS}, {surface_columns}
+         FROM intelligence_claims current_claim
+         WHERE json_valid(subject_ref) = 1
+           AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
+           AND json_extract(subject_ref, '$.id') = ?2
+           {claim_type_filter}
+           AND {lifecycle_where}
+           AND sensitivity IN ('public', 'internal')
+         ORDER BY created_at DESC{limit_clause}"
+    );
+    let mut stmt = db.conn_ref().prepare(&sql)?;
+    let mut rows = match (claim_type, limit) {
+        (Some(claim_type), Some(limit)) => {
+            stmt.query(params![kind, id, claim_type, limit as i64])?
+        }
+        (Some(claim_type), None) => stmt.query(params![kind, id, claim_type])?,
+        (None, Some(limit)) => stmt.query(params![kind, id, limit as i64])?,
+        (None, None) => stmt.query(params![kind, id])?,
+    };
     let mut claims = Vec::new();
     while let Some(row) = rows.next()? {
         claims.push(read_claim_row_with_surface_shadow_state(row)?);
@@ -9069,13 +9249,34 @@ pub fn load_claims_active_for_surface(
     claim_type: Option<&str>,
     surface: &str,
 ) -> Result<Vec<IntelligenceClaim>, ClaimError> {
-    let mut visible = Vec::new();
-    for claim in load_claims_active(db, subject_ref, claim_type)? {
-        if !is_claim_dismissed_on_surface(db, &claim.id, surface)? {
-            visible.push(claim);
-        }
+    load_claims_where_for_surface_limited(
+        db,
+        subject_ref,
+        claim_type,
+        "claim_state = 'active' AND surfacing_state = 'active'",
+        surface,
+        None,
+    )
+}
+
+pub fn load_claims_active_for_surface_limited(
+    db: &ActionDb,
+    subject_ref: &str,
+    claim_type: Option<&str>,
+    surface: &str,
+    limit: usize,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    if limit == 0 {
+        return Ok(Vec::new());
     }
-    Ok(visible)
+    load_claims_where_for_surface_limited(
+        db,
+        subject_ref,
+        claim_type,
+        "claim_state = 'active' AND surfacing_state = 'active'",
+        surface,
+        Some(limit),
+    )
 }
 
 pub fn load_claims_active_by_source_ref_for_surface(
@@ -9219,14 +9420,118 @@ pub fn load_entity_context_claims_active_for_surface(
     depth: usize,
     surface: &str,
 ) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    load_entity_context_claims_active_for_surface_inner(
+        db,
+        entity_type,
+        entity_id,
+        depth,
+        surface,
+        None,
+    )
+}
+
+pub fn load_entity_context_claims_active_for_surface_limited(
+    db: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    depth: usize,
+    surface: &str,
+    limit: usize,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    load_entity_context_claims_active_for_surface_inner(
+        db,
+        entity_type,
+        entity_id,
+        depth,
+        surface,
+        Some(limit),
+    )
+}
+
+pub fn load_entity_context_prompt_claims_active_for_surface_limited(
+    db: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    depth: usize,
+    surface: &str,
+    limit: usize,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    load_entity_context_claims_active_for_surface_inner_filtered(
+        db,
+        entity_type,
+        entity_id,
+        depth,
+        surface,
+        Some(limit),
+        true,
+    )
+}
+
+fn load_entity_context_claims_active_for_surface_inner(
+    db: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    depth: usize,
+    surface: &str,
+    limit: Option<usize>,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    load_entity_context_claims_active_for_surface_inner_filtered(
+        db,
+        entity_type,
+        entity_id,
+        depth,
+        surface,
+        limit,
+        false,
+    )
+}
+
+fn load_entity_context_claims_active_for_surface_inner_filtered(
+    db: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    depth: usize,
+    surface: &str,
+    limit: Option<usize>,
+    prompt_safe_only: bool,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
     let root = entity_context_subject(entity_type, entity_id)?;
     let subjects = entity_context_subjects_within_depth(db, root, depth.max(1))?;
+    if let Some(limit) = limit {
+        return load_entity_context_claims_for_subjects_limited(
+            db,
+            &subjects,
+            surface,
+            limit,
+            prompt_safe_only,
+        );
+    }
+
     let mut seen_claims = HashSet::new();
     let mut claims = Vec::new();
 
     for subject in subjects {
         let subject_ref = entity_context_subject_ref_json(&subject);
-        for claim in load_claims_active_for_surface(db, &subject_ref, None, surface)? {
+        let subject_claims = if prompt_safe_only {
+            load_claims_where_for_surface_limited_filtered(
+                db,
+                &subject_ref,
+                None,
+                "claim_state = 'active' AND surfacing_state = 'active'",
+                surface,
+                None,
+                true,
+            )?
+        } else {
+            load_claims_active_for_surface(db, &subject_ref, None, surface)?
+        };
+        for claim in subject_claims {
             if seen_claims.insert(claim.id.clone()) {
                 claims.push(claim);
             }
@@ -9234,6 +9539,79 @@ pub fn load_entity_context_claims_active_for_surface(
     }
 
     claims.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+    Ok(claims)
+}
+
+fn load_entity_context_claims_for_subjects_limited(
+    db: &ActionDb,
+    subjects: &[EntityContextSubject],
+    surface: &str,
+    limit: usize,
+    prompt_safe_only: bool,
+) -> Result<Vec<IntelligenceClaim>, ClaimError> {
+    if limit == 0 || subjects.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let surface = normalize_claim_surface(surface)?;
+    let has_surface_dismissals = table_exists_sqlite(db.conn_ref(), "claim_surface_dismissals")?;
+    let surface_columns = claim_surface_shadow_columns(db.conn_ref(), "current_claim")?;
+    let mut bound_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut subject_predicates = Vec::with_capacity(subjects.len());
+
+    for subject in subjects {
+        let kind_position = bound_params.len() + 1;
+        bound_params.push(Box::new(subject.kind.to_string()));
+        let id_position = bound_params.len() + 1;
+        bound_params.push(Box::new(subject.id.clone()));
+        subject_predicates.push(format!(
+            "(lower(json_extract(current_claim.subject_ref, '$.kind')) = ?{kind_position} \
+             AND json_extract(current_claim.subject_ref, '$.id') = ?{id_position})"
+        ));
+    }
+
+    let prompt_safe_filter = if prompt_safe_only {
+        "AND current_claim.sensitivity IN ('public', 'internal')"
+    } else {
+        ""
+    };
+    let dismissal_filter = if has_surface_dismissals {
+        let surface_position = bound_params.len() + 1;
+        bound_params.push(Box::new(surface.as_str().to_string()));
+        format!(
+            "AND NOT EXISTS (
+                SELECT 1
+                FROM claim_surface_dismissals dismissal
+                WHERE dismissal.claim_id = current_claim.id
+                  AND dismissal.surface = ?{surface_position}
+            )"
+        )
+    } else {
+        String::new()
+    };
+    let limit_position = bound_params.len() + 1;
+    bound_params.push(Box::new(limit as i64));
+    let subject_filter = subject_predicates.join(" OR ");
+    let sql = format!(
+        "SELECT {CLAIM_COLUMNS}, {surface_columns}
+         FROM intelligence_claims current_claim
+         WHERE json_valid(current_claim.subject_ref) = 1
+           AND ({subject_filter})
+           AND current_claim.claim_state = 'active'
+           AND current_claim.surfacing_state = 'active'
+           {prompt_safe_filter}
+           {dismissal_filter}
+         ORDER BY current_claim.created_at DESC
+         LIMIT ?{limit_position}"
+    );
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        bound_params.iter().map(|param| param.as_ref()).collect();
+    let mut stmt = db.conn_ref().prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(param_refs))?;
+    let mut claims = Vec::new();
+    while let Some(row) = rows.next()? {
+        claims.push(read_claim_row_with_surface_shadow_state(row)?);
+    }
     Ok(claims)
 }
 
@@ -14264,6 +14642,206 @@ mod tests {
         .map(|claim| claim.id)
         .collect::<Vec<_>>();
         assert!(entity_detail_ids.contains(&claim_id));
+    }
+
+    #[test]
+    fn entity_context_surface_limited_reader_caps_visible_claims() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        for index in 0..8 {
+            let claim_text = format!("Visible claim {index} belongs on the account detail page.");
+            let mut p = proposal(&claim_text);
+            p.field_path = Some(format!("health.limit_fixture_{index}"));
+            p.source_ref = Some(format!("fixture-email-{index}"));
+            p.observed_at = format!("2026-05-02T12:{index:02}:00Z");
+            inserted_claim_id(commit_claim(&ctx, &db, p).unwrap());
+        }
+
+        let visible = load_entity_context_claims_active_for_surface_limited(
+            &db,
+            "account",
+            "acct-1",
+            1,
+            ClaimDismissalSurface::TauriEntityDetail.as_str(),
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(
+            visible.len(),
+            3,
+            "entity intelligence must not load the full claim set before applying the render page cap"
+        );
+    }
+
+    #[test]
+    fn entity_context_surface_limited_reader_applies_global_cap_across_related_subjects() {
+        let db = test_db();
+        seed_account(&db);
+        for index in 0..8 {
+            let child_id = format!("acct-child-{index}");
+            db.conn_ref()
+                .execute(
+                    "INSERT INTO accounts (id, name, parent_id, updated_at)
+                     VALUES (?1, ?2, 'acct-1', ?3)",
+                    params![child_id, format!("Child Account {index}"), TS],
+                )
+                .expect("seed child account");
+            let subject_ref = format!(r#"{{"kind":"account","id":"acct-child-{index}"}}"#);
+            insert_fixture_claim(
+                &db,
+                &format!("claim-child-{index}"),
+                &subject_ref,
+                "risk",
+                &format!("Child account claim {index}"),
+                ClaimState::Active,
+                SurfacingState::Active,
+            );
+            db.conn_ref()
+                .execute(
+                    "UPDATE intelligence_claims
+                     SET created_at = ?1
+                     WHERE id = ?2",
+                    params![
+                        format!("2026-05-02T13:{index:02}:00Z"),
+                        format!("claim-child-{index}")
+                    ],
+                )
+                .expect("set child claim recency");
+        }
+
+        let visible = load_entity_context_claims_active_for_surface_limited(
+            &db,
+            "account",
+            "acct-1",
+            2,
+            ClaimDismissalSurface::TauriEntityDetail.as_str(),
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(
+            visible
+                .iter()
+                .map(|claim| claim.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claim-child-7", "claim-child-6", "claim-child-5"],
+            "related-subject entity reads must apply one global recency cap, not one cap per subject"
+        );
+    }
+
+    #[test]
+    fn entity_context_subject_lookup_uses_expression_index() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Indexed claim lookup fixture")).unwrap(),
+        );
+
+        let mut stmt = db
+            .conn_ref()
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT id
+                 FROM intelligence_claims current_claim
+                 WHERE json_valid(subject_ref) = 1
+                   AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
+                   AND json_extract(subject_ref, '$.id') = ?2
+                   AND claim_state = 'active'
+                   AND surfacing_state = 'active'
+                 ORDER BY created_at DESC
+                 LIMIT ?3",
+            )
+            .expect("prepare plan probe");
+        let details = stmt
+            .query_map(params!["account", "acct-1", 3_i64], |row| {
+                row.get::<_, String>(3)
+            })
+            .expect("query plan")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect query plan");
+
+        assert!(
+            details.iter().any(|detail| {
+                detail.contains("idx_claims_subject_kind_id_lifecycle_untyped_created")
+            }),
+            "untyped entity claim reads should use the order-covering subject lookup index, got plan: {details:?}"
+        );
+        assert!(
+            details
+                .iter()
+                .all(|detail| !detail.contains("USE TEMP B-TREE")),
+            "untyped entity claim reads should not temp-sort before the page cap, got plan: {details:?}"
+        );
+    }
+
+    #[test]
+    fn entity_context_prompt_claim_reader_filters_sensitivity_before_cap() {
+        let db = test_db();
+        seed_account(&db);
+
+        for index in 0..51 {
+            let id = format!("claim-confidential-newer-{index}");
+            insert_fixture_claim(
+                &db,
+                &id,
+                SUBJECT,
+                "risk",
+                &format!("Confidential fixture claim {index}"),
+                ClaimState::Active,
+                SurfacingState::Active,
+            );
+            db.conn_ref()
+                .execute(
+                    "UPDATE intelligence_claims
+                     SET sensitivity = 'confidential', created_at = ?1
+                     WHERE id = ?2",
+                    params![format!("2026-05-02T12:{index:02}:00Z"), id],
+                )
+                .expect("mark fixture claim confidential and newer");
+        }
+
+        insert_fixture_claim(
+            &db,
+            "claim-internal-older",
+            SUBJECT,
+            "risk",
+            "Older prompt-safe claim should survive the bounded read.",
+            ClaimState::Active,
+            SurfacingState::Active,
+        );
+        db.conn_ref()
+            .execute(
+                "UPDATE intelligence_claims
+                 SET sensitivity = 'internal', created_at = ?1
+                 WHERE id = 'claim-internal-older'",
+                params!["2026-05-02T11:00:00Z"],
+            )
+            .expect("mark prompt-safe fixture older");
+
+        let claims = load_entity_context_prompt_claims_active_for_surface_limited(
+            &db,
+            "account",
+            "acct-1",
+            1,
+            ClaimDismissalSurface::McpTool.as_str(),
+            51,
+        )
+        .expect("prompt-safe entity context read");
+
+        assert_eq!(
+            claims
+                .iter()
+                .map(|claim| claim.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claim-internal-older"],
+            "MCP/agent readers must filter prompt-unsafe claims before the page cap"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -372,6 +372,16 @@ fn open_loop_claim_for_action(
     action: crate::db::DbAction,
     query: &ListOpenLoopsQuery,
 ) -> Option<abilities_runtime::types::IntelligenceClaim> {
+    // Action rows do not carry the source claim sensitivity that MCP/agent
+    // prompt surfaces need. Keep them visible to first-party Tauri surfaces,
+    // but do not synthesize them as Public claim text for MCP.
+    if matches!(
+        query.surface,
+        ClaimDismissalSurface::McpTool | ClaimDismissalSurface::McpToolDetail
+    ) {
+        return None;
+    }
+
     let (entity_type, entity_id) = open_loop_subject_for_action(&action, query)?;
     let claim_type = if action.action_kind == crate::action_status::KIND_COMMITMENT {
         abilities_runtime::ClaimType::Commitment.as_str()
@@ -478,6 +488,62 @@ impl EntityContextClaimReadHandle for LiveEntityContextClaimReader {
                     &entity_id,
                     depth,
                     surface.as_str(),
+                )
+                .map_err(|error| format!("Entity context claim read failed: {error}"))
+            })
+            .await
+            .map_err(|error| format!("Entity context claim read task failed: {error}"))?
+        })
+    }
+
+    fn read_entity_context_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let db =
+                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
+                        .map_err(|error| format!("Database unavailable: {error}"))?;
+                crate::services::claims::load_entity_context_claims_active_for_surface_limited(
+                    &db,
+                    &entity_type,
+                    &entity_id,
+                    depth,
+                    surface.as_str(),
+                    limit,
+                )
+                .map_err(|error| format!("Entity context claim read failed: {error}"))
+            })
+            .await
+            .map_err(|error| format!("Entity context claim read task failed: {error}"))?
+        })
+    }
+
+    fn read_entity_context_prompt_claims_limited<'a>(
+        &'a self,
+        entity_type: String,
+        entity_id: String,
+        surface: ClaimDismissalSurface,
+        depth: usize,
+        limit: usize,
+    ) -> EntityContextClaimReadFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let db =
+                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
+                        .map_err(|error| format!("Database unavailable: {error}"))?;
+                crate::services::claims::load_entity_context_prompt_claims_active_for_surface_limited(
+                    &db,
+                    &entity_type,
+                    &entity_id,
+                    depth,
+                    surface.as_str(),
+                    limit,
                 )
                 .map_err(|error| format!("Entity context claim read failed: {error}"))
             })
@@ -689,6 +755,77 @@ fn project_daily_readiness_context_snapshot(
 mod tests {
     use super::*;
     use rusqlite::params;
+
+    fn fixture_action() -> crate::db::DbAction {
+        crate::db::DbAction {
+            id: "action-1".to_string(),
+            title: "Follow up on renewal risk".to_string(),
+            priority: 1,
+            status: crate::action_status::UNSTARTED.to_string(),
+            created_at: "2026-05-23T08:00:00Z".to_string(),
+            due_date: None,
+            completed_at: None,
+            account_id: Some("acct-1".to_string()),
+            project_id: None,
+            source_type: Some("transcript".to_string()),
+            source_id: Some("meeting-1".to_string()),
+            source_label: Some("meeting".to_string()),
+            action_kind: crate::action_status::KIND_TASK.to_string(),
+            commitment_id: None,
+            owner_raw: Some("Alex".to_string()),
+            owner_entity_id: None,
+            owner_confidence: None,
+            owner_source: None,
+            trust_score: Some(0.8),
+            trust_band: Some("likely_current".to_string()),
+            commitment_source_count: Some(1),
+            context: None,
+            waiting_on: None,
+            updated_at: "2026-05-23T08:00:00Z".to_string(),
+            person_id: None,
+            account_name: None,
+            next_meeting_title: None,
+            next_meeting_start: None,
+            needs_decision: false,
+            decision_owner: None,
+            decision_stakes: None,
+            linear_identifier: None,
+            linear_url: None,
+        }
+    }
+
+    #[test]
+    fn action_open_loop_synthesis_is_not_mcp_visible_without_claim_sensitivity() {
+        let action = fixture_action();
+        let mcp_query = ListOpenLoopsQuery {
+            entity_type: Some("account".to_string()),
+            entity_id: Some("acct-1".to_string()),
+            surface: ClaimDismissalSurface::McpTool,
+        };
+        assert!(
+            open_loop_claim_for_action(action.clone(), &mcp_query).is_none(),
+            "action rows must not become MCP prompt context without source claim sensitivity"
+        );
+        let mcp_detail_query = ListOpenLoopsQuery {
+            entity_type: Some("account".to_string()),
+            entity_id: Some("acct-1".to_string()),
+            surface: ClaimDismissalSurface::McpToolDetail,
+        };
+        assert!(
+            open_loop_claim_for_action(action.clone(), &mcp_detail_query).is_none(),
+            "MCP detail provenance must not synthesize action rows without source claim sensitivity"
+        );
+
+        let tauri_query = ListOpenLoopsQuery {
+            entity_type: Some("account".to_string()),
+            entity_id: Some("acct-1".to_string()),
+            surface: ClaimDismissalSurface::TauriEntityDetail,
+        };
+        assert!(
+            open_loop_claim_for_action(action, &tauri_query).is_some(),
+            "first-party Tauri surfaces can still render local action open loops"
+        );
+    }
 
     #[test]
     fn daily_readiness_context_warns_when_linked_subjects_cannot_be_read() {

--- a/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
+++ b/src-tauri/tests/dos168_mcp_v2_migration_smoke_test.rs
@@ -4,13 +4,13 @@
 //! Runs the full migration chain against an in-memory SQLite and asserts the
 //! schema landed correctly: tables exist, expected columns are present, and
 //! the composite UNIQUE constraints + indexes from ADR-0102 §C.bis.schema are
-//! enforced while the removed remote-transport nonce ledger stays absent.
+//! enforced while obsolete transient transport state is absent.
 
 use dailyos_lib::migration_test_api::run_migrations;
 use rusqlite::Connection;
 
 #[test]
-fn dos168_v255_v259_migrations_land_canonical_schema() {
+fn dos168_v255_v261_migrations_land_canonical_schema() {
     let conn = Connection::open_in_memory().expect("open in-memory database");
     run_migrations(&conn).expect("migrations apply cleanly");
 

--- a/src-tauri/tests/dos412_render_policy_test.rs
+++ b/src-tauri/tests/dos412_render_policy_test.rs
@@ -335,6 +335,9 @@ fn setup_migration_runner_state(conn: &Connection) {
             confidence REAL NOT NULL,
             decay_half_life_days REAL NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS emails (
+            email_id TEXT PRIMARY KEY
+        );
         CREATE TABLE IF NOT EXISTS intelligence_claims (
             id TEXT PRIMARY KEY,
             text TEXT NOT NULL DEFAULT '',

--- a/src-tauri/tests/release_gate_hermetic_test.rs
+++ b/src-tauri/tests/release_gate_hermetic_test.rs
@@ -17,21 +17,16 @@ use serde_json::json;
 
 const TEST_GIT_SHA: &str = RELEASE_GATE_BUILD_GIT_SHA;
 const W6_TEST_FIXTURE_IDS: &[&str] = &[
-    "w6-01-default-wp-mcp-no-dailyos",
-    "w6-02-mcp-exposure-none-hidden",
-    "w6-03-frontend-js-no-dailyos-secrets",
-    "w6-04-gutenberg-rejects-raw-runtime-payloads",
-    "w6-05-projection-tampered-typed-error",
-    "w6-06-stale-claim-version-feedback-409",
-    "w6-07-cross-user-presence-nonce",
-    "w6-08-presence-nonce-replay-rejected",
-    "w6-09-phase3-budget-charge-fail-closed",
-    "w6-10-direct-plugin-claim-table-write-lint",
-    "w6-11-payload-json-redaction",
-    "w6-12-stock-theme-account-overview-render",
-    "w6-13-cold-start-stale-marker-notice",
-    "w6-14-hot-tauri-restart-sentinel-discovery",
-    "w6-15-hot-studio-restart-first-render",
+    "v144a-w6-01-frontend-surface-contracts",
+    "v144a-w6-02-daily-briefing-bounded-expansion",
+    "v144a-w6-03-daily-briefing-cursor",
+    "v144a-w6-04-entity-claim-read-cap",
+    "v144a-w6-05-mcp-action-redaction",
+    "v144a-w6-06-entity-fixture-harness",
+    "v144a-w6-07-foreground-contention",
+    "v144a-w6-08-email-refresh-coalescing",
+    "v144a-w6-09-dos412-render-policy-drift",
+    "v144a-w6-10-dos168-mcp-migration-drift",
 ];
 
 type BundleStatus = (u32, bool, u64);
@@ -278,7 +273,7 @@ fn release_gate_requires_w6_fixture_report() {
     write_dos288_evidence(&output_dir, "dos288_bleed_detection_test", "pass");
     write_dos288_evidence(&output_dir, "dos288_ownership_validator_test", "pass");
     let config = config_for_report(&report_path, &output_dir);
-    fs::remove_file(output_dir.join("w6-fixtures.json")).expect("remove W6 evidence");
+    fs::remove_file(output_dir.join("v144a-w6-fixtures.json")).expect("remove W6 evidence");
 
     let outcome = run_gate_with_db_reader(&config, &UnusedDbReader).expect("gate writes evidence");
     let evidence = read_evidence(&outcome.evidence_json_path);
@@ -303,17 +298,14 @@ fn release_gate_requires_w6_fixture_failures_green() {
     write_dos288_evidence(&output_dir, "dos288_bleed_detection_test", "pass");
     write_dos288_evidence(&output_dir, "dos288_ownership_validator_test", "pass");
     let config = config_for_report(&report_path, &output_dir);
-    write_w6_fixture_evidence(
-        &output_dir,
-        &[("w6-05-projection-tampered-typed-error", "fail")],
-    );
+    write_w6_fixture_evidence(&output_dir, &[("v144a-w6-05-mcp-action-redaction", "fail")]);
 
     let outcome = run_gate_with_db_reader(&config, &UnusedDbReader).expect("gate writes evidence");
     let evidence = read_evidence(&outcome.evidence_json_path);
 
     assert_eq!(outcome.exit_code, EXIT_MANDATORY_FAILURE);
     assert!(evidence.invariants.iter().any(|invariant| {
-        invariant.id == "w6-05-projection-tampered-typed-error"
+        invariant.id == "v144a-w6-05-mcp-action-redaction"
             && invariant.status == GateStatus::Fail
             && invariant.mandatory
     }));
@@ -333,7 +325,7 @@ fn release_gate_treats_w6_skipped_fixture_as_failure() {
     let config = config_for_report(&report_path, &output_dir);
     write_w6_fixture_evidence(
         &output_dir,
-        &[("w6-14-hot-tauri-restart-sentinel-discovery", "skipped")],
+        &[("v144a-w6-08-email-refresh-coalescing", "skipped")],
     );
 
     let outcome = run_gate_with_db_reader(&config, &UnusedDbReader).expect("gate writes evidence");
@@ -341,7 +333,7 @@ fn release_gate_treats_w6_skipped_fixture_as_failure() {
 
     assert_eq!(outcome.exit_code, EXIT_MANDATORY_FAILURE);
     assert!(evidence.invariants.iter().any(|invariant| {
-        invariant.id == "w6-14-hot-tauri-restart-sentinel-discovery"
+        invariant.id == "v144a-w6-08-email-refresh-coalescing"
             && invariant.status == GateStatus::Fail
             && invariant
                 .failure_summary
@@ -478,9 +470,9 @@ fn write_w6_fixture_evidence(output_dir: &Path, overrides: &[(&str, &str)]) {
         "fail"
     };
     fs::write(
-        output_dir.join("w6-fixtures.json"),
+        output_dir.join("v144a-w6-fixtures.json"),
         serde_json::to_string_pretty(&json!({
-            "schema_version": "w6_negative_fixture_results_v1",
+            "schema_version": "v144a_w6_fixture_results_v1",
             "status": status,
             "git_sha": TEST_GIT_SHA,
             "fixtures_hash": live_fixtures_hash(),

--- a/src/pages/EmailsPage.test.tsx
+++ b/src/pages/EmailsPage.test.tsx
@@ -1,0 +1,190 @@
+/** @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import EmailsPage from "./EmailsPage";
+import type { EmailBriefingData, EmailSyncStats } from "@/types";
+
+const { invokeMock, eventHandlers, navigateMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  eventHandlers: new Map<string, () => void>(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock("@/hooks/useMagazineShell", () => ({
+  useRegisterMagazineShell: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePersonality", () => ({
+  usePersonality: () => ({ personality: "default" }),
+}));
+
+vi.mock("@/hooks/useGoogleAuth", () => ({
+  useGoogleAuth: () => ({
+    status: { status: "authenticated", email: "user@example.com" },
+  }),
+}));
+
+vi.mock("@/hooks/useTauriEvent", () => ({
+  useTauriEvent: (event: string, handler: () => void) => {
+    eventHandlers.set(event, handler);
+  },
+}));
+
+const emptyBriefing: EmailBriefingData = {
+  highPriority: [],
+  mediumPriority: [],
+  lowPriority: [],
+  entityThreads: [],
+  stats: {
+    total: 0,
+    highCount: 0,
+    mediumCount: 0,
+    lowCount: 0,
+    needsAction: 0,
+  },
+  hasEnrichment: true,
+};
+
+const syncStats: EmailSyncStats = {
+  lastFetchAt: null,
+  lastSuccessfulFetchAt: null,
+  total: 0,
+  enriched: 0,
+  pending: 0,
+  failed: 0,
+  permanentlyFailed: 0,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function installResolvedInvoke() {
+  invokeMock.mockImplementation((command: string) => {
+    switch (command) {
+      case "get_emails_enriched":
+        return Promise.resolve(emptyBriefing);
+      case "list_dismissed_email_items":
+        return Promise.resolve([]);
+      case "get_email_sync_status":
+        return Promise.resolve(syncStats);
+      case "sync_email_inbox_presence":
+        return Promise.resolve(true);
+      default:
+        return Promise.resolve(null);
+    }
+  });
+}
+
+function getEmailReadCount() {
+  return invokeMock.mock.calls.filter(([command]) => command === "get_emails_enriched").length;
+}
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("EmailsPage refresh behavior", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    invokeMock.mockReset();
+    navigateMock.mockReset();
+    eventHandlers.clear();
+    installResolvedInvoke();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("coalesces backend email event bursts into one silent foreground read", async () => {
+    render(<EmailsPage />);
+    await flushMicrotasks();
+    expect(getEmailReadCount()).toBe(1);
+
+    act(() => {
+      eventHandlers.get("emails-updated")?.();
+      eventHandlers.get("workflow-completed")?.();
+      eventHandlers.get("email-enrichment-progress")?.();
+      vi.advanceTimersByTime(749);
+    });
+    expect(getEmailReadCount()).toBe(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+
+    await flushMicrotasks();
+    expect(getEmailReadCount()).toBe(2);
+  });
+
+  it("queues one silent refresh when a backend event fires during an active load", async () => {
+    const firstRead = deferred<EmailBriefingData>();
+    let emailReadCalls = 0;
+    invokeMock.mockImplementation((command: string) => {
+      switch (command) {
+        case "get_emails_enriched":
+          emailReadCalls += 1;
+          return emailReadCalls === 1 ? firstRead.promise : Promise.resolve(emptyBriefing);
+        case "list_dismissed_email_items":
+          return Promise.resolve([]);
+        case "get_email_sync_status":
+          return Promise.resolve(syncStats);
+        case "sync_email_inbox_presence":
+          return Promise.resolve(true);
+        default:
+          return Promise.resolve(null);
+      }
+    });
+
+    render(<EmailsPage />);
+    expect(getEmailReadCount()).toBe(1);
+
+    act(() => {
+      eventHandlers.get("emails-updated")?.();
+      vi.advanceTimersByTime(750);
+    });
+    expect(getEmailReadCount()).toBe(1);
+
+    await act(async () => {
+      firstRead.resolve(emptyBriefing);
+      await firstRead.promise;
+      await Promise.resolve();
+    });
+    await flushMicrotasks();
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+      await Promise.resolve();
+    });
+
+    await flushMicrotasks();
+    expect(getEmailReadCount()).toBe(2);
+  });
+});

--- a/src/pages/EmailsPage.tsx
+++ b/src/pages/EmailsPage.tsx
@@ -89,8 +89,18 @@ export default function EmailsPage() {
   const [failureActionInFlight, setFailureActionInFlight] = useState(false);
   const [, startTransition] = useTransition();
   const inboxSyncInFlight = useRef(false);
+  const loadEmailsInFlight = useRef(false);
+  const pendingSilentRefresh = useRef(false);
+  const silentRefreshTimer = useRef<number | null>(null);
 
   const loadEmails = useCallback(async (silent = false) => {
+    if (loadEmailsInFlight.current) {
+      if (silent) {
+        pendingSilentRefresh.current = true;
+      }
+      return;
+    }
+    loadEmailsInFlight.current = true;
     try {
       const [result, dismissedItems, stats] = await Promise.all([
         invoke<EmailBriefingData>("get_emails_enriched"),
@@ -115,7 +125,12 @@ export default function EmailsPage() {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      loadEmailsInFlight.current = false;
       setLoading(false);
+      if (pendingSilentRefresh.current) {
+        pendingSilentRefresh.current = false;
+        window.setTimeout(() => { void loadEmails(true); }, 0);
+      }
     }
   }, []);
 
@@ -162,7 +177,22 @@ export default function EmailsPage() {
   }, [syncInboxPresence]);
 
   // Silent refresh on backend email events — uses transition to avoid blink
-  const silentRefresh = useCallback(() => { loadEmails(true); }, [loadEmails]);
+  const silentRefresh = useCallback(() => {
+    if (silentRefreshTimer.current !== null) {
+      window.clearTimeout(silentRefreshTimer.current);
+    }
+    silentRefreshTimer.current = window.setTimeout(() => {
+      silentRefreshTimer.current = null;
+      void loadEmails(true);
+    }, 750);
+  }, [loadEmails]);
+
+  useEffect(() => () => {
+    if (silentRefreshTimer.current !== null) {
+      window.clearTimeout(silentRefreshTimer.current);
+    }
+  }, []);
+
   useTauriEvent("emails-updated", silentRefresh);
   useTauriEvent("workflow-completed", silentRefresh);
   useTauriEvent("email-enrichment-progress", silentRefresh);

--- a/src/services/entity-intelligence/invoke.test.ts
+++ b/src/services/entity-intelligence/invoke.test.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ENVELOPE_SCHEMA_VERSION } from "./contracts";
 import { invokeEntityIntelligenceAbility } from "./invoke";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -38,7 +39,7 @@ describe("invokeEntityIntelligenceAbility", () => {
     expect(invokeMock).toHaveBeenCalledWith("invoke_ability", {
       abilityName: "get_entity_intelligence",
       inputJson: {
-        schemaVersion: 2,
+        schemaVersion: ENVELOPE_SCHEMA_VERSION,
         entityType: "meeting",
         entityId: "meeting-1",
         depth: "standard",


### PR DESCRIPTION
## Linear ticket

DOS-514

## Summary

v1.4.4a now has a release gate for the claim-backed briefing and entity-intelligence surfaces. The read path is bounded at the service layer, prompt-safe for Agent/MCP consumers, and covered by W6 fixtures instead of the old WordPress-era gate.

## What changed

- Added the v1.4.4a W6 fixture runner and wired the release gate to the W6 fixture catalog.
- Bounded Daily Briefing expansion to current, next, and visible upcoming meetings.
- Moved entity-intelligence claim reads onto limited service readers, including prompt-safe-before-cap reads for Agent/MCP and a global related-subject SQL cap.
- Added v263 claim SubjectRef lookup indexes and migration coverage.
- Suppressed synthetic action open-loop claims for MCP surfaces without backing claim sensitivity and removed raw `noise_reason` logging.
- Coalesced foreground email refresh bursts to avoid stacked reloads.
- Recorded W6 proof, Suite S/E/P evidence, L2 outcomes, and the W6 retro.
- Fixed parallel key-rotation/global DB-service test interference that surfaced during the rebased pre-commit hook run.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` passes (covered by Suite E and W6 fixture frontend tests)
- [x] Manual verification: `scripts/release-gate/run-v144a-w6-fixtures.sh`, Suite S, Suite E, Suite P published run, release-gate hermetic test, targeted v263 migration/smoke tests, targeted rotation cluster, and L2 reviewer reruns passed locally.

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

Note: Rust validation included repeated parallel `cargo test --lib` hook runs, focused release-gate/integration tests, and a full single-threaded lib suite. One local pre-push attempt hit a macOS SIGBUS before a deterministic assertion failure; retrying the same push gauntlet passed.

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: Security L2 ran because this touches services, abilities, MCP exposure, migrations, sensitivity filtering, and redaction.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Route-level Suite P benchmarks for Daily Briefing, Meeting Briefing, entity detail, actions, and emails remain a maintenance item.

## Notes for review

Pre-push L2 was rerun after remediation with migration, security, performance, adversarial, and testing reviewers. The final W6 fixture runner passed with 10/10 fixtures. Suite P published evidence is refreshed against the rebased feature commit and recorded as `dirty: false`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
