### PR TITLE
Maintenance path-alpha batch 4

### DIFF
--- a/.docs/design/primitives/IntelligenceQualityBadge.md
+++ b/.docs/design/primitives/IntelligenceQualityBadge.md
@@ -3,7 +3,7 @@
 **Tier:** primitive
 **Status:** integrated
 **Owner:** James
-**Last updated:** 2026-05-02
+**Last updated:** 2026-05-25
 **`data-ds-name`:** `IntelligenceQualityBadge`
 **`data-ds-spec`:** `primitives/IntelligenceQualityBadge.md`
 **Variants:** `quality="sparse" | "developing" | "ready" | "fresh"`
@@ -39,13 +39,13 @@ D-spine adds two related labels that map to the same primitive:
 
 Quality dot color (per `_shared/primitives.css`):
 - sparse → `--color-text-tertiary` (grey)
-- developing → `--color-spice-saffron`
+- developing → `--color-spice-turmeric`
 - ready → `--color-garden-sage`
 - fresh → `--color-garden-sage` brighter
 
 ## Tokens consumed
 
-- `--color-garden-sage`, `--color-spice-saffron`, `--color-text-tertiary` (per variant dot)
+- `--color-garden-sage`, `--color-spice-turmeric`, `--color-text-tertiary` (per variant dot)
 - `--font-mono` (label, uppercase, small-caps treatment)
 - `--space-xs`, `--space-sm`
 
@@ -79,3 +79,4 @@ Existing primitive in `src/`. Confirmed in synthesis D5 — keep this name; do n
 - 2026-05-02 — Documented as canonical (existing src/ primitive).
 - Audit 04 — surfaced as the existing primitive most components touch for completeness signaling.
 - Audit 03 — D-spine `prep-state` consolidation candidate.
+- 2026-05-25 — Aligned `developing` with the shipped turmeric token.

--- a/.docs/design/primitives/Pill.md
+++ b/.docs/design/primitives/Pill.md
@@ -3,7 +3,7 @@
 **Tier:** primitive
 **Status:** integrated
 **Owner:** James
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-25
 **`data-ds-name`:** `Pill`
 **`data-ds-spec`:** `primitives/Pill.md`
 **Variants:** `tone="sage" | "turmeric" | "terracotta" | "larkspur" | "neutral"`
@@ -61,6 +61,9 @@ CSS class form (matches `_shared/.pill`):
 </span>
 ```
 
+The WordPress block projection uses the `dailyos-pill--tone-*` class as its
+tone authority and omits a parallel `data-tone` attribute.
+
 ## Source
 
 - **Mockup substrate:** `.docs/_archive/mockups/claude-design-project/mockups/surfaces/_shared/primitives.css` (`.pill`)
@@ -78,3 +81,4 @@ Wave 1 consumers (direct or via composing primitives): DailyBriefing, AccountDet
 
 - 2026-05-02 — Promoted to canonical from `_shared/.pill`. Audit 03 surfaced 7+ existing pill variants across surfaces — consolidation to this primitive begins with v1.4.3.
 - 2026-05-05 — Source updated to shipped React primitive.
+- 2026-05-25 — Documented class-only tone authority for the WordPress block projection.

--- a/.docs/design/primitives/ProvenanceTag.md
+++ b/.docs/design/primitives/ProvenanceTag.md
@@ -3,10 +3,10 @@
 **Tier:** primitive
 **Status:** integrated
 **Owner:** James
-**Last updated:** 2026-05-02
+**Last updated:** 2026-05-25
 **`data-ds-name`:** `ProvenanceTag`
 **`data-ds-spec`:** `primitives/ProvenanceTag.md`
-**Variants:** plain (label only); `discrepancy` (highlights when sources disagree)
+**Variants:** plain (label only); `with-source`; `age-only`; `discrepancy` (highlights when sources disagree)
 **Design system version introduced:** 0.1.0
 
 ## Job
@@ -29,6 +29,8 @@ Render a muted source-attribution label for a piece of intelligence — "where d
 ## States / variants
 
 - **default** — small muted label with source name (e.g., "Glean", "Salesforce", "Email")
+- **with-source** — explicit source-attribution phrase when the source should be visible in prose (e.g., "from Glean", "from Salesforce", "from email")
+- **age-only** — recency-only provenance treatment for surfaces that already name the source elsewhere; use `FreshnessIndicator` instead when the job is purely raw freshness
 - **discrepancy** — when sources disagree on a fact, render with attention treatment (subtle outline or warn color)
 
 Note from Audit 04: production behavior intentionally hides `pty_synthesis` provenance — synthesized intelligence renders without the tag by default. Document this explicitly.
@@ -45,6 +47,8 @@ Note from Audit 04: production behavior intentionally hides `pty_synthesis` prov
 ```tsx
 <ProvenanceTag itemSource="glean" />
 <ProvenanceTag itemSource="Salesforce" discrepancy />
+<ProvenanceTag itemSource="email" data-variant="with-source" />
+<ProvenanceTag itemSource="local_file" data-variant="age-only" />
 {/* Renders nothing for synthesized: */}
 <ProvenanceTag itemSource="pty_synthesis" />
 ```
@@ -66,3 +70,4 @@ Existing primitive in `src/`. The mockup substrate proposes a related `Provenanc
 
 - 2026-05-02 — Documented as canonical (existing src/ primitive).
 - Audit 04 — confirmed pty_synthesis suppression behavior.
+- 2026-05-25 — Added `with-source` and `age-only` variants to match shipped provenance treatments.

