### PR TITLE
Resolve path-alpha maintenance batch

### DIFF
--- a/scripts/check_runtime_client_filter_registered.sh
+++ b/scripts/check_runtime_client_filter_registered.sh
@@ -19,6 +19,95 @@ fail() {
   failures=$((failures + 1))
 }
 
+runtime_filter_registered_in_plugin_init() {
+  local plugin_php="$1"
+
+  awk '
+    function brace_delta(line, opens, closes) {
+      opens = gsub(/\{/, "{", line)
+      closes = gsub(/\}/, "}", line)
+      return opens - closes
+    }
+
+    BEGIN {
+      in_class = 0
+      pending_class = 0
+      class_depth = 0
+      in_init = 0
+      pending_init = 0
+      init_depth = 0
+      registration = "add_filter\\([[:space:]]*'\''dailyos_runtime_client_for_block'\''[[:space:]]*,[[:space:]]*\\[[[:space:]]*\\$this[[:space:]]*,[[:space:]]*'\''default_runtime_client_for_block'\''[[:space:]]*\\][[:space:]]*,[[:space:]]*5"
+    }
+
+    !in_class && !pending_class && $0 ~ /^[[:space:]]*(final[[:space:]]+)?class[[:space:]]+DailyOS_Plugin([[:space:]]|\{)/ {
+      pending_class = 1
+    }
+
+    pending_class {
+      if ($0 ~ /\{/) {
+        in_class = 1
+        pending_class = 0
+        class_depth = brace_delta($0)
+        if (class_depth <= 0) {
+          in_class = 0
+        }
+      }
+      next
+    }
+
+    in_class && !in_init && !pending_init && $0 ~ /^[[:space:]]*public[[:space:]]+function[[:space:]]+init[[:space:]]*\(/ {
+      pending_init = 1
+    }
+
+    pending_init {
+      if ($0 ~ /\{/) {
+        in_init = 1
+        pending_init = 0
+        init_depth = brace_delta($0)
+        if ($0 ~ registration) {
+          found = 1
+          exit
+        }
+        if (init_depth <= 0) {
+          in_init = 0
+        }
+      }
+      class_depth += brace_delta($0)
+      if (class_depth <= 0) {
+        in_class = 0
+      }
+      next
+    }
+
+    in_init {
+      if ($0 ~ registration) {
+        found = 1
+        exit
+      }
+      init_depth += brace_delta($0)
+      if (init_depth <= 0) {
+        in_init = 0
+      }
+      class_depth += brace_delta($0)
+      if (class_depth <= 0) {
+        in_class = 0
+      }
+      next
+    }
+
+    in_class {
+      class_depth += brace_delta($0)
+      if (class_depth <= 0) {
+        in_class = 0
+      }
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$plugin_php"
+}
+
 # ----- inv #1: global filter registered in init() -----
 PLUGIN_PHP="$ROOT_DIR/wp/dailyos/includes/class-dailyos-plugin.php"
 
@@ -27,8 +116,8 @@ if [ ! -f "$PLUGIN_PHP" ]; then
 else
   # The registration must appear inside init() and reference the
   # default_runtime_client_for_block callback at priority 5.
-  if ! grep -qE "add_filter\(\s*'dailyos_runtime_client_for_block'\s*,\s*\[\s*\\\$this\s*,\s*'default_runtime_client_for_block'\s*\]\s*,\s*5" "$PLUGIN_PHP"; then
-    fail "inv #1: default_runtime_client_for_block filter not registered at priority 5 in $PLUGIN_PHP — every dailyos/* block will render is-empty regardless of runtime state"
+  if ! runtime_filter_registered_in_plugin_init "$PLUGIN_PHP"; then
+    fail "inv #1: default_runtime_client_for_block filter not registered at priority 5 inside DailyOS_Plugin::init() in $PLUGIN_PHP — every dailyos/* block will render is-empty regardless of runtime state"
   fi
 fi
 

--- a/scripts/check_runtime_client_filter_registered_test.sh
+++ b/scripts/check_runtime_client_filter_registered_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Purpose: fixture-test the runtime-client filter lint gate.
+# Exit codes: 0 when all fixture assertions pass; 1 when any assertion fails.
+# How to run: ./scripts/check_runtime_client_filter_registered_test.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+LINT_SCRIPT="${ROOT_DIR}/scripts/check_runtime_client_filter_registered.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/runtime-client-filter-lint.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "runtime-client filter lint fixture test failed: $1" >&2
+  if [ "${2:-}" != "" ] && [ -f "$2" ]; then
+    sed 's/^/  /' "$2" >&2
+  fi
+  exit 1
+}
+
+make_fixture_root() {
+  local root="$1"
+
+  mkdir -p \
+    "$root/wp/dailyos/includes" \
+    "$root/wp/dailyos/blocks/example"
+
+  cat > "$root/wp/dailyos/blocks/example/render-functions.php" <<'PHP'
+<?php
+
+$runtime_client = apply_filters( 'dailyos_runtime_client_for_block', null );
+$runtime_client->fetch_account_overview();
+PHP
+}
+
+VALID_ROOT="$TMP_DIR/valid"
+make_fixture_root "$VALID_ROOT"
+cat > "$VALID_ROOT/wp/dailyos/includes/class-dailyos-plugin.php" <<'PHP'
+<?php
+
+class DailyOS_Plugin {
+	public function init(): void {
+		add_filter( 'dailyos_runtime_client_for_block', [ $this, 'default_runtime_client_for_block' ], 5, 1 );
+	}
+
+	public function default_runtime_client_for_block( mixed $existing ): mixed {
+		return $existing;
+	}
+}
+PHP
+
+VALID_OUT="$TMP_DIR/valid.out"
+set +e
+DAILYOS_LINT_ROOT="$VALID_ROOT" "$LINT_SCRIPT" > "$VALID_OUT" 2>&1
+VALID_STATUS=$?
+set -e
+
+if [ "$VALID_STATUS" -ne 0 ]; then
+  fail "expected init-scoped registration fixture to exit 0, got ${VALID_STATUS}" "$VALID_OUT"
+fi
+
+INVALID_ROOT="$TMP_DIR/invalid"
+make_fixture_root "$INVALID_ROOT"
+cat > "$INVALID_ROOT/wp/dailyos/includes/class-dailyos-plugin.php" <<'PHP'
+<?php
+
+class Other_Plugin {
+	public function init(): void {
+		add_filter( 'dailyos_runtime_client_for_block', [ $this, 'default_runtime_client_for_block' ], 5, 1 );
+	}
+}
+
+class DailyOS_Plugin {
+	public function init(): void {
+		$this->register_blocks();
+	}
+
+	public function register_rest_routes(): void {
+		add_filter( 'dailyos_runtime_client_for_block', [ $this, 'default_runtime_client_for_block' ], 5, 1 );
+	}
+
+	public function default_runtime_client_for_block( mixed $existing ): mixed {
+		return $existing;
+	}
+}
+PHP
+
+INVALID_OUT="$TMP_DIR/invalid.out"
+set +e
+DAILYOS_LINT_ROOT="$INVALID_ROOT" "$LINT_SCRIPT" > "$INVALID_OUT" 2>&1
+INVALID_STATUS=$?
+set -e
+
+if [ "$INVALID_STATUS" -ne 1 ]; then
+  fail "expected out-of-init registration fixture to exit 1, got ${INVALID_STATUS}" "$INVALID_OUT"
+fi
+
+if ! grep -q "inside DailyOS_Plugin::init()" "$INVALID_OUT"; then
+  fail "expected out-of-init failure to name DailyOS_Plugin::init()" "$INVALID_OUT"
+fi
+
+echo "runtime-client filter lint fixture test: ok"

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -5327,6 +5327,12 @@ fn validate_feedback_actor(actor: &str) -> Result<(), ClaimError> {
     }
 }
 
+const INVALID_FEEDBACK_PAYLOAD_JSON_MESSAGE: &str = "payload_json must be valid JSON";
+
+fn invalid_feedback_payload_json() -> ClaimError {
+    ClaimError::InvalidFeedback(INVALID_FEEDBACK_PAYLOAD_JSON_MESSAGE.to_string())
+}
+
 fn validate_feedback_payload(
     input: &ClaimFeedbackInput,
     metadata: &ClaimFeedbackMetadata,
@@ -5338,9 +5344,8 @@ fn validate_feedback_payload(
         .filter(|s| !s.is_empty());
     let payload = raw_payload
         .map(|payload| {
-            serde_json::from_str::<serde_json::Value>(payload).map_err(|e| {
-                ClaimError::InvalidFeedback(format!("payload_json must be valid JSON: {e}"))
-            })
+            serde_json::from_str::<serde_json::Value>(payload)
+                .map_err(|_| invalid_feedback_payload_json())
         })
         .transpose()?;
 
@@ -5429,9 +5434,8 @@ fn payload_string(payload_json: Option<&str>, key: &str) -> Result<Option<String
     else {
         return Ok(None);
     };
-    let payload: serde_json::Value = serde_json::from_str(raw).map_err(|e| {
-        ClaimError::InvalidFeedback(format!("payload_json must be valid JSON: {e}"))
-    })?;
+    let payload: serde_json::Value =
+        serde_json::from_str(raw).map_err(|_| invalid_feedback_payload_json())?;
     Ok(payload
         .get(key)
         .and_then(serde_json::Value::as_str)
@@ -15403,6 +15407,37 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn dos716_malformed_feedback_payload_reports_generic_json_error() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let marker = "private-feedback-marker";
+        let malformed_payload = format!(r#"{{"corrected_text":"{marker}","#);
+        let mut input = feedback_input("claim-not-needed", FeedbackAction::NeedsNuance);
+        input.payload_json = Some(malformed_payload.clone());
+
+        let err = record_claim_feedback(&ctx, &db, input)
+            .expect_err("malformed feedback JSON should reject before claim lookup");
+        let display = err.to_string();
+        assert!(matches!(
+            &err,
+            ClaimError::InvalidFeedback(message)
+                if message == INVALID_FEEDBACK_PAYLOAD_JSON_MESSAGE
+        ));
+        assert!(!display.contains(marker));
+        assert!(!display.contains("line"));
+
+        let helper_err = payload_string(Some(&malformed_payload), "corrected_text")
+            .expect_err("payload_string must use the same safe JSON error");
+        assert!(matches!(
+            &helper_err,
+            ClaimError::InvalidFeedback(message)
+                if message == INVALID_FEEDBACK_PAYLOAD_JSON_MESSAGE
+        ));
+        assert!(!helper_err.to_string().contains(marker));
     }
 
     #[test]

--- a/src-tauri/src/services/fail_improve.rs
+++ b/src-tauri/src/services/fail_improve.rs
@@ -793,20 +793,6 @@ where
         .await
 }
 
-/// Legacy direct-fallback adapter. Registry signal typing fail-improve wrapping
-/// lives at `IntelligenceProvider::complete` via `complete_registry_signal_typing`.
-pub async fn execute_registry_signal_typing<L, LFut>(
-    input: SignalTypingInput,
-    llm_fallback: L,
-    _ctx: &ServiceContext<'_>,
-) -> Result<String>
-where
-    L: FnOnce(&SignalTypingInput) -> LFut,
-    LFut: Future<Output = Result<String>>,
-{
-    llm_fallback(&input).await
-}
-
 pub fn record_unknown_signal_type(
     signal_type: &str,
     payload: Value,
@@ -1256,6 +1242,36 @@ mod tests {
         }
     }
 
+    struct CountingRegistryCompletionFixtureProvider {
+        calls: Arc<Mutex<usize>>,
+    }
+
+    #[async_trait::async_trait]
+    impl IntelligenceProvider for CountingRegistryCompletionFixtureProvider {
+        async fn complete(
+            &self,
+            _prompt: PromptInput,
+            _tier: ModelTier,
+        ) -> std::result::Result<Completion, ProviderError> {
+            *self.calls.lock() += 1;
+            Ok(Completion {
+                text: serde_json::json!({
+                    "signal_type": "account_risk",
+                })
+                .to_string(),
+                fingerprint_metadata: Default::default(),
+            })
+        }
+
+        fn provider_kind(&self) -> crate::intelligence::provider::ProviderKind {
+            crate::intelligence::provider::ProviderKind::Other("counting_fixture")
+        }
+
+        fn current_model(&self, _tier: ModelTier) -> crate::intelligence::provider::ModelName {
+            crate::intelligence::provider::ModelName::new("counting-fixture")
+        }
+    }
+
     #[tokio::test]
     async fn deterministic_hit_updates_counts_without_jsonl_entry() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1291,6 +1307,46 @@ mod tests {
         assert_eq!(counts.llm_fallbacks, 0);
         assert_eq!(counts.deterministic_rate, 1.0);
         assert_eq!(counts.updated_at, "2026-05-09T14:30:00+00:00");
+    }
+
+    #[tokio::test]
+    async fn registry_completion_deterministic_hit_skips_provider_and_records_hit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let loop_ = FailImproveLoop::new(tmp.path().to_path_buf());
+        let (clock, rng, ext) = test_ctx();
+        let ctx = ServiceContext::new_live(&clock, &rng, &ext);
+        let input = SignalTypingInput {
+            signal_type: "account_created".to_string(),
+        };
+        let prompt = registry_signal_typing_prompt_input(&input, None);
+        let calls = Arc::new(Mutex::new(0));
+        let provider = CountingRegistryCompletionFixtureProvider {
+            calls: Arc::clone(&calls),
+        };
+
+        let output = complete_registry_signal_typing_with_loop(
+            &loop_,
+            &provider,
+            input,
+            prompt,
+            ModelTier::Mechanical,
+            &ctx,
+        )
+        .await
+        .expect("provider completion");
+
+        assert_eq!(output, "account_created");
+        assert_eq!(*calls.lock(), 0);
+        assert!(loop_
+            .read_artifact_to_string(SIGNAL_TYPING_OPERATION, ArtifactKind::Jsonl)
+            .expect("read jsonl")
+            .is_none());
+
+        let counts = read_counts(&loop_, SIGNAL_TYPING_OPERATION);
+        assert_eq!(counts.total_calls, 1);
+        assert_eq!(counts.deterministic_hits, 1);
+        assert_eq!(counts.llm_fallbacks, 0);
+        assert_eq!(counts.deterministic_rate, 1.0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/surface_nonce.rs
+++ b/src-tauri/src/services/surface_nonce.rs
@@ -120,10 +120,11 @@ impl SurfaceNonceService {
         fallback_request_id: &str,
         request_meta: PresenceNonceRequestMeta,
     ) -> Result<SurfaceNonceIssue, SurfaceNonceError> {
-        ensure_surface_client(session, fallback_request_id)?;
+        let now = ctx.clock.now();
+        ensure_surface_client(session, fallback_request_id, now)?;
         let request = IssueNonceRequest::parse(payload, fallback_request_id)
-            .map_err(|error| self.shape_error(session, error, request_meta.clone()))?;
-        let audit = NonceAuditContext::from_issue(session, &request).with_request_meta(
+            .map_err(|error| self.shape_error(session, error, request_meta.clone(), now))?;
+        let audit = NonceAuditContext::from_issue(session, &request, now).with_request_meta(
             request_meta.ip_hash.clone(),
             request_meta.user_agent_hash.clone(),
         );
@@ -185,7 +186,6 @@ impl SurfaceNonceService {
             ));
         }
 
-        let now = ctx.clock.now();
         let expires_at = now + self.inner.config.ttl;
         let fields = PresenceNonceBindingFields {
             surface_client_id: session.surface_client_id.clone(),
@@ -237,10 +237,11 @@ impl SurfaceNonceService {
         fallback_request_id: &str,
         request_meta: PresenceNonceRequestMeta,
     ) -> Result<SurfaceNonceVerify, SurfaceNonceError> {
-        ensure_surface_client(session, fallback_request_id)?;
+        let now = ctx.clock.now();
+        ensure_surface_client(session, fallback_request_id, now)?;
         let request = VerifyNonceRequest::parse(payload, fallback_request_id)
-            .map_err(|error| self.shape_error(session, error, request_meta.clone()))?;
-        let audit = NonceAuditContext::from_verify(session, &request).with_request_meta(
+            .map_err(|error| self.shape_error(session, error, request_meta.clone(), now))?;
+        let audit = NonceAuditContext::from_verify(session, &request, now).with_request_meta(
             request_meta.ip_hash.clone(),
             request_meta.user_agent_hash.clone(),
         );
@@ -262,14 +263,11 @@ impl SurfaceNonceService {
         })?;
         let digest = self.inner.digest_key.digest(&nonce_bytes);
 
-        match self.inner.store.verify_and_consume(
-            ctx,
-            db,
-            digest,
-            &request,
-            ctx.clock.now(),
-            audit.clone(),
-        ) {
+        match self
+            .inner
+            .store
+            .verify_and_consume(ctx, db, digest, &request, now, audit.clone())
+        {
             Ok(verified) => {
                 let audit_events = vec![audit_event(
                     "presence_nonce_verified",
@@ -319,7 +317,7 @@ impl SurfaceNonceService {
             composition_id,
             current_version,
             now,
-            NonceAuditContext::from_session(session, request_id),
+            NonceAuditContext::from_session(session, request_id, now),
         )
     }
 
@@ -366,8 +364,9 @@ impl SurfaceNonceService {
         session: &ValidatedSurfaceSession,
         error: RequestShapeError,
         request_meta: PresenceNonceRequestMeta,
+        now: DateTime<Utc>,
     ) -> SurfaceNonceError {
-        let audit = NonceAuditContext::from_session(session, &error.request_id)
+        let audit = NonceAuditContext::from_session(session, &error.request_id, now)
             .with_request_meta(request_meta.ip_hash, request_meta.user_agent_hash);
         self.charge_failure_best_effort(session, None, &audit);
         SurfaceNonceError::rejected(error.reason, audit)
@@ -385,8 +384,9 @@ impl SurfaceNonceService {
         session: &ValidatedSurfaceSession,
         request_meta: PresenceNonceRequestMeta,
         request_id: &str,
+        now: DateTime<Utc>,
     ) {
-        let audit = NonceAuditContext::from_session(session, request_id)
+        let audit = NonceAuditContext::from_session(session, request_id, now)
             .with_request_meta(request_meta.ip_hash, request_meta.user_agent_hash);
         self.charge_failure_best_effort(session, None, &audit);
     }
@@ -1373,7 +1373,11 @@ struct NonceAuditContext {
 }
 
 impl NonceAuditContext {
-    fn from_session(session: &ValidatedSurfaceSession, request_id: &str) -> Self {
+    fn from_session(
+        session: &ValidatedSurfaceSession,
+        request_id: &str,
+        now: DateTime<Utc>,
+    ) -> Self {
         Self {
             session: session.clone(),
             request_id: request_id.to_string(),
@@ -1390,7 +1394,7 @@ impl NonceAuditContext {
             attempted_surface_client_id: None,
             ip_hash: None,
             user_agent_hash: None,
-            now: Utc::now(),
+            now,
         }
     }
 
@@ -1414,8 +1418,12 @@ impl NonceAuditContext {
         self
     }
 
-    fn from_issue(session: &ValidatedSurfaceSession, request: &IssueNonceRequest) -> Self {
-        let mut audit = Self::from_session(session, &request.request_id);
+    fn from_issue(
+        session: &ValidatedSurfaceSession,
+        request: &IssueNonceRequest,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let mut audit = Self::from_session(session, &request.request_id, now);
         audit.claim_id = Some(request.claim_id.clone());
         audit.field_path = Some(request.field_path.clone());
         audit.presented_claim_version = Some(request.claim_version);
@@ -1425,8 +1433,12 @@ impl NonceAuditContext {
         audit
     }
 
-    fn from_verify(session: &ValidatedSurfaceSession, request: &VerifyNonceRequest) -> Self {
-        let mut audit = Self::from_session(session, &request.request_id);
+    fn from_verify(
+        session: &ValidatedSurfaceSession,
+        request: &VerifyNonceRequest,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let mut audit = Self::from_session(session, &request.request_id, now);
         audit.claim_id = Some(request.claim_id.clone());
         audit.field_path = Some(request.field_path.clone());
         audit.presented_claim_version = Some(request.claim_version);
@@ -1527,17 +1539,18 @@ fn session_hash(session_id: &str) -> String {
 fn ensure_surface_client(
     session: &ValidatedSurfaceSession,
     request_id: &str,
+    now: DateTime<Utc>,
 ) -> Result<(), SurfaceNonceError> {
     if !matches!(session.actor, Actor::SurfaceClient { .. }) {
         return Err(SurfaceNonceError::rejected(
             PresenceNonceRejectReason::WrongActor,
-            NonceAuditContext::from_session(session, request_id),
+            NonceAuditContext::from_session(session, request_id, now),
         ));
     }
     if session.wp_user_id.is_none() {
         return Err(SurfaceNonceError::rejected(
             PresenceNonceRejectReason::WrongUser,
-            NonceAuditContext::from_session(session, request_id),
+            NonceAuditContext::from_session(session, request_id, now),
         ));
     }
     Ok(())
@@ -2392,6 +2405,114 @@ mod tests {
     }
 
     #[test]
+    fn dos714_issue_budget_rolls_over_on_fixed_service_clock() {
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(1);
+        let ext = ExternalClients::default();
+        let ctx = ctx(&clock, &rng, &ext);
+        let db = db();
+        let service = service(SurfaceNonceConfig {
+            issue_budget_per_minute: 1,
+            ..SurfaceNonceConfig::default()
+        });
+        let session = session("session-1", 42);
+
+        let mut first_payload = issue_payload();
+        first_payload["request_id"] = json!("dos714-issue-1");
+        service
+            .issue_nonce(
+                &ctx,
+                &db,
+                &session,
+                first_payload,
+                "dos714-issue-1",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect("first issue consumes the fixed-clock budget window");
+
+        let mut blocked_payload = issue_payload();
+        blocked_payload["request_id"] = json!("dos714-issue-blocked");
+        let blocked = service
+            .issue_nonce(
+                &ctx,
+                &db,
+                &session,
+                blocked_payload,
+                "dos714-issue-blocked",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect_err("same fixed-clock minute is rate limited");
+        assert_eq!(blocked.reason, PresenceNonceRejectReason::RateLimited);
+
+        clock.advance(Duration::seconds(60));
+
+        let mut second_payload = issue_payload();
+        second_payload["request_id"] = json!("dos714-issue-2");
+        service
+            .issue_nonce(
+                &ctx,
+                &db,
+                &session,
+                second_payload,
+                "dos714-issue-2",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect("advanced fixed clock opens a new issue budget window");
+    }
+
+    #[test]
+    fn dos714_verify_budget_rolls_over_on_fixed_service_clock() {
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(1);
+        let ext = ExternalClients::default();
+        let ctx = ctx(&clock, &rng, &ext);
+        let db = db();
+        let service = service(SurfaceNonceConfig {
+            verify_budget_per_minute: 1,
+            ..SurfaceNonceConfig::default()
+        });
+        let session = session("session-1", 42);
+        let first_token = issue_token(&service, &ctx, &db, &session, "dos714-verify-issue-1");
+        let second_token = issue_token(&service, &ctx, &db, &session, "dos714-verify-issue-2");
+
+        service
+            .verify_nonce(
+                &ctx,
+                &db,
+                &session,
+                verify_payload(&first_token),
+                "dos714-verify-1",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect("first verify consumes the fixed-clock budget window");
+
+        let blocked = service
+            .verify_nonce(
+                &ctx,
+                &db,
+                &session,
+                verify_payload(&second_token),
+                "dos714-verify-blocked",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect_err("same fixed-clock minute is rate limited");
+        assert_eq!(blocked.reason, PresenceNonceRejectReason::RateLimited);
+
+        clock.advance(Duration::seconds(60));
+
+        service
+            .verify_nonce(
+                &ctx,
+                &db,
+                &session,
+                verify_payload(&second_token),
+                "dos714-verify-2",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect("advanced fixed clock opens a new verify budget window");
+    }
+
+    #[test]
     fn dos571_fixture_store_pressure_lru() {
         let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap());
         let rng = SeedableRng::new(1);
@@ -2644,7 +2765,8 @@ mod tests {
         // Constructs a NonceAuditContext with synthetic ip/UA hashes and
         // verifies audit_event surfaces them in the detail JSON.
         let session = session("session-1", 42);
-        let mut audit = NonceAuditContext::from_session(&session, "request-1")
+        let now = Utc.with_ymd_and_hms(2026, 5, 19, 12, 0, 0).unwrap();
+        let mut audit = NonceAuditContext::from_session(&session, "request-1", now)
             .with_request_meta(Some("ip_hash:abc".into()), Some("ua_hash:def".into()));
         audit.action = Some(PresenceNonceAction::NeedsNuance);
 
@@ -2659,7 +2781,8 @@ mod tests {
     #[test]
     fn audit_event_records_attempted_wp_user_on_wrong_user_rejection() {
         let session = session("session-1", 42);
-        let audit = NonceAuditContext::from_session(&session, "request-1")
+        let now = Utc.with_ymd_and_hms(2026, 5, 19, 12, 0, 0).unwrap();
+        let audit = NonceAuditContext::from_session(&session, "request-1", now)
             .with_attempted_user(Some(999), Some("attacker-client".into()));
 
         let event = audit_event(
@@ -2953,6 +3076,7 @@ mod tests {
             &session,
             PresenceNonceRequestMeta::default(),
             "phase3-record-feedback-failed",
+            clock.now(),
         );
 
         let failure_key = NonceBudgetKey::narrow(&session, NonceBudgetClass::Failure);

--- a/src-tauri/src/signals/bus.rs
+++ b/src-tauri/src/signals/bus.rs
@@ -674,7 +674,7 @@ fn emit_signal_event(
 
 fn record_unknown_signal_type_observation(
     typed_signal: &SignalType,
-    payload_privacy: PayloadPrivacy,
+    _original_payload_privacy: PayloadPrivacy,
     signal: &EmitSignalEvent<'_>,
 ) {
     if !matches!(typed_signal, SignalType::Legacy { .. }) {
@@ -693,7 +693,8 @@ fn record_unknown_signal_type_observation(
     crate::services::fail_improve::record_unknown_signal_type(
         signal.signal_type,
         payload,
-        payload_privacy,
+        // The payload above is the redacted envelope, not the original signal body.
+        PayloadPrivacy::NonPiiMetadata,
     );
 }
 
@@ -1692,6 +1693,94 @@ mod tests {
     }
 
     #[test]
+    fn dos495_legacy_sensitive_unknown_signals_write_redacted_fail_improve_observations() {
+        let _env_guard = fail_improve_env_lock().lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _restore = EnvRestore {
+            previous: std::env::var_os("DAILYOS_FAIL_IMPROVE_ROOT"),
+        };
+        std::env::set_var("DAILYOS_FAIL_IMPROVE_ROOT", tmp.path());
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            let sender_restore = UnknownSignalSenderRestore::replace(Some(tx));
+            let worker = tokio::spawn(
+                crate::services::fail_improve::run_unknown_signal_observation_worker(rx),
+            );
+
+            let db = test_db();
+            for (prefix, sensitive_value) in [
+                ("claim_dos495_unknown_", "raw claim body should not persist"),
+                (
+                    "correction_dos495_unknown_",
+                    "raw correction body should not persist",
+                ),
+                (
+                    "feedback_dos495_unknown_",
+                    "raw feedback body should not persist",
+                ),
+            ] {
+                let signal_type = format!("{prefix}{}", Uuid::new_v4().simple());
+                emit_signal_event(
+                    &db,
+                    EmitSignalEvent {
+                        entity_type: "account",
+                        entity_id: "acct-dos495-sensitive",
+                        signal_type: &signal_type,
+                        source: "unit_test",
+                        value: Some(sensitive_value),
+                        confidence: 1.0,
+                        source_context: Some("private source context should not persist"),
+                        id: None,
+                        created_at: Some("2026-05-25T16:00:00Z"),
+                        decay_half_life_days: Some(7),
+                        insert_mode: SignalInsertMode::Insert,
+                        channel: SignalEmissionChannel::ServiceFacade,
+                        refresh_meetings: false,
+                    },
+                )
+                .expect("emit unknown sensitive legacy signal");
+
+                let entry = wait_for_unknown_signal_jsonl_entry(tmp.path(), &signal_type).await;
+                let payload = entry.payload.as_object().expect("payload object");
+                let keys = payload
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<std::collections::BTreeSet<_>>();
+                assert_eq!(
+                    keys,
+                    std::collections::BTreeSet::from([
+                        "channel",
+                        "createdAt",
+                        "entityType",
+                        "observedAt",
+                        "signalType",
+                        "source",
+                    ])
+                );
+                assert_eq!(
+                    payload
+                        .get("signalType")
+                        .and_then(serde_json::Value::as_str),
+                    Some(signal_type.as_str())
+                );
+
+                let raw = read_unknown_signal_jsonl(tmp.path()).expect("unknown signal jsonl");
+                assert!(!raw.contains(sensitive_value));
+                assert!(!raw.contains("private source context should not persist"));
+                assert!(!raw.contains("acct-dos495-sensitive"));
+            }
+
+            sender_restore.restore();
+            worker.await.expect("worker exits after channel closes");
+        });
+    }
+
+    #[test]
     fn dos262_concurrent_unknown_signal_type_uses_single_llm_resolution_and_cache() {
         let _env_guard = fail_improve_env_lock().lock().expect("env lock");
         let _resolution_restore =
@@ -1963,21 +2052,25 @@ mod tests {
         panic!("unknown signal observation was not queued for {signal_type}");
     }
 
-    async fn wait_for_unknown_signal_jsonl_entry(root: &std::path::Path, signal_type: &str) {
+    async fn wait_for_unknown_signal_jsonl_entry(
+        root: &std::path::Path,
+        signal_type: &str,
+    ) -> crate::services::fail_improve::UnknownSignalTypeObservation {
         for _ in 0..50 {
             if let Some(raw) = read_unknown_signal_jsonl(root) {
-                let found = raw.lines().any(|line| {
+                let found = raw.lines().find_map(|line| {
                     let entry: crate::services::fail_improve::UnknownSignalTypeObservation =
                         serde_json::from_str(line).expect("entry");
-                    entry.signal_type == signal_type
+                    (entry.signal_type == signal_type
                         && entry
                             .payload
                             .get("signalType")
                             .and_then(serde_json::Value::as_str)
-                            == Some(signal_type)
+                            == Some(signal_type))
+                    .then_some(entry)
                 });
-                if found {
-                    return;
+                if let Some(entry) = found {
+                    return entry;
                 }
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/src-tauri/src/signals/policy_registry.rs
+++ b/src-tauri/src/signals/policy_registry.rs
@@ -996,4 +996,25 @@ mod tests {
             ));
         }
     }
+
+    #[test]
+    fn dos705_salience_signals_use_coalesced_invalidation_policy() {
+        for signal in [
+            SignalType::SurfacingDecisionMade,
+            SignalType::SalienceCandidateRefreshTriggered,
+        ] {
+            let policy = policy_for(&signal);
+            assert_eq!(
+                policy.durability,
+                DurabilityClass::CoalescedDurablePropagation
+            );
+            assert_eq!(policy.role, SignalRole::Invalidation);
+            assert!(matches!(
+                policy.propagation,
+                PropagationPolicy::PropagateAsync {
+                    coalesce: Some(CoalescingPolicy::EntitySignal { window })
+                } if window == Duration::from_millis(500)
+            ));
+        }
+    }
 }

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -46,6 +46,7 @@ use crate::bridges::types::{
     AbilityResponseJson, BridgeActor, BridgeSurface, RequestScopedInvocation,
 };
 use crate::bridges::BridgeSurfaceError;
+use crate::services::claims::ClaimError;
 use crate::services::context::ClaimDismissalSurface;
 use crate::services::surface_nonce::{
     PresenceNonceRequestMeta, SurfaceNonceError, SurfaceNonceService,
@@ -3049,8 +3050,72 @@ enum VerifyWireThroughOutcome {
     },
     PhaseThreeFailed {
         verify: crate::services::surface_nonce::SurfaceNonceVerify,
-        claim_error: crate::services::claims::ClaimError,
+        claim_error: ClaimError,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SafeClaimErrorLogFields {
+    class: &'static str,
+    message: &'static str,
+}
+
+fn safe_phase_three_claim_error_log_fields(error: &ClaimError) -> SafeClaimErrorLogFields {
+    match error {
+        ClaimError::InvalidFeedback(_) => SafeClaimErrorLogFields {
+            class: "invalid_feedback",
+            message: "feedback payload rejected",
+        },
+        ClaimError::InvalidActor(_)
+        | ClaimError::ActorClassNotAllowed { .. }
+        | ClaimError::ActorNotPermittedForClaimType { .. } => SafeClaimErrorLogFields {
+            class: "actor_rejected",
+            message: "feedback actor rejected",
+        },
+        ClaimError::UnknownClaimId(_) | ClaimError::ClaimNotFound(_) => SafeClaimErrorLogFields {
+            class: "claim_lookup_failed",
+            message: "claim lookup failed",
+        },
+        ClaimError::StaleVersion { .. }
+        | ClaimError::InflatedVersion { .. }
+        | ClaimError::MissingExpectedClaimVersion { .. }
+        | ClaimError::ClaimVersionOverflow { .. }
+        | ClaimError::MidFlightMutation { .. } => SafeClaimErrorLogFields {
+            class: "claim_version_rejected",
+            message: "claim version rejected",
+        },
+        ClaimError::Mode(_) => SafeClaimErrorLogFields {
+            class: "mode_rejected",
+            message: "feedback write rejected by execution mode",
+        },
+        ClaimError::SubjectRef(_) => SafeClaimErrorLogFields {
+            class: "subject_ref_rejected",
+            message: "claim subject reference rejected",
+        },
+        ClaimError::UnknownClaimType(_) => SafeClaimErrorLogFields {
+            class: "claim_type_rejected",
+            message: "claim type rejected",
+        },
+        ClaimError::InvalidSupersession(_) => SafeClaimErrorLogFields {
+            class: "supersession_rejected",
+            message: "claim supersession rejected",
+        },
+        ClaimError::TombstonedPreGate => SafeClaimErrorLogFields {
+            class: "tombstone_pre_gate",
+            message: "tombstoned claim rejected",
+        },
+        ClaimError::ImmutableColumnUpdate(_) => SafeClaimErrorLogFields {
+            class: "immutable_column_update",
+            message: "claim update rejected",
+        },
+        ClaimError::Transaction(_)
+        | ClaimError::Db(_)
+        | ClaimError::Rusqlite(_)
+        | ClaimError::Serde(_) => SafeClaimErrorLogFields {
+            class: "substrate_error",
+            message: "feedback write substrate error",
+        },
+    }
 }
 
 async fn surface_nonce_verify_response(
@@ -3158,13 +3223,16 @@ async fn surface_nonce_verify_response(
                 &validated,
                 request_meta,
                 &verify.request_id,
+                verify.consumed_at,
             );
+            let error_log = safe_phase_three_claim_error_log_fields(&claim_error);
             log::warn!(
                 "surface nonce verify consumed but record_claim_feedback failed: \
-                 claim_id={} request_id={} error={}",
-                verify.claim_id,
-                verify.request_id,
-                claim_error,
+                 claim_id_hash={} request_id_hash={} error_class={} error_message={}",
+                hmac::hash_prefix(&verify.claim_id),
+                hmac::hash_prefix(&verify.request_id),
+                error_log.class,
+                error_log.message,
             );
             json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -6715,6 +6783,29 @@ mod tests {
             !normalized.contains("surface_client_bridge.authorize("),
             "project_composition route must not charge standard authorize"
         );
+    }
+
+    #[test]
+    fn dos716_phase_three_claim_error_log_fields_redact_payload_context() {
+        let marker = "private-feedback-marker";
+        let err = ClaimError::InvalidFeedback(format!("malformed feedback payload near {marker}"));
+
+        let fields = safe_phase_three_claim_error_log_fields(&err);
+        let rendered = format!(
+            "error_class={} error_message={}",
+            fields.class, fields.message
+        );
+
+        assert_eq!(
+            fields,
+            SafeClaimErrorLogFields {
+                class: "invalid_feedback",
+                message: "feedback payload rejected",
+            }
+        );
+        assert!(!rendered.contains(marker));
+        assert!(!rendered.contains("expected value"));
+        assert!(!rendered.contains("payload_json"));
     }
 
     #[test]

--- a/wp/dailyos/README.md
+++ b/wp/dailyos/README.md
@@ -25,6 +25,8 @@ The marker contains `marker_version`, `runtime_instance_id`, `site_nonce_hash`, 
 
 Session material is request-local. The plugin retrieves it through the gated `dailyos_wp_bridge_session_key` filter and never persists HMAC keys, derived keys, pairing tokens, or session keys in WordPress storage or browser-visible state.
 
+`dailyos_runtime_client_for_block` is a reserved DailyOS filter namespace. Runtime block renderers expect this filter to resolve to a `DailyOS_Runtime_Client` instance or `null`; third-party duck-typed clients are outside the contract.
+
 ## MCP Server
 
 The plugin registers a DailyOS-specific MCP server with `wordpress/mcp-adapter` v0.5.0. The server uses an explicit allowlist from the ability inventory, defaults to Read/Transform invocable abilities, and filters DailyOS tools out of non-DailyOS MCP server listings.

--- a/wp/dailyos/includes/class-dailyos-plugin.php
+++ b/wp/dailyos/includes/class-dailyos-plugin.php
@@ -746,6 +746,7 @@ final class DailyOS_Plugin {
 	public static function invalidate_runtime_endpoint_cache(): void {
 		self::$sentinel_cache     = null;
 		self::$sentinel_cached_at = 0.0;
+		DailyOS_Runtime_Client::clear_runtime_base_url_cache();
 	}
 
 	/**
@@ -836,13 +837,17 @@ final class DailyOS_Plugin {
 	 * scope a client to a single render) run after this and win — preserving
 	 * the existing test seam.
 	 *
-	 * When unpaired, returns the existing filter value (null by default) so the
-	 * renderer short-circuits to its is-empty fallback. When paired but transport
-	 * is unreachable, the client's request() returns WP_Error and the renderer
-	 * routes to runtime_unavailable_notice downstream.
+	 * This filter namespace is reserved for DailyOS runtime-client wiring.
+	 * Callbacks must return a DailyOS_Runtime_Client instance or null; duck-typed
+	 * third-party objects are not part of the contract.
+	 *
+	 * When unpaired, returns null so the renderer short-circuits to its is-empty
+	 * fallback. When paired but transport is unreachable, the client's request()
+	 * returns WP_Error and the renderer routes to runtime_unavailable_notice
+	 * downstream.
 	 *
 	 * @param mixed $existing Existing filter value from prior callbacks.
-	 * @return mixed Runtime client when paired and no override; $existing otherwise.
+	 * @return DailyOS_Runtime_Client|null Runtime client when paired; null otherwise.
 	 */
 	public function default_runtime_client_for_block( mixed $existing ): mixed {
 		if ( $existing instanceof DailyOS_Runtime_Client ) {
@@ -850,7 +855,7 @@ final class DailyOS_Plugin {
 		}
 		$store = new DailyOS_Credential_Store();
 		if ( ! $store->is_paired() ) {
-			return $existing;
+			return null;
 		}
 		return new DailyOS_Runtime_Client( $store, new DailyOS_Hmac_Signer( $store ) );
 	}

--- a/wp/dailyos/includes/mcp/class-dailyos-mcp-audit.php
+++ b/wp/dailyos/includes/mcp/class-dailyos-mcp-audit.php
@@ -43,6 +43,10 @@ final class DailyOS_Mcp_Audit {
 			}
 		}
 
+		if ( ! is_string( $event['actor_instance'] ) || '' === trim( $event['actor_instance'] ) ) {
+			throw new \InvalidArgumentException( 'Invalid MCP audit actor instance.' );
+		}
+
 		if (
 			defined( 'WP_DEBUG_LOG' )
 			&& WP_DEBUG_LOG

--- a/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
+++ b/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
@@ -16,6 +16,17 @@ final class DailyOS_Runtime_Client {
 	private const CONTENT_TYPE = 'application/json';
 
 	/**
+	 * Request-scoped cache for validated runtime base URLs.
+	 *
+	 * Normal PHP requests discard this with the process/request lifecycle. Tests
+	 * and long-running CLI loops can call clear_runtime_base_url_cache() between
+	 * logical requests so filters and sentinel discovery can re-evaluate.
+	 *
+	 * @var array<string, string|null>
+	 */
+	private static array $runtime_base_url_cache = [];
+
+	/**
 	 * Non-secret marker and process-local credential source.
 	 *
 	 * @var DailyOS_Credential_Store
@@ -38,6 +49,16 @@ final class DailyOS_Runtime_Client {
 	public function __construct( DailyOS_Credential_Store $credential_store, DailyOS_Hmac_Signer $signer ) {
 		$this->credential_store = $credential_store;
 		$this->signer           = $signer;
+	}
+
+	/**
+	 * Clear the request-scoped runtime base URL cache.
+	 *
+	 * Use when a long-running process starts a new logical request or after an
+	 * endpoint invalidation needs the next runtime call to re-run discovery.
+	 */
+	public static function clear_runtime_base_url_cache(): void {
+		self::$runtime_base_url_cache = [];
 	}
 
 	/**
@@ -555,6 +576,7 @@ final class DailyOS_Runtime_Client {
 		// original failure may be transient. A previous "only retry if URL
 		// differs" guard missed same-port transient refusals.
 		if ( self::is_connection_refused( $response ) ) {
+			self::clear_runtime_base_url_cache();
 			\DailyOS\DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			$retry_base_url = $this->discover_runtime_base_url( $marker );
 			if ( null !== $retry_base_url ) {
@@ -609,6 +631,7 @@ final class DailyOS_Runtime_Client {
 		$response = wp_remote_post( $url, $post_args );
 
 		if ( self::is_connection_refused( $response ) ) {
+			self::clear_runtime_base_url_cache();
 			\DailyOS\DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			$retry_base_url = $this->discover_runtime_base_url( $marker );
 			if ( null !== $retry_base_url ) {
@@ -839,19 +862,28 @@ final class DailyOS_Runtime_Client {
 	 * @return string|null Base URL, or null when not paired.
 	 */
 	private function discover_runtime_base_url( array $marker ): ?string {
+		$marker_runtime_url = isset( $marker['runtime_url'] ) ? (string) $marker['runtime_url'] : '';
+		$can_filter         = ! function_exists( 'current_user_can' ) || current_user_can( 'manage_options' );
+		$cache_key          = ( $can_filter ? 'filterable' : 'restricted' ) . '|' . $marker_runtime_url;
+
+		if ( array_key_exists( $cache_key, self::$runtime_base_url_cache ) ) {
+			return self::$runtime_base_url_cache[ $cache_key ];
+		}
+
 		// Prefer the sentinel-discovered URL (current runtime port across
 		// restarts) over the stored marker (may be stale after the runtime
 		// restarts on a new port). Signed callers still authenticate at the
 		// route; local callers only need this shared discovery result.
 		$sentinel_url = \DailyOS\DailyOS_Plugin::discover_runtime_base_url();
 
-		$marker_url = isset( $marker['runtime_url'] ) ? self::normalize_loopback_runtime_url( (string) $marker['runtime_url'] ) : null;
+		$marker_url = '' !== $marker_runtime_url ? self::normalize_loopback_runtime_url( $marker_runtime_url ) : null;
 
 		// Admin filter override path retained — admins can still pin a specific URL
 		// for dev/testing. Sentinel is the runtime-tracked default; marker is the
 		// post-pairing baseline; filter overrides both for power users.
-		if ( function_exists( 'current_user_can' ) && ! current_user_can( 'manage_options' ) ) {
-			return $sentinel_url ?? $marker_url;
+		if ( ! $can_filter ) {
+			self::$runtime_base_url_cache[ $cache_key ] = $sentinel_url ?? $marker_url;
+			return self::$runtime_base_url_cache[ $cache_key ];
 		}
 
 		$filter_seed  = $sentinel_url ?? ( $marker_url ?? '' );
@@ -861,13 +893,15 @@ final class DailyOS_Runtime_Client {
 			$normalized_filtered_url = self::normalize_loopback_runtime_url( $filtered_url );
 
 			if ( null !== $normalized_filtered_url ) {
-				return $normalized_filtered_url;
+				self::$runtime_base_url_cache[ $cache_key ] = $normalized_filtered_url;
+				return self::$runtime_base_url_cache[ $cache_key ];
 			}
 
 			$this->log_invalid_runtime_url_override();
 		}
 
-		return $sentinel_url ?? $marker_url;
+		self::$runtime_base_url_cache[ $cache_key ] = $sentinel_url ?? $marker_url;
+		return self::$runtime_base_url_cache[ $cache_key ];
 	}
 
 	/**

--- a/wp/dailyos/tests/ActivationTest.php
+++ b/wp/dailyos/tests/ActivationTest.php
@@ -226,18 +226,21 @@ final class DailyOS_ActivationTest extends TestCase {
 
 		DailyOS_Plugin::instance()->init();
 
-		$this->assertNotEmpty(
-			$GLOBALS['dailyos_test_filters']['dailyos_runtime_client_for_block'] ?? [],
+		$expected_callback = [ DailyOS_Plugin::instance(), 'default_runtime_client_for_block' ];
+
+		$this->assertSame(
+			5,
+			has_filter( 'dailyos_runtime_client_for_block' ),
 			'init() must register the default dailyos_runtime_client_for_block filter so the live render path can reach the typed runtime_unavailable_notice when transport is unreachable'
 		);
-		$this->assertArrayHasKey(
+		$this->assertSame(
 			5,
-			$GLOBALS['dailyos_test_filters']['dailyos_runtime_client_for_block'],
+			has_filter( 'dailyos_runtime_client_for_block', $expected_callback ),
 			'default filter must register at priority 5 so per-render overrides at priority 10 (REST preview, test fixtures) continue to win'
 		);
 		[ $callback, $accepted_args ] = $GLOBALS['dailyos_test_filters']['dailyos_runtime_client_for_block'][5][0];
 		$this->assertIsArray( $callback, 'callback must be an instance-method tuple [ $plugin, method_name ]' );
-		$this->assertSame( DailyOS_Plugin::instance(), $callback[0], 'callback must dispatch to the plugin singleton' );
+		$this->assertSame( $expected_callback[0], $callback[0], 'callback must dispatch to the plugin singleton' );
 		$this->assertSame( 'default_runtime_client_for_block', $callback[1], 'callback must point at default_runtime_client_for_block' );
 		$this->assertSame( 1, $accepted_args, 'callback must accept the existing filter value to preserve per-render overrides' );
 	}
@@ -257,11 +260,26 @@ final class DailyOS_ActivationTest extends TestCase {
 		$this->assertSame( $pre_existing, $result, 'default provider must defer to a priority-10 override that already supplied a client (REST preview + test seam)' );
 	}
 
-	public function test_default_runtime_client_for_block_returns_existing_when_unpaired(): void {
+	public function test_default_runtime_client_for_block_returns_null_when_unpaired(): void {
 		// Test bootstrap leaves the credential store unpaired (no options seeded).
 		$result = DailyOS_Plugin::instance()->default_runtime_client_for_block( null );
 
 		$this->assertNull( $result, 'unpaired state must surface as null so the renderer falls through to its is-empty path; runtime-unavailable diagnostics fire post-pair when transport itself fails' );
+	}
+
+	public function test_default_runtime_client_for_block_rejects_duck_typed_existing_when_unpaired(): void {
+		$pre_existing = new class() {
+			/**
+			 * Duck-typed method that renderers look for.
+			 */
+			public function project_composition_for_surface(): array {
+				return [];
+			}
+		};
+
+		$result = DailyOS_Plugin::instance()->default_runtime_client_for_block( $pre_existing );
+
+		$this->assertNull( $result, 'unpaired state must not preserve arbitrary duck-typed objects registered before the reserved DailyOS runtime-client provider' );
 	}
 
 	/**

--- a/wp/dailyos/tests/bootstrap.php
+++ b/wp/dailyos/tests/bootstrap.php
@@ -300,6 +300,30 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( 'has_filter' ) ) {
+		function has_filter( string $hook_name, mixed $callback = false ): int|false {
+			if ( empty( $GLOBALS['dailyos_test_filters'][ $hook_name ] ) ) {
+				return false;
+			}
+
+			ksort( $GLOBALS['dailyos_test_filters'][ $hook_name ] );
+
+			if ( false === $callback ) {
+				return (int) array_key_first( $GLOBALS['dailyos_test_filters'][ $hook_name ] );
+			}
+
+			foreach ( $GLOBALS['dailyos_test_filters'][ $hook_name ] as $priority => $callbacks ) {
+				foreach ( $callbacks as [ $registered_callback ] ) {
+					if ( $registered_callback === $callback ) {
+						return (int) $priority;
+					}
+				}
+			}
+
+			return false;
+		}
+	}
+
 	if ( ! function_exists( 'do_action' ) ) {
 		function do_action( string $hook_name, mixed ...$args ): void {
 			$GLOBALS['dailyos_test_current_actions'][] = $hook_name;

--- a/wp/dailyos/tests/mcp/McpAuditTest.php
+++ b/wp/dailyos/tests/mcp/McpAuditTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * DailyOS MCP audit tests.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+use DailyOS\Mcp\DailyOS_Mcp_Audit;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies MCP audit event validation.
+ */
+final class DailyOS_McpAuditTest extends TestCase {
+	/**
+	 * Reset WordPress test doubles.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		dailyos_test_reset_globals();
+	}
+
+	/**
+	 * Missing actor instance rejects the audit event.
+	 */
+	public function test_missing_actor_instance_fails(): void {
+		$event = $this->valid_event();
+		unset( $event['actor_instance'] );
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Missing MCP audit event key.' );
+
+		DailyOS_Mcp_Audit::emit( $event );
+	}
+
+	/**
+	 * Invalid actor instance rejects the audit event.
+	 *
+	 * @param mixed $actor_instance Actor instance value.
+	 */
+	#[DataProvider( 'invalid_actor_instance_provider' )]
+	public function test_invalid_actor_instance_fails( mixed $actor_instance ): void {
+		$event                   = $this->valid_event();
+		$event['actor_instance'] = $actor_instance;
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Invalid MCP audit actor instance.' );
+
+		DailyOS_Mcp_Audit::emit( $event );
+	}
+
+	/**
+	 * Valid audit event emits through the WordPress action.
+	 */
+	public function test_valid_audit_event_emits(): void {
+		$event = $this->valid_event();
+
+		DailyOS_Mcp_Audit::emit( $event );
+
+		$this->assertSame( [ $event ], $GLOBALS['dailyos_test_audit_events'] );
+	}
+
+	/**
+	 * Invalid actor instance values.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public static function invalid_actor_instance_provider(): array {
+		return [
+			'empty string' => [ '' ],
+			'whitespace'   => [ " \t\n" ],
+			'null'         => [ null ],
+			'integer'      => [ 42 ],
+		];
+	}
+
+	/**
+	 * Create a valid MCP audit event.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function valid_event(): array {
+		return [
+			'mcp_exposure_path'  => DailyOS_Mcp_Audit::EXPOSURE_INVOCABLE,
+			'actor_instance'     => 'plugin-1',
+			'wp_user_id'         => 42,
+			'ability_name'       => 'dailyos/account-overview',
+			'scope_check_result' => 'allowed',
+		];
+	}
+}

--- a/wp/dailyos/tests/mcp/McpPermissionTest.php
+++ b/wp/dailyos/tests/mcp/McpPermissionTest.php
@@ -12,6 +12,7 @@ use DailyOS\Mcp\DailyOS_Mcp_Audit;
 use DailyOS\Mcp\DailyOS_Mcp_Permission;
 use DailyOS\Mcp\DailyOS_Mcp_Roles;
 use DailyOS\Mcp\DailyOS_Mcp_Server;
+use DailyOS\Transport\DailyOS_Credential_Store;
 use PHPUnit\Framework\TestCase;
 use WP\MCP\Core\McpAdapter;
 
@@ -36,6 +37,13 @@ final class DailyOS_McpPermissionTest extends TestCase {
 		$GLOBALS['dailyos_test_user_can_callback'] = static function ( int $user_id, string $capability ): bool {
 			return 42 === $user_id && 'dailyos_invoke_mcp_ability' === $capability;
 		};
+
+		( new DailyOS_Credential_Store() )->save_marker(
+			[
+				'runtime_instance_id'  => 'runtime-123',
+				'plugin_instance_uuid' => 'plugin-1',
+			]
+		);
 	}
 
 	/**

--- a/wp/dailyos/tests/transport/RuntimeClientTest.php
+++ b/wp/dailyos/tests/transport/RuntimeClientTest.php
@@ -233,6 +233,81 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 	}
 
 	/**
+	 * Runtime URL filter validation is cached within one logical request.
+	 */
+	public function test_runtime_url_filter_is_evaluated_once_for_two_runtime_calls_in_one_request(): void {
+		$this->save_marker();
+		$this->add_session_key_filter();
+
+		$filter_calls = 0;
+
+		add_filter(
+			'dailyos_wp_bridge_runtime_url',
+			static function () use ( &$filter_calls ): string {
+				++$filter_calls;
+				return 'http://127.0.0.1:54322';
+			},
+			10,
+			1
+		);
+
+		$GLOBALS['dailyos_test_remote_post_response'] = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"ok":true}',
+		];
+
+		$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
+		$client->invoke_ability( 'briefing.daily', [], [] );
+		$client->invoke_ability( 'briefing.daily', [ 'depth' => 'standard' ], [] );
+
+		$this->assertSame( 1, $filter_calls );
+		$this->assertCount( 2, $GLOBALS['dailyos_test_remote_post_calls'] );
+		$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+		$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][1]['url'] );
+	}
+
+	/**
+	 * Clearing the request cache lets long-running loops re-evaluate the filter.
+	 */
+	public function test_runtime_url_cache_clear_allows_new_request_to_re_evaluate_filter(): void {
+		$this->save_marker();
+		$this->add_session_key_filter();
+
+		$filter_calls = 0;
+		$port         = 54322;
+
+		add_filter(
+			'dailyos_wp_bridge_runtime_url',
+			static function () use ( &$filter_calls, &$port ): string {
+				++$filter_calls;
+				return 'http://127.0.0.1:' . $port;
+			},
+			10,
+			1
+		);
+
+		$GLOBALS['dailyos_test_remote_post_response'] = [
+			'response' => [ 'code' => 200 ],
+			'body'     => '{"ok":true}',
+		];
+
+		$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
+		$client->invoke_ability( 'briefing.daily', [], [] );
+		$port = 54323;
+		$client->invoke_ability( 'briefing.daily', [], [] );
+
+		$this->assertSame( 1, $filter_calls );
+		$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
+		$this->assertSame( 'http://127.0.0.1:54322/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][1]['url'] );
+
+		DailyOS_Runtime_Client::clear_runtime_base_url_cache();
+		$client->invoke_ability( 'briefing.daily', [], [] );
+
+		$this->assertSame( 2, $filter_calls );
+		$this->assertSame( 'http://127.0.0.1:54323/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][2]['url'] );
+	}
+
+	/**
 	 * Sentinel discovery follows the new port after a hot Tauri restart.
 	 */
 	public function test_runtime_sentinel_cache_resets_after_restart_and_uses_new_port(): void {


### PR DESCRIPTION
## Linear ticket

DOS-595, DOS-596, DOS-736, DOS-738, DOS-739, DOS-495, DOS-496, DOS-705, DOS-714, DOS-716

## Summary

This PR resolves the first DailyOS path-alpha maintenance batch: five WordPress bridge hardening/test issues and five Rust signal/nonce/feedback safety issues. The batch was selected after validating each issue against the existing v1.4.4, v1.4.4a, v1.4.5, and abilities-runtime plans.

## What changed

- Tightened WordPress MCP audit attribution validation and covered empty/non-string `actor_instance` failures.
- Added request-scoped runtime endpoint caching with invalidation on sentinel refresh and connection refusal.
- Hardened the reserved `dailyos_runtime_client_for_block` filter contract and the registration gate/test shim around it.
- Fixed redacted unknown-signal fail-improve observations so sensitive legacy signal families still produce safe envelope-only records.
- Removed the stale direct registry-typing adapter that could bypass fail-improve recording.
- Added salience signal policy-registry coverage for coalesced durable invalidation.
- Routed nonce audit/failure-budget timestamps through deterministic service-clock values.
- Removed raw serde/claim error display from phase-three feedback failure logging.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [ ] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (if frontend changes)
- [x] `./vendor/bin/phpunit --no-coverage tests/ActivationTest.php`
- [x] `./vendor/bin/phpunit --no-coverage tests/mcp`
- [x] `HOME=$(mktemp -d) ./vendor/bin/phpunit --no-coverage tests/transport/RuntimeClientTest.php`
- [x] `bash scripts/check_runtime_client_filter_registered.sh && bash scripts/check_runtime_client_filter_registered_test.sh`
- [x] Focused Rust regressions: `unknown_signal`, `services::fail_improve::tests`, `dos705_salience_signals_use_coalesced_invalidation_policy`, `dos714`, `dos716_`, `dos719_phase_three_failure_charges_failure_budget_fail_closed`
- [x] Manual verification: reviewed the touched behavior against v1.4.4, v1.4.4a, v1.4.5, and abilities-runtime plan constraints before patching.

## Definition of Done

- [x] Acceptance criteria from the Linear tickets are validated with real data (not stubs)
- [x] End-to-end flow works through the affected service/test surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced
- [ ] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (if `security_auditor_invoked: false`): _none_

**Exemption rationale**: Security-relevant service and redaction paths changed; no exemption claimed.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Run local L2 diff review before marking the PR ready.
- Run `pnpm tsc --noEmit` before merge if the merge bar requires the full DoD command set despite no frontend TypeScript changes.

## Notes for review

Linear issues remain In Progress until this PR merges; they should move to Done at merge time.