### PR TITLE
Wire MCP workspace placement handler

### DIFF
--- a/.docs/plans/wave-W5-v146/validation-report.md
+++ b/.docs/plans/wave-W5-v146/validation-report.md
@@ -3,7 +3,7 @@
 **Status:** blocked by upstream dependencies  
 **Issue:** DOS-476  
 **Packet:** `.docs/plans/v1.4.5-workspace-memory/L0-packet-W5-B-DOS-476.md`  
-**Branch:** `codex/v1.4.5-w5-graph-audit-validation`
+**Branch:** `codex/v1.4.5-w5-mcp-placement-validation`
 
 ## Harness Status
 
@@ -12,7 +12,7 @@
 | `bash tests/v146_validation/redaction_lint.sh --self-test` | pass | Positive and negative lint fixtures behaved as expected. |
 | `bash tests/v146_validation/redaction_lint.sh` | pass | Current report draft is privacy-safe. |
 | `bash tests/v146_validation/run.sh backfill` | pass | W5-A conservative backfill registration tests pass on the rebased base. |
-| `bash tests/v146_validation/run.sh graph-audit` | blocked | Entity-seeded and inbox assignment provenance-chain fixtures plus workspace graph audit projection tests pass; actual MCP placement handler path remains incomplete. |
+| `bash tests/v146_validation/run.sh graph-audit` | blocked | Entity-seeded and inbox assignment provenance-chain fixtures, workspace graph audit projection tests, and MCP placement handler registration evidence pass; successful MCP placement-to-claim fixture remains incomplete. |
 | `bash tests/v146_validation/run.sh filesystem` | pass | Registry path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips pass with privacy-safe evidence. |
 | `bash tests/v146_validation/run.sh signals` | pass | `WorkspaceFileIngested -> EntityIntelligenceUpdated -> prep invalidation` evidence passes with privacy-safe payloads. |
 | `bash tests/v146_validation/run.sh redaction` | pass | Redaction axis is green. |
@@ -24,11 +24,11 @@
 | Dependency | Status | Evidence |
 | --- | --- | --- |
 | W5-A backfill registration | green | Folded into active PR #389 after PR #388 closed unmerged; focused backfill and migration coverage pass. |
-| W4 source-management and placement stack | partial | Source-management read/action substrate landed, but the MCP placement handler remains a placeholder. |
-| Graph projection service | partial | Workspace graph projection unit tests pass and explicit ingestion provenance chains have zero local graph-audit gaps for direct entity-seeded and inbox assignment fixtures; MCP placement path remains incomplete. |
-| Workspace extractor claim production | partial | Explicit note-like workspace ingestion commits through `commit_claim` with privacy-safe provenance for entity-seeded and inbox assignment paths; MCP placement path coverage is not complete. |
+| W4 source-management and placement stack | partial | Source-management read/action substrate landed; MCP placement now has a registered v2 handler path, but successful placement fixture coverage remains incomplete. |
+| Graph projection service | partial | Workspace graph projection unit tests pass and explicit ingestion provenance chains have zero local graph-audit gaps for direct entity-seeded and inbox assignment fixtures; successful MCP placement graph evidence remains incomplete. |
+| Workspace extractor claim production | partial | Explicit note-like workspace ingestion commits through `commit_claim` with privacy-safe provenance for entity-seeded and inbox assignment paths; successful MCP placement-to-claim coverage is not complete. |
 | Workspace lifecycle signal wiring | green | Explicit ingestion emits `workspace_file_ingested`, emits the `entity_intelligence_updated` middle hop, and invalidates affected prep through the middle-hop signal. |
-| MCP placement path | blocked | Actual MCP/gateway or registered-handler execution is required; catalog presence is not enough. |
+| MCP placement path | partial | Registered-handler/gateway scope-denial execution is now covered; successful MCP placement execution through the live workspace intake path still needs a hermetic fixture. |
 | Source lifecycle actions | partial | Current action contract exposes reingest, quarantine, and relink only; ignore/scratchpad plus archive/delete are missing. |
 
 ## Evidence Matrix
@@ -36,10 +36,10 @@
 | Axis | Status | Current evidence |
 | --- | --- | --- |
 | Backfill registration safety | green | Focused W5-A backfill service/bin tests plus v268 migration coverage pass on the rebased base. |