--- a/.docs/design/primitives/TrustBandBadge.md
+++ b/.docs/design/primitives/TrustBandBadge.md
@@ -1,9 +1,9 @@
 # TrustBandBadge
 
 **Tier:** primitive
-**Status:** proposed
+**Status:** integrated
 **Owner:** James
-**Last updated:** 2026-05-02
+**Last updated:** 2026-05-25
 **`data-ds-name`:** `TrustBandBadge`
 **`data-ds-spec`:** `primitives/TrustBandBadge.md`
 **Variants:** `band="likely_current" | "use_with_caution" | "needs_verification"`
@@ -69,3 +69,4 @@ Distinct from `IntelligenceQualityBadge` (completeness vocabulary) and `Freshnes
 ## History
 
 - 2026-05-02 — Proposed primitive per design system D5. Maps to v1.4.0 substrate render contract.
+- 2026-05-25 — Promoted to integrated after source implementation shipped.

--- a/.docs/design/primitives/TypeBadge.md
+++ b/.docs/design/primitives/TypeBadge.md
@@ -3,7 +3,7 @@
 **Tier:** primitive
 **Status:** integrated
 **Owner:** James
-**Last updated:** 2026-05-02
+**Last updated:** 2026-05-25
 **`data-ds-name`:** `TypeBadge`
 **`data-ds-spec`:** `primitives/TypeBadge.md`
 **Variants:** `accountType="customer" | "internal" | "partner"` (extensible)
@@ -27,7 +27,7 @@ Render an account-type categorical badge (Customer / Internal / Partner) with th
 
 ## States / variants
 
-- `accountType="customer"` — turmeric tone (background turmeric-12, text turmeric)
+- `accountType="customer"` — account tone (background account-12, text account)
 - `accountType="internal"` — larkspur tone (background larkspur-15, text larkspur)
 - `accountType="partner"` — rosemary tone (background rosemary-12, text rosemary)
 - Optional `editable` — adds a chevron and dropdown affordance (existing AccountTypeBadge in src does this)
@@ -36,7 +36,7 @@ Mockup `.type-badge` adds an optional `chev` for the dropdown variant.
 
 ## Tokens consumed
 
-- `--color-spice-turmeric-12`, `--color-spice-turmeric` (customer)
+- `--color-account-12`, `--color-account` (customer)
 - `--color-garden-larkspur-15`, `--color-garden-larkspur` (internal)
 - `--color-garden-rosemary-12`, `--color-garden-rosemary` (partner)
 - `--font-mono` (label, small-caps treatment)
@@ -71,3 +71,4 @@ Audit 02 surfaced `AccountTypeBadge` (the local dropdown implementation) as a "s
 
 - 2026-05-02 — Promoted to canonical from mockup `_shared/.type-badge` + production `AccountTypeBadge`.
 - Audit 02 — flagged AccountTypeBadge as local-reimplementation candidate.
+- 2026-05-25 — Aligned customer colors with shipped account tokens.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,12 @@ jobs:
         working-directory: src-tauri
         run: cargo test --workspace
 
+      - name: Run DOS589 cursor fixture harness tests
+        working-directory: src-tauri
+        run: |
+          cargo test --features test-harness --test dos589_fixture_signal_replay_cursor
+          cargo test --features test-harness --test dos589_fixture_signal_scope_leak
+
       - name: Run MCP dynamic reader harness test
         working-directory: src-tauri
         run: cargo test --features test-harness --test w05_a_mcp_dynamic_tool_readers_test

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -183,3 +183,13 @@ strip = true
 [[test]]
 name = "block_kit_integration_harness"
 path = "abilities-runtime/tests/block_kit_integration_harness.rs"
+
+[[test]]
+name = "dos589_fixture_signal_replay_cursor"
+path = "tests/dos589_fixture_signal_replay_cursor.rs"
+required-features = ["test-harness"]
+
+[[test]]
+name = "dos589_fixture_signal_scope_leak"
+path = "tests/dos589_fixture_signal_scope_leak.rs"
+required-features = ["test-harness"]

--- a/src-tauri/abilities-runtime/tests/fixtures/pill_integration_fixture.rs
+++ b/src-tauri/abilities-runtime/tests/fixtures/pill_integration_fixture.rs
@@ -41,7 +41,7 @@ pub fn pill_fixture() -> BlockIntegrationFixture {
             },
             RendererBranchAssertion {
                 branch_label: "default-tone".to_string(),
-                expected_html_pattern: "data-tone=\"neutral\"".to_string(),
+                expected_html_pattern: "dailyos-pill--tone-neutral".to_string(),
             },
         ],
         expected_wrapper: BlockWrapperAssertion {

--- a/src-tauri/src/bridges/mcp.rs
+++ b/src-tauri/src/bridges/mcp.rs
@@ -692,8 +692,8 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
 
-    use chrono::{TimeZone, Utc};
-    use rusqlite::{params, Connection};
+    use chrono::Utc;
+    use rusqlite::Connection;
     use serde_json::json;
 
     use super::*;
@@ -993,7 +993,10 @@ CREATE TABLE accounts (
         sensitivity: ClaimSensitivity,
         created_at: &str,
     ) -> String {
-        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 9, 12, 0, 0).unwrap());
+        let created_at_ts = chrono::DateTime::parse_from_rfc3339(created_at)
+            .expect("MCP fixture created_at must parse")
+            .with_timezone(&Utc);
+        let clock = FixedClock::new(created_at_ts);
         let rng = SeedableRng::new(309);
         let external = ExternalClients::default();
         let ctx = ServiceContext::new_live(&clock, &rng, &external).with_actor("agent:test");
@@ -1033,12 +1036,6 @@ CREATE TABLE accounts (
             CommittedClaim::Inserted { claim } => claim.id,
             other => panic!("expected inserted claim, got {other:?}"),
         };
-        db.conn_ref()
-            .execute(
-                "UPDATE intelligence_claims SET created_at = ?1 WHERE id = ?2",
-                params![created_at, claim_id.as_str()],
-            )
-            .expect("pin MCP fixture claim created_at");
         claim_id
     }
 

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -14702,8 +14702,8 @@ mod tests {
             );
             db.conn_ref()
                 .execute(
-                    "UPDATE intelligence_claims
-                     SET created_at = ?1
+                    "UPDATE intelligence_claims /* dos7-allowed: entity context unit test pins fixture recency */
+                     SET created_at = ?1 /* dos7-allowed: entity context unit test pins fixture recency */
                      WHERE id = ?2",
                     params![
                         format!("2026-05-02T13:{index:02}:00Z"),
@@ -14798,8 +14798,9 @@ mod tests {
             );
             db.conn_ref()
                 .execute(
-                    "UPDATE intelligence_claims
-                     SET sensitivity = 'confidential', created_at = ?1
+                    "UPDATE intelligence_claims /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */
+                     SET sensitivity = 'confidential' /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */,
+                         created_at = ?1 /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */
                      WHERE id = ?2",
                     params![format!("2026-05-02T12:{index:02}:00Z"), id],
                 )
@@ -14817,8 +14818,9 @@ mod tests {
         );
         db.conn_ref()
             .execute(
-                "UPDATE intelligence_claims
-                 SET sensitivity = 'internal', created_at = ?1
+                "UPDATE intelligence_claims /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */
+                 SET sensitivity = 'internal' /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */,
+                     created_at = ?1 /* dos7-allowed: prompt-context unit test seeds sensitivity ordering */
                  WHERE id = 'claim-internal-older'",
                 params!["2026-05-02T11:00:00Z"],
             )

--- a/src-tauri/src/services/composition_render_orchestrator.rs
+++ b/src-tauri/src/services/composition_render_orchestrator.rs
@@ -206,7 +206,20 @@ pub fn resolve_producer_ability_name(composition_id: &str) -> Option<&'static st
 /// Extract the account_id encoded in an `account-overview` composition_id.
 /// Pattern: `dailyos/account-overview:account:{account_id}`.
 pub fn extract_account_id_from_composition_id(composition_id: &str) -> Option<&str> {
-    composition_id.strip_prefix("dailyos/account-overview:account:")
+    let account_id = composition_id.strip_prefix("dailyos/account-overview:account:")?;
+    if is_valid_account_id_tail(account_id) {
+        Some(account_id)
+    } else {
+        None
+    }
+}
+
+fn is_valid_account_id_tail(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -318,5 +331,24 @@ mod tests {
             Some("acct-42")
         );
         assert!(extract_account_id_from_composition_id("dailyos/other:foo").is_none());
+    }
+
+    #[test]
+    fn account_id_extract_rejects_malformed_tails() {
+        for bad in &[
+            "".to_string(),
+            "acct/42".to_string(),
+            "acct\n42".to_string(),
+            "acct 42".to_string(),
+            "acct.42".to_string(),
+            "acct:42".to_string(),
+            "x".repeat(65),
+        ] {
+            let composition_id = format!("dailyos/account-overview:account:{bad}");
+            assert!(
+                extract_account_id_from_composition_id(&composition_id).is_none(),
+                "malformed account id tail must be rejected: {bad:?}"
+            );
+        }
     }
 }

--- a/src-tauri/src/services/version_dispatcher.rs
+++ b/src-tauri/src/services/version_dispatcher.rs
@@ -1271,21 +1271,19 @@ fn dispatched_event_from_row(row: &VersionEventRow) -> DispatchedEvent {
 }
 
 // ---------------------------------------------------------------------------
-// Test introspection helpers (cargo test only)
+// Test introspection helpers
 // ---------------------------------------------------------------------------
 //
-// Marked `#[doc(hidden)]` to keep them off the public API docs. Reaching
-// these requires an `ActionDb` handle, which is itself behind the
-// substrate trust boundary — no remote route can call them. The tighter
-// `#[cfg(any(test, feature = "test-harness"))]` gate would require the
-// workspace CI invocation to opt into the feature for the dos589
-// fixtures; see the linked maintenance ticket for that follow-up.
+// Marked `#[doc(hidden)]` to keep them off the public API docs, and gated so
+// production builds do not expose fixture-only cursor/key introspection.
 
