### PR TITLE
test: expand W5 graph audit path evidence

### DIFF
--- a/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
+++ b/.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md
@@ -29,6 +29,7 @@ W5-B must not make W5-A historical backfill an implicit claim producer. Claim-pr
 - **V1.3** - Rebased-base readiness refresh. Records that W5-A is folded into the active W5 validation PR, explicit ingestion and graph projection now have partial automated evidence, filesystem negative fixtures have partial automated evidence, and MCP placement/lifecycle/signal-middle-hop gaps remain blocked.
 - **V1.4** - Release-gate branch refresh. Records that the signal middle hop is now present and green: explicit workspace ingestion emits `WorkspaceFileIngested`, emits `EntityIntelligenceUpdated`, and invalidates affected prep through the middle-hop signal.
 - **V1.5** - Filesystem-axis refresh. Records green automated evidence for registry-level unsafe path rejection, explicit ingestion size/format rejection, non-UTF8 path byte-input rejection, and conservative backfill hidden/managed/unsupported skips.
+- **V1.6** - Graph-axis refresh. Records automated entity-seeded and inbox assignment provenance evidence with zero workspace graph audit gaps; keeps MCP placement handler evidence as the remaining Axis 2 blocker.
 
 ---
 
@@ -168,7 +169,7 @@ Read-only prep on 2026-05-25, refreshed after rebasing on merged W4/W5-A substra
 - Source-management action round trip must be validated through a real action path, not render-only ledger reads. Current action substrate exposes `reingest`, `quarantine`, and `relink`; ignore/scratchpad plus archive/delete remain missing and block Axis 6.
 - MCP placement has contract/catalog pieces, but the actual MCP v2 handler path is not fully wired. MCP/headless parity remains blocked until a real MCP/gateway or registered-handler path is exercised.
 - Scratchpad/ignored and archive/delete lifecycle effects are named DOS-476 ACs; missing actions block Axis 6 and W5 release close.
-- Automated explicit-ingestion evidence proves a direct pipeline fixture creates lifecycle, run, link, and `commit_claim` rows with privacy-safe provenance, but Axis 2 remains release-blocked until entity-intake, `_inbox`, and MCP placement path coverage is complete.
+- Automated explicit-ingestion evidence proves direct entity-seeded ingestion and inbox assignment create lifecycle, run, link, and `commit_claim` rows with privacy-safe provenance and zero graph-audit gaps, but Axis 2 remains release-blocked until actual MCP placement handler coverage is complete.
 - Automated signal evidence proves workspace ingestion emits privacy-safe `WorkspaceFileIngested`, emits privacy-safe `EntityIntelligenceUpdated`, and queues prep invalidation through that middle-hop signal. Axis 4 is green on the release-gate branch.
 - Automated filesystem evidence covers traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, non-UTF8 path byte-input rejection, hardlink rejection when supported, explicit ingestion oversized/unsupported-format rejection, and conservative backfill hidden/managed/unsupported skips. Axis 7 is green on the filesystem-validation branch.
 - `WorkspaceExtractor` is intentionally narrow: note-like, linked Account/Project/Person content becomes `UserNote` claim proposals. W5-B fixtures must use that shape for claim-producing automated tests.

--- a/.docs/plans/wave-W5-v146/validation-report.md
+++ b/.docs/plans/wave-W5-v146/validation-report.md
@@ -3,7 +3,7 @@
 **Status:** blocked by upstream dependencies  
 **Issue:** DOS-476  
 **Packet:** `.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md`  
-**Branch:** `codex/v1.4.5-w5-filesystem-validation`
+**Branch:** `codex/v1.4.5-w5-graph-audit-validation`
 
 ## Harness Status
 
@@ -12,7 +12,7 @@
 | `bash tests/v146_validation/redaction_lint.sh --self-test` | pass | Positive and negative lint fixtures behaved as expected. |
 | `bash tests/v146_validation/redaction_lint.sh` | pass | Current report draft is privacy-safe. |
 | `bash tests/v146_validation/run.sh backfill` | pass | W5-A conservative backfill registration tests pass on the rebased base. |
