### PR TITLE
W5: wire workspace signal middle hop

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
+++ b/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
@@ -27,6 +27,7 @@ W5-B must not make W5-A historical backfill an implicit claim producer. Claim-pr
 - **V1.1** - L0 cycle-1 blocker fold. Removes false-green release-gate path, makes entity-intake and `_inbox` mandatory ingestion paths, treats MCP/headless parity and source lifecycle suppression as fail-closed gates, moves hermetic graph assertions into Rust integration tests, adds W5-B release-gate wiring, adds manual-evidence redaction contract, and expands K-in references.
 - **V1.2** - L0 cycle-2 feasibility fix. Splits POSIX-impossible NUL filename coverage into an invalid path/input rejection test and platform-gates non-UTF8 filename plus hardlink fixtures where the host filesystem cannot represent them.
 - **V1.3** - Rebased-base readiness refresh. Records that W5-A is folded into the active W5 validation PR, explicit ingestion and graph projection now have partial automated evidence, filesystem negative fixtures have partial automated evidence, and MCP placement/lifecycle/signal-middle-hop gaps remain blocked.
+- **V1.4** - Release-gate branch refresh. Records that the signal middle hop is now present and green: explicit workspace ingestion emits `WorkspaceFileIngested`, emits `EntityIntelligenceUpdated`, and invalidates affected prep through the middle-hop signal.
 
 ---
 
@@ -167,7 +168,7 @@ Read-only prep on 2026-05-25, refreshed after rebasing on merged W4/W5-A substra
 - MCP placement has contract/catalog pieces, but the actual MCP v2 handler path is not fully wired. MCP/headless parity remains blocked until a real MCP/gateway or registered-handler path is exercised.
 - Scratchpad/ignored and archive/delete lifecycle effects are named DOS-476 ACs; missing actions block Axis 6 and W5 release close.
 - Automated explicit-ingestion evidence proves a direct pipeline fixture creates lifecycle, run, link, and `commit_claim` rows with privacy-safe provenance, but Axis 2 remains release-blocked until entity-intake, `_inbox`, and MCP placement path coverage is complete.
-- Automated partial signal evidence proves workspace ingestion emits privacy-safe `WorkspaceFileIngested` and queues prep invalidation, but static code inspection still does not confirm a literal `WorkspaceFileIngested -> EntityIntelligenceUpdated` derivation. Axis 4 remains release-blocked unless the implemented base proves the literal wave-plan chain or the owning substrate issue lands that hop.
+- Automated signal evidence proves workspace ingestion emits privacy-safe `WorkspaceFileIngested`, emits privacy-safe `EntityIntelligenceUpdated`, and queues prep invalidation through that middle-hop signal. Axis 4 is green on the release-gate branch.
 - Automated partial filesystem evidence covers traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, and hardlink rejection when supported. Axis 7 remains release-blocked until oversized, non-UTF8, managed/hidden, and unsupported-file cases are automated in this W5-B axis.
 - `WorkspaceExtractor` is intentionally narrow: note-like, linked Account/Project/Person content becomes `UserNote` claim proposals. W5-B fixtures must use that shape for claim-producing automated tests.
 - Stale-source trust-band validation likely requires explicit trust recompute/job execution. W5-B must include the existing recompute step; hand-setting trust scores is not valid evidence.

--- a/.docs/plans/wave-W5-v146/validation-report.md
+++ b/.docs/plans/wave-W5-v146/validation-report.md
@@ -14,9 +14,9 @@
 | `bash tests/v146_validation/run.sh backfill` | pass | W5-A conservative backfill registration tests pass on the rebased base. |
 | `bash tests/v146_validation/run.sh graph-audit` | blocked | Partial explicit ingestion provenance-chain fixture and workspace graph audit projection tests pass; full path matrix remains incomplete. |
 | `bash tests/v146_validation/run.sh filesystem` | blocked | Partial negative path validation fixtures pass and leave workspace lifecycle/run/link/claim tables untouched; full negative fixture matrix remains incomplete. |
-| `bash tests/v146_validation/run.sh signals` | blocked | Partial signal evidence passes; the literal `WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation` chain is still not present. |
+| `bash tests/v146_validation/run.sh signals` | pass | `WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation` evidence passes with privacy-safe payloads. |
 | `bash tests/v146_validation/run.sh redaction` | pass | Redaction axis is green. |
-| `bash tests/v146_validation/run.sh all` | blocked | Backfill and redaction are green; graph-audit, trust, signals, contexts, lifecycle, and filesystem remain blocked. |
+| `bash tests/v146_validation/run.sh all` | blocked | Backfill, signals, and redaction are green; graph-audit, trust, contexts, lifecycle, and filesystem remain blocked. |
 | `bash scripts/release-gate/run-v146-validation.sh` | blocked | Wrapper delegates to the W5-B runner and preserves the blocked exit status. |
 
 ## Dependency Gate
@@ -27,7 +27,7 @@
 | W4 source-management and placement stack | partial | Source-management read/action substrate landed, but the MCP placement handler remains a placeholder. |
 | Graph projection service | partial | Workspace graph projection unit tests pass and explicit ingestion provenance chain has no local gaps for the direct pipeline fixture; full path matrix remains incomplete. |
 | Workspace extractor claim production | partial | Explicit note-like workspace ingestion commits through `commit_claim` with privacy-safe provenance; entity-intake, inbox, and MCP placement path coverage is not complete. |
-| Workspace lifecycle signal wiring | partial | Workspace signal emission and direct prep invalidation evidence pass; the required `EntityIntelligenceUpdated` middle hop is absent. |
+| Workspace lifecycle signal wiring | green | Explicit ingestion emits `workspace_file_ingested`, emits the `entity_intelligence_updated` middle hop, and invalidates affected prep through the middle-hop signal. |
 | MCP placement path | blocked | Actual MCP/gateway or registered-handler execution is required; catalog presence is not enough. |
 | Source lifecycle actions | partial | Current action contract exposes reingest, quarantine, and relink only; ignore/scratchpad plus archive/delete are missing. |
 
@@ -38,7 +38,7 @@
 | Backfill registration safety | green | Focused W5-A backfill service/bin tests plus v268 migration coverage pass on the rebased base. |
 | Explicit ingestion to claim provenance | blocked | `src-tauri/tests/v146_validation.rs` proves direct explicit ingestion creates lifecycle, run, link, and claim rows through service APIs; packet-level path matrix remains blocked on entity-intake, inbox, and MCP placement evidence. |
 | Trust-band discipline | blocked | Full matrix still needs recent, stale, pending-review, and reingest-without-freshness cases through real recompute. |
-| Signal propagation and prep invalidation | blocked | Partial evidence proves workspace ingestion emits privacy-safe `workspace_file_ingested` and queues prep invalidation; required middle-hop chain remains absent. |
+| Signal propagation and prep invalidation | green | `src-tauri/tests/v146_validation.rs` proves workspace ingestion emits privacy-safe `workspace_file_ingested`, emits privacy-safe `entity_intelligence_updated`, and queues prep invalidation for the affected meeting. |
 | Context inclusion and MCP/privacy parity | blocked | `dailyos.write.place_document` is cataloged, but the MCP v2 handler is still a placeholder. |
 | Lifecycle actions and user correction | blocked | Source-management action contract currently exposes only reingest, quarantine, and relink; ignore/scratchpad and archive/delete remain unavailable. |
 | Filesystem validation negative fixtures | blocked | Rust negative fixtures cover traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, and hardlink rejection when supported; oversized, non-UTF8, managed/hidden, and unsupported-file cases remain to be automated in this axis. |

--- a/src-tauri/src/services/workspace_ingestion/signals.rs
+++ b/src-tauri/src/services/workspace_ingestion/signals.rs
@@ -17,6 +17,7 @@ pub const WORKSPACE_FILE_PENDING_ENTITY_ASSIGNMENT: &str =
 pub const WORKSPACE_FILE_QUARANTINED: &str = "workspace_file_quarantined";
 pub const WORKSPACE_FILE_ENTITY_LINK_CHANGED: &str = "workspace_file_entity_link_changed";
 pub const WORKSPACE_SOURCE_POLICY_CHANGED: &str = "workspace_source_policy_changed";
+pub const ENTITY_INTELLIGENCE_UPDATED: &str = "entity_intelligence_updated";
 
 const WORKSPACE_SIGNAL_SOURCE: &str = "workspace_ingestion";
 const WORKSPACE_FILE_ENTITY_TYPE: &str = "workspace_file";