+#[cfg(any(test, feature = "test-harness"))]
 #[doc(hidden)]
 pub fn __test_encode_cursor(cursor_uuid: &str, subscription_id: &str, local_key: &[u8]) -> String {
     CursorEnvelope::encode(cursor_uuid, subscription_id, local_key)
 }
 
+#[cfg(any(test, feature = "test-harness"))]
 #[doc(hidden)]
 pub fn __test_decode_cursor_subscription_id(wire: &str) -> Option<String> {
     CursorEnvelope::decode(wire).map(|env| env.subscription_id)
@@ -1295,6 +1293,7 @@ pub fn __test_decode_cursor_subscription_id(wire: &str) -> Option<String> {
 /// valid cursor envelope without going through a delivered event. Production
 /// callers never need this — the dispatcher always encodes envelopes on the
 /// caller's behalf.
+#[cfg(any(test, feature = "test-harness"))]
 #[doc(hidden)]
 pub fn __test_load_local_key(
     db: &ActionDb,

--- a/src-tauri/src/services/workspace_ingestion/contracts.rs
+++ b/src-tauri/src/services/workspace_ingestion/contracts.rs
@@ -91,7 +91,29 @@ impl WorkspaceCategory {
             Self::Notes => "notes",
             Self::Contracts => "contracts",
             Self::Attachments => "attachments",
-            Self::Other(s) => s.as_str(),
+            Self::Other(s) => {
+                debug_assert!(
+                    is_valid_slug_shape(s),
+                    "WorkspaceCategory::Other must carry a lexically valid slug"
+                );
+                debug_assert!(
+                    !is_known_category_slug(s),
+                    "WorkspaceCategory::Other must not duplicate a known category slug"
+                );
+                s.as_str()
+            }
+        }
+    }
+
+    /// Builds an `Other` category only when the slug is lexically valid and
+    /// does not shadow a known category slug. Registry allow/deny semantics
+    /// still live at `WorkspaceCategoryRegistry::validate`.
+    pub fn other_slug(s: impl Into<String>) -> Option<Self> {
+        let s = s.into();
+        if is_valid_slug_shape(&s) && !is_known_category_slug(&s) {
+            Some(Self::Other(s))
+        } else {
+            None
         }
     }
 
@@ -111,6 +133,13 @@ impl WorkspaceCategory {
             _ => None,
         }
     }
+}
+
+fn is_known_category_slug(s: &str) -> bool {
+    matches!(
+        s,
+        "presentations" | "transcripts" | "meetings" | "notes" | "contracts" | "attachments"
+    )
 }
 
 fn is_valid_slug_shape(s: &str) -> bool {

--- a/src-tauri/src/services/workspace_ingestion/lifecycle.rs
+++ b/src-tauri/src/services/workspace_ingestion/lifecycle.rs
@@ -9,7 +9,7 @@
 
 use abilities_runtime::abilities::provenance::source::DataSource;
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, types::Type, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::entity::EntityType;
@@ -158,8 +158,8 @@ impl LifecycleRepo {
             params![
                 file_id,
                 canonical_path,
-                identity.device as i64,
-                identity.inode as i64,
+                u64_to_sql_i64("device", identity.device)?,
+                u64_to_sql_i64("inode", identity.inode)?,
                 workspace_file_kind_slug(source_type),
                 data_source_json,
                 source_asof.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
@@ -321,8 +321,8 @@ fn row_to_lifecycle(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkspaceFileLi
     Ok(WorkspaceFileLifecycle {
         file_id: row.get(0)?,
         canonical_path: row.get(1)?,
-        device: row.get::<_, i64>(2)? as u64,
-        inode: row.get::<_, i64>(3)? as u64,
+        device: sql_i64_to_u64(row.get::<_, i64>(2)?, 2)?,
+        inode: sql_i64_to_u64(row.get::<_, i64>(3)?, 3)?,
         source_type: workspace_file_kind_from_slug(&source_type_raw)
             .unwrap_or(WorkspaceFileKind::Inbox),
         data_source: serde_json::from_str(&data_source_raw).unwrap_or(DataSource::WorkspaceFile {
@@ -343,6 +343,20 @@ fn row_to_lifecycle(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkspaceFileLi
         },
         created_at: parse_dt(&created_at_raw),
         updated_at: parse_dt(&updated_at_raw),
+    })
+}
+
+fn u64_to_sql_i64(field: &str, value: u64) -> Result<i64, LifecycleError> {
+    i64::try_from(value).map_err(|_| {
+        LifecycleError::DbError(format!(
+            "{field} value {value} exceeds SQLite INTEGER positive range"
+        ))
+    })
+}
+
+fn sql_i64_to_u64(value: i64, column: usize) -> rusqlite::Result<u64> {
+    u64::try_from(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(column, Type::Integer, Box::new(error))
     })
 }
 

--- a/src-tauri/src/surface_runtime/hmac.rs
+++ b/src-tauri/src/surface_runtime/hmac.rs
@@ -981,7 +981,7 @@ fn content_type_for_canonical_request(headers: &HeaderMap) -> Result<String, Sig
     let value = value
         .to_str()
         .map_err(|_| SignedTransportError::canonicalization_mismatch("content_type_non_utf8"))?;
-    Ok(trim_ascii_whitespace(value).to_string())
+    Ok(trim_http_ows(value).to_string())
 }
 
 fn required_session_id_header(headers: &HeaderMap) -> Result<&str, SignedTransportError> {
@@ -1206,8 +1206,8 @@ fn is_safe_identifier(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
-fn trim_ascii_whitespace(value: &str) -> &str {
-    value.trim_matches(|character: char| character.is_ascii_whitespace())
+fn trim_http_ows(value: &str) -> &str {
+    value.trim_matches(|character: char| matches!(character, ' ' | '\t' | '\n' | '\r'))
 }
 
 fn parseable_active_session_id(
@@ -1678,6 +1678,28 @@ mod tests {
         assert!(rendered.contains("path_query:29\n/v1/surface/abilities?a=1&a=2\n"));
         assert!(rendered.contains("content_type:0\n\n"));
         assert!(rendered.contains("body:0\n\n"));
+    }
+
+    #[test]
+    fn content_type_trim_preserves_non_http_ows_edges() {
+        assert_eq!(
+            trim_http_ows(
+                " \t\n\r\u{0000}\u{000b}\u{000c}application/json\u{000c}\u{000b}\u{0000}\r\n\t "
+            ),
+            "\u{0000}\u{000b}\u{000c}application/json\u{000c}\u{000b}\u{0000}"
+        );
+        assert_eq!(
+            trim_http_ows("\u{0000}application/json\u{0000}"),
+            "\u{0000}application/json\u{0000}"
+        );
+        assert_eq!(
+            trim_http_ows("\u{000b}application/json\u{000b}"),
+            "\u{000b}application/json\u{000b}"
+        );
+        assert_eq!(
+            trim_http_ows("\u{000c}application/json\u{000c}"),
+            "\u{000c}application/json\u{000c}"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.rs
+++ b/src-tauri/tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.rs
@@ -1,0 +1,19 @@
+use chrono::Utc;
+use dailyos_lib::services::workspace_ingestion::lifecycle::WorkspaceFileLifecycle;
+
+fn main() {
+    let now = Utc::now();
+    let _ = WorkspaceFileLifecycle {
+        file_id: "wf-trybuild".to_string(),
+        canonical_path: "/tmp/workspace/file.md".to_string(),
+        device: 1,
+        inode: 2,
+        entity_id: None,
+        entity_type: None,
+        content_sha256: None,
+        category: None,
+        user_override: None,
+        created_at: now,
+        updated_at: now,
+    };
+}

--- a/src-tauri/tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.stderr
+++ b/src-tauri/tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.stderr
@@ -1,0 +1,5 @@
+error[E0063]: missing fields `data_source`, `lifecycle_state`, `source_asof` and 1 other field in initializer of `WorkspaceFileLifecycle`
+ --> tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.rs:6:13
+  |
+6 |     let _ = WorkspaceFileLifecycle {
+  |             ^^^^^^^^^^^^^^^^^^^^^^ missing `data_source`, `lifecycle_state`, `source_asof` and 1 other field

--- a/src-tauri/tests/workspace_ingestion_lifecycle_trybuild_test.rs
+++ b/src-tauri/tests/workspace_ingestion_lifecycle_trybuild_test.rs
@@ -1,0 +1,5 @@
+#[test]
+fn workspace_file_lifecycle_requires_core_provenance_fields() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/trybuild/workspace_file_lifecycle_missing_core_fields_fails.rs");
+}

--- a/src-tauri/tests/workspace_ingestion_no_substrate_reinvention.rs
+++ b/src-tauri/tests/workspace_ingestion_no_substrate_reinvention.rs
@@ -4,20 +4,19 @@
 //! findings (V1.1 invented `TrustFactorInput` colliding with canonical
 //! `TrustFactorInputs`; V1.2 had local `SourceAttribution` colliding with the
 //! canonical 7-field struct; V1.2 had `SourceType` mirroring canonical
-//! `WorkspaceFileKind`). The structural fix is this CI grep gate: any
-//! `pub struct/enum/trait` under `services/workspace_ingestion/` whose name
-//! matches the canonical substrate primitive list fails the test.
+//! `WorkspaceFileKind`). The structural fix is this AST-aware CI gate: any
+//! exported struct/enum/trait/type definitions under `services/workspace_ingestion/`
+//! whose name matches the canonical substrate primitive list fail the test.
 //!
-//! Gate scope: catches `pub struct`, `pub enum`, `pub trait`. Does NOT catch
-//! `pub(crate)` definitions, `pub type` aliases, or same-shape renamed
-//! clones — strengthening to a Rust-AST-aware lint is filed as Codebase
-//! Maintenance follow-up. The current gate catches the actual reinvention
-//! shape that fired three times during L0 (always `pub struct/enum/trait`),
-//! which is the highest-value structural prevention available without a
-//! lint rewrite.
+//! Gate scope: parses Rust items instead of grepping so it catches `pub`,
+//! `pub(crate)`, `pub(super)`, `pub(in ...)`, and `pub type` alias shapes.
+//! Same-shape renamed clones still need human review; this gate prevents the
+//! named reinvention class that fired during L0 from drifting back in.
 
 use std::fs;
 use std::path::PathBuf;
+
+use syn::{Item, Type, Visibility};
 
 const REINVENTION_NAMES: &[&str] = &[
     "SourceAttribution",
@@ -43,25 +42,9 @@ fn no_substrate_reinvention_in_workspace_ingestion() {
             continue;
         }
         let source = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
-        for (lineno_zero, line) in source.lines().enumerate() {
-            let lineno = lineno_zero + 1;
-            for name in REINVENTION_NAMES {
-                let needle_struct = format!("pub struct {name}");
-                let needle_enum = format!("pub enum {name}");
-                let needle_trait = format!("pub trait {name}");
-                if line.contains(&needle_struct)
-                    || line.contains(&needle_enum)
-                    || line.contains(&needle_trait)
-                {
-                    violations.push(format!(
-                        "{}:{}: reinvents canonical substrate primitive `{}` — \
-                         consume the canonical type instead of defining a parallel",
-                        path.display(),
-                        lineno,
-                        name
-                    ));
-                }
-            }
+        let parsed = syn::parse_file(&source).unwrap_or_else(|e| panic!("parse {path:?}: {e}"));
+        for item in &parsed.items {
+            inspect_item(&path, item, &mut violations);
         }
     }
 
@@ -71,4 +54,73 @@ fn no_substrate_reinvention_in_workspace_ingestion() {
         violations.len(),
         violations.join("\n  ")
     );
+}
+
+fn inspect_item(path: &std::path::Path, item: &Item, violations: &mut Vec<String>) {
+    match item {
+        Item::Struct(item) if is_exported(&item.vis) => {
+            push_if_reinvention(path, "struct", &item.ident.to_string(), violations);
+        }
+        Item::Enum(item) if is_exported(&item.vis) => {
+            push_if_reinvention(path, "enum", &item.ident.to_string(), violations);
+        }
+        Item::Trait(item) if is_exported(&item.vis) => {
+            push_if_reinvention(path, "trait", &item.ident.to_string(), violations);
+        }
+        Item::Type(item) if is_exported(&item.vis) => {
+            let alias_name = item.ident.to_string();
+            push_if_reinvention(path, "type alias", &alias_name, violations);
+            if let Some(target_name) = type_leaf_ident(&item.ty) {
+                if is_reinvention_name(&target_name) && !is_reinvention_name(&alias_name) {
+                    violations.push(format!(
+                        "{}: exported type alias `{alias_name}` points at canonical substrate \
+                         primitive `{target_name}` — re-export the canonical type instead",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Item::Mod(item) => {
+            if let Some((_, items)) = &item.content {
+                for nested in items {
+                    inspect_item(path, nested, violations);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_exported(vis: &Visibility) -> bool {
+    matches!(vis, Visibility::Public(_) | Visibility::Restricted(_))
+}
+
+fn push_if_reinvention(
+    path: &std::path::Path,
+    kind: &str,
+    name: &str,
+    violations: &mut Vec<String>,
+) {
+    if is_reinvention_name(name) {
+        violations.push(format!(
+            "{}: exported {kind} `{name}` reinvents a canonical substrate primitive — \
+             consume the canonical type instead of defining a parallel",
+            path.display()
+        ));
+    }
+}
+
+fn is_reinvention_name(name: &str) -> bool {
+    REINVENTION_NAMES.contains(&name)
+}
+
+fn type_leaf_ident(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(path) => path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        _ => None,
+    }
 }

--- a/src-tauri/tests/workspace_ingestion_unit.rs
+++ b/src-tauri/tests/workspace_ingestion_unit.rs
@@ -75,6 +75,11 @@ fn workspace_category_as_slug_and_from_slug_round_trip_for_known_variants() {
 fn workspace_category_other_accepts_lex_valid_lowercase_ascii_slugs() {
     let ok = ["custom_slug", "another-slug", "slug_with_42_digits"];
     for slug in &ok {
+        assert_eq!(
+            WorkspaceCategory::other_slug(*slug),
+            Some(WorkspaceCategory::Other((*slug).to_string())),
+            "other_slug must construct only non-built-in custom slugs"
+        );
         let parsed = WorkspaceCategory::from_slug(slug)
             .unwrap_or_else(|| panic!("from_slug must accept lex-valid {slug}"));
         match &parsed {
@@ -84,6 +89,24 @@ fn workspace_category_other_accepts_lex_valid_lowercase_ascii_slugs() {
             }
             other => panic!("expected Other({slug}), got {other:?}"),
         }
+    }
+}
+
+#[test]
+fn workspace_category_other_constructor_rejects_known_slugs() {
+    for known in &[
+        "presentations",
+        "transcripts",
+        "meetings",
+        "notes",
+        "contracts",
+        "attachments",
+    ] {
+        assert_eq!(
+            WorkspaceCategory::other_slug(*known),
+            None,
+            "known category slug {known:?} must use its dedicated variant"
+        );
     }
 }
 
@@ -256,23 +279,34 @@ fn migrations_v250_v251_apply_against_in_memory_db_and_register_columns() {
 }
 
 #[test]
-fn migrations_slice_max_version_is_at_least_251() {
-    // Internal substrate check: ensures W1-A's v251 lands at the tail of the
-    // registered MIGRATIONS slice (i.e., `version > current` runner filter
-    // will pick up new DBs at any version ≤251). We assert ≥251 rather than
-    // ==251 so future maintenance migrations don't false-fail this test.
-    // The actual MIGRATIONS slice is internal; the schema_version table
-    // populated by a fresh `run_migrations` walks the slice. As a proxy,
-    // verify the SQL files exist (compile-time `include_str!` already
-    // guarantees this if the registration is wired correctly).
-    let v250_sql = include_str!("../src/migrations/250_workspace_file_lifecycle.sql");
-    let v251_sql = include_str!("../src/migrations/251_workspace_file_lifecycle_category.sql");
+fn migrations_runner_registers_workspace_lifecycle_versions() {
+    use dailyos_lib::migration_test_api::run_migrations;
+    use rusqlite::Connection;
+
+    let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+    run_migrations(&conn).expect("production migration runner applies");
+
+    let max_version: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read schema_version max");
     assert!(
-        v250_sql.contains("CREATE TABLE IF NOT EXISTS workspace_file_lifecycle"),
-        "v250 must create workspace_file_lifecycle"
+        max_version >= 251,
+        "production MIGRATIONS slice must register at least v251, got {max_version}"
     );
-    assert!(
-        v251_sql.contains("ADD COLUMN category"),
-        "v251 must add category column"
+
+    let category_col_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('workspace_file_lifecycle') WHERE name = 'category'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("inspect workspace_file_lifecycle columns");
+    assert_eq!(
+        category_col_count, 1,
+        "migration runner must apply v251 category column"
     );
 }

--- a/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo.rs
+++ b/src-tauri/tests/workspace_ingestion_w2a_lifecycle_repo.rs
@@ -1,7 +1,9 @@
 use abilities_runtime::abilities::provenance::source::WorkspaceFileKind;
 use chrono::Utc;
 use dailyos_lib::services::workspace_ingestion::contracts::{FileIdentity, WorkspaceCategory};
-use dailyos_lib::services::workspace_ingestion::lifecycle::{LifecycleRepo, LifecycleState};
+use dailyos_lib::services::workspace_ingestion::lifecycle::{
+    LifecycleError, LifecycleRepo, LifecycleState,
+};
 use rusqlite::Connection;
 
 fn conn() -> Connection {
@@ -54,4 +56,26 @@ fn lifecycle_repo_writes_pending_transition_override_and_category() {
     assert_eq!(row.lifecycle_state, LifecycleState::Ingesting);
     assert_eq!(row.category, Some(WorkspaceCategory::Notes));
     assert_eq!(row.user_override.expect("override").actor_id, "user-1");
+}
+
+#[test]
+fn lifecycle_repo_rejects_device_inode_values_outside_sqlite_integer_range() {
+    let conn = conn();
+    let mut too_large = identity();
+    too_large.device = i64::MAX as u64 + 1;
+
+    let err = LifecycleRepo::insert_pending(
+        &conn,
+        "wf-overflow",
+        &too_large,
+        &WorkspaceFileKind::Inbox,
+        Utc::now(),
+        None,
+    )
+    .expect_err("device overflow must reject before SQLite write");
+
+    assert!(
+        matches!(err, LifecycleError::DbError(ref message) if message.contains("device")),
+        "expected device range error, got {err:?}"
+    );
 }

--- a/wp/dailyos/blocks/pill/render-functions.php
+++ b/wp/dailyos/blocks/pill/render-functions.php
@@ -36,9 +36,8 @@ function dailyos_pill_render( array $attributes ): string {
 	$label_html = esc_html( $label );
 
 	return sprintf(
-		'<span class="%s" data-tone="%s" data-ds-name="Pill" data-ds-tier="primitive" data-ds-spec="primitives/Pill.md">%s%s</span>',
+		'<span class="%s" data-ds-name="Pill" data-ds-tier="primitive" data-ds-spec="primitives/Pill.md">%s%s</span>',
 		esc_attr( implode( ' ', $classes ) ),
-		esc_attr( $tone ),
 		$dot_html,
 		$label_html
 	);

--- a/wp/dailyos/includes/transport/class-dailyos-hmac-signer.php
+++ b/wp/dailyos/includes/transport/class-dailyos-hmac-signer.php
@@ -52,7 +52,7 @@ final class DailyOS_Hmac_Signer {
 		string $request_id = ''
 	): string {
 		$normalized_method       = strtoupper( $method );
-		$normalized_content_type = trim( $content_type, " \t\n\r\0\x0B" );
+		$normalized_content_type = trim( $content_type, " \t\n\r" );
 
 		$this->assert_utf8( 'method', $normalized_method );
 		$this->assert_utf8( 'path_query', $path_query );

--- a/wp/dailyos/scripts/translate-tauri.mjs
+++ b/wp/dailyos/scripts/translate-tauri.mjs
@@ -293,9 +293,8 @@ function dailyos_pill_render(array $attributes): string {
 	$label_html = esc_html($label);
 
 	return sprintf(
-		'<span class="%s" data-tone="%s" data-ds-name="Pill" data-ds-tier="primitive" data-ds-spec="primitives/Pill.md">%s%s</span>',
+		'<span class="%s" data-ds-name="Pill" data-ds-tier="primitive" data-ds-spec="primitives/Pill.md">%s%s</span>',
 		esc_attr(implode(' ', $classes)),
-		esc_attr($tone),
 		$dot_html,
 		$label_html
 	);

--- a/wp/dailyos/tests/fixtures/hmac_canonical_vectors.json
+++ b/wp/dailyos/tests/fixtures/hmac_canonical_vectors.json
@@ -67,5 +67,28 @@
         "timestamp": "2024-11-13T12:16:40Z",
         "expected_canonical_bytes_b64": "REFJTFlPUy1XUC1CUklER0UtSE1BQy1WMQptZXRob2Q6MwpQVVQKcGF0aF9xdWVyeToyNwovZGFpbHlvcy92MS9leGFtcGxlP2Zvbz1iYXIKY29udGVudF90eXBlOjMxCmFwcGxpY2F0aW9uL2pzb247IGNoYXJzZXQ9dXRmLTgKYm9keToyCltdCnNpdGVfYmluZGluZ19kaWdlc3Q6NjQKY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYwpzaXRlX25vbmNlOjE3CnNpdGVOb25jZUdhbW1hNzg5CndwX3VzZXJfaWQ6MwoxMDgKd3Bfc2l0ZV9pZDoxNgppbnN0YWxsLWdhbW1hOjEyCmhvbWVfdXJsOjIwCmh0dHBzOi8vZXhhbXBsZS50ZXN0CnNpdGVfdXJsOjI4Cmh0dHBzOi8vZXhhbXBsZS50ZXN0L25ldHdvcmsKd3BfaW5zdGFsbF91dWlkOjM2CjAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDEwMwpwbHVnaW5faW5zdGFuY2VfdXVpZDozNgowMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAyMDMKbXVsdGlzaXRlX2Jsb2dfaWQ6MgoxMgpub25jZToxNQpub25jZS1nYW1tYS03ODkKdGltZXN0YW1wOjIwCjIwMjQtMTEtMTNUMTI6MTY6NDBaCnJlcXVlc3RfaWQ6MAoK",
         "expected_signature_hex": "3c0fb5e0921a281caa50ace4cd4a519981ef6b0edb11374abc3d153aeef7d4af"
+    },
+    {
+        "name": "content_type_preserves_non_http_ows_edges",
+        "session_key_hex": "4545454545454545454545454545454545454545454545454545454545454545",
+        "method": "POST",
+        "path_query": "/dailyos/v1/ows",
+        "content_type": " \t\n\r\u0000\u000b\fapplication/json\f\u000b\u0000\r\n\t ",
+        "body_b64": "e30=",
+        "identity": {
+            "site_binding_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "site_nonce": "siteNonceDelta012",
+            "wp_user_id": "64",
+            "wp_site_id": "site-2",
+            "home_url": "https://example.test",
+            "site_url": "https://example.test/wp",
+            "wp_install_uuid": "00000000-0000-4000-8000-000000000104",
+            "plugin_instance_uuid": "00000000-0000-4000-8000-000000000204",
+            "multisite_blog_id": ""
+        },
+        "nonce": "nonce-delta-012",
+        "timestamp": "2024-11-13T12:18:20Z",
+        "expected_canonical_bytes_b64": "REFJTFlPUy1XUC1CUklER0UtSE1BQy1WMQptZXRob2Q6NApQT1NUCnBhdGhfcXVlcnk6MTUKL2RhaWx5b3MvdjEvb3dzCmNvbnRlbnRfdHlwZToyMgoACwxhcHBsaWNhdGlvbi9qc29uDAsACmJvZHk6Mgp7fQpzaXRlX2JpbmRpbmdfZGlnZXN0OjY0CmRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGQKc2l0ZV9ub25jZToxNwpzaXRlTm9uY2VEZWx0YTAxMgp3cF91c2VyX2lkOjIKNjQKd3Bfc2l0ZV9pZDo2CnNpdGUtMgpob21lX3VybDoyMApodHRwczovL2V4YW1wbGUudGVzdApzaXRlX3VybDoyMwpodHRwczovL2V4YW1wbGUudGVzdC93cAp3cF9pbnN0YWxsX3V1aWQ6MzYKMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMTA0CnBsdWdpbl9pbnN0YW5jZV91dWlkOjM2CjAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDIwNAptdWx0aXNpdGVfYmxvZ19pZDowCgpub25jZToxNQpub25jZS1kZWx0YS0wMTIKdGltZXN0YW1wOjIwCjIwMjQtMTEtMTNUMTI6MTg6MjBaCnJlcXVlc3RfaWQ6MAoK",
+        "expected_signature_hex": "12c32b6bf31ff5e89b80e4bf22ebdbbdcfaccdb21b927ff50960eacda353e907"
     }
 ]


### PR DESCRIPTION
## Linear ticket

DOS-697, DOS-632, DOS-598, DOS-634, DOS-751

## Summary

Resolves a fourth path-alpha maintenance batch across the v1.4.4, v1.4.4a, v1.4.5, and abilities-runtime plans. This batch covers design primitive drift, account composition ID validation, HMAC OWS canonicalization, dispatcher test-helper gating, and workspace ingestion regression guards.

## What changed

- Aligned Pill, ProvenanceTag, IntelligenceQualityBadge, TypeBadge, and TrustBandBadge docs plus WP Pill rendering with shipped class-token contracts.
- Updated the block-kit Pill fixture and Tauri-to-WP generator template so `data-tone` does not drift back into generated Pill markup.
- Hardened `extract_account_id_from_composition_id` to reject malformed account ID suffixes before producer invocation.
- Aligned PHP/Rust HMAC Content-Type trimming on HTTP OWS and added cross-implementation vectors for NUL, VT, and FF edge bytes.
- Gated dispatcher cursor/key test helpers behind `test` or `test-harness` and wired DOS589 cursor fixture tests into CI with the feature enabled.
- Strengthened workspace-ingestion category, lifecycle integer, migration-runner, trybuild, and AST reinvention guards.
- Cleaned up pre-existing DOS-7 claim-lint fixture drift so test-only claim recency/sensitivity setup stays explicit and the full suite remains green.

## Test plan

- [x] `cargo clippy -- -D warnings` clean (`cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`)
- [x] `cargo test --lib` passes (pre-push hook after final commit)
- [x] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (not run; no frontend runtime source changed)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes
- [x] Manual verification: PHP lint for Pill and HMAC signer, PHP HMAC vector harness (`4 HMAC vectors passed`), release/no-feature cargo check, DOS589 `test-harness` fixtures, workspace-ingestion trybuild guard, block-kit Pill fixture, MCP bridge tests, and DOS-7 claim-lint tests.

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (if `security_auditor_invoked: false`): _none_

**Exemption rationale**:

Security-sensitive paths are touched: services, bridge tests, HMAC transport canonicalization, claim-substrate fixture SQL, and CI workflow coverage. Keep this draft in WIP until L2/security review is recorded.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- DOS-633 remains live but is better handled after the native actor binding work lands.
- DOS-700 and DOS-756 still have unresolved subitems and were left out of this low-effort batch.

## Notes for review

Issues remain In Progress in Linear until this PR merges. Commit is intentionally WIP with `L2-status: not-run-acknowledged`; run L2 before marking this ready.