-| Explicit ingestion to claim provenance | blocked | `src-tauri/tests/v146_validation.rs` proves direct entity-seeded ingestion and inbox assignment create lifecycle, run, link, and claim rows through service APIs with zero graph-audit gaps; packet-level path matrix remains blocked on actual MCP placement handler evidence. |
+| Explicit ingestion to claim provenance | blocked | `src-tauri/tests/v146_validation.rs` proves direct entity-seeded ingestion and inbox assignment create lifecycle, run, link, and claim rows through service APIs with zero graph-audit gaps; the MCP placement handler is registered, but the packet-level path matrix remains blocked on successful placement-to-claim fixture evidence. |
 | Trust-band discipline | blocked | Full matrix still needs recent, stale, pending-review, and reingest-without-freshness cases through real recompute. |
 | Signal propagation and prep invalidation | green | `src-tauri/tests/v146_validation.rs` proves workspace ingestion emits privacy-safe `workspace_file_ingested`, emits privacy-safe `entity_intelligence_updated`, and queues prep invalidation for the affected meeting. |
-| Context inclusion and MCP/privacy parity | blocked | `dailyos.write.place_document` is cataloged, but the MCP v2 handler is still a placeholder. |
+| Context inclusion and MCP/privacy parity | blocked | `dailyos.write.place_document` now has a registered MCP v2 handler and privacy-safe receipt metadata rendering, but full Tauri/MCP context parity and sensitivity sweep remain unimplemented. |
 | Lifecycle actions and user correction | blocked | Source-management action contract currently exposes only reingest, quarantine, and relink; ignore/scratchpad and archive/delete remain unavailable. |
 | Filesystem validation negative fixtures | green | Rust negative fixtures cover traversal, encoded traversal, outside absolute paths, workspace root equality, symlink escape, NUL input, non-UTF8 path byte-input rejection, hardlink rejection when supported, explicit ingestion oversized/unsupported-format rejection, and conservative backfill hidden/managed/unsupported skips. |
 | Redaction lint | green | Self-test and current report scan passed. |