@@ -31,6 +32,13 @@ pub struct WorkspaceFileIngestedSignal {
     pub ingestion_run_id: String,
     pub entity_type: String,
     pub entity_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceEntityIntelligenceUpdatedSignal {
+    pub file_id: String,
+    pub ingestion_run_id: String,
+    pub reason_code: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -114,6 +122,18 @@ impl SignalEmitter for WorkspaceSignalEmitter {
             entity_type,
             entity_id,
             &payload,
+        )?;
+        let intelligence_payload = WorkspaceEntityIntelligenceUpdatedSignal {
+            file_id: file_id.to_string(),
+            ingestion_run_id: ingestion_run_id.to_string(),
+            reason_code: WORKSPACE_FILE_INGESTED.to_string(),
+        };
+        emit_invalidating(
+            ctx,
+            ENTITY_INTELLIGENCE_UPDATED,
+            entity_type,
+            entity_id,
+            &intelligence_payload,
         )
     }
 

--- a/src-tauri/src/signals/invalidation.rs
+++ b/src-tauri/src/signals/invalidation.rs
@@ -45,7 +45,7 @@ pub fn check_and_invalidate_preps(
         "relationship_reclassified",
         "transcript_outcomes", // manually attached transcript — invalidate linked future meeting preps
         "field_updated", // DOS-110: account field changes (including sentiment) invalidate prep
-        "workspace_file_ingested",
+        "entity_intelligence_updated",
         "workspace_file_quarantined",
         "workspace_file_entity_link_changed",
         "workspace_source_policy_changed",
@@ -220,9 +220,20 @@ mod tests {
         )
         .unwrap();
 
+        let raw_ingestion_queue = Mutex::new(Vec::<String>::new());
+        check_and_invalidate_preps(
+            &db,
+            &make_signal("workspace_file_ingested", 0.85),
+            &raw_ingestion_queue,
+        );
+        assert!(
+            raw_ingestion_queue.lock().is_empty(),
+            "workspace_file_ingested should route through entity_intelligence_updated for prep invalidation"
+        );
+
         for signal_type in [
             "stakeholder_change",
-            "workspace_file_ingested",
+            "entity_intelligence_updated",
             "workspace_file_quarantined",
             "workspace_file_entity_link_changed",
         ] {

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -135,7 +135,7 @@ fn graph_audit_zero_gaps_on_hermetic_fixture_db() {
 }
 
 #[test]
-fn signal_propagation_invalidates_prep_partial_evidence() {
+fn signal_propagation_invalidates_prep() {
     let fixture = Fixture::new();
     fixture.seed_account("acct-v146-signal", "Signal Account");
     fixture.seed_upcoming_meeting("meeting-v146-signal", "acct-v146-signal");
@@ -160,24 +160,50 @@ fn signal_propagation_invalidates_prep_partial_evidence() {
         .lock()
         .contains(&"meeting-v146-signal".to_string()));
 
-    let (entity_type, entity_id, value): (String, String, Option<String>) = fixture
+    let (entity_type, entity_id, source, value): (String, String, String, Option<String>) = fixture
         .conn
         .query_row(
-            "SELECT entity_type, entity_id, value
+            "SELECT entity_type, entity_id, data_source, value
              FROM signal_events
              WHERE signal_type = 'workspace_file_ingested'
              ORDER BY created_at DESC
              LIMIT 1",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .expect("workspace_file_ingested signal");
     assert_eq!(entity_type, "account");
     assert_eq!(entity_id, "acct-v146-signal");
+    assert_eq!(source, "workspace_ingestion");
 
     let payload = value.expect("signal payload");
     assert!(payload.contains(&receipt.file_id));
     assert!(payload.contains(&receipt.ingestion_run_id.0));
+    assert!(!payload.contains("Signal Account"));
+    assert!(!payload.contains("signal-note.md"));
+    assert!(!payload.contains("Signal validation context"));
+    assert!(!payload.contains(fixture.workspace_root.to_string_lossy().as_ref()));
+
+    let (entity_type, entity_id, source, value): (String, String, String, Option<String>) = fixture
+        .conn
+        .query_row(
+            "SELECT entity_type, entity_id, data_source, value
+             FROM signal_events
+             WHERE signal_type = 'entity_intelligence_updated'
+             ORDER BY created_at DESC
+             LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("entity_intelligence_updated signal");
+    assert_eq!(entity_type, "account");
+    assert_eq!(entity_id, "acct-v146-signal");
+    assert_eq!(source, "workspace_ingestion");
+
+    let payload = value.expect("entity intelligence payload");
+    assert!(payload.contains(&receipt.file_id));
+    assert!(payload.contains(&receipt.ingestion_run_id.0));
+    assert!(payload.contains("workspace_file_ingested"));
     assert!(!payload.contains("Signal Account"));
     assert!(!payload.contains("signal-note.md"));
     assert!(!payload.contains("Signal validation context"));

--- a/tests/v146_validation/README.md
+++ b/tests/v146_validation/README.md
@@ -10,8 +10,9 @@ Current status:
 
 - L0 passed locally on 2026-05-25.
 - W5-A is folded into the active W5 validation PR; backfill and redaction axes have automated green checks on the rebased base.
-- Graph-audit, signal, and filesystem axes now have automated partial evidence, but remain blocked at packet level until their full matrices are covered.
-- Full validation remains dependency-gated on the trust-band matrix, the literal workspace signal middle hop, actual MCP placement handler execution, and missing lifecycle actions.
+- Signal propagation is green on the release-gate branch.
+- Graph-audit and filesystem axes have automated partial evidence, but remain blocked at packet level until their full matrices are covered.
+- Full validation remains dependency-gated on the trust-band matrix, actual MCP placement handler execution, and missing lifecycle actions.
 - A blocked axis is not a pass. Interim reports may record `blocked`, but W5-B Done requires all mandatory axes to be green.
 
 ## Commands

--- a/tests/v146_validation/run.sh
+++ b/tests/v146_validation/run.sh
@@ -65,11 +65,11 @@ status_for_axis() {
     signals)
       if (
         cd "$ROOT_DIR"
-        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation signal_propagation_invalidates_prep_partial_evidence >/dev/null
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation signal_propagation_invalidates_prep >/dev/null
       ); then
-        printf 'blocked\tcargo test --test v146_validation signal_propagation_invalidates_prep_partial_evidence\tpartial signal evidence passed; blocked until WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation is present\n'
+        printf 'pass\tcargo test --test v146_validation signal_propagation_invalidates_prep\tWorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation evidence passed with privacy-safe payloads\n'
       else
-        printf 'fail\tcargo test --test v146_validation signal_propagation_invalidates_prep_partial_evidence\tpartial workspace signal/prep invalidation evidence failed\n'
+        printf 'fail\tcargo test --test v146_validation signal_propagation_invalidates_prep\tworkspace signal middle-hop/prep invalidation evidence failed\n'
       fi
       ;;
     contexts)


### PR DESCRIPTION
## Linear ticket

DOS-476

## Summary

Wire the W5 workspace signal middle hop so explicit workspace ingestion emits `workspace_file_ingested`, then `entity_intelligence_updated`, and prep invalidation keys off the middle-hop signal.

## What changed

- Added a privacy-safe `WorkspaceEntityIntelligenceUpdatedSignal` payload under workspace ingestion signal emission.
- Emitted `entity_intelligence_updated` through `services::signals::emit_and_propagate` immediately after `workspace_file_ingested`.
- Moved prep invalidation for ingestion from raw `workspace_file_ingested` to `entity_intelligence_updated`.
- Updated W5 validation evidence/docs so the signal axis is green while the remaining W5 axes stay blocked.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation signal_propagation_invalidates_prep`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib signals::invalidation::tests`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib signals::policy_registry::tests`
- [x] `bash tests/v146_validation/run.sh signals`
- [x] `bash tests/v146_validation/run.sh all` exits `2` as expected with non-signal W5 axes still blocked
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --test v146_validation -- -D warnings`
- [x] Local L2: `codex review --uncommitted` clean, no actionable correctness issues
- [x] Pre-commit hook: full `cargo clippy -- -D warnings` and `cargo test --lib` passed

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data for the signal axis.
- [x] End-to-end flow works through workspace ingestion signal emission to prep invalidation for the signal axis.
- [x] No stubs, TODOs, or tracked-later deferrals introduced.
- [ ] Full W5 release-gate remains blocked by non-signal axes; tracked on DOS-476.

## §4 Security

`security_auditor_invoked: true`

Security/privacy notes: local L2 was run with privacy payload leakage and signal-propagation contracts in scope. The payloads carry file IDs, run IDs, entity IDs, and reason codes only; tests assert no raw path, file name, entity name, or file content leaks into either signal payload.

Security checklist:

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic? Privacy-safe signal payload assertions were updated.
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Complete remaining W5 axes: graph-audit full path matrix, trust-band matrix, MCP placement handler execution, lifecycle actions, filesystem full matrix, and release-gate wrapper pass.

## Notes for review

This PR intentionally does not touch claim lifecycle/retraction, account/Glean producer code, MCP placement handling, or lower-level signal bus semantics.
