### PR TITLE
test: complete W5 filesystem validation axis

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
+++ b/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
@@ -28,6 +28,7 @@ W5-B must not make W5-A historical backfill an implicit claim producer. Claim-pr
 - **V1.2** - L0 cycle-2 feasibility fix. Splits POSIX-impossible NUL filename coverage into an invalid path/input rejection test and platform-gates non-UTF8 filename plus hardlink fixtures where the host filesystem cannot represent them.
 - **V1.3** - Rebased-base readiness refresh. Records that W5-A is folded into the active W5 validation PR, explicit ingestion and graph projection now have partial automated evidence, filesystem negative fixtures have partial automated evidence, and MCP placement/lifecycle/signal-middle-hop gaps remain blocked.
 - **V1.4** - Release-gate branch refresh. Records that the signal middle hop is now present and green: explicit workspace ingestion emits `WorkspaceFileIngested`, emits `EntityIntelligenceUpdated`, and invalidates affected prep through the middle-hop signal.
+- **V1.5** - Filesystem-axis refresh. Records green automated evidence for registry-level unsafe path rejection, explicit ingestion size/format rejection, non-UTF8 path byte-input rejection, and conservative backfill hidden/managed/unsupported skips.
 
 ---
 
@@ -169,7 +170,7 @@ Read-only prep on 2026-05-25, refreshed after rebasing on merged W4/W5-A substra
 - Scratchpad/ignored and archive/delete lifecycle effects are named DOS-476 ACs; missing actions block Axis 6 and W5 release close.
 - Automated explicit-ingestion evidence proves a direct pipeline fixture creates lifecycle, run, link, and `commit_claim` rows with privacy-safe provenance, but Axis 2 remains release-blocked until entity-intake, `_inbox`, and MCP placement path coverage is complete.
 - Automated signal evidence proves workspace ingestion emits privacy-safe `WorkspaceFileIngested`, emits privacy-safe `EntityIntelligenceUpdated`, and queues prep invalidation through that middle-hop signal. Axis 4 is green on the release-gate branch.
-- Automated partial filesystem evidence covers traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, and hardlink rejection when supported. Axis 7 remains release-blocked until oversized, non-UTF8, managed/hidden, and unsupported-file cases are automated in this W5-B axis.
+- Automated filesystem evidence covers traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, non-UTF8 path byte-input rejection, hardlink rejection when supported, explicit ingestion oversized/unsupported-format rejection, and conservative backfill hidden/managed/unsupported skips. Axis 7 is green on the filesystem-validation branch.
 - `WorkspaceExtractor` is intentionally narrow: note-like, linked Account/Project/Person content becomes `UserNote` claim proposals. W5-B fixtures must use that shape for claim-producing automated tests.
 - Stale-source trust-band validation likely requires explicit trust recompute/job execution. W5-B must include the existing recompute step; hand-setting trust scores is not valid evidence.
 

--- a/.docs/plans/wave-W5-v146/validation-report.md
+++ b/.docs/plans/wave-W5-v146/validation-report.md
@@ -3,7 +3,7 @@
 **Status:** blocked by upstream dependencies  
 **Issue:** DOS-476  
 **Packet:** `.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md`  
-**Branch:** `codex/v1.4.5-w5-e2e-validation`
+**Branch:** `codex/v1.4.5-w5-filesystem-validation`
 
 ## Harness Status
 
@@ -13,10 +13,10 @@
 | `bash tests/v146_validation/redaction_lint.sh` | pass | Current report draft is privacy-safe. |
 | `bash tests/v146_validation/run.sh backfill` | pass | W5-A conservative backfill registration tests pass on the rebased base. |
 | `bash tests/v146_validation/run.sh graph-audit` | blocked | Partial explicit ingestion provenance-chain fixture and workspace graph audit projection tests pass; full path matrix remains incomplete. |
-| `bash tests/v146_validation/run.sh filesystem` | blocked | Partial negative path validation fixtures pass and leave workspace lifecycle/run/link/claim tables untouched; full negative fixture matrix remains incomplete. |
+| `bash tests/v146_validation/run.sh filesystem` | pass | Registry path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips pass with privacy-safe evidence. |
 | `bash tests/v146_validation/run.sh signals` | pass | `WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation` evidence passes with privacy-safe payloads. |
 | `bash tests/v146_validation/run.sh redaction` | pass | Redaction axis is green. |
-| `bash tests/v146_validation/run.sh all` | blocked | Backfill, signals, and redaction are green; graph-audit, trust, contexts, lifecycle, and filesystem remain blocked. |
+| `bash tests/v146_validation/run.sh all` | blocked | Backfill, signals, filesystem, and redaction are green; graph-audit, trust, contexts, and lifecycle remain blocked. |
 | `bash scripts/release-gate/run-v146-validation.sh` | blocked | Wrapper delegates to the W5-B runner and preserves the blocked exit status. |
 
 ## Dependency Gate
@@ -41,7 +41,7 @@
 | Signal propagation and prep invalidation | green | `src-tauri/tests/v146_validation.rs` proves workspace ingestion emits privacy-safe `workspace_file_ingested`, emits privacy-safe `entity_intelligence_updated`, and queues prep invalidation for the affected meeting. |
 | Context inclusion and MCP/privacy parity | blocked | `dailyos.write.place_document` is cataloged, but the MCP v2 handler is still a placeholder. |
 | Lifecycle actions and user correction | blocked | Source-management action contract currently exposes only reingest, quarantine, and relink; ignore/scratchpad and archive/delete remain unavailable. |
-| Filesystem validation negative fixtures | blocked | Rust negative fixtures cover traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, and hardlink rejection when supported; oversized, non-UTF8, managed/hidden, and unsupported-file cases remain to be automated in this axis. |
+| Filesystem validation negative fixtures | green | Rust negative fixtures cover traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, non-UTF8 path byte-input rejection, hardlink rejection when supported, explicit ingestion oversized/unsupported-format rejection, and conservative backfill hidden/managed/unsupported skips. |
 | Redaction lint | green | Self-test and current report scan passed. |
 
 ## Manual Evidence Contract

