### PR TITLE
Maintenance path-alpha batch 6

### DIFF
--- a/.github/workflows/block-kit-integration.yml
+++ b/.github/workflows/block-kit-integration.yml
@@ -218,10 +218,17 @@ jobs:
             exit 1
           fi
 
-          # inv #2: no inline style="" in templates/parts.
-          if grep -RnE 'style="' wp/dailyos/theme/templates wp/dailyos/theme/parts 2>/dev/null \
-              | grep -vE 'flex-basis|gap|padding|margin'; then
-            : # Allow inline style for layout flex-basis on FSE column blocks (standard FSE output)
+          # inv #2: no inline style="" in templates/parts, except standard
+          # FSE layout attributes emitted for column/group layout controls.
+          disallowed_inline_styles="$(
+            grep -RnE 'style="' wp/dailyos/theme/templates wp/dailyos/theme/parts 2>/dev/null \
+              | grep -vE 'flex-basis|gap|padding|margin' \
+              || true
+          )"
+          if [ -n "$disallowed_inline_styles" ]; then
+            echo "$disallowed_inline_styles" >&2
+            echo "FAIL: W3 theme template/part files contain disallowed inline style attributes" >&2
+            exit 1
           fi
 
           # inv #14: customTemplates empty in W3.

--- a/wp/dailyos/tests/theme/StyleVariationSchemaTest.php
+++ b/wp/dailyos/tests/theme/StyleVariationSchemaTest.php
@@ -4,8 +4,11 @@
  *
  * Validates v1.4.3 W3 magazine theme style variations against
  * L0 Packet E §8.5: well-formed JSON, declared schema/version/title,
- * and the §6 #3 "no new tokens" invariant (all color values resolve
- * via `var(--wp--preset--color--*)` references, never literal hex).
+ * and the §6 #3 "no new tokens" invariant (color values under `styles.*`
+ * resolve via `var(--wp--preset--color--*)` references, never literal hex).
+ * WordPress style variation previews require `settings.color.background`
+ * to remain a literal color value, so that field is intentionally outside
+ * the token-reference gate.
  *
  * @package DailyOS
  */
@@ -109,6 +112,26 @@ final class DailyOS_StyleVariationSchemaTest extends TestCase {
 			sprintf(
 				'Style variation %s.json must not embed literal hex colors inside styles.* — '
 				. 'use var(--wp--preset--color--*) references instead (§6 #3 no-new-tokens invariant).',
+				$slug
+			)
+		);
+	}
+
+	/**
+	 * WordPress style variations use `settings.color.background` as preview
+	 * metadata, where the FSE schema expects a literal color value rather than
+	 * a palette variable reference.
+	 *
+	 * @dataProvider variation_provider
+	 */
+	public function test_settings_background_remains_literal_for_fse_preview( string $slug ): void {
+		$payload = self::load_variation( $slug );
+
+		$this->assertMatchesRegularExpression(
+			'/^#[0-9a-fA-F]{6}$/',
+			(string) ( $payload['settings']['color']['background'] ?? '' ),
+			sprintf(
+				'Style variation %s.json should keep settings.color.background as a literal FSE preview color.',
 				$slug
 			)
 		);


### PR DESCRIPTION
## Linear ticket

DOS-700

## Summary

Resolves the still-live v1.4.3 W3 theme invariant drift from DOS-700. The inline-style CI gate now fails on real violations, and the style-variation test suite records the FSE decision that `settings.color.background` stays literal preview metadata while `styles.*` remains token-only.

## What changed

- Changed the W3 inline-style grep gate from a no-op success branch to an explicit failure with the offending lines printed.
- Kept the existing FSE layout-style allowlist for `flex-basis`, `gap`, `padding`, and `margin`.
- Documented and tested that `settings.color.background` remains a literal hex color for WordPress style-variation previews.
- Verified the previously reported palette gap is already superseded on current `dev`: `meeting`, `meeting-8`, and `text-quaternary` are present in canonical tokens and `theme.json`; the old composite-boundary `grep -v test` gate is no longer present in the workflow.

## Test plan

- [ ] `cargo clippy -- -D warnings` clean (not run; no Rust source changed)
- [ ] `cargo test --lib` passes (not run; no Rust source changed)
- [ ] `pnpm tsc --noEmit` clean (not run; no TypeScript source changed)
- [ ] `pnpm test` passes (not run; no frontend runtime source changed)
- [x] `php -l wp/dailyos/tests/theme/StyleVariationSchemaTest.php`
- [x] `./vendor/bin/phpunit --no-coverage tests/theme/StyleVariationSchemaTest.php`
- [x] Manual verification: ran the W3 theme invariant shell body locally against current templates/parts/theme.json.

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through the affected CI/test gates
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [ ] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` (not run because this PR is workflow/PHP theme-test only)

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (if `security_auditor_invoked: false`): _none_

**Exemption rationale**: _none_

- [ ] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [x] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

Security review result: APPROVE. The scoped review found no new network egress, secret access, command injection path, unsafe glob/grep behavior, or merge/publish authority.

## Follow-ups

- None for DOS-700. The palette-gap and composite-boundary-gate findings are superseded by current `dev` state.

## Notes for review

DOS-700 remains In Progress in Linear until this PR merges. Commit is intentionally WIP with `L2-status: not-run-acknowledged`; run full L2 before marking this ready.
