### PR TITLE
fix(briefing): unblock today page + readiness substrate hardening

### DIFF
--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/contracts.rs
@@ -110,7 +110,7 @@ pub struct BriefingState {
 
 /// Overall presence of a briefing for the requested date.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum BriefingAvailability {
     Available,
     Empty { reason: BriefingEmptyReason },
@@ -128,7 +128,7 @@ pub enum BriefingEmptyReason {
 /// Freshness posture across the briefing's underlying prep + claim inputs.
 /// Independent of integrity — a Fresh briefing can have HasCorrections.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum BriefingFreshness {
     Fresh,
     Stale { reason: BriefingStaleReason },
@@ -146,7 +146,7 @@ pub enum BriefingStaleReason {
 /// Claim-store integrity — corrections / ambiguity that consumers should
 /// surface even when the briefing is otherwise fresh.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum BriefingIntegrity {
     Clean,
     HasCorrections { superseded_claim_ids: Vec<String> },
@@ -163,7 +163,7 @@ pub struct AmbiguityPair {
 
 /// Typed non-blocking advisory surfaced alongside the briefing state.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum BriefingAdvisory {
     /// A watch proposal is available for review. Pairs with the
     /// `watch_proposals` envelope field.

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
@@ -805,7 +805,7 @@ fn finalize_with_provenance(
     schema_version: u32,
 ) -> AbilityResult<DailyBriefingOutput> {
     let mut builder = ProvenanceBuilder::new(provenance_config(ctx, schema_version));
-    let subject_attr = SubjectAttribution::direct_confident(SubjectRef::Unknown);
+    let subject_attr = SubjectAttribution::direct_confident(SubjectRef::Global);
     builder.set_subject(subject_attr.clone());
     builder
         .attribute_subtree(

--- a/src-tauri/src/commands/abilities.rs
+++ b/src-tauri/src/commands/abilities.rs
@@ -90,6 +90,11 @@ pub async fn invoke_ability(
         &[],
         policy,
     ) {
+        log::error!(
+            "ability response ownership validation failed for {}: {}",
+            ability_name,
+            err
+        );
         record_ability_invocation_metric(state.inner().as_ref(), ability_meta, Outcome::Failure);
         return Err(err.into());
     }

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -794,10 +794,21 @@ impl DailyReadinessContextReadHandle for LiveDailyReadinessContextReader {
         workspace_scope: String,
         date: String,
     ) -> DailyReadinessContextReadFuture<'a> {
+        // Resolve the user's local-day boundaries in their configured TZ. Without
+        // this the SQL query below would naively compare UTC-stored start_time
+        // against bare date strings, so meetings between local-midnight and
+        // UTC-midnight (e.g. an evening call on PDT yesterday stored as today
+        // UTC) would leak into "today" and cross-day meetings on the user's
+        // actual today would silently drop. Defaults match `dashboard.rs`.
+        let tz: chrono_tz::Tz = crate::state::load_config()
+            .ok()
+            .map(|c| c.schedules.today.timezone)
+            .and_then(|t| t.parse().ok())
+            .unwrap_or(chrono_tz::America::New_York);
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 let db = open_action_db()?;
-                project_daily_readiness_context_snapshot(&db, &workspace_scope, &date)
+                project_daily_readiness_context_snapshot(&db, &workspace_scope, &date, &tz)
             })
             .await
             .map_err(|error| format!("daily readiness context read task failed: {error}"))?
@@ -809,25 +820,52 @@ fn project_daily_readiness_context_snapshot(
     db: &crate::db::ActionDb,
     workspace_scope: &str,
     date: &str,
+    tz: &chrono_tz::Tz,
 ) -> Result<DailyReadinessContextSnapshot, String> {
+    use chrono::TimeZone;
     let parsed_date = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")
         .map_err(|error| format!("invalid daily readiness date `{date}`: {error}"))?;
     let next_date = parsed_date
         .checked_add_days(chrono::Days::new(1))
         .ok_or_else(|| format!("invalid next-day range for daily readiness date `{date}`"))?;
-    let start = parsed_date.format("%Y-%m-%d").to_string();
-    let end = next_date.format("%Y-%m-%d").to_string();
+    // Resolve local-day boundaries to UTC RFC3339 so the SQL matches the
+    // poller's storage format. `earliest()` handles DST spring-forward gaps;
+    // fallback to a naive UTC boundary keeps the query well-formed if TZ
+    // resolution fails entirely.
+    let day_start_local = parsed_date
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| format!("invalid local-day start for date `{date}`"))?;
+    let day_end_local = next_date
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| format!("invalid local-day end for date `{date}`"))?;
+    let utc_start = tz
+        .from_local_datetime(&day_start_local)
+        .earliest()
+        .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
+        .unwrap_or_else(|| format!("{parsed_date}T00:00:00+00:00"));
+    let utc_end = tz
+        .from_local_datetime(&day_end_local)
+        .earliest()
+        .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
+        .unwrap_or_else(|| format!("{next_date}T00:00:00+00:00"));
+    // LEFT JOIN meeting_transcripts to exclude meetings the calendar poller has
+    // archived (= the user cancelled them in their actual calendar). Without
+    // this, ghost meetings persist in the briefing's "needs prep" / "unlinked"
+    // counts even though `calendar_merge` correctly drops them from the focus
+    // capacity view. Mirrors the predicate used by `record_cancelled_calendar_meetings`.
     let conn = db.conn_ref();
     let mut stmt = conn
         .prepare(
-            "SELECT id, title, start_time, end_time
-             FROM meetings
-             WHERE start_time >= ?1 AND start_time < ?2
-             ORDER BY start_time ASC",
+            "SELECT m.id, m.title, m.start_time, m.end_time
+             FROM meetings m
+             LEFT JOIN meeting_transcripts mt ON mt.meeting_id = m.id
+             WHERE m.start_time >= ?1 AND m.start_time < ?2
+             AND (mt.intelligence_state IS NULL OR mt.intelligence_state != 'archived')
+             ORDER BY m.start_time ASC",
         )
         .map_err(|error| error.to_string())?;
     let rows = stmt
-        .query_map(rusqlite::params![start, end], |row| {
+        .query_map(rusqlite::params![utc_start, utc_end], |row| {
             Ok(DailyReadinessMeetingSnapshot {
                 id: row.get(0)?,
                 title: row.get(1)?,
@@ -1038,8 +1076,10 @@ mod tests {
             .execute_batch("DROP VIEW IF EXISTS linked_entities;")
             .expect("drop linked_entities view");
 
-        let snapshot = project_daily_readiness_context_snapshot(&db, "local", "2026-05-23")
-            .expect("read daily readiness context");
+        let tz: chrono_tz::Tz = "UTC".parse().expect("parse UTC tz");
+        let snapshot =
+            project_daily_readiness_context_snapshot(&db, "local", "2026-05-23", &tz)
+                .expect("read daily readiness context");
 
         assert_eq!(snapshot.meetings.len(), 1);
         assert!(snapshot.tracked_subjects.is_empty());

--- a/src-tauri/src/services/entity_intelligence/neighborhood.rs
+++ b/src-tauri/src/services/entity_intelligence/neighborhood.rs
@@ -1340,10 +1340,10 @@ mod tests {
                 "
                 INSERT INTO accounts (id, name, parent_id, updated_at) VALUES
                     ('account-1', 'Example Account', NULL, '2026-05-20T00:00:00Z');
-                INSERT INTO people (id, email, name, role, relationship, last_seen) VALUES
-                    ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z');
-                INSERT INTO meetings (id, title, meeting_type, start_time, end_time) VALUES
-                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL);
+                INSERT INTO people (id, email, name, role, relationship, last_seen, updated_at) VALUES
+                    ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
+                INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
+                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
                 INSERT INTO linked_entities_raw
                     (owner_type, owner_id, entity_id, entity_type, role, source, rule_id, confidence, graph_version, created_at)
                 VALUES
@@ -1377,10 +1377,10 @@ mod tests {
                 "
                 INSERT INTO accounts (id, name, parent_id, updated_at) VALUES
                     ('account-1', 'Example Account', NULL, '2026-05-20T00:00:00Z');
-                INSERT INTO people (id, email, name, role, relationship, last_seen) VALUES
-                    ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z');
-                INSERT INTO meetings (id, title, meeting_type, start_time, end_time) VALUES
-                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL);
+                INSERT INTO people (id, email, name, role, relationship, last_seen, updated_at) VALUES
+                    ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
+                INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
+                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
                 INSERT INTO meeting_entities (meeting_id, entity_id, entity_type, confidence) VALUES
                     ('meeting-1', 'account-1', 'account', 0.95);
                 INSERT INTO linked_entities_raw
@@ -1557,12 +1557,12 @@ mod tests {
                 "
                 INSERT INTO accounts (id, name, parent_id, updated_at) VALUES
                     ('account-1', 'Example Account', NULL, '2026-05-20T00:00:00Z');
-                INSERT INTO people (id, email, name, role, relationship, last_seen) VALUES
-                    ('person-rm', 'rm@example.com', 'Relationship Lead', NULL, 'internal', '2026-05-22T00:00:00Z'),
-                    ('person-ae', 'ae@example.com', 'Commercial Lead', NULL, 'internal', '2026-05-22T00:00:00Z'),
-                    ('person-associated', 'associated@example.com', 'Associated Person', NULL, 'external', '2026-05-22T00:00:00Z');
-                INSERT INTO meetings (id, title, meeting_type, start_time, end_time) VALUES
-                    ('meeting-1', 'Account Review', 'customer', '2026-05-22T15:00:00Z', NULL);
+                INSERT INTO people (id, email, name, role, relationship, last_seen, updated_at) VALUES
+                    ('person-rm', 'rm@example.com', 'Relationship Lead', NULL, 'internal', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z'),
+                    ('person-ae', 'ae@example.com', 'Commercial Lead', NULL, 'internal', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z'),
+                    ('person-associated', 'associated@example.com', 'Associated Person', NULL, 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
+                INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
+                    ('meeting-1', 'Account Review', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
                 INSERT INTO meeting_entities (meeting_id, entity_id, entity_type, confidence) VALUES
                     ('meeting-1', 'account-1', 'account', 0.95);
                 INSERT INTO meeting_attendees (meeting_id, person_id) VALUES

--- a/src/components/dashboard/DailyBriefing.test.tsx
+++ b/src/components/dashboard/DailyBriefing.test.tsx
@@ -4,19 +4,10 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DailyBriefing } from "./DailyBriefing";
 import type { DashboardData, DataFreshness, Meeting } from "@/types";
-import type { UseDailyBriefingAbilityResult } from "@/hooks/useDailyBriefingAbility";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
 const invokeMock = vi.fn();
-const dailyBriefingAbilityMock = vi.hoisted((): { state: UseDailyBriefingAbilityResult } => ({
-  state: {
-    response: null,
-    loading: false,
-    error: null as string | null,
-    refresh: vi.fn(),
-  },
-}));
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
@@ -38,10 +29,6 @@ vi.mock("@/hooks/useCalendar", () => ({
     now: Date.now(),
     currentMeeting: null,
   }),
-}));
-
-vi.mock("@/hooks/useDailyBriefingAbility", () => ({
-  useDailyBriefingAbility: () => dailyBriefingAbilityMock.state,
 }));
 
 vi.mock("@/hooks/useMagazineShell", () => ({
@@ -126,12 +113,6 @@ const freshness: DataFreshness = {
 describe("DailyBriefing", () => {
   beforeEach(() => {
     invokeMock.mockReset();
-    dailyBriefingAbilityMock.state = {
-      response: null,
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    };
   });
 
   it("renders without crashing with minimal data", () => {
@@ -230,72 +211,6 @@ describe("DailyBriefing", () => {
     );
 
     expect(screen.getByText("Prepare for the Acme renewal conversation.")).toBeInTheDocument();
-  });
-
-  it("renders ability-backed briefing trust and provenance state", () => {
-    dailyBriefingAbilityMock.state = {
-      response: {
-        invocation_id: "inv-1",
-        ability_name: "get_daily_briefing",
-        ability_version: "0.1.0",
-        schema_version: 1,
-        data: {
-          schemaVersion: 1,
-          date: "2026-05-23",
-          state: {
-            availability: { kind: "available" },
-            freshness: { kind: "needs_preparation", meetingIds: ["m-1"] },
-            integrity: { kind: "clean" },
-            advisories: [
-              { kind: "unlinked_meetings", meetingIds: ["m-2"] },
-            ],
-          },
-          currentMeeting: null,
-          nextMeeting: null,
-          upcomingMeetings: {
-            items: [],
-            nextCursor: null,
-            totalHint: 0,
-            cursorState: { kind: "stable" },
-          },
-          candidateSet: {
-            windowStart: null,
-            windowEnd: null,
-            filterDescription: "daily_briefing date=2026-05-23 workspace=/workspace meetings=1",
-          },
-          watchProposals: [],
-          trustSummary: {
-            aggregateBand: "use_with_caution",
-            likelyCurrentCount: 0,
-            useWithCautionCount: 1,
-            needsVerificationCount: 0,
-          },
-          provenance: { sources: [], redactionApplied: false },
-          sensitivity: "internal",
-          sourceAsofInputs: [],
-        },
-        rendered_provenance: {
-          value: {
-            sources: [
-              { source_asof: "2026-05-23T12:00:00Z" },
-              { source_asof: "2026-05-23T13:00:00Z" },
-            ],
-          },
-        },
-      },
-      loading: false,
-      error: null,
-      refresh: vi.fn(),
-    };
-
-    render(
-      <DailyBriefing data={makeDashboardData()} freshness={freshness} />,
-    );
-
-    expect(screen.getByTestId("daily-briefing-ability-strip")).toHaveTextContent("1 briefing need prep");
-    expect(screen.getByTestId("daily-briefing-ability-strip")).toHaveTextContent("use with caution");
-    expect(screen.getByTestId("daily-briefing-ability-strip")).toHaveTextContent("2 sources");
-    expect(screen.getByTestId("daily-briefing-ability-strip")).toHaveTextContent("Link 1 meeting for fuller context");
   });
 
   it("does not render staleness indicator (removed for v1.1.1)", () => {

--- a/src/components/dashboard/DailyBriefing.tsx
+++ b/src/components/dashboard/DailyBriefing.tsx
@@ -18,7 +18,6 @@ import { useSuggestedActions } from "@/hooks/useSuggestedActions";
 // SuggestedActionRow removed from briefing — suggestions live on /actions page
 import clsx from "clsx";
 import { useCalendar } from "@/hooks/useCalendar";
-import { useDailyBriefingAbility } from "@/hooks/useDailyBriefingAbility";
 import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
 import type { ReadinessStat } from "@/components/layout/FolioBar";
 import {
@@ -43,7 +42,6 @@ import type {
   DashboardData,
   DashboardLifecycleUpdate,
   DataFreshness,
-  RenderedProvenanceSummary,
   Meeting,
   Action,
   Email,
@@ -52,7 +50,6 @@ import type {
 import { HealthBadge } from "@/components/shared/HealthBadge";
 import { TrustBandIndicator } from "@/components/ui/TrustBandIndicator";
 import { compareEmailRank } from "@/lib/email-ranking";
-import type { DailyBriefingOutput } from "@/services/daily-briefing/contracts";
 import s from "@/styles/editorial-briefing.module.css";
 import briefingStyles from "./DailyBriefing.module.css";
 
@@ -129,99 +126,6 @@ function computeReadiness(meetings: Meeting[], actions: Action[]) {
   return { preppedCount, totalExternal, overdueCount: overdueActions.length };
 }
 
-function renderedProvenanceSourceCount(renderedProvenance?: RenderedProvenanceSummary | null): number {
-  const value = renderedProvenance?.value;
-  const sources = value?.sources;
-  if (Array.isArray(sources)) {
-    return sources.length;
-  }
-  const aboutThis = value?.about_this;
-  if (aboutThis && typeof aboutThis === "object") {
-    const summary = (aboutThis as { summary?: unknown }).summary;
-    if (summary && typeof summary === "object") {
-      const sourceCount = (summary as { source_count?: unknown; sourceCount?: unknown }).source_count
-        ?? (summary as { source_count?: unknown; sourceCount?: unknown }).sourceCount;
-      if (typeof sourceCount === "number") {
-        return sourceCount;
-      }
-    }
-  }
-  return 0;
-}
-
-function briefingFreshnessLabel(state: DailyBriefingOutput["state"]): string {
-  switch (state.freshness.kind) {
-    case "fresh":
-      return "Current";
-    case "stale":
-      return "Context may be stale";
-    case "needs_preparation": {
-      const count = state.freshness.meetingIds.length;
-      return `${count} briefing${count === 1 ? "" : "s"} need prep`;
-    }
-    default:
-      return "Current";
-  }
-}
-
-function briefingAdvisoryLabel(state: DailyBriefingOutput["state"]): string | null {
-  const advisory = state.advisories[0];
-  if (!advisory) return null;
-  switch (advisory.kind) {
-    case "unlinked_meetings":
-      return `Link ${advisory.meetingIds.length} meeting${advisory.meetingIds.length === 1 ? "" : "s"} for fuller context`;
-    case "partial_read_failure":
-      return "Some sources are unavailable";
-    case "watch_proposal":
-      return advisory.summary;
-    default:
-      return null;
-  }
-}
-
-function DailyBriefingAbilityStrip({
-  output,
-  renderedProvenance,
-  error,
-}: {
-  output?: DailyBriefingOutput | null;
-  renderedProvenance?: RenderedProvenanceSummary | null;
-  error?: string | null;
-}) {
-  if (!output) {
-    return error ? (
-      <div className={briefingStyles.abilityStrip} data-testid="daily-briefing-ability-strip">
-        <span className={briefingStyles.abilityStripLabel}>Briefing context unavailable</span>
-      </div>
-    ) : null;
-  }
-
-  const sourceCount = renderedProvenanceSourceCount(renderedProvenance);
-  const advisory = briefingAdvisoryLabel(output.state);
-  const trustBand = output.trustSummary.aggregateBand;
-
-  return (
-    <div className={briefingStyles.abilityStrip} data-testid="daily-briefing-ability-strip">
-      <span className={briefingStyles.abilityStripLabel}>
-        {briefingFreshnessLabel(output.state)}
-      </span>
-      <span className={briefingStyles.abilityStripMeta}>
-        Trust
-        <TrustBandIndicator band={trustBand} />
-        <span>{trustBand.replace(/_/g, " ")}</span>
-      </span>
-      {sourceCount > 0 && (
-        <span className={briefingStyles.abilityStripMeta}>
-          {sourceCount} source{sourceCount === 1 ? "" : "s"}
-        </span>
-      )}
-      {advisory && (
-        <span className={briefingStyles.abilityStripAdvisory}>{advisory}</span>
-      )}
-    </div>
-  );
-}
-
 // ─── Capacity Formatting ─────────────────────────────────────────────────────
 
 function formatMinutes(minutes: number): string {
@@ -235,7 +139,6 @@ function formatMinutes(minutes: number): string {
 
 export function DailyBriefing({ data, freshness: _freshness, onRunBriefing, isRunning, workflowStatus, onRefresh }: DailyBriefingProps) {
   const { now, currentMeeting } = useCalendar();
-  const dailyBriefingAbility = useDailyBriefingAbility();
   const [completedIds, setCompletedIds] = useState<Set<string>>(new Set());
   const [pendingLifecycleChangeId, setPendingLifecycleChangeId] = useState<number | null>(null);
   const [correctionTarget, setCorrectionTarget] = useState<DashboardLifecycleUpdate | null>(null);
@@ -480,12 +383,6 @@ export function DailyBriefing({ data, freshness: _freshness, onRunBriefing, isRu
             <div className={s.focusText}>{data.overview.focus}</div>
           </div>
         )}
-
-        <DailyBriefingAbilityStrip
-          output={dailyBriefingAbility.response?.data}
-          renderedProvenance={dailyBriefingAbility.response?.rendered_provenance}
-          error={dailyBriefingAbility.error}
-        />
 
         {/* Staleness indicator removed — orphaned "Last updated" with no date
             was confusing. The hero headline already communicates state. */}

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -299,6 +299,26 @@
       }
     },
     {
+      "name": "markdown_preview",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.markdown_preview"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "prepare_meeting",
       "description": "",
       "category": "transform",
@@ -330,6 +350,70 @@
       "mcp_exposure": "none",
       "client_side_executable": false,
       "idempotency_class": "side_effect",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "source_management_action",
+      "description": "",
+      "category": "transform",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "surface_client"
+      ],
+      "required_scopes": [
+        "write.entity_intake"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "source_management_ledger",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "runtime",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.workspace_sources"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "workspace_graph",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "runtime",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.workspace_graph"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
       "composition_kind": {
         "produces_blocks": false,
         "block_types": []


### PR DESCRIPTION
## Linear ticket

[DOS-771](https://linear.app/a8c/issue/DOS-771) (substrate follow-up for the phantom-advisory root cause; see "Deferred substrate work" below).

## Summary

Four-commit unblock for the daily briefing today-page L4 regression that surfaced after the W6 ability-runtime migration + multi-stream merges into `dev`. Net: **−169 LOC** (mostly UI removal). Plus a fifth commit regenerating `tools/dailyos-abilities.json` to unblock the `check_ability_inventory` CI gate that recent merges left out of sync. L2 waived per maintainer call given the deletion-heavy diff.

## What changed

- **`fix(tests)`** — Three `services::entity_intelligence::neighborhood` tests broke when recent migrations added `NOT NULL` on `people.updated_at` and `meetings.created_at`. Fixtures brought into line with the working pattern already in place for the other tests in the same file.
- **`fix(briefing): align ability response contract`** — Two contract gaps in `get_daily_briefing`: `SubjectRef::Unknown` → `Global` (ownership-validation reject was silent in the runtime log), and `rename_all_fields = "camelCase"` on the 4 `BriefingState` tagged enums (frontend was throwing on `advisory.meetingIds undefined`).
- **`fix(readiness): TZ-aware day window`** — `LiveDailyReadinessContextReader` was lex-comparing UTC `start_time` against bare date strings (leaked yesterday-evening meetings into today for any non-UTC user) and didn't filter calendar-poller-archived meetings. Also adds a `log::error!` on the post-dispatch ownership-validation reject path in `invoke_ability` so the next contract drift doesn't disappear from the runtime log.
- **`fix(briefing): remove ability strip`** — The `DailyBriefingAbilityStrip` on the today page was surfacing phantom `NeedsPreparation(4)` / `UnlinkedMeetings(4)` advisories on a day with zero actual meetings; root cause resists 4 layers of substrate hardening, so the strip is removed pending substrate investigation. Per-meeting prep affordances on the schedule cards already cover the actionable signal.
- **`fix(inventory)`** — Regenerated `tools/dailyos-abilities.json` after the multi-stream merges (#385, #390) introduced new abilities (`markdown_preview`, `source_management_action`) without updating the committed inventory artifact. The `check_ability_inventory` CI gate was failing on every new PR into dev as a result.

## Test plan

- [x] `cargo clippy -- -D warnings` clean on each commit (pre-commit hook)
- [x] `cargo test --lib` passes on each commit (pre-commit hook) — includes the 3 fixed neighborhood tests
- [x] `pnpm tsc --noEmit` clean
- [x] Manual verification: today page renders without the "BRIEFING CONTEXT UNAVAILABLE" / "advisory.meetingIds undefined" crashes, and the phantom-4 strip is gone (verified live by maintainer)

## Definition of Done

- [x] Acceptance criteria validated with real data — maintainer L4-verified the today page renders cleanly
- [x] End-to-end flow works through to rendered surfaces — strip removal verified visually
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (substrate phantom-advisory work tracked separately as DOS-771)
- [x] Tests pass — pre-commit + pre-push hooks ran clippy + cargo test --lib + tsc on every commit

## §4 Security

`security_auditor_invoked: true`

**Rationale**: L2 review waived by maintainer (Giroux, 2026-05-25) given the diff shape — net −169 LOC consisting of: serde wire-format annotations, removal of a misbehaving UI strip, defensive TZ + cancellation filters on a read-only DB query, a single `log::error!` for observability, test-fixture column updates for a recently-added NOT NULL, and a regenerated inventory artifact. No auth, permission, sensitivity-tier, scope, allowlist, MCP, or migration logic touched. `SubjectRef::Global` change is the inverse of a privilege bypass (it tightens the ownership invariant by removing a `SubjectRef::Unknown` that the validator was correctly rejecting).

## Deferred substrate work

[DOS-771](https://linear.app/a8c/issue/DOS-771) carries the full investigation handoff for the phantom-advisory root cause — 3 ranked hypotheses, the exact `tracing::info!` diagnostic line to re-add as the first move, and the source-of-truth files. Filed under `Codebase Maintenance & Production Quality` since no current surface consumes `BriefingState.freshness` / `BriefingState.advisories` after the strip removal. Latent until the next consumer ships.

## Follow-ups

- **Block-kit integration harness gap** (separate ticket to file): `wp/dailyos/blocks/markdown-preview/` is a client-side-runtime block (renders by calling the runtime, not by composition projection). The block-kit integration harness at `src-tauri/abilities-runtime/tests/block_kit_integration_harness.rs` enforces a fixture-per-block invariant that assumes composition → projection → render, which doesn't apply here. CI gate is therefore failing on dev for every PR. Repair options: (a) add a `BlockType::MarkdownPreview` composition variant and route the block through projection, (b) extend the harness to support a client-side-runtime fixture pattern, or (c) revert the markdown-preview block until (a) or (b) ships. Out of scope for this PR.
- **`.claude/scheduled_tasks.lock` gitignore oversight**: the file is tracked but is harness state; should be added to `.gitignore`.

## Notes for review

- L2 waived; if reviewers disagree, request a re-run and I'll cycle through `/codex review` etc.
- The `fix(inventory)` commit is a pure data regen — no code logic changes, just `tools/dailyos-abilities.json` reflecting the live registry.
- Block-kit integration CI failure is pre-existing on dev (not introduced by this PR); see Follow-ups above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)