### PR TITLE
Maintenance path-alpha batch 5

### DIFF
--- a/.docs/design/primitives/README.md
+++ b/.docs/design/primitives/README.md
@@ -14,47 +14,47 @@ A primitive is *not* a primitive if it knows about claims, trust, briefings, or 
 
 ### Wave 1 (v1.4.3 substrate, 0.1.0)
 
-| Name | Status | Job (one line) | Source |
-|---|---|---|---|
-| [`Pill`](./Pill.md) | integrated | Visual primitive for inline status / label / category badges | `src/components/ui/Pill.tsx` |
-| [`HealthBadge`](./HealthBadge.md) | integrated | Shared health score dot/score/trend visual | `src/components/shared/HealthBadge.tsx` |
-| [`StatusDot`](./StatusDot.md) | integrated | Connector/system status dot with optional label | `src/components/shared/StatusDot.tsx` |
-| [`Avatar`](./Avatar.md) | integrated | Person photo/initial fallback avatar | `src/components/ui/Avatar.tsx` |
-| [`TrustBandBadge`](./TrustBandBadge.md) | integrated | v1.4.0 surface trust band (`likely_current` / `use_with_caution` / `needs_verification`) | `src/components/ui/TrustBandBadge.tsx` |
-| [`IntelligenceQualityBadge`](./IntelligenceQualityBadge.md) | integrated | Intelligence completeness (`sparse` / `developing` / `ready` / `fresh`) | `src/components/entity/` |
-| [`FreshnessIndicator`](./FreshnessIndicator.md) | integrated | Raw recency timestamp + relative age | `src/components/ui/FreshnessIndicator.tsx` |
-| [`ProvenanceTag`](./ProvenanceTag.md) | integrated | Source attribution label, suppresses synthesized | `src/components/ui/` |
-| [`EntityChip`](./EntityChip.md) | integrated | Entity reference with entity-type color | `src/components/ui/EntityChip.tsx` |
-| [`TypeBadge`](./TypeBadge.md) | integrated | Account-type categorical (Customer / Internal / Partner) | `src/components/ui/TypeBadge.tsx` |
-| [`ScoreBand`](./ScoreBand.md) | proposed | DOS-325 band-label score (`on-track` / `watching` / `action-needed` / `no-read`) | `src/components/ui/ScoreBand.tsx` |
+| Name | Status | Interaction | Job (one line) | Source |
+|---|---|---|---|---|
+| [`Pill`](./Pill.md) | integrated | render-only | Visual primitive for inline status / label / category badges | `src/components/ui/Pill.tsx` |
+| [`HealthBadge`](./HealthBadge.md) | integrated | render-only | Shared health score dot/score/trend visual | `src/components/shared/HealthBadge.tsx` |
+| [`StatusDot`](./StatusDot.md) | integrated | render-only | Connector/system status dot with optional label | `src/components/shared/StatusDot.tsx` |
+| [`Avatar`](./Avatar.md) | integrated | render-only | Person photo/initial fallback avatar | `src/components/ui/Avatar.tsx` |
+| [`TrustBandBadge`](./TrustBandBadge.md) | integrated | render-only | v1.4.0 surface trust band (`likely_current` / `use_with_caution` / `needs_verification`) | `src/components/ui/TrustBandBadge.tsx` |
+| [`IntelligenceQualityBadge`](./IntelligenceQualityBadge.md) | integrated | render-only | Intelligence completeness (`sparse` / `developing` / `ready` / `fresh`) | `src/components/entity/` |
+| [`FreshnessIndicator`](./FreshnessIndicator.md) | integrated | render-only | Raw recency timestamp + relative age | `src/components/ui/FreshnessIndicator.tsx` |
+| [`ProvenanceTag`](./ProvenanceTag.md) | integrated | render-only | Source attribution label, suppresses synthesized | `src/components/ui/` |
+| [`EntityChip`](./EntityChip.md) | integrated | mixed | Entity reference with entity-type color | `src/components/ui/EntityChip.tsx` |
+| [`TypeBadge`](./TypeBadge.md) | integrated | mixed | Account-type categorical (Customer / Internal / Partner) | `src/components/ui/TypeBadge.tsx` |
+| [`ScoreBand`](./ScoreBand.md) | proposed | render-only | DOS-325 band-label score (`on-track` / `watching` / `action-needed` / `no-read`) | `src/components/ui/ScoreBand.tsx` |
 
 ### Wave 2 (v1.4.4 trust UI, 0.2.0)
 
-| Name | Status | Job (one line) | Source |
-|---|---|---|---|
-| [`SourceCoverageLine`](./SourceCoverageLine.md) | proposed | Compact line summarizing source coverage (e.g., "Glean · 4 sources · 2 stale") | `src/components/ui/SourceCoverageLine.tsx` |
-| [`ConfidenceScoreChip`](./ConfidenceScoreChip.md) | proposed | Numerical confidence score chip with threshold-based tone | `src/components/ui/ConfidenceScoreChip.tsx` |
-| [`VerificationStatusFlag`](./VerificationStatusFlag.md) | proposed | Consistency state per v1.4.0 (`ok` / `corrected` / `flagged`) | `src/components/ui/VerificationStatusFlag.tsx` |
-| [`DataGapNotice`](./DataGapNotice.md) | proposed | Inline warning that intelligence is missing critical inputs | `src/components/ui/DataGapNotice.tsx` |
-| [`AsOfTimestamp`](./AsOfTimestamp.md) | proposed | Static "as of" timestamp label (companion to FreshnessIndicator) | `src/components/ui/AsOfTimestamp.tsx` |
+| Name | Status | Interaction | Job (one line) | Source |
+|---|---|---|---|---|
+| [`SourceCoverageLine`](./SourceCoverageLine.md) | proposed | render-only | Compact line summarizing source coverage (e.g., "Glean · 4 sources · 2 stale") | `src/components/ui/SourceCoverageLine.tsx` |
+| [`ConfidenceScoreChip`](./ConfidenceScoreChip.md) | proposed | render-only | Numerical confidence score chip with threshold-based tone | `src/components/ui/ConfidenceScoreChip.tsx` |
+| [`VerificationStatusFlag`](./VerificationStatusFlag.md) | proposed | render-only | Consistency state per v1.4.0 (`ok` / `corrected` / `flagged`) | `src/components/ui/VerificationStatusFlag.tsx` |
+| [`DataGapNotice`](./DataGapNotice.md) | proposed | render-only | Inline warning that intelligence is missing critical inputs | `src/components/ui/DataGapNotice.tsx` |
+| [`AsOfTimestamp`](./AsOfTimestamp.md) | proposed | render-only | Static "as of" timestamp label (companion to FreshnessIndicator) | `src/components/ui/AsOfTimestamp.tsx` |
 
 ### Wave 3 (Settings substrate, 0.3.0)
 
-| Name | Status | Job (one line) | Source |
-|---|---|---|---|
-| [`InlineInput`](./InlineInput.md) | proposed | Click-to-edit text input with pencil affordance | target `src/components/ui/InlineInput.tsx` |
-| [`EditableText`](./EditableText.md) | integrated | Click-to-edit display text used by meeting, entity, and report surfaces | `src/components/ui/EditableText.tsx` |
-| [`FolioRefreshButton`](./FolioRefreshButton.md) | integrated | Editorial mono refresh/run button used in folio and hero action areas | `src/components/ui/folio-refresh-button.tsx` |
-| [`Switch`](./Switch.md) | integrated | Aria-checked toggle button | `src/components/ui/Switch.tsx` |
-| [`Segmented`](./Segmented.md) | integrated | Tinted button group with `aria-pressed` state | `src/components/ui/Segmented.tsx` |
-| [`RemovableChip`](./RemovableChip.md) | integrated | Chip with × removal affordance (distinct from `Pill`) | `src/components/ui/RemovableChip.tsx` |
-| [`GlanceCell`](./GlanceCell.md) | proposed | Single key/value stat cell (composed in `GlanceRow`) | `src/components/ui/GlanceCell.tsx` |
+| Name | Status | Interaction | Job (one line) | Source |
+|---|---|---|---|---|
+| [`InlineInput`](./InlineInput.md) | proposed | editable | Click-to-edit text input with pencil affordance | target `src/components/ui/InlineInput.tsx` |
+| [`EditableText`](./EditableText.md) | integrated | editable | Click-to-edit display text used by meeting, entity, and report surfaces | `src/components/ui/EditableText.tsx` |
+| [`FolioRefreshButton`](./FolioRefreshButton.md) | integrated | action | Editorial mono refresh/run button used in folio and hero action areas | `src/components/ui/folio-refresh-button.tsx` |
+| [`Switch`](./Switch.md) | integrated | interactive | Aria-checked toggle button | `src/components/ui/Switch.tsx` |
+| [`Segmented`](./Segmented.md) | integrated | interactive | Tinted button group with `aria-pressed` state | `src/components/ui/Segmented.tsx` |
+| [`RemovableChip`](./RemovableChip.md) | integrated | interactive | Chip with x removal affordance (distinct from `Pill`) | `src/components/ui/RemovableChip.tsx` |
+| [`GlanceCell`](./GlanceCell.md) | proposed | render-only | Single key/value stat cell (composed in `GlanceRow`) | `src/components/ui/GlanceCell.tsx` |
 
 ### Wave 4 (Meeting Detail substrate, 0.4.0)
 
-| Name | Status | Job (one line) | Source |
-|---|---|---|---|
-| [`MeetingStatusPill`](./MeetingStatusPill.md) | integrated | Meeting temporal state (`upcoming` / `in-progress` / `past` / `cancelled`) | `src/components/meeting/MeetingStatusPill.tsx` |
+| Name | Status | Interaction | Job (one line) | Source |
+|---|---|---|---|---|
+| [`MeetingStatusPill`](./MeetingStatusPill.md) | integrated | render-only | Meeting temporal state (`upcoming` / `in-progress` / `past` / `cancelled`) | `src/components/meeting/MeetingStatusPill.tsx` |
 
 ## Conventions
 

--- a/.docs/plans/v1.4.3-wp-foundation/L0-packet-F-feedback-write-infrastructure.md
+++ b/.docs/plans/v1.4.3-wp-foundation/L0-packet-F-feedback-write-infrastructure.md
@@ -35,7 +35,7 @@
   - **Migration v182:** index on `(surface_client_id, expires_at)` for efficient sweep.
   - **Migration v183 (reserved):** rollback path if any.
   - **Rust service:** `src-tauri/src/services/surface_feedback.rs` with `issue_nonce`, `consume_nonce`, `expire_nonces_sweep`.
-  - **Audit event types:** `pairing.feedback.nonce_issued`, `.consumed`, `.expired`, `.replay_rejected`.
+  - **Audit event types:** `presence_nonce_issued`, `presence_nonce_verified`, `presence_nonce_invalidated`, `presence_nonce_rejected`.
   - **PHP REST endpoint:** `wp/dailyos/v1/feedback` (POST issues + consumes the 2-phase nonce flow).
   - **JS feedback affordance UI:** per-block React component rendered inline when claim has feedback affordance enabled; button + optional textarea (`user_intent_text`, 500 char cap, sensitivity=User).
   - **Wire-up:** consume_nonce → `record_claim_feedback` substrate service.