--- a/src-tauri/src/mcp/main.rs
+++ b/src-tauri/src/mcp/main.rs
@@ -1695,8 +1695,14 @@ async fn run_v2_server() -> anyhow::Result<()> {
 
     let mut gateway = Gateway::new();
     gateway.set_taxonomy(Arc::clone(&catalog));
-    register_v147_handlers(&mut gateway, &catalog, tokio::runtime::Handle::current())
-        .map_err(|e| anyhow::anyhow!("Failed to register MCP v2 handlers: {e}"))?;
+    let signal_engine = Arc::new(dailyos_lib::signals::propagation::default_engine());
+    register_v147_handlers(
+        &mut gateway,
+        &catalog,
+        tokio::runtime::Handle::current(),
+        signal_engine,
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to register MCP v2 handlers: {e}"))?;
 
     let registered_tools: Vec<ScopedName> = gateway.registered_tools().cloned().collect();
     let pending_catalog_tools = gateway

--- a/src-tauri/src/services/mcp_v2/handlers/registration.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/registration.rs
@@ -8,8 +8,10 @@ use std::sync::Arc;
 use crate::services::mcp_v2::contracts::ScopedName;
 use crate::services::mcp_v2::gateway::Gateway;
 use crate::services::mcp_v2::taxonomy::TaxonomyCatalog;
+use crate::signals::propagation::PropagationEngine;
 
 use super::tool_account_status::AccountStatusHandler;
+use super::tool_placement::PlacementHandler;
 
 /// Errors registering wave-scoped handlers at boot.
 #[derive(Debug)]
@@ -38,12 +40,15 @@ impl std::error::Error for RegistrationError {}
 
 /// Register all v1.4.7 W2-A Phase-A handlers on the gateway.
 ///
-/// Cycle-1 scope: `dailyos.read.account_status` only. Phase-B (daily_briefing)
-/// adds its handler via this same helper once its sub-ticket lands.
+/// Current registered scope includes the account status read tool plus the
+/// v1.4.5 workspace placement write tool once its placement substrate is
+/// present on the rebased base. Phase-B (daily_briefing) adds its handler via
+/// this same helper once its sub-ticket lands.
 pub fn register_v147_handlers(
     gateway: &mut Gateway,
     catalog: &Arc<dyn TaxonomyCatalog>,
     runtime: tokio::runtime::Handle,
+    signal_engine: Arc<PropagationEngine>,
 ) -> Result<(), RegistrationError> {
     let account_status_name = ScopedName::new("dailyos.read.account_status");
     let description = catalog
@@ -51,9 +56,57 @@ pub fn register_v147_handlers(
         .ok_or_else(|| RegistrationError::CatalogEntryMissing(account_status_name.clone()))?
         .clone();
 
-    let handler = AccountStatusHandler::from_runtime(description, runtime)
+    let handler = AccountStatusHandler::from_runtime(description, runtime.clone())
+        .map_err(RegistrationError::AbilityRegistry)?;
+    gateway.register(Arc::new(handler));
+
+    let placement_name = ScopedName::new("dailyos.write.place_document");
+    let description = catalog
+        .description_for(&placement_name)
+        .ok_or_else(|| RegistrationError::CatalogEntryMissing(placement_name.clone()))?
+        .clone();
+
+    let handler = PlacementHandler::from_runtime(description, runtime, Arc::clone(&signal_engine))
         .map_err(RegistrationError::AbilityRegistry)?;
     gateway.register(Arc::new(handler));
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::services::mcp_v2::contracts::ScopedName;
+    use crate::services::mcp_v2::gateway::Gateway;
+    use crate::services::mcp_v2::taxonomy::{TaxonomyCatalog, YamlTaxonomyCatalog};
+    use crate::signals::propagation::default_engine;
+
+    use super::*;
+
+    #[test]
+    fn registers_workspace_placement_handler_from_catalog() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        let catalog: Arc<dyn TaxonomyCatalog> =
+            Arc::new(YamlTaxonomyCatalog::load_embedded().expect("catalog"));
+        let mut gateway = Gateway::new();
+        gateway.set_taxonomy(Arc::clone(&catalog));
+
+        register_v147_handlers(
+            &mut gateway,
+            &catalog,
+            runtime.handle().clone(),
+            Arc::new(default_engine()),
+        )
+        .expect("register handlers");
+
+        let registered = gateway.registered_tools().cloned().collect::<Vec<_>>();
+        assert!(registered.contains(&ScopedName::new("dailyos.read.account_status")));
+        assert!(registered.contains(&ScopedName::new("dailyos.write.place_document")));
+        let pending = gateway.seal().expect("registered handlers match catalog");
+        assert!(
+            !pending.contains(&ScopedName::new("dailyos.write.place_document")),
+            "placement handler should no longer be a catalog-only placeholder"
+        );
+    }
 }

--- a/src-tauri/src/services/mcp_v2/handlers/tool_placement.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_placement.rs
@@ -1,1 +1,390 @@
-//! Placeholder. Handler implementation pending.
+//! `dailyos.write.place_document` MCP tool handler.
+//!
+//! Wraps the claim-producing `workspace_place_document` ability from
+//! `abilities-runtime`. The handler stays at the v2 MCP bridge edge:
+//! gateway/auth/rate-limit semantics remain owned by `gateway.rs`, while
+//! workspace mutation behavior remains owned by `WorkspaceIntakeService`.
+//! Sync `McpToolHandler::invoke` is called from within
+//! `tokio::task::spawn_blocking` at the transport boundary, so
+//! `runtime.block_on(...)` on a captured handle is safe.
+
+use std::sync::Arc;
+
+use abilities_runtime::abilities::registry::{AbilityRegistry, McpExposure};
+use abilities_runtime::abilities::tracer::NOOP_ABILITY_TRACER;
+use abilities_runtime::services::workspace_intake::WORKSPACE_PLACE_DOCUMENT_TOOL_NAME;
+use serde_json::Value;
+
+use crate::bridges::types::{
+    invoke_registry_json_for_actor, AbilityInvokeError, BridgeSurfaceError,
+    RequestScopedInvocation, BRIDGE_NOOP_INTELLIGENCE_PROVIDER,
+};
+use crate::bridges::{BridgeActor, BridgeSurface};
+use crate::services::context::{
+    attach_live_workspace_readers_with_signal_engine, ClaimDismissalSurface, ExternalClients,
+    ServiceContext, SystemClock, SystemRng,
+};
+use crate::services::mcp_v2::actor_policy::{project_actor, ToolGrant, ToolRateLimit};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::signals::propagation::PropagationEngine;
+
+const ABILITY_NAME: &str = "workspace_place_document";
+const TOOL_NAME: &str = WORKSPACE_PLACE_DOCUMENT_TOOL_NAME;
+const ACTOR_LABEL: &str = concat!("agent:dailyos-mcp-v2:", env!("CARGO_PKG_VERSION"));
+
+pub struct PlacementHandler {
+    description: ToolDescription,
+    registry: &'static AbilityRegistry,
+    runtime: tokio::runtime::Handle,
+    signal_engine: Arc<PropagationEngine>,
+}
+
+impl PlacementHandler {
+    pub fn new(
+        description: ToolDescription,
+        registry: &'static AbilityRegistry,
+        runtime: tokio::runtime::Handle,
+        signal_engine: Arc<PropagationEngine>,
+    ) -> Self {
+        Self {
+            description,
+            registry,
+            runtime,
+            signal_engine,
+        }
+    }
+
+    pub fn from_runtime(
+        description: ToolDescription,
+        runtime: tokio::runtime::Handle,
+        signal_engine: Arc<PropagationEngine>,
+    ) -> Result<Self, &'static str> {
+        let registry = AbilityRegistry::global_checked()
+            .map_err(|_| "ability registry violations present at startup")?;
+        Ok(Self::new(description, registry, runtime, signal_engine))
+    }
+
+    fn invoke_with_services(
+        &self,
+        actor: &McpActor,
+        params: Value,
+        services: &ServiceContext<'_>,
+    ) -> Result<Value, ToolError> {
+        let McpActor::Client {
+            client_id,
+            conversation_handle,
+            tool_name,
+            granted_scopes,
+        } = actor;
+
+        let synthetic_grant = ToolGrant {
+            tool_name: tool_name.clone(),
+            scopes_granted: granted_scopes.clone(),
+            exposure: McpExposure::Invocable,
+            rate_limit: ToolRateLimit {
+                max_calls: 0,
+                window_seconds: 0,
+            },
+        };
+        let runtime_actor =
+            project_actor(client_id, &synthetic_grant, conversation_handle.as_ref());
+
+        self.runtime.block_on(async {
+            let invocation = RequestScopedInvocation {
+                registry_actor: runtime_actor,
+                response_actor: BridgeActor::McpClient,
+                surface: BridgeSurface::McpTool,
+                claim_dismissal_surface: ClaimDismissalSurface::McpTool,
+                dry_run: false,
+                confirmation: None,
+                confirmation_store: None,
+            };
+            let response = invoke_registry_json_for_actor(
+                self.registry,
+                services,
+                &BRIDGE_NOOP_INTELLIGENCE_PROVIDER,
+                &NOOP_ABILITY_TRACER,
+                invocation,
+                ABILITY_NAME,
+                params,
+            )
+            .await
+            .map_err(map_invoke_error)?;
+
+            Ok(mcp_safe_response(response.data))
+        })
+    }
+}
+
+impl McpToolHandler for PlacementHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(&self, actor: &McpActor, params: Value) -> Result<Value, ToolError> {
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let services = attach_live_workspace_readers_with_signal_engine(
+            ServiceContext::new_live(&clock, &rng, &external).with_actor(ACTOR_LABEL),
+            Some(Arc::clone(&self.signal_engine)),
+        );
+        self.invoke_with_services(actor, params, &services)
+    }
+}
+
+fn mcp_safe_response(mut value: Value) -> Value {
+    if let Value::Object(object) = &mut value {
+        object.insert("resolved_path".to_string(), Value::Null);
+        object.insert("resolvedPath".to_string(), Value::Null);
+    }
+    value
+}
+
+fn map_invoke_error(err: AbilityInvokeError) -> ToolError {
+    eprintln!("mcp_v2 {TOOL_NAME} invoke failed: {err:?}");
+
+    match err {
+        AbilityInvokeError::Surface(BridgeSurfaceError::InputSchemaInvalid)
+        | AbilityInvokeError::Surface(BridgeSurfaceError::InputReservedField)
+        | AbilityInvokeError::Surface(BridgeSurfaceError::Validation(_)) => ToolError::BadParams {
+            detail: "workspace placement request failed bridge validation".to_string(),
+        },
+        AbilityInvokeError::Surface(BridgeSurfaceError::ProducerUnavailable) => {
+            ToolError::UpstreamFailure {
+                detail: "workspace placement service unavailable".to_string(),
+            }
+        }
+        AbilityInvokeError::Ability(error) => map_placement_ability_error(&error.message),
+        AbilityInvokeError::InvalidEnvelope => ToolError::Internal {
+            trace_id: "invalid_envelope".to_string(),
+        },
+        AbilityInvokeError::ProvenanceTooLarge => ToolError::Internal {
+            trace_id: "provenance_too_large".to_string(),
+        },
+        AbilityInvokeError::ProvenanceSerialize(_) => ToolError::Internal {
+            trace_id: "provenance_serialize".to_string(),
+        },
+        AbilityInvokeError::Surface(_) => ToolError::Internal {
+            trace_id: "bridge_surface".to_string(),
+        },
+    }
+}
+
+fn map_placement_ability_error(message: &str) -> ToolError {
+    let placement_error = serde_json::from_str::<Value>(message).ok();
+    let code = placement_error
+        .as_ref()
+        .and_then(|error| error.get("code"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    match code {
+        "rate_limited" => ToolError::RateLimited {
+            retry_after_seconds: placement_error
+                .as_ref()
+                .and_then(|error| error.get("retry_after_seconds"))
+                .and_then(Value::as_u64)
+                .and_then(|seconds| u32::try_from(seconds).ok())
+                .unwrap_or(60),
+        },
+        "target_not_found_or_unauthorized" | "entity_not_routable" => ToolError::NotFound {
+            resource: "placement_target".to_string(),
+        },
+        "invalid_request_shape"
+        | "invalid_entity_type"
+        | "invalid_entity_id"
+        | "invalid_category"
+        | "category_not_allowed"
+        | "invalid_content_encoding"
+        | "invalid_content_type"
+        | "content_too_large"
+        | "invalid_filename_hint"
+        | "invalid_client_dedup_key"
+        | "unsupported_schema_version"
+        | "idempotency_in_progress"
+        | "previous_attempt_failed"
+        | "placement_path_rejected" => ToolError::BadParams {
+            detail: format!("workspace placement failed with code {code}"),
+        },
+        "ingestion_failed" => ToolError::UpstreamFailure {
+            detail: "workspace placement ingestion failed".to_string(),
+        },
+        "placement_internal" => ToolError::Internal {
+            trace_id: placement_error
+                .as_ref()
+                .and_then(|error| error.get("trace_id"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| "workspace_placement_internal".to_string()),
+        },
+        _ => ToolError::Internal {
+            trace_id: "workspace_placement_ability".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use abilities_runtime::services::workspace_intake::{
+        PlacementError, PlacementErrorCode, PlacementInvocationContext, WorkspaceIntakeError,
+        WorkspaceIntakeReceipt, WorkspaceIntakeRequest, WorkspaceIntakeService,
+        WorkspacePlaceDocumentReceipt, WorkspacePlaceDocumentRequest,
+        WorkspacePlacementMutationCursor,
+    };
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use super::*;
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, Scope, ScopedName, Side,
+    };
+
+    struct StubWorkspaceIntake;
+
+    #[async_trait]
+    impl WorkspaceIntakeService for StubWorkspaceIntake {
+        async fn ingest(
+            &self,
+            _ctx: &abilities_runtime::abilities::registry::AbilityContext<'_>,
+            _request: WorkspaceIntakeRequest,
+        ) -> Result<WorkspaceIntakeReceipt, WorkspaceIntakeError> {
+            Err(WorkspaceIntakeError::DbError(
+                "stub does not implement ingest".to_string(),
+            ))
+        }
+
+        async fn place_document(
+            &self,
+            _ctx: &abilities_runtime::abilities::registry::AbilityContext<'_>,
+            _invocation: PlacementInvocationContext,
+            request: WorkspacePlaceDocumentRequest,
+        ) -> Result<WorkspacePlaceDocumentReceipt, PlacementError> {
+            Ok(WorkspacePlaceDocumentReceipt {
+                schema_version: 1,
+                document_handle: Some("document_opaque".to_string()),
+                source_handle: Some("source_opaque".to_string()),
+                entity_type: request.entity.entity_type,
+                entity_id: request.entity.entity_id,
+                category: request.category,
+                workspace_file_kind: "mcp_placement".to_string(),
+                source_asof: Some("2026-05-26T00:00:00.000Z".to_string()),
+                lifecycle_state: "ingested".to_string(),
+                claim_count_produced: 1,
+                idempotent_replay: false,
+                dry_run: false,
+                resolved_path: Some("Accounts/example/private-note.md".to_string()),
+                mutation_cursor: WorkspacePlacementMutationCursor::WorkspacePlacement {
+                    document_handle: "document_opaque".to_string(),
+                    source_handle: "source_opaque".to_string(),
+                    idempotency_id: "placement_opaque".to_string(),
+                },
+            })
+        }
+    }
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new(TOOL_NAME),
+            summary: "place document".to_string(),
+            when_to_call: "when placing a document".to_string(),
+            when_not_to_call: "when uploading elsewhere".to_string(),
+            side: Side::Write,
+            parameters: vec![],
+            returns: crate::services::mcp_v2::contracts::ReturnSpec {
+                schema: crate::services::mcp_v2::contracts::ParamSchema(json!({})),
+                description: "receipt".to_string(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("write.workspace_place_document")],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("test-client"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv")),
+            tool_name: ScopedName::new(TOOL_NAME),
+            granted_scopes: vec![Scope::new("write.workspace_place_document")],
+        }
+    }
+
+    fn placement_params() -> Value {
+        json!({
+            "schema_version": 1,
+            "entity": {
+                "entity_type": "account",
+                "entity_id": "acct_opaque"
+            },
+            "content_b64": "aGVsbG8=",
+            "content_type": "text/markdown",
+            "category": "notes",
+            "dry_run": false
+        })
+    }
+
+    #[test]
+    fn placement_handler_invokes_ability_and_scrubs_paths() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        let handler = PlacementHandler::new(
+            description(),
+            AbilityRegistry::global_checked().expect("registry"),
+            runtime.handle().clone(),
+            Arc::new(PropagationEngine::new()),
+        );
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let services = ServiceContext::new_live(&clock, &rng, &external)
+            .with_workspace_intake(Arc::new(StubWorkspaceIntake));
+
+        let result = handler
+            .invoke_with_services(&actor(), placement_params(), &services)
+            .expect("placement succeeds");
+
+        assert_eq!(result["document_handle"], "document_opaque");
+        assert_eq!(result["source_handle"], "source_opaque");
+        assert_eq!(result["resolved_path"], Value::Null);
+        assert_eq!(result["resolvedPath"], Value::Null);
+        assert_eq!(
+            result["mutation_cursor"]["kind"], "workspace_placement",
+            "write responses must expose a mutation cursor for gateway audit"
+        );
+    }
+
+    #[test]
+    fn mcp_safe_response_scrubs_path_key_variants() {
+        let result = mcp_safe_response(json!({
+            "document_handle": "document_opaque",
+            "resolved_path": "Accounts/example/private-note.md",
+            "resolvedPath": "Accounts/example/private-note.md",
+            "mutation_cursor": {
+                "kind": "workspace_placement",
+                "document_handle": "document_opaque",
+                "source_handle": "source_opaque",
+                "idempotency_id": "placement_opaque"
+            }
+        }));
+
+        assert_eq!(result["resolved_path"], Value::Null);
+        assert_eq!(result["resolvedPath"], Value::Null);
+    }
+
+    #[test]
+    fn placement_rate_limit_maps_to_tool_error_retry() {
+        let error = PlacementError::new(PlacementErrorCode::RateLimited, "rate limited")
+            .with_retry_after(42);
+        let tool_error = map_placement_ability_error(
+            &serde_json::to_string(&error).expect("placement error serializes"),
+        );
+
+        assert_eq!(
+            tool_error,
+            ToolError::RateLimited {
+                retry_after_seconds: 42
+            }
+        );
+    }
+}

--- a/src-tauri/src/services/sensitivity.rs
+++ b/src-tauri/src/services/sensitivity.rs
@@ -1034,6 +1034,100 @@ struct McpAbilityMetadataPathRule {
 }
 
 const MCP_ABILITY_METADATA_STRING_ALLOWLIST: &[McpAbilityMetadataPathRule] = &[
+    // workspace_place_document returns opaque receipt metadata. Paths, content,
+    // names, and claim text are intentionally absent from this allowlist.
+    McpAbilityMetadataPathRule {
+        pattern: &["document_handle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["documentHandle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["source_handle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["sourceHandle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["entity_type"],
+        value_class: McpAbilityMetadataValueClass::EntityKind,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["entityType"],
+        value_class: McpAbilityMetadataValueClass::EntityKind,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["entity_id"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["entityId"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["category"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["workspace_file_kind"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["workspaceFileKind"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["source_asof"],
+        value_class: McpAbilityMetadataValueClass::Timestamp,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["sourceAsof"],
+        value_class: McpAbilityMetadataValueClass::Timestamp,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["lifecycle_state"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["lifecycleState"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutation_cursor", "kind"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutationCursor", "kind"],
+        value_class: McpAbilityMetadataValueClass::MetadataToken,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutation_cursor", "document_handle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutationCursor", "documentHandle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutation_cursor", "source_handle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutationCursor", "sourceHandle"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutation_cursor", "idempotency_id"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
+    McpAbilityMetadataPathRule {
+        pattern: &["mutationCursor", "idempotencyId"],
+        value_class: McpAbilityMetadataValueClass::Identifier,
+    },
     // get_entity_context legacy data was a top-level EntityContextEntry array.
     McpAbilityMetadataPathRule {
         pattern: &["*", "id"],

--- a/src-tauri/tests/mcp_v2_runtime_authority_lint_test.rs
+++ b/src-tauri/tests/mcp_v2_runtime_authority_lint_test.rs
@@ -14,6 +14,7 @@ fn mcp_comparison_path_rejects_legacy_authority() {
     let comparison_path_files = [
         "src/bridges/mcp.rs",
         "src/services/mcp_v2/handlers/tool_account_status.rs",
+        "src/services/mcp_v2/handlers/tool_placement.rs",
         "src/services/mcp_v2/runtime_projection.rs",
         "src/services/mcp_v2/transport.rs",
     ];

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use dailyos_lib::abilities::provenance::source::EntityId;
+use dailyos_lib::abilities::registry::McpExposure;
 use dailyos_lib::abilities::workspace_graph::contracts::{
     WorkspaceGraphInput, WorkspaceGraphPrivacyProfile, WorkspaceGraphReadRequest,
     WorkspaceGraphResponse,
@@ -10,6 +11,13 @@ use dailyos_lib::abilities::workspace_graph::contracts::{
 use dailyos_lib::db::{ActionDb, DbAccount};
 use dailyos_lib::entity::EntityType;
 use dailyos_lib::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
+use dailyos_lib::services::mcp_v2::actor_policy::{ToolGrant, ToolRateLimit};
+use dailyos_lib::services::mcp_v2::contracts::{
+    McpClientId, McpToolRequestEnvelope, McpToolResult, Scope, ScopedName, ToolError,
+};
+use dailyos_lib::services::mcp_v2::gateway::Gateway;
+use dailyos_lib::services::mcp_v2::handlers::registration::register_v147_handlers;
+use dailyos_lib::services::mcp_v2::taxonomy::{TaxonomyCatalog, YamlTaxonomyCatalog};
 use dailyos_lib::services::workspace_ingestion::contracts::{
     NullExtractor, RejectionReason, WorkspaceFileKind,
 };
@@ -25,6 +33,54 @@ use dailyos_lib::services::workspace_ingestion::signals::WorkspaceSignalEmitter;
 use dailyos_lib::services::workspace_ingestion::wiring;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection};
+
+#[test]
+fn mcp_placement_handler_registered_for_headless_path() {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let catalog: Arc<dyn TaxonomyCatalog> =
+        Arc::new(YamlTaxonomyCatalog::load_embedded().expect("catalog"));
+    let mut gateway = Gateway::new();
+    gateway.set_taxonomy(Arc::clone(&catalog));
+    register_v147_handlers(
+        &mut gateway,
+        &catalog,
+        runtime.handle().clone(),
+        Arc::new(dailyos_lib::signals::propagation::default_engine()),
+    )
+    .expect("register v2 handlers");
+    gateway.seal().expect("registered handlers validate");
+
+    let tool_name = ScopedName::new("dailyos.write.place_document");
+    assert!(gateway.registered_tools().any(|name| name == &tool_name));
+
+    let response = gateway.handle_local_stdio_tool_call(
+        &McpClientId::new("validation-client"),
+        McpToolRequestEnvelope {
+            conversation_handle: None,
+            tool_name: tool_name.clone(),
+            params: serde_json::json!({}),
+        },
+        &[ToolGrant {
+            tool_name,
+            scopes_granted: vec![],
+            exposure: McpExposure::Invocable,
+            rate_limit: ToolRateLimit {
+                max_calls: 0,
+                window_seconds: 0,
+            },
+        }],
+    );
+
+    assert_eq!(
+        response.result,
+        McpToolResult::Error {
+            error: ToolError::Unauthorized {
+                missing_scope: Scope::new("write.workspace_place_document")
+            }
+        },
+        "registered placement handler should be resolved before scope denial"
+    );
+}
 
 #[test]
 fn graph_audit_zero_gaps_on_hermetic_fixture_db() {

--- a/tests/v146_validation/README.md
+++ b/tests/v146_validation/README.md
@@ -12,8 +12,8 @@ Current status:
 - W5-A is folded into the active W5 validation PR; backfill and redaction axes have automated green checks on the rebased base.
 - Signal propagation is green on the release-gate branch.
 - Filesystem validation is green for registry-level path rejection, explicit ingestion size/format rejection, and conservative backfill hidden/managed/unsupported skips.
-- Graph-audit has automated entity-seeded and inbox assignment evidence, but remains blocked at packet level until the actual MCP placement handler path is covered.
-- Full validation remains dependency-gated on the trust-band matrix, actual MCP placement handler execution, and missing lifecycle actions.
+- Graph-audit has automated entity-seeded and inbox assignment evidence plus MCP placement handler registration evidence, but remains blocked at packet level until a successful MCP placement-to-claim fixture is covered.
+- Full validation remains dependency-gated on the trust-band matrix, successful MCP placement execution, full context parity, and missing lifecycle actions.
 - A blocked axis is not a pass. Interim reports may record `blocked`, but W5-B Done requires all mandatory axes to be green.
 
 ## Commands

--- a/tests/v146_validation/run.sh
+++ b/tests/v146_validation/run.sh
@@ -53,11 +53,12 @@ status_for_axis() {
         cd "$ROOT_DIR"
         cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db >/dev/null &&
         cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment >/dev/null &&
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation mcp_placement_handler_registered_for_headless_path >/dev/null &&
         cargo test --manifest-path src-tauri/Cargo.toml --lib workspace_ingestion::graph::tests >/dev/null
       ); then
-        printf 'blocked\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + cargo test --lib workspace_ingestion::graph::tests\tentity-seeded and inbox graph audit evidence passed; blocked until actual MCP placement handler path is complete\n'
+        printf 'blocked\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + mcp_placement_handler_registered_for_headless_path + cargo test --lib workspace_ingestion::graph::tests\tentity-seeded and inbox graph audit evidence plus MCP placement handler registration passed; blocked until a successful MCP placement fixture proves the placement-to-claim graph path\n'
       else
-        printf 'fail\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + cargo test --lib workspace_ingestion::graph::tests\texplicit ingestion provenance chain or graph audit projection tests failed\n'
+        printf 'fail\tcargo test --test v146_validation graph_audit_zero_gaps_on_hermetic_fixture_db + explicit_ingestion_to_claim_provenance_covers_entity_seeded_and_inbox_assignment + mcp_placement_handler_registered_for_headless_path + cargo test --lib workspace_ingestion::graph::tests\texplicit ingestion provenance chain, MCP placement registration, or graph audit projection tests failed\n'
       fi
       ;;
     trust)
@@ -74,7 +75,14 @@ status_for_axis() {
       fi
       ;;
     contexts)
-      printf 'blocked\tcargo test --test v146_validation context_inclusion_privacy_parity\tblocked because dailyos.write.place_document catalog exists but the MCP v2 handler remains a placeholder\n'
+      if (
+        cd "$ROOT_DIR"
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation mcp_placement_handler_registered_for_headless_path >/dev/null
+      ); then
+        printf 'blocked\tcargo test --test v146_validation mcp_placement_handler_registered_for_headless_path + context_inclusion_privacy_parity\tMCP placement handler registration is real; blocked until full Tauri/MCP context privacy parity is automated\n'
+      else
+        printf 'fail\tcargo test --test v146_validation mcp_placement_handler_registered_for_headless_path\tMCP placement handler registration evidence failed\n'
+      fi
       ;;
     lifecycle)
       printf 'blocked\tcargo test --test v146_validation lifecycle_actions_and_user_correction_round_trip\tblocked because source-management actions currently expose reingest/quarantine/relink only, not ignore/scratchpad or archive/delete\n'


### PR DESCRIPTION
## Linear ticket

DOS-476

## Summary

Registers the real `dailyos.write.place_document` MCP v2 handler so the headless gateway path now resolves through the claim-producing `workspace_place_document` ability instead of remaining catalog-only. The response and audit paths stay privacy-safe, and the W5 validation report now records handler-registration evidence while keeping the remaining W5 blockers explicit.

## What changed

- Added `PlacementHandler` for `dailyos.write.place_document`, wired through the ability registry, live workspace intake readers, and the service signal propagation engine.
- Registered the placement handler at MCP v2 startup alongside account status, with gateway seal coverage proving it is no longer pending/catalog-only.
- Extended MCP response metadata allowlisting only for opaque placement receipt fields and force-null both `resolved_path` and `resolvedPath` before returning to MCP clients.
- Added focused handler, registration, runtime-authority, and W5 harness coverage; updated the validation report to distinguish registration evidence from the still-missing successful placement-to-claim fixture.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --test v146_validation -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml tool_placement --lib -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation mcp_placement_handler_registered_for_headless_path -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test mcp_v2_runtime_authority_lint_test -- --nocapture`
- [x] `pnpm tsc --noEmit`
- [x] `bash tests/v146_validation/redaction_lint.sh`
- [x] `bash tests/v146_validation/run.sh contexts` exits blocked after passing MCP placement registration evidence
- [x] `bash tests/v146_validation/run.sh graph-audit` exits blocked after passing entity/inbox graph and MCP placement registration evidence
- [x] `git diff --check`
- [ ] `pnpm test` passes (not run; no frontend changes)

## Definition of Done

- [x] Acceptance criteria for this PR slice are validated with runtime/gateway evidence.
- [x] MCP handler registration and response rendering work through the headless gateway path.
- [x] No stubs, TODOs, or untracked deferrals introduced; remaining W5 blockers stay named in the validation report.
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

Security audit exemption: none. Local L2 security/privacy review passed after a path-key scrub fix.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Complete the successful MCP placement-to-claim fixture in W5 once the remaining hermetic workspace setup is available.
- Complete the full W5 trust-band matrix, Tauri/MCP context privacy parity, and lifecycle action coverage tracked in the validation report.

## Notes for review

Local L2 verdict: PASS. It checked MCP response privacy, audit payload persistence, gateway handler registration, and raw path/content/claim text/name leakage. The first L2 cycle found the camelCase `resolvedPath` path-key gap; this PR includes the fix and regression coverage.