-| `bash tests/v146_validation/run.sh graph-audit` | blocked | Partial explicit ingestion provenance-chain fixture and workspace graph audit projection tests pass; full path matrix remains incomplete. |
+| `bash tests/v146_validation/run.sh graph-audit` | blocked | Entity-seeded and inbox assignment provenance-chain fixtures plus workspace graph audit projection tests pass; actual MCP placement handler path remains incomplete. |
 | `bash tests/v146_validation/run.sh filesystem` | pass | Registry path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips pass with privacy-safe evidence. |
 | `bash tests/v146_validation/run.sh signals` | pass | `WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation` evidence passes with privacy-safe payloads. |
 | `bash tests/v146_validation/run.sh redaction` | pass | Redaction axis is green. |
@@ -25,8 +25,8 @@
 | --- | --- | --- |
 | W5-A backfill registration | green | Folded into active PR #389 after PR #388 closed unmerged; focused backfill and migration coverage pass. |
 | W4 source-management and placement stack | partial | Source-management read/action substrate landed, but the MCP placement handler remains a placeholder. |
-| Graph projection service | partial | Workspace graph projection unit tests pass and explicit ingestion provenance chain has no local gaps for the direct pipeline fixture; full path matrix remains incomplete. |
-| Workspace extractor claim production | partial | Explicit note-like workspace ingestion commits through `commit_claim` with privacy-safe provenance; entity-intake, inbox, and MCP placement path coverage is not complete. |
+| Graph projection service | partial | Workspace graph projection unit tests pass and explicit ingestion provenance chains have zero local graph-audit gaps for direct entity-seeded and inbox assignment fixtures; MCP placement path remains incomplete. |
+| Workspace extractor claim production | partial | Explicit note-like workspace ingestion commits through `commit_claim` with privacy-safe provenance for entity-seeded and inbox assignment paths; MCP placement path coverage is not complete. |
 | Workspace lifecycle signal wiring | green | Explicit ingestion emits `workspace_file_ingested`, emits the `entity_intelligence_updated` middle hop, and invalidates affected prep through the middle-hop signal. |
 | MCP placement path | blocked | Actual MCP/gateway or registered-handler execution is required; catalog presence is not enough. |
 | Source lifecycle actions | partial | Current action contract exposes reingest, quarantine, and relink only; ignore/scratchpad plus archive/delete are missing. |
@@ -36,7 +36,7 @@
 | Axis | Status | Current evidence |
 | --- | --- | --- |
 | Backfill registration safety | green | Focused W5-A backfill service/bin tests plus v268 migration coverage pass on the rebased base. |
-| Explicit ingestion to claim provenance | blocked | `src-tauri/tests/v146_validation.rs` proves direct explicit ingestion creates lifecycle, run, link, and claim rows through service APIs; packet-level path matrix remains blocked on entity-intake, inbox, and MCP placement evidence. |
+| Explicit ingestion to claim provenance | blocked | `src-tauri/tests/v146_validation.rs` proves direct entity-seeded ingestion and inbox assignment create lifecycle, run, link, and claim rows through service APIs with zero graph-audit gaps; packet-level path matrix remains blocked on actual MCP placement handler evidence. |
 | Trust-band discipline | blocked | Full matrix still needs recent, stale, pending-review, and reingest-without-freshness cases through real recompute. |
 | Signal propagation and prep invalidation | green | `src-tauri/tests/v146_validation.rs` proves workspace ingestion emits privacy-safe `workspace_file_ingested`, emits privacy-safe `entity_intelligence_updated`, and queues prep invalidation for the affected meeting. |
 | Context inclusion and MCP/privacy parity | blocked | `dailyos.write.place_document` is cataloged, but the MCP v2 handler is still a placeholder. |

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1012,7 +1012,7 @@ fn assign_inbox_entity_in_db(
                 entity_id: EntityId::new(entity_id.clone()),
                 entity_name: Some(entity_name.clone()),
             }),
-            mode: IngestionMode::Realtime,
+            mode: IngestionMode::EntitySeeded,
             category_hint: None,
             invocation_actor: "user".to_string(),
             validated_content: Some(validated_content),

--- a/src-tauri/src/services/workspace_ingestion/graph.rs
+++ b/src-tauri/src/services/workspace_ingestion/graph.rs
@@ -56,7 +56,7 @@ impl WorkspaceGraphDiagnosticKey {
         Self { bytes }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-harness", debug_assertions))]
     pub(crate) fn for_tests(label: &str) -> Self {
         Self::from_install_secret(label.as_bytes())
     }
@@ -84,6 +84,12 @@ pub fn local_install_diagnostic_key() -> Result<WorkspaceGraphDiagnosticKey, Str
     let bytes = crate::db::local_db_workspace_graph_diagnostic_key_bytes()
         .map_err(|error| format!("diagnostic key unavailable: {error}"))?;
     Ok(WorkspaceGraphDiagnosticKey::from_derived_bytes(bytes))
+}
+
+#[cfg(any(test, feature = "test-harness", debug_assertions))]
+#[doc(hidden)]
+pub fn diagnostic_key_for_tests(label: &str) -> WorkspaceGraphDiagnosticKey {
+    WorkspaceGraphDiagnosticKey::for_tests(label)
 }
 
 #[cfg(test)]

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -3,11 +3,18 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use dailyos_lib::abilities::provenance::source::EntityId;
+use dailyos_lib::abilities::workspace_graph::contracts::{
+    WorkspaceGraphInput, WorkspaceGraphPrivacyProfile, WorkspaceGraphReadRequest,
+    WorkspaceGraphResponse,
+};
 use dailyos_lib::db::{ActionDb, DbAccount};
 use dailyos_lib::entity::EntityType;
 use dailyos_lib::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
 use dailyos_lib::services::workspace_ingestion::contracts::{
     NullExtractor, RejectionReason, WorkspaceFileKind,
+};
+use dailyos_lib::services::workspace_ingestion::graph::{
+    diagnostic_key_for_tests, read_workspace_graph,
 };
 use dailyos_lib::services::workspace_ingestion::pipeline::{
     file_id_from_identity, EntityRef, IngestError, IngestPipeline, IngestReceipt, IngestRequest,
@@ -135,6 +142,147 @@ fn graph_audit_zero_gaps_on_hermetic_fixture_db() {
     assert!(!serialized_provenance.contains("Graph Account"));
     assert!(!serialized_provenance.contains("graph-note.md"));
     assert!(!serialized_provenance.contains("Graph validation context"));
+
+    assert_graph_zero_gaps_for_entity(
+        &fixture,
+        "account",
+        "acct-v146-graph",
+        1,
+        1,
+        &[
+            &receipt.file_id,
+            "Graph Account",
+            "graph-note.md",
+            "Graph validation context",
+        ],
+    );
+}
+
+#[test]
+fn explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment() {
+    let fixture = Fixture::new();
+    fixture.seed_account("acct-v146-paths", "Path Matrix Account");
+
+    let entity_seeded_note = fixture.write_account_file(
+        "Path Matrix Account",
+        "entity-seeded-note.md",
+        "Entity seeded graph validation note.",
+    );
+    let entity_seeded = fixture.ingest_account_note_with_mode(
+        &entity_seeded_note,
+        EntityRef {
+            entity_type: EntityType::Account,
+            entity_id: EntityId::new("acct-v146-paths".to_string()),
+            entity_name: Some("Path Matrix Account".to_string()),
+        },
+        IngestionMode::EntitySeeded,
+        None,
+    );
+    assert_eq!(entity_seeded.claim_proposals.len(), 1);
+    assert_workspace_claim(
+        &fixture.conn,
+        &entity_seeded.file_id,
+        "acct-v146-paths",
+        "workspace_file:entity_doc",
+        "entity_doc",
+    );
+    assert_eq!(
+        count(
+            &fixture.conn,
+            "SELECT COUNT(*)
+             FROM document_ingestion_runs
+             WHERE run_id = ?1
+               AND mode = 'entity_seeded'
+               AND status = 'success'
+               AND claim_count_produced = 1",
+            params![&entity_seeded.ingestion_run_id.0],
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &fixture.conn,
+            "SELECT COUNT(*)
+             FROM document_entity_links
+             WHERE file_id = ?1
+               AND attribution_source = 'entity_intake'
+               AND rejected = 0",
+            params![&entity_seeded.file_id],
+        ),
+        1
+    );
+
+    let inbox_note = fixture.write_inbox_file(
+        "assigned-note.md",
+        "Inbox assignment graph validation note.",
+    );
+    let process_result = dailyos_lib::command_test_api::process_inbox_file_for_tests(
+        ActionDb::from_conn(&fixture.conn),
+        &fixture.workspace_root,
+        "assigned-note.md",
+    )
+    .expect("process inbox");
+    assert_eq!(process_result["status"], "needs_entity");
+
+    let inbox_file_id = file_id_for_path(&fixture.workspace_root, &inbox_note);
+    let inbox_receipt = dailyos_lib::command_test_api::assign_inbox_entity_for_tests(
+        ActionDb::from_conn(&fixture.conn),
+        &fixture.workspace_root,
+        inbox_file_id.clone(),
+        "account".to_string(),
+        "acct-v146-paths".to_string(),
+        "path-matrix-account".to_string(),
+        "inbox".to_string(),
+    )
+    .expect("assign inbox entity");
+    assert_eq!(inbox_receipt.file_id, inbox_file_id);
+    assert_eq!(inbox_receipt.lifecycle_state_after, "ingested");
+    assert_workspace_claim(
+        &fixture.conn,
+        &inbox_receipt.file_id,
+        "acct-v146-paths",
+        "workspace_file:inbox",
+        "inbox",
+    );
+    assert_eq!(
+        count(
+            &fixture.conn,
+            "SELECT COUNT(*)
+             FROM document_entity_links
+             WHERE file_id = ?1
+               AND attribution_source = 'user_relink'
+               AND rejected = 0",
+            params![&inbox_receipt.file_id],
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &fixture.conn,
+            "SELECT COUNT(*)
+             FROM intelligence_claims
+             WHERE subject_ref LIKE '%acct-v146-paths%'",
+            [],
+        ),
+        2
+    );
+
+    assert_graph_zero_gaps_for_entity(
+        &fixture,
+        "account",
+        "acct-v146-paths",
+        2,
+        2,
+        &[
+            &entity_seeded.file_id,
+            &inbox_receipt.file_id,
+            "Path Matrix Account",
+            "entity-seeded-note.md",
+            "assigned-note.md",
+            "Entity seeded graph validation note",
+            "Inbox assignment graph validation note",
+        ],
+    );
 }
 
 #[test]
@@ -457,10 +605,28 @@ impl Fixture {
         path
     }
 
+    fn write_inbox_file(&self, filename: &str, content: &str) -> PathBuf {
+        let dir = self.workspace_root.join("_inbox");
+        std::fs::create_dir_all(&dir).expect("inbox dir");
+        let path = dir.join(filename);
+        std::fs::write(&path, content).expect("write inbox note");
+        path
+    }
+
     fn ingest_account_note(
         &self,
         path: &Path,
         entity: EntityRef,
+        prep_queue: Option<Arc<Mutex<Vec<String>>>>,
+    ) -> IngestReceipt {
+        self.ingest_account_note_with_mode(path, entity, IngestionMode::Realtime, prep_queue)
+    }
+
+    fn ingest_account_note_with_mode(
+        &self,
+        path: &Path,
+        entity: EntityRef,
+        mode: IngestionMode,
         prep_queue: Option<Arc<Mutex<Vec<String>>>>,
     ) -> IngestReceipt {
         let (file, identity) = WorkspaceSourceRegistry::open_validated(&self.workspace_root, path)
@@ -479,7 +645,7 @@ impl Fixture {
             source_asof,
             source_type: WorkspaceFileKind::EntityDoc,
             entity: Some(entity),
-            mode: IngestionMode::Realtime,
+            mode,
             category_hint: None,
             invocation_actor: "user".to_string(),
             validated_content: None,
@@ -500,6 +666,113 @@ impl Fixture {
             .run_with_signal_engine(&ctx, db, &signal_engine, request)
             .expect("ingest succeeds")
     }
+}
+
+fn assert_workspace_claim(
+    conn: &Connection,
+    file_id: &str,
+    entity_id: &str,
+    expected_data_source: &str,
+    expected_kind: &str,
+) {
+    let source_ref = format!("workspace_file:{file_id}");
+    let claim = conn
+        .query_row(
+            "SELECT subject_ref, data_source, source_ref, source_asof,
+                    provenance_json, metadata_json, sensitivity
+             FROM intelligence_claims
+             WHERE source_ref = ?1",
+            [&source_ref],
+            |row| {
+                Ok(ClaimRow {
+                    subject_ref: row.get(0)?,
+                    data_source: row.get(1)?,
+                    source_ref: row.get(2)?,
+                    source_asof: row.get(3)?,
+                    provenance_json: row.get(4)?,
+                    metadata_json: row.get(5)?,
+                    sensitivity: row.get(6)?,
+                })
+            },
+        )
+        .expect("workspace claim row");
+    let subject_ref: serde_json::Value =
+        serde_json::from_str(&claim.subject_ref).expect("subject_ref json");
+    assert_eq!(subject_ref["kind"], "account");
+    assert_eq!(subject_ref["id"], entity_id);
+    assert_eq!(claim.data_source, expected_data_source);
+    assert_eq!(claim.source_ref, source_ref);
+    assert!(!claim.source_asof.trim().is_empty());
+    assert_eq!(claim.sensitivity, "user_only");
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(&claim.metadata_json).expect("metadata json");
+    assert_eq!(metadata["producer"], "workspace_ingestion");
+    assert_eq!(metadata["workspace_file_id"], file_id);
+    assert_eq!(metadata["workspace_file_kind"], expected_kind);
+    assert!(metadata["ingestion_run_id"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert!(metadata["document_entity_link_id"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+}
+
+fn assert_graph_zero_gaps_for_entity(
+    fixture: &Fixture,
+    entity_type: &str,
+    entity_id: &str,
+    expected_file_links: usize,
+    expected_claim_total: u32,
+    forbidden_fragments: &[&str],
+) {
+    let response = read_workspace_graph(
+        &fixture.conn,
+        WorkspaceGraphReadRequest {
+            input: WorkspaceGraphInput {
+                schema_version: 1,
+                entity_filter: None,
+                category_filter: None,
+                cursor: None,
+                if_none_match: None,
+                include_entity_names: false,
+                page_size: 50,
+            },
+            privacy_profile: WorkspaceGraphPrivacyProfile::FirstParty,
+        },
+        &diagnostic_key_for_tests("v146-graph-audit"),
+    )
+    .expect("workspace graph read");
+    let WorkspaceGraphResponse::Projection(projection) = response else {
+        panic!("expected workspace graph projection");
+    };
+    assert!(
+        projection.audit.gaps.is_empty(),
+        "workspace graph audit gaps: {:?}",
+        projection.audit.gaps
+    );
+    let entity = projection
+        .projection
+        .entities
+        .iter()
+        .find(|entity| entity.entity_type == entity_type && entity.entity_id == entity_id)
+        .expect("graph entity");
+    assert_eq!(entity.file_links.len(), expected_file_links);
+    assert_eq!(entity.claim_summary.total, expected_claim_total);
+
+    let serialized = serde_json::to_string(&projection).expect("projection json");
+    for fragment in forbidden_fragments {
+        assert!(
+            !serialized.contains(fragment),
+            "graph projection should not leak raw fixture fragment `{fragment}`"
+        );
+    }
+}
+
+fn file_id_for_path(workspace_root: &Path, path: &Path) -> String {
+    let (_file, identity) =
+        WorkspaceSourceRegistry::open_validated(workspace_root, path).expect("open validated");
+    file_id_from_identity(&identity, workspace_root).expect("file id")
 }
 
 fn assert_rejected(workspace_root: &Path, path: &Path, expected: RejectionReason) {

--- a/tests/v146_validation/README.md
+++ b/tests/v146_validation/README.md
@@ -12,7 +12,7 @@ Current status:
 - W5-A is folded into the active W5 validation PR; backfill and redaction axes have automated green checks on the rebased base.
 - Signal propagation is green on the release-gate branch.
 - Filesystem validation is green for registry-level path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips.
-- Graph-audit has automated partial evidence, but remains blocked at packet level until its full matrix is covered.
+- Graph-audit has automated entity-seeded and inbox assignment evidence, but remains blocked at packet level until the actual MCP placement handler path is covered.
 - Full validation remains dependency-gated on the trust-band matrix, actual MCP placement handler execution, and missing lifecycle actions.
 - A blocked axis is not a pass. Interim reports may record `blocked`, but W5-B Done requires all mandatory axes to be green.
 

--- a/tests/v146_validation/run.sh
+++ b/tests/v146_validation/run.sh
@@ -51,12 +51,13 @@ status_for_axis() {
     graph-audit)
       if (
         cd "$ROOT_DIR"
-        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db >/dev/null
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db >/dev/null &&
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment >/dev/null &&
         cargo test --manifest-path src-tauri/Cargo.toml --lib workspace_ingestion::graph::tests >/dev/null
       ); then
-        printf 'blocked\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + cargo test --lib workspace_ingestion::graph::tests\tpartial explicit ingestion and graph audit evidence passed; blocked until entity-intake, inbox, and MCP placement path matrix is complete\n'
+        printf 'blocked\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + cargo test --lib workspace_ingestion::graph::tests\tentity-seeded and inbox graph audit evidence passed; blocked until actual MCP placement handler path is complete\n'
       else
-        printf 'fail\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + cargo test --lib workspace_ingestion::graph::tests\texplicit ingestion provenance chain or graph audit projection tests failed\n'
+        printf 'fail\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + cargo test --lib workspace_ingestion::graph::tests\texplicit ingestion provenance chain or graph audit projection tests failed\n'
       fi
       ;;
     trust)


### PR DESCRIPTION
## Linear ticket

DOS-476

## Summary

Expands W5 graph-audit validation to cover real entity-seeded ingestion and inbox assignment claim provenance, while keeping the W5 gate blocked on the remaining MCP placement path.

## What changed

- Corrected inbox entity assignment reruns to use `IngestionMode::EntitySeeded` so assignment can produce claims after realtime inbox staging.
- Added graph-audit validation for entity-seeded notes and assigned inbox files, including claim provenance, active file links, and privacy-safe projection assertions.
- Exposed a debug/test-harness diagnostic key helper for integration tests only.
- Updated W5 validation docs and the `graph-audit` runner to include the new evidence while preserving the blocked gate status.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --test v146_validation -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test workspace_ingestion_w2d_assign_inbox_entity -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test workspace_ingestion_w2d_assign_inbox_entity_transaction_rollback -- --nocapture`
- [x] `bash tests/v146_validation/run.sh graph-audit` exits blocked after passing graph-audit checks, pending MCP placement work
- [x] `bash tests/v146_validation/run.sh all` exits blocked with expected remaining W5 blockers
- [x] `bash tests/v146_validation/redaction_lint.sh`
- [x] Local L2: `codex review --uncommitted`
- [x] Security review: focused Codex CSO/security pass on `public/dev...HEAD`
- [ ] `pnpm tsc --noEmit` clean, not run for this Rust/doc-only slice
- [ ] `pnpm test` passes, not run for this Rust/doc-only slice

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data for this graph-audit slice
- [ ] End-to-end flow works through to rendered surfaces, still blocked on actual MCP placement path and broader W5 gates
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced; remaining W5 blockers are already tracked in DOS-476 validation docs
- [ ] Full release-gate suite remains blocked by known W5 axes; this PR preserves that status

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: N/A. Security review was invoked because this touches `src-tauri/src/services/` and `src-tauri/src/commands/`.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Complete actual MCP placement handler validation before marking W5 graph-audit/context parity green.
- Continue the remaining W5 release-gate axes: trust recompute matrix, context/MCP privacy parity, source-management lifecycle actions, and final all-green wrapper.

## Notes for review

This PR intentionally keeps `tests/v146_validation/run.sh graph-audit` returning the blocked sentinel after the new evidence passes. The point is to close entity-seeded and inbox assignment graph evidence without pretending MCP placement is done.