@@ -55,7 +55,7 @@
 | actor-filtered provenance, sensitivity=User | ADR-0108 | `user_intent_text` (the optional textarea note) carries sensitivity=User. Audit log displays only the actor handle + redacted hash, never the raw text. Per-surface display policy must redact the text unless the requesting actor === the originating actor. |
 | W4-F presence-nonce v1.4.2 spike artifacts | `wp/dailyos/includes/class-dailyos-plugin.php:520-816` + `wp/dailyos/tests/PresenceNonceTest.php` | The presence-nonce REST scaffold (`issue_presence_nonce`, `can_issue_presence_nonce`, `strip_presence_nonces_from_post_data`, `sweep_presence_nonces`) is the existing seam W4 extends. W4 adds a sibling endpoint (`/v1/feedback`) using the same authorization shape (signed runtime call) and a parallel table (`surface_feedback_nonces` vs `surface_presence_nonces`). |
 | `MutationGuard`, `check_mutation_allowed` | `services/claims.rs` | Existing chokepoint contract. `record_claim_feedback` already passes `ctx.check_mutation_allowed()`; W4 service `surface_feedback::consume_nonce` must do the same before signing through to claims. |
-| audit events, pairing.feedback | none specifically; ADR-0094 (audit-log + enterprise observability) covers the event-shape contract | New event types must register with the existing audit infrastructure (no schema additions; the `event_type` column accepts the 4 new strings). |
+| audit events, presence_nonce | ADR-0094 (audit-log + enterprise observability) covers the event-shape contract | W4 reuses the existing `presence_nonce_*` vocabulary already emitted by the nonce substrate; no schema additions are required because `event_type` is `TEXT`. |
 
 **Net K-in conclusion:** W4 is the WRITE-PATH WIRE-UP between (a) WP's per-block feedback affordance UI and (b) the substrate's already-locked `record_claim_feedback`. Net-new: a 2-phase nonce lifecycle service + table + audit events + REST endpoint + per-block JS affordance. Every piece either consumes an already-shipped substrate OR mirrors an existing pattern (presence-nonce shape, ClaimFeedback row shape).
 