--- a/src-tauri/src/services/workspace_backfill.rs
+++ b/src-tauri/src/services/workspace_backfill.rs
@@ -1491,6 +1491,90 @@ mod tests {
         assert!(!json.contains("same source text"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn workspace_backfill_filesystem_negative_matrix_skips_without_writes() {
+        let db = test_db();
+        let temp = TempDir::new().expect("temp");
+        seed_account(db.conn_ref(), temp.path());
+        std::fs::create_dir_all(temp.path().join("_archive")).expect("managed root");
+        let account_notes = temp.path().join("Accounts/ExampleCo/notes");
+
+        std::fs::write(account_notes.join(".hidden.md"), "hidden").expect("hidden file");
+        std::fs::write(temp.path().join("_archive/source.md"), "managed root")
+            .expect("managed root file");
+        std::fs::write(temp.path().join("CLAUDE.md"), "managed").expect("managed file");
+        std::fs::write(account_notes.join("dashboard.json"), "{}").expect("generated file");
+        std::fs::write(account_notes.join("archive.zip"), "unsupported").expect("unsupported file");
+        std::fs::write(account_notes.join("invalid-content.md"), [0xff, 0xfe])
+            .expect("non-UTF8 content");
+        std::fs::write(account_notes.join("large.md"), "012345678").expect("large file");
+
+        let write_boundary = [
+            "workspace_file_lifecycle",
+            "workspace_backfill_runs",
+            "workspace_backfill_items",
+            "workspace_backfill_operations",
+            "document_entity_links",
+            "document_ingestion_runs",
+            "content_index",
+            "content_embeddings",
+            "intelligence_claims",
+            "signal_events",
+        ];
+        let before = table_counts(db.conn_ref(), &write_boundary);
+        let key = BackfillHandleKey::for_tests("install-a");
+
+        let summary = run_workspace_backfill(
+            &db,
+            WorkspaceBackfillOptions {
+                workspace_root: Some(temp.path().to_path_buf()),
+                mode: BackfillMode::DryRun,
+                resume_run_id: None,
+                max_file_bytes: 4,
+            },
+            &key,
+            None,
+        )
+        .expect("dry-run");
+
+        assert_eq!(summary.eligible_count, 0);
+        for (reason, expected_count) in [
+            ("hidden_path", 1),
+            ("managed_root", 1),
+            ("managed_file", 1),
+            ("generated_file", 1),
+            ("unsupported_format", 1),
+            ("non_utf8_file", 1),
+            ("file_too_large", 1),
+        ] {
+            assert_eq!(
+                summary.reason_counts.get(reason),
+                Some(&expected_count),
+                "missing reason {reason}",
+            );
+        }
+        assert_eq!(table_counts(db.conn_ref(), &write_boundary), before);
+
+        let json = serde_json::to_string(&summary).expect("summary json");
+        let root_text = temp.path().to_string_lossy().to_string();
+        for raw in [
+            "ExampleCo",
+            ".hidden.md",
+            "CLAUDE.md",
+            "dashboard.json",
+            "archive.zip",
+            "invalid-content.md",
+            "large.md",
+            root_text.as_str(),
+        ] {
+            assert!(
+                !json.contains(raw),
+                "summary leaked raw fixture data: {raw}"
+            );
+        }
+    }
+
     #[test]
     fn apply_registers_pending_review_source_and_graph_excludes_it() {
         let db = test_db();

--- a/src-tauri/src/services/workspace_ingestion/registry.rs
+++ b/src-tauri/src/services/workspace_ingestion/registry.rs
@@ -176,10 +176,12 @@ impl WorkspaceSourceRegistry {
             let normalized_components: Vec<String> = path
                 .components()
                 .map(|c| {
-                    let s: String = c.as_os_str().to_string_lossy().nfkc().collect();
-                    s
+                    c.as_os_str()
+                        .to_str()
+                        .map(|s| s.nfkc().collect())
+                        .ok_or(RejectionReason::PathTraversalAttempt)
                 })
-                .collect();
+                .collect::<Result<_, _>>()?;
             for c in &normalized_components {
                 if c == ".." || c.contains("\\..\\") || c.contains("/..") || c.contains("../") {
                     return Err(RejectionReason::PathTraversalAttempt);
@@ -859,6 +861,19 @@ mod tests {
         let ws = make_workspace();
         let bad = std::path::PathBuf::from("foo\0bar");
         let err = WorkspaceSourceRegistry::open_validated(ws.path(), &bad).expect_err("NUL");
+        assert!(matches!(err, RejectionReason::PathTraversalAttempt));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_validated_rejects_non_utf8_path_component() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let ws = make_workspace();
+        let bad = std::path::Path::new(OsStr::from_bytes(b"bad-\xff.md"));
+        let err =
+            WorkspaceSourceRegistry::open_validated(ws.path(), bad).expect_err("non-UTF8 path");
         assert!(matches!(err, RejectionReason::PathTraversalAttempt));
     }
 

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -6,12 +6,15 @@ use dailyos_lib::abilities::provenance::source::EntityId;
 use dailyos_lib::db::{ActionDb, DbAccount};
 use dailyos_lib::entity::EntityType;
 use dailyos_lib::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
-use dailyos_lib::services::workspace_ingestion::contracts::{RejectionReason, WorkspaceFileKind};
+use dailyos_lib::services::workspace_ingestion::contracts::{
+    NullExtractor, RejectionReason, WorkspaceFileKind,
+};
 use dailyos_lib::services::workspace_ingestion::pipeline::{
-    file_id_from_identity, EntityRef, IngestReceipt, IngestRequest,
+    file_id_from_identity, EntityRef, IngestError, IngestPipeline, IngestReceipt, IngestRequest,
 };
 use dailyos_lib::services::workspace_ingestion::registry::WorkspaceSourceRegistry;
 use dailyos_lib::services::workspace_ingestion::runs::IngestionMode;
+use dailyos_lib::services::workspace_ingestion::signals::WorkspaceSignalEmitter;
 use dailyos_lib::services::workspace_ingestion::wiring;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection};
@@ -262,6 +265,13 @@ fn filesystem_validation_negative_fixtures() {
         RejectionReason::PathTraversalAttempt,
     );
 
+    let non_utf8_path = Path::new(OsStr::from_bytes(b"non-utf8-\xff.md"));
+    assert_rejected(
+        &fixture.workspace_root,
+        non_utf8_path,
+        RejectionReason::PathTraversalAttempt,
+    );
+
     let hardlink_source = fixture.workspace_root.join("hardlink-source.md");
     let hardlink_alias = fixture.workspace_root.join("hardlink-alias.md");
     std::fs::write(&hardlink_source, "hardlink").expect("hardlink source");
@@ -283,7 +293,70 @@ fn filesystem_validation_negative_fixtures() {
         assert_eq!(
             count(&fixture.conn, &sql, []),
             0,
-            "{table} should stay empty"
+            "{table} should stay empty for registry-level rejections"
+        );
+    }
+
+    let explicit = Fixture::new();
+    std::fs::write(explicit.workspace_root.join("oversized.md"), "012345678")
+        .expect("oversized write");
+    std::fs::write(
+        explicit.workspace_root.join("invalid-utf8.md"),
+        [0xff, 0xfe],
+    )
+    .expect("invalid utf8 write");
+    std::fs::write(
+        explicit.workspace_root.join("nul-content.md"),
+        b"safe\0unsafe",
+    )
+    .expect("nul content write");
+
+    assert_pipeline_rejected(
+        &explicit,
+        Path::new("oversized.md"),
+        RejectionReason::FileTooLarge,
+        8,
+    );
+    assert_pipeline_rejected(
+        &explicit,
+        Path::new("invalid-utf8.md"),
+        RejectionReason::UnsupportedFormat,
+        1024,
+    );
+    assert_pipeline_rejected(
+        &explicit,
+        Path::new("nul-content.md"),
+        RejectionReason::UnsupportedFormat,
+        1024,
+    );
+
+    assert_eq!(
+        count(
+            &explicit.conn,
+            "SELECT COUNT(*)
+             FROM workspace_file_lifecycle
+             WHERE lifecycle_state = 'rejected'",
+            [],
+        ),
+        3,
+        "pipeline-level rejections should leave only rejected lifecycle audit rows",
+    );
+    assert_rejection_signal_reasons(
+        &explicit.conn,
+        &["file_too_large", "unsupported_format", "unsupported_format"],
+    );
+    for table in [
+        "document_ingestion_runs",
+        "document_entity_links",
+        "content_index",
+        "content_embeddings",
+        "intelligence_claims",
+    ] {
+        let sql = format!("SELECT COUNT(*) FROM {table}");
+        assert_eq!(
+            count(&explicit.conn, &sql, []),
+            0,
+            "{table} should stay empty for pipeline-level rejections"
         );
     }
 }
@@ -433,6 +506,89 @@ fn assert_rejected(workspace_root: &Path, path: &Path, expected: RejectionReason
     let err = WorkspaceSourceRegistry::open_validated(workspace_root, path)
         .expect_err("path should be rejected");
     assert_eq!(err, expected);
+}
+
+fn assert_pipeline_rejected(
+    fixture: &Fixture,
+    path: &Path,
+    expected: RejectionReason,
+    max_file_bytes: u64,
+) {
+    let (file, identity) = WorkspaceSourceRegistry::open_validated(&fixture.workspace_root, path)
+        .expect("open validated before pipeline rejection");
+    let source_asof: DateTime<Utc> = identity
+        .canonical_path
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .expect("source asof")
+        .into();
+    let file_id = file_id_from_identity(&identity, &fixture.workspace_root).expect("file id");
+    let request = IngestRequest {
+        file,
+        identity,
+        file_id,
+        source_asof,
+        source_type: WorkspaceFileKind::EntityDoc,
+        entity: None,
+        mode: IngestionMode::Realtime,
+        category_hint: None,
+        invocation_actor: "user".to_string(),
+        validated_content: None,
+    };
+
+    let clock = SystemClock;
+    let rng = SystemRng;
+    let external = ExternalClients::default();
+    let ctx =
+        ServiceContext::new_live(&clock, &rng, &external).with_actor("system:v146_validation");
+    let db = ActionDb::from_conn(&fixture.conn);
+    let pipeline = IngestPipeline::new(
+        Box::new(NullExtractor),
+        Box::new(WorkspaceSignalEmitter),
+        max_file_bytes,
+        "workspace-validation-null-extractor-v1",
+        fixture.workspace_root.clone(),
+    );
+    let err = pipeline
+        .run(&ctx, db, request)
+        .expect_err("ingest should reject");
+    match err {
+        IngestError::Rejected(reason) => assert_eq!(reason, expected),
+        other => panic!("unexpected ingest error: {other:?}"),
+    }
+}
+
+fn assert_rejection_signal_reasons(conn: &Connection, expected: &[&str]) {
+    let mut stmt = conn
+        .prepare(
+            "SELECT value
+             FROM signal_events
+             WHERE signal_type = 'workspace_file_rejected'",
+        )
+        .expect("signal query");
+    let mut reasons = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("signal rows")
+        .map(|row| {
+            let payload = row.expect("signal payload");
+            assert!(!payload.contains("oversized.md"));
+            assert!(!payload.contains("invalid-utf8.md"));
+            assert!(!payload.contains("nul-content.md"));
+            let value: serde_json::Value =
+                serde_json::from_str(&payload).expect("signal json payload");
+            value["reason_code"]
+                .as_str()
+                .expect("reason_code")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    reasons.sort();
+    let mut expected = expected
+        .iter()
+        .map(|reason| reason.to_string())
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(reasons, expected);
 }
 
 fn count<P>(conn: &Connection, sql: &str, params: P) -> i64

--- a/tests/v146_validation/README.md
+++ b/tests/v146_validation/README.md
@@ -11,7 +11,8 @@ Current status:
 - L0 passed locally on 2026-05-25.
 - W5-A is folded into the active W5 validation PR; backfill and redaction axes have automated green checks on the rebased base.
 - Signal propagation is green on the release-gate branch.
-- Graph-audit and filesystem axes have automated partial evidence, but remain blocked at packet level until their full matrices are covered.
+- Filesystem validation is green for registry-level path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips.
+- Graph-audit has automated partial evidence, but remains blocked at packet level until its full matrix is covered.
 - Full validation remains dependency-gated on the trust-band matrix, actual MCP placement handler execution, and missing lifecycle actions.
 - A blocked axis is not a pass. Interim reports may record `blocked`, but W5-B Done requires all mandatory axes to be green.
 

--- a/tests/v146_validation/run.sh
+++ b/tests/v146_validation/run.sh
@@ -81,11 +81,12 @@ status_for_axis() {
     filesystem)
       if (
         cd "$ROOT_DIR"
-        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation filesystem_validation_negative_fixtures >/dev/null
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation filesystem_validation_negative_fixtures >/dev/null &&
+        cargo test --manifest-path src-tauri/Cargo.toml workspace_backfill_filesystem_negative_matrix_skips_without_writes --lib >/dev/null
       ); then
-        printf 'blocked\tcargo test --test v146_validation filesystem_validation_negative_fixtures\tpartial negative filesystem/path validation fixtures passed; blocked until oversized, non-UTF8, managed/hidden, and unsupported-file matrix is complete\n'
+        printf 'pass\tcargo test --test v146_validation filesystem_validation_negative_fixtures + cargo test workspace_backfill_filesystem_negative_matrix_skips_without_writes --lib\tnegative filesystem/path validation matrix passed for registry, explicit ingestion, and conservative backfill skips\n'
       else
-        printf 'fail\tcargo test --test v146_validation filesystem_validation_negative_fixtures\tnegative filesystem/path validation fixtures failed\n'
+        printf 'fail\tcargo test --test v146_validation filesystem_validation_negative_fixtures + cargo test workspace_backfill_filesystem_negative_matrix_skips_without_writes --lib\tnegative filesystem/path validation matrix failed\n'
       fi
       ;;
     *)


### PR DESCRIPTION
## Linear ticket

DOS-476

## Summary

Completes the W5-B filesystem validation axis by adding negative-path coverage for registry validation, explicit ingestion rejection, and conservative backfill skips. The validation runner now reports the filesystem axis as green only when both filesystem test groups pass.

## What changed

- Reject non-UTF8 path components in `WorkspaceSourceRegistry::open_validated` before canonicalization.
- Expand `src-tauri/tests/v146_validation.rs` to cover registry unsafe path cases plus explicit ingestion size/format rejection without downstream writes.
- Add conservative backfill skip coverage for hidden, managed, generated, unsupported, non-UTF8-content, and oversized files.
- Update `tests/v146_validation/run.sh` and W5 evidence docs so the filesystem axis is green and fail-closed.

## Test plan

- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation filesystem_validation_negative_fixtures` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml workspace_backfill_filesystem_negative_matrix_skips_without_writes --lib` passes
- [x] `bash tests/v146_validation/run.sh filesystem` passes
- [x] `bash tests/v146_validation/run.sh all` remains blocked as expected on graph-audit, trust, contexts, and lifecycle axes
- [x] `bash tests/v146_validation/redaction_lint.sh` passes
- [x] Local L2: passed
- [ ] `pnpm tsc --noEmit` clean (not run; no frontend changes)
- [ ] `pnpm test` passes (not run; no frontend changes)

## Definition of Done

- [x] Acceptance criteria for the filesystem validation axis are validated with real hermetic fixtures
- [x] End-to-end rejection behavior is verified through registry, ingestion, signal, lifecycle, and backfill validation paths
- [x] No stubs, TODOs, or untracked deferrals introduced
- [ ] Full W5-B release gate remains blocked until graph-audit, trust, contexts/MCP handler, and lifecycle axes are green

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: n/a

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Complete the remaining W5-B blocked axes: graph-audit, trust, contexts/MCP handler parity, and lifecycle/source-management actions.

## Notes for review

`cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` currently has unrelated pre-existing needless-borrow warnings in two test files outside this slice; default clippy and lib tests pass.