@@ -122,7 +122,7 @@ pub fn issue_nonce(
     input: IssueNonceInput,
 ) -> Result<IssueNonceOutcome, SurfaceFeedbackError> {
     ctx.check_mutation_allowed()?;
-    // … validate input, write row, emit pairing.feedback.nonce_issued audit event.
+    // ... validate input, write row, emit presence_nonce_issued audit event.
 }
 
 pub fn consume_nonce(
@@ -134,7 +134,7 @@ pub fn consume_nonce(
     // 1. Load nonce by nonce_id.
     // 2. Validate: not consumed (replay rejection), not expired, action_kind matches issued,
     //    requesting actor === issuing actor (presence binding).
-    // 3. Mark consumed; emit pairing.feedback.nonce_consumed audit event.
+    // 3. Mark consumed; emit presence_nonce_verified audit event.
     // 4. Translate to ClaimFeedbackInput (using the nonce's claim_id + user_intent_text).
     // 5. Call services::claim::record_claim_feedback (which itself enters MutationGuard +
     //    enqueue_signals_for_feedback).
@@ -146,22 +146,22 @@ pub fn expire_nonces_sweep(
     now: DateTime<Utc>,
 ) -> Result<SweepOutcome, SurfaceFeedbackError> {
     // Reap rows where expires_at < now AND consumed_at IS NULL.
-    // Emit pairing.feedback.nonce_expired audit event per row reaped (batch-write for efficiency).
+    // Emit presence_nonce_invalidated audit event per row reaped (batch-write for efficiency).
 }
 ```
 
 **Error variants** (`SurfaceFeedbackError`): `NonceNotFound`, `NonceExpired`, `NonceAlreadyConsumed`, `ActorMismatch` (replay-from-different-session), `ActionKindMismatch` (UI race or replay), `UnknownClaimId`, `Mutation(ClaimError)` (downstream from `record_claim_feedback`).
 
-### 5.5 Audit events (4 types)
+### 5.5 Audit events (implemented presence-nonce vocabulary)
 
-Added to the audit-event allowlist; no schema migration required (the `event_type` column is `TEXT`).
+Added to the audit-event allowlist; no schema migration required (the `event_type` column is `TEXT`). The current substrate keeps the pre-existing `presence_nonce_*` event vocabulary so nonce forensics share one query surface across issue, verify, replay, expiry, and invalidation. Earlier packet drafts used a feedback-specific namespace; those names are historical only.
 
 | Event type | Emitted when | Payload (`event_data` JSON) |
 |---|---|---|
-| `pairing.feedback.nonce_issued` | `issue_nonce` succeeds | `{ nonce_id, surface_client_id, session_id, claim_id, action_kind, expires_at, actor_kind, request_id }` |
-| `pairing.feedback.nonce_consumed` | `consume_nonce` succeeds (BEFORE the downstream `record_claim_feedback` audit row, so the chain is `nonce_issued → nonce_consumed → claim_feedback_recorded`) | `{ nonce_id, claim_id, action_kind, request_id, claim_feedback_id, ... }` |
-| `pairing.feedback.nonce_expired` | `expire_nonces_sweep` reaps an un-consumed nonce past `expires_at` | `{ nonce_id, claim_id, expires_at, swept_at }` |
-| `pairing.feedback.replay_rejected` | `consume_nonce` rejects because the nonce was already consumed or the actor doesn't match | `{ nonce_id, claim_id, rejection_reason: 'already_consumed' \| 'actor_mismatch' \| 'expired', request_id }` |
+| `presence_nonce_issued` | `issue_nonce` succeeds | `{ nonce_digest_prefix, surface_client_id_hash, session_id_hash, claim_id_hash, action, expires_at, request_id, ... }` |
+| `presence_nonce_verified` | `verify_nonce` succeeds and consumes the nonce before downstream `record_claim_feedback` | `{ nonce_digest_prefix, claim_id_hash, action, request_id, ... }` |
+| `presence_nonce_rejected` | `verify_nonce` rejects, including replay (`reason = "replayed"`) and actor/tuple mismatch cases | `{ nonce_digest_prefix, claim_id_hash, reason, request_id, ... }` |
+| `presence_nonce_invalidated` | expiry, store pressure, or composition refresh invalidates a live nonce | `{ nonce_digest_prefix, claim_id_hash, reason, count?, request_id, ... }` |
 
 `user_intent_text` is **NEVER** emitted in audit event payloads — sensitivity=User per ADR-0108. Audit consumers can look up the redacted text via the actor-filtered projection if authorized.
 
@@ -201,15 +201,15 @@ CSS: per-block `style.css` + plugin-owned baseline tokens (no inline CSS per mem
 2. Simulate JS: POST `/v1/feedback` with `action_kind: 'mark_outdated'`. Receive `nonce_id`.
 3. POST `/v1/feedback` again with `nonce_id` + same action_kind. Runtime consumes the nonce + records feedback.
 4. Re-render: claim now shows `superseded` lifecycle + `UseWithCaution` (or `NeedsVerification`) trust band per ADR-0123 §1.
-5. Audit log contains: `nonce_issued → nonce_consumed → claim_feedback_recorded`.
-6. Replay: POST `/v1/feedback` a third time with the same `nonce_id`. Runtime rejects + emits `replay_rejected`. Render unchanged.
+5. Audit log contains: `presence_nonce_issued -> presence_nonce_verified -> claim_feedback_recorded`.
+6. Replay: POST `/v1/feedback` a third time with the same `nonce_id`. Runtime rejects + emits `presence_nonce_rejected` with `reason = "replayed"`. Render unchanged.
 
 ## 6. Decisions to lock at L0
 
 1. **All write paths go through `services::surface_feedback`.** WP REST handler is a thin envelope: validates request, signs the runtime call, relays the response. No DB writes from WP. (Locks ADR-0111 + ADR-0126 mirror.)
 2. **`record_claim_feedback` is consumed unchanged.** W4 does not modify `services::claims::record_claim_feedback` or the 9-variant `FeedbackAction` enum. CI gate: PR must not touch `services/claims.rs` non-test files. (Mirrors v1.4.3 W3 §9 inv #13 composite boundary discipline.)
 3. **Two-phase nonce.** No single-shot path. Every feedback write requires `issue_nonce` THEN `consume_nonce` from the same actor on the same surface_client_id.
-4. **Replay-rejection is non-negotiable.** A consumed nonce can never be consumed again; the rejection is recorded as `pairing.feedback.replay_rejected` audit event for forensic trail.
+4. **Replay-rejection is non-negotiable.** A consumed nonce can never be consumed again; the rejection is recorded as a `presence_nonce_rejected` audit event with `reason = "replayed"` for forensic trail.
 5. **`user_intent_text` sensitivity=User.** Never appears in audit event payloads. Redaction enforced at the projection layer per W2 DOS-477 leak guards (extend the existing channel list to cover the new feedback-render path).
 6. **24h default TTL on un-consumed nonces.** Sweep job runs hourly (mirrors `dailyos_nonce_sweep` cron). Expired rows transition to audit-only trail; not deleted.
 7. **W4 ships affordance UI ONLY on `dailyos/account-overview`** for v1.4.3 acceptance. Other W2 primitive blocks + composites get affordance UI in v1.4.4 surface migration. Decision rationale: smallest surface area that proves the end-to-end loop without expanding scope into v1.4.4 entity-surface composition.
@@ -225,7 +225,7 @@ L4 captures: 9 affordance states (one per `FeedbackAction` variant) + 3 chrome s
 `src-tauri/abilities-runtime/tests/surface_feedback_nonce_lifecycle.rs` — happy path: issue → consume → audit trail correct.
 
 ### 8.2 Rust integration: replay rejection
-`src-tauri/abilities-runtime/tests/surface_feedback_replay_rejection.rs` — issue → consume → consume-again rejected with `replay_rejected` audit event.
+`src-tauri/abilities-runtime/tests/surface_feedback_replay_rejection.rs` — issue -> consume -> consume-again rejected with `presence_nonce_rejected` / `reason = "replayed"` audit event.
 
 ### 8.3 Rust integration: expiry sweep
 `src-tauri/abilities-runtime/tests/surface_feedback_expire_sweep.rs` — issue → wait past expires_at → run sweep → audit event emitted, row marked expired.
@@ -249,7 +249,7 @@ L4 captures: 9 affordance states (one per `FeedbackAction` variant) + 3 chrome s
 `wp/dailyos/tests/FeedbackUserIntentRedactionTest.php` — `user_intent_text` is NEVER returned to a non-originating actor. Cross-references W2 DOS-477 channel list (extends from 10 to 11 channels: add "feedback-projection rendering" if not already covered).
 
 ### 8.10 Audit log forensic test
-`src-tauri/abilities-runtime/tests/surface_feedback_audit_trail.rs` — for a happy-path feedback, verify the chain `nonce_issued → nonce_consumed → claim_feedback_recorded` lands in the audit log with consistent `request_id` correlation.
+`src-tauri/abilities-runtime/tests/surface_feedback_audit_trail.rs` — for a happy-path feedback, verify the chain `presence_nonce_issued -> presence_nonce_verified -> claim_feedback_recorded` lands in the audit log with consistent `request_id` correlation.
 
 ## 9. Invariants (CI-enforced)
 
@@ -258,7 +258,7 @@ L4 captures: 9 affordance states (one per `FeedbackAction` variant) + 3 chrome s
 3. **`surface_feedback::consume_nonce` MUST pass through `ctx.check_mutation_allowed()`.** Grep gate on `services/surface_feedback.rs`.
 4. **No raw `user_intent_text` in audit event payloads.** Grep gate on `audit-event writer` callers in surface_feedback service.
 5. **REST endpoint MUST use `DailyOS_Runtime_Client` for runtime calls.** No raw `wp_remote_post` to the runtime sentinel from feedback handler.
-6. **Replay-rejection MUST emit `pairing.feedback.replay_rejected`.** Verified by §8.2 integration test.
+6. **Replay-rejection MUST emit `presence_nonce_rejected` with `reason = "replayed"`.** Verified by §8.2 integration test.
 7. **No customer-specific data in test fixtures.** CLAUDE.md rule. Use `acct-test-001`, `claim-test-001` generic IDs.
 8. **No PII in commit messages.** CLAUDE.md rule.
 9. **L2-status on every code commit.** CLAUDE.md rule + commit-msg hook.

--- a/src-tauri/abilities-runtime/src/sensitivity.rs
+++ b/src-tauri/abilities-runtime/src/sensitivity.rs
@@ -66,6 +66,10 @@ impl ClaimDismissalSurface {
         }
     }
 
+    pub const fn allows_dismissal_write(self) -> bool {
+        !matches!(self, Self::Worker | Self::Eval)
+    }
+
     pub fn from_name(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
             "tauri_entity_detail" | "entity_detail" => Some(Self::TauriEntityDetail),

--- a/src-tauri/src/bridges/mcp.rs
+++ b/src-tauri/src/bridges/mcp.rs
@@ -692,8 +692,8 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Arc;
 
-    use chrono::{TimeZone, Utc};
-    use rusqlite::{params, Connection};
+    use chrono::Utc;
+    use rusqlite::Connection;
     use serde_json::json;
 
     use super::*;
@@ -993,7 +993,11 @@ CREATE TABLE accounts (
         sensitivity: ClaimSensitivity,
         created_at: &str,
     ) -> String {
-        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 9, 12, 0, 0).unwrap());
+        let clock = FixedClock::new(
+            chrono::DateTime::parse_from_rfc3339(created_at)
+                .expect("fixture created_at must be RFC3339")
+                .with_timezone(&Utc),
+        );
         let rng = SeedableRng::new(309);
         let external = ExternalClients::default();
         let ctx = ServiceContext::new_live(&clock, &rng, &external).with_actor("agent:test");
@@ -1029,17 +1033,10 @@ CREATE TABLE accounts (
         )
         .expect("commit MCP entity context claim");
 
-        let claim_id = match committed {
+        match committed {
             CommittedClaim::Inserted { claim } => claim.id,
             other => panic!("expected inserted claim, got {other:?}"),
-        };
-        db.conn_ref()
-            .execute(
-                "UPDATE intelligence_claims SET created_at = ?1 WHERE id = ?2",
-                params![created_at, claim_id.as_str()],
-            )
-            .expect("pin MCP fixture claim created_at");
-        claim_id
+        }
     }
 
     fn dismiss_claim_on_surface(db: &ActionDb, claim_id: &str, surface: &str) {

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -5455,6 +5455,20 @@ fn normalize_claim_surface(surface: &str) -> Result<ClaimDismissalSurface, Claim
     })
 }
 
+fn normalize_claim_dismissal_write_surface(
+    surface: &str,
+) -> Result<ClaimDismissalSurface, ClaimError> {
+    let surface = normalize_claim_surface(surface)?;
+    if surface.allows_dismissal_write() {
+        return Ok(surface);
+    }
+
+    Err(ClaimError::InvalidFeedback(format!(
+        "surface dismissal writes are not supported for read-context-only surface '{}'",
+        surface.as_str()
+    )))
+}
+
 fn feedback_metadata_for_claim(
     claim: &IntelligenceClaim,
     input: &ClaimFeedbackInput,
@@ -7692,7 +7706,7 @@ fn targeted_repair_policy_repair_coalescing_surface(
                 "surface_inappropriate repair requires payload_json.surface".to_string(),
             )
         })
-        .and_then(|surface| normalize_claim_surface(&surface))?;
+        .and_then(|surface| normalize_claim_dismissal_write_surface(&surface))?;
     Ok(Some(format!("surface:{}", surface.as_str())))
 }
 
@@ -8469,7 +8483,7 @@ fn targeted_repair_apply_policy_repair(
                 "surface_inappropriate repair requires payload_json.surface".to_string(),
             )
         })
-        .and_then(|surface| normalize_claim_surface(&surface))?;
+        .and_then(|surface| normalize_claim_dismissal_write_surface(&surface))?;
     let surface = surface.as_str();
 
     tx.conn_ref().execute(
@@ -14645,6 +14659,48 @@ mod tests {
     }
 
     #[test]
+    fn targeted_repair_surface_inappropriate_rejects_read_context_only_surfaces() {
+        for read_context_surface in [
+            ClaimDismissalSurface::Worker.as_str(),
+            ClaimDismissalSurface::Eval.as_str(),
+        ] {
+            let db = test_db();
+            seed_account(&db);
+            let (clock, rng, external) = ctx_parts();
+            let ctx = live_ctx(&clock, &rng, &external);
+            let claim_id = inserted_claim_id(
+                commit_claim(
+                    &ctx,
+                    &db,
+                    proposal("Read-context surfaces must not persist dismissals"),
+                )
+                .unwrap(),
+            );
+
+            let mut input = feedback_input(&claim_id, FeedbackAction::SurfaceInappropriate);
+            input.payload_json =
+                Some(serde_json::json!({ "surface": read_context_surface }).to_string());
+
+            let error = record_claim_feedback(&ctx, &db, input)
+                .expect_err("read-context-only surface rejected");
+            assert!(
+                matches!(error, ClaimError::InvalidFeedback(ref message) if message.contains("read-context-only surface")),
+                "unexpected error for {read_context_surface}: {error:?}"
+            );
+
+            let dismissals: i64 = db
+                .conn_ref()
+                .query_row(
+                    "SELECT count(*) FROM claim_surface_dismissals WHERE claim_id = ?1",
+                    params![&claim_id],
+                    |row| row.get(0),
+                )
+                .expect("dismissal count");
+            assert_eq!(dismissals, 0);
+        }
+    }
+
+    #[test]
     fn entity_context_surface_limited_reader_caps_visible_claims() {
         let db = test_db();
         seed_account(&db);
@@ -14702,7 +14758,7 @@ mod tests {
             );
             db.conn_ref()
                 .execute(
-                    "UPDATE intelligence_claims
+                    "UPDATE intelligence_claims /* dos7-allowed: entity context cap ordering fixture */
                      SET created_at = ?1
                      WHERE id = ?2",
                     params![
@@ -14798,7 +14854,7 @@ mod tests {
             );
             db.conn_ref()
                 .execute(
-                    "UPDATE intelligence_claims
+                    "UPDATE intelligence_claims /* dos7-allowed: prompt safety page-cap fixture */
                      SET sensitivity = 'confidential', created_at = ?1
                      WHERE id = ?2",
                     params![format!("2026-05-02T12:{index:02}:00Z"), id],
@@ -14817,7 +14873,7 @@ mod tests {
         );
         db.conn_ref()
             .execute(
-                "UPDATE intelligence_claims
+                "UPDATE intelligence_claims /* dos7-allowed: prompt safety page-cap fixture */
                  SET sensitivity = 'internal', created_at = ?1
                  WHERE id = 'claim-internal-older'",
                 params!["2026-05-02T11:00:00Z"],

--- a/src-tauri/src/services/surface_nonce.rs
+++ b/src-tauri/src/services/surface_nonce.rs
@@ -1790,7 +1790,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("nonce.sqlite");
         std::mem::forget(dir);
-        let db = ActionDb::open_at_unencrypted(path).expect("db");
+        seeded_db_at(&path)
+    }
+
+    fn seeded_db_at(path: &std::path::Path) -> ActionDb {
+        let db = ActionDb::open_at_unencrypted(path.to_path_buf()).expect("db");
         db.conn_ref()
             .execute(
                 "INSERT INTO accounts (id, name, updated_at) VALUES (?1, ?2, ?3)",
@@ -2084,6 +2088,101 @@ mod tests {
             .expect_err("replay");
         assert_eq!(replay.reason, PresenceNonceRejectReason::Replayed);
         assert_eq!(replay.status, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn dos718_concurrent_verify_consumes_nonce_once() {
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nonce.sqlite");
+        let db = seeded_db_at(&path);
+        let service = service(SurfaceNonceConfig::default());
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(1);
+        let ext = ExternalClients::default();
+        let ctx = ctx(&clock, &rng, &ext);
+        let session = session("session-1", 42);
+        let issued = service
+            .issue_nonce(
+                &ctx,
+                &db,
+                &session,
+                issue_payload(),
+                "request-1",
+                PresenceNonceRequestMeta::default(),
+            )
+            .expect("issue");
+        drop(db);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let results = std::thread::scope(|scope| {
+            let first = {
+                let barrier = Arc::clone(&barrier);
+                let service = service.clone();
+                let session = session.clone();
+                let path = path.clone();
+                let token = issued.presence_nonce.clone();
+                scope.spawn(move || {
+                    verify_nonce_from_thread(barrier, service, path, session, token, "first")
+                })
+            };
+            let second = {
+                let barrier = Arc::clone(&barrier);
+                let service = service.clone();
+                let session = session.clone();
+                let path = path.clone();
+                let token = issued.presence_nonce.clone();
+                scope.spawn(move || {
+                    verify_nonce_from_thread(barrier, service, path, session, token, "second")
+                })
+            };
+
+            vec![first.join().unwrap(), second.join().unwrap()]
+        });
+
+        let success_count = results.iter().filter(|result| result.is_ok()).count();
+        let replay_errors = results
+            .into_iter()
+            .filter_map(Result::err)
+            .collect::<Vec<_>>();
+
+        assert_eq!(success_count, 1);
+        assert_eq!(replay_errors.len(), 1);
+        let replay = replay_errors.into_iter().next().expect("one replay error");
+        assert_eq!(replay.reason, PresenceNonceRejectReason::Replayed);
+        let replay_event = replay
+            .audit_events
+            .iter()
+            .find(|event| event.event_kind == "presence_nonce_rejected")
+            .expect("replay rejection audit event");
+        assert_eq!(replay_event.detail["reason"], "replayed");
+    }
+
+    fn verify_nonce_from_thread(
+        barrier: std::sync::Arc<std::sync::Barrier>,
+        service: SurfaceNonceService,
+        db_path: std::path::PathBuf,
+        session: ValidatedSurfaceSession,
+        token: String,
+        request_id: &'static str,
+    ) -> Result<SurfaceNonceVerify, SurfaceNonceError> {
+        barrier.wait();
+        let db = ActionDb::open_at_unencrypted(db_path).expect("db");
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(1);
+        let ext = ExternalClients::default();
+        let ctx = ctx(&clock, &rng, &ext);
+        let mut payload = verify_payload(&token);
+        payload["feedback_request_id"] = json!(request_id);
+        service.verify_nonce(
+            &ctx,
+            &db,
+            &session,
+            payload,
+            request_id,
+            PresenceNonceRequestMeta::default(),
+        )
     }
 
     #[test]

--- a/wp/dailyos/includes/class-dailyos-plugin.php
+++ b/wp/dailyos/includes/class-dailyos-plugin.php
@@ -619,6 +619,13 @@ final class DailyOS_Plugin {
 	private static float $sentinel_cached_at = 0.0;
 
 	/**
+	 * Test-only override for the runtime sentinel path.
+	 *
+	 * @var string|null
+	 */
+	private static ?string $runtime_endpoint_sentinel_path_for_tests = null;
+
+	/**
 	 * Discover the current Tauri runtime endpoint via the sentinel file.
 	 *
 	 * Reads `~/.dailyos/runtime-endpoint.json` written by the Tauri runtime on bind.
@@ -749,9 +756,25 @@ final class DailyOS_Plugin {
 	}
 
 	/**
+	 * Override runtime sentinel discovery in tests.
+	 *
+	 * @internal
+	 *
+	 * @param string|null $path Sentinel path, or null to restore HOME-based discovery.
+	 */
+	public static function set_runtime_endpoint_sentinel_path_for_tests( ?string $path ): void {
+		self::$runtime_endpoint_sentinel_path_for_tests = $path;
+		self::invalidate_runtime_endpoint_cache();
+	}
+
+	/**
 	 * Path to the runtime sentinel file. Returns null if HOME is unavailable.
 	 */
 	private static function runtime_endpoint_sentinel_path(): ?string {
+		if ( null !== self::$runtime_endpoint_sentinel_path_for_tests ) {
+			return self::$runtime_endpoint_sentinel_path_for_tests;
+		}
+
 		$home = getenv( 'HOME' );
 		if ( ! is_string( $home ) || '' === trim( $home ) ) {
 			return null;

--- a/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
+++ b/wp/dailyos/includes/transport/class-dailyos-runtime-client.php
@@ -533,6 +533,10 @@ final class DailyOS_Runtime_Client {
 			$headers['X-DailyOS-Multisite-Blog-Id'] = $identity['multisite_blog_id'];
 		}
 
+		foreach ( $this->originating_request_headers() as $name => $value ) {
+			$headers[ $name ] = $value;
+		}
+
 		// Cold-cache producer commits + writer-mutex contention from background
 		// workers can take >5s in local-to-local deployments. The original 5s
 		// timeout was sized for a remote-shaped expectation; local renders
@@ -569,6 +573,63 @@ final class DailyOS_Runtime_Client {
 		}
 
 		return $parsed;
+	}
+
+	/**
+	 * Forward sanitized browser request metadata for runtime-side audit hashing.
+	 *
+	 * @return array<string, string> Header names and values.
+	 */
+	private function originating_request_headers(): array {
+		$headers = [];
+
+		$forwarded_for = $this->safe_origin_header( $_SERVER['HTTP_X_FORWARDED_FOR'] ?? null, 512 );
+		if ( null !== $forwarded_for ) {
+			$headers['X-Forwarded-For'] = $forwarded_for;
+		} else {
+			$real_ip = $this->safe_origin_header(
+				$_SERVER['HTTP_X_REAL_IP'] ?? ( $_SERVER['REMOTE_ADDR'] ?? null ),
+				128
+			);
+			if ( null !== $real_ip ) {
+				$headers['X-Real-IP'] = $real_ip;
+			}
+		}
+
+		$user_agent = $this->safe_origin_header( $_SERVER['HTTP_USER_AGENT'] ?? null, 512 );
+		if ( null !== $user_agent ) {
+			$headers['User-Agent'] = $user_agent;
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Normalize server-provided request metadata before forwarding as a header.
+	 *
+	 * @param mixed $value Header candidate.
+	 * @param int   $max_length Maximum header length.
+	 * @return string|null Sanitized header value, or null when empty/invalid.
+	 */
+	private function safe_origin_header( mixed $value, int $max_length ): ?string {
+		if ( ! is_scalar( $value ) ) {
+			return null;
+		}
+
+		$value = trim( (string) $value );
+		if ( '' === $value ) {
+			return null;
+		}
+
+		$value = preg_replace( '/[\r\n]+/', ' ', $value );
+		$value = preg_replace( '/[^\x20-\x7E\t]/', '', is_string( $value ) ? $value : '' );
+		$value = trim( is_string( $value ) ? $value : '' );
+
+		if ( '' === $value ) {
+			return null;
+		}
+
+		return substr( $value, 0, $max_length );
 	}
 
 	/**

--- a/wp/dailyos/scripts/new-block.mjs
+++ b/wp/dailyos/scripts/new-block.mjs
@@ -195,7 +195,7 @@ async function copyTemplate( src, dst, vars ) {
 }
 
 /**
- * Build the 5-step paste-snippet manifest per V1.3 §5.4.
+ * Build the 6-step paste-snippet manifest per V1.3 §5.4.
  * @param {string} blockName
  * @param {string} abilityName
  */

--- a/wp/dailyos/tests/PresenceNonceTest.php
+++ b/wp/dailyos/tests/PresenceNonceTest.php
@@ -70,6 +70,32 @@ final class DailyOS_PresenceNonceTest extends TestCase {
 	}
 
 	/**
+	 * The signed nonce transport forwards browser request metadata for runtime audit hashing.
+	 */
+	public function test_issue_presence_nonce_forwards_originating_request_meta_headers(): void {
+		$GLOBALS['dailyos_test_is_user_logged_in'] = true;
+		$GLOBALS['dailyos_test_current_user_id']   = 42;
+		$_SERVER['REMOTE_ADDR']                    = '203.0.113.10';
+		$_SERVER['HTTP_USER_AGENT']                = 'DailyOS Test Browser';
+		$this->save_marker();
+		$this->add_session_key_filter();
+
+		$GLOBALS['dailyos_test_remote_post_response'] = [
+			'response' => [
+				'code' => 200,
+			],
+			'body'     => '{"ok":true,"presence_nonce":"nonce-token"}',
+		];
+
+		$result = DailyOS_Plugin::instance()->issue_presence_nonce( $this->nonce_request() );
+
+		$this->assertTrue( $result['ok'] );
+		$headers = $GLOBALS['dailyos_test_remote_post_calls'][0]['args']['headers'];
+		$this->assertSame( '203.0.113.10', $headers['X-Real-IP'] );
+		$this->assertSame( 'DailyOS Test Browser', $headers['User-Agent'] );
+	}
+
+	/**
 	 * Claim_version must be a JSON integer, not a coercible string.
 	 */
 	public function test_issue_presence_nonce_rejects_string_claim_version(): void {

--- a/wp/dailyos/tests/bootstrap.php
+++ b/wp/dailyos/tests/bootstrap.php
@@ -123,6 +123,19 @@ namespace {
 		$GLOBALS['dailyos_test_next_uuid']            = 1;
 		$GLOBALS['dailyos_test_current_blog_id']      = 1;
 		$GLOBALS['dailyos_test_is_multisite']         = false;
+
+		unset(
+			$_SERVER['HTTP_X_FORWARDED_FOR'],
+			$_SERVER['HTTP_X_REAL_IP'],
+			$_SERVER['REMOTE_ADDR'],
+			$_SERVER['HTTP_USER_AGENT']
+		);
+
+		if ( class_exists( '\DailyOS\DailyOS_Plugin' ) ) {
+			\DailyOS\DailyOS_Plugin::set_runtime_endpoint_sentinel_path_for_tests(
+				sys_get_temp_dir() . '/dailyos-runtime-endpoint-test-unset-' . getmypid() . '.json'
+			);
+		}
 	}
 
 	$GLOBALS['wpdb'] = new class() {

--- a/wp/dailyos/tests/transport/RuntimeClientTest.php
+++ b/wp/dailyos/tests/transport/RuntimeClientTest.php
@@ -250,6 +250,9 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 			];
 
 			$this->write_runtime_sentinel( $home, 54322 );
+			DailyOS_Plugin::set_runtime_endpoint_sentinel_path_for_tests(
+				$home . '/.dailyos/runtime-endpoint.json'
+			);
 			DailyOS_Plugin::invalidate_runtime_endpoint_cache();
 			$client = new DailyOS_Runtime_Client( new DailyOS_Credential_Store(), new DailyOS_Hmac_Signer() );
 			$client->invoke_ability( 'briefing.daily', [], [] );
@@ -261,7 +264,7 @@ final class DailyOS_RuntimeClientTest extends TestCase {
 			$client->invoke_ability( 'briefing.daily', [], [] );
 			$this->assertSame( 'http://127.0.0.1:54323/v1/local/invoke', $GLOBALS['dailyos_test_remote_post_calls'][0]['url'] );
 		} finally {
-			DailyOS_Plugin::invalidate_runtime_endpoint_cache();
+			DailyOS_Plugin::set_runtime_endpoint_sentinel_path_for_tests( null );
 			if ( false === $original_home ) {
 				putenv( 'HOME' );
 			} else {


### PR DESCRIPTION
## Linear ticket

DOS-735, DOS-717, DOS-715, DOS-718, DOS-512, DOS-684, DOS-694

## Summary

Resolves a fifth path-alpha maintenance batch across the v1.4.4, v1.4.4a, v1.4.5, and abilities-runtime plans. This batch tightens nonce replay behavior, runtime request provenance, read-context claim write guards, and low-risk doc/process drift that was still valid on current `dev`.

## What changed

- Isolated WP runtime sentinel discovery in tests so host `HOME` state cannot leak into transport tests.
- Forwarded sanitized browser request metadata (`X-Forwarded-For`/`X-Real-IP`, `User-Agent`) through signed runtime requests for nonce/audit hashing.
- Canonicalized the feedback-write infrastructure packet to the implemented `presence_nonce_*` audit vocabulary.
- Added a file-backed concurrent nonce verification regression: exactly one verifier consumes the nonce and the loser records `presence_nonce_rejected` with `reason = "replayed"`.
- Rejected Worker/Eval read-context-only surfaces before claim dismissal writes can persist `claim_surface_dismissals` rows.
- Added the missing primitive `Interaction` inventory column and corrected the block scaffolding helper text from five steps to six.
- Removed a direct claim fixture timestamp update from MCP bridge tests and marked the remaining claim-lint fixture updates as explicit test-only exceptions.

## Test plan

- [x] `cargo clippy -- -D warnings` clean (`cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`)
- [x] `cargo test --lib` passes (commit hook after final commit)
- [x] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (not run; no frontend runtime source changed)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` passes
- [x] `./vendor/bin/phpunit --no-coverage` passes (263 tests, 1330 assertions; existing 4 deprecations and 12 skipped)
- [x] Manual verification: PHP lint for changed WP files, focused PresenceNonce/RuntimeClient/PairingScopeRefresh PHPUnit coverage, DOS718 concurrent nonce replay regression, claim dismissal write-surface regression, and DOS-7 D4 claim-lint gate.

## Definition of Done

- [x] Acceptance criteria from the Linear tickets are validated with real data (not stubs)
- [x] End-to-end flow works through runtime nonce verification, signed WP transport, and claim feedback write validation paths
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (if `security_auditor_invoked: false`): _none_

**Exemption rationale**:

Security-sensitive paths are touched: runtime signed transport, services, nonce replay handling, sensitivity/dismissal policy, bridge tests, and claim-substrate fixture SQL. Keep this draft in WIP until L2/security review is recorded.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- DOS-734, DOS-630, DOS-631, DOS-633, DOS-700, and DOS-756 remain live or mixed and should be handled in later batches with narrower plans.
- DOS-654 appears superseded by current `dev`: the full Cargo suite now passes, including the previously failing lib paths.

## Notes for review

Issues remain In Progress in Linear until this PR merges. Commit is intentionally WIP with `L2-status: not-run-acknowledged`; run L2 and security review before marking this ready.
