### PR TITLE
Close v1.4.5 workspace memory release gates

### DIFF
--- a/src-tauri/abilities-runtime/src/abilities/source_management_ledger/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/source_management_ledger/contracts.rs
@@ -48,6 +48,10 @@ pub enum SourceManagementActionKind {
     Reingest,
     Quarantine,
     Relink,
+    Ignore,
+    Scratchpad,
+    Archive,
+    Delete,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -92,6 +96,10 @@ pub struct SourceManagementActionPolicy {
     pub reingest_enabled: bool,
     pub quarantine_enabled: bool,
     pub relink_enabled: bool,
+    pub ignore_enabled: bool,
+    pub scratchpad_enabled: bool,
+    pub archive_enabled: bool,
+    pub delete_enabled: bool,
     pub disabled_reason: String,
 }
 
@@ -163,5 +171,9 @@ pub struct SourceManagementSourceActions {
     pub can_reingest: bool,
     pub can_quarantine: bool,
     pub can_relink: bool,
+    pub can_ignore: bool,
+    pub can_scratchpad: bool,
+    pub can_archive: bool,
+    pub can_delete: bool,
     pub disabled_reason: String,
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1095,6 +1095,10 @@ fn lifecycle_state_to_slug(state: LifecycleState) -> &'static str {
         LifecycleState::Superseded => "superseded",
         LifecycleState::Rejected => "rejected",
         LifecycleState::Quarantined => "quarantined",
+        LifecycleState::Ignored => "ignored",
+        LifecycleState::Scratchpad => "scratchpad",
+        LifecycleState::Archived => "archived",
+        LifecycleState::Deleted => "deleted",
     }
 }
 

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -5205,6 +5205,8 @@ fn load_claims_where_limited(
         (None, Some(_)) => " LIMIT ?3",
         _ => "",
     };
+    let workspace_lifecycle_filter =
+        workspace_source_lifecycle_filter(db.conn_ref(), "current_claim")?;
     let sql = format!(
         "SELECT {CLAIM_COLUMNS}, {surface_columns}
          FROM intelligence_claims current_claim
@@ -5213,6 +5215,7 @@ fn load_claims_where_limited(
            AND json_extract(subject_ref, '$.id') = ?2
            {claim_type_filter}
            AND {lifecycle_where}
+           {workspace_lifecycle_filter}
          ORDER BY created_at DESC{limit_clause}"
     );
     let mut stmt = db.conn_ref().prepare(&sql)?;
@@ -5292,6 +5295,8 @@ fn load_claims_where_for_surface_limited_filtered(
         (None, Some(_)) => " LIMIT ?4",
         _ => "",
     };
+    let workspace_lifecycle_filter =
+        workspace_source_lifecycle_filter(db.conn_ref(), "current_claim")?;
     let sql = format!(
         "SELECT {CLAIM_COLUMNS}, {surface_columns}
          FROM intelligence_claims current_claim
@@ -5301,6 +5306,7 @@ fn load_claims_where_for_surface_limited_filtered(
            {claim_type_filter}
            AND {lifecycle_where}
            {prompt_safe_filter}
+           {workspace_lifecycle_filter}
            AND NOT EXISTS (
                SELECT 1
                FROM claim_surface_dismissals dismissal
@@ -5350,6 +5356,8 @@ fn load_claims_where_limited_prompt_safe(
         (None, Some(_)) => " LIMIT ?3",
         _ => "",
     };
+    let workspace_lifecycle_filter =
+        workspace_source_lifecycle_filter(db.conn_ref(), "current_claim")?;
     let sql = format!(
         "SELECT {CLAIM_COLUMNS}, {surface_columns}
          FROM intelligence_claims current_claim
@@ -5359,6 +5367,7 @@ fn load_claims_where_limited_prompt_safe(
            {claim_type_filter}
            AND {lifecycle_where}
            AND sensitivity IN ('public', 'internal')
+           {workspace_lifecycle_filter}
          ORDER BY created_at DESC{limit_clause}"
     );
     let mut stmt = db.conn_ref().prepare(&sql)?;
@@ -5375,6 +5384,31 @@ fn load_claims_where_limited_prompt_safe(
         claims.push(read_claim_row_with_surface_shadow_state(row)?);
     }
     Ok(claims)
+}
+
+fn workspace_source_lifecycle_filter(
+    conn: &Connection,
+    claim_alias: &str,
+) -> Result<String, ClaimError> {
+    if !table_exists_sqlite(conn, "workspace_file_lifecycle")? {
+        return Ok(String::new());
+    }
+    Ok(format!(
+        "AND NOT EXISTS (
+            SELECT 1
+            FROM workspace_file_lifecycle workspace_lifecycle
+            WHERE {claim_alias}.source_ref = 'workspace_file:' || workspace_lifecycle.file_id
+              AND workspace_lifecycle.lifecycle_state IN (
+                'rejected',
+                'quarantined',
+                'superseded',
+                'ignored',
+                'scratchpad',
+                'archived',
+                'deleted'
+              )
+        )"
+    ))
 }
 
 fn actor_class_for_actor(actor: &str) -> Option<ClaimActorClass> {
@@ -9741,6 +9775,8 @@ fn load_entity_context_claims_for_subjects_limited(
     } else {
         String::new()
     };
+    let workspace_lifecycle_filter =
+        workspace_source_lifecycle_filter(db.conn_ref(), "current_claim")?;
     let limit_position = bound_params.len() + 1;
     bound_params.push(Box::new(limit as i64));
     let subject_filter = subject_predicates.join(" OR ");
@@ -9753,6 +9789,7 @@ fn load_entity_context_claims_for_subjects_limited(
            AND current_claim.surfacing_state = 'active'
            {prompt_safe_filter}
            {dismissal_filter}
+           {workspace_lifecycle_filter}
          ORDER BY current_claim.created_at DESC
          LIMIT ?{limit_position}"
     );

--- a/src-tauri/src/services/source_management_ledger.rs
+++ b/src-tauri/src/services/source_management_ledger.rs
@@ -36,9 +36,14 @@ use crate::db::ActionDb;
 use crate::entity::EntityType;
 use crate::services::workspace_ingestion::contracts::{SignalEmitContext, SignalEmitter};
 use crate::services::workspace_ingestion::graph::WorkspaceGraphDiagnosticKey;
+use crate::services::workspace_ingestion::lifecycle::{
+    lifecycle_state_from_slug, lifecycle_state_slug, LifecycleRepo, LifecycleState,
+};
 use crate::services::workspace_ingestion::link::{LinkAttributionSource, LinkError, LinkRepo};
 use crate::services::workspace_ingestion::pipeline::{quarantine_source, QuarantineActor};
-use crate::services::workspace_ingestion::signals::WorkspaceSignalEmitter;
+use crate::services::workspace_ingestion::signals::{
+    emit_source_policy_changed, WorkspaceSignalEmitter, WorkspaceSourcePolicyChangedInput,
+};
 use crate::signals::propagation::PropagationEngine;
 
 const SCHEMA_VERSION: u32 = 1;
@@ -155,6 +160,42 @@ pub fn apply_source_management_action(
         SourceManagementActionKind::Relink => {
             apply_relink_action(ctx, db, signal_engine, &request, &target)
         }
+        SourceManagementActionKind::Ignore => apply_lifecycle_policy_action(
+            ctx,
+            db,
+            signal_engine,
+            &request,
+            &target,
+            LifecycleState::Ignored,
+            "ignored",
+        ),
+        SourceManagementActionKind::Scratchpad => apply_lifecycle_policy_action(
+            ctx,
+            db,
+            signal_engine,
+            &request,
+            &target,
+            LifecycleState::Scratchpad,
+            "scratchpad",
+        ),
+        SourceManagementActionKind::Archive => apply_lifecycle_policy_action(
+            ctx,
+            db,
+            signal_engine,
+            &request,
+            &target,
+            LifecycleState::Archived,
+            "archived",
+        ),
+        SourceManagementActionKind::Delete => apply_lifecycle_policy_action(
+            ctx,
+            db,
+            signal_engine,
+            &request,
+            &target,
+            LifecycleState::Deleted,
+            "deleted",
+        ),
     }
 }
 
@@ -372,6 +413,80 @@ fn apply_relink_action(
         &target.lifecycle.lifecycle_state,
         latest_run_for_file(db.conn_ref(), &target.lifecycle.file_id)?,
     ))
+}
+
+fn apply_lifecycle_policy_action(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    signal_engine: Option<Arc<PropagationEngine>>,
+    request: &SourceManagementActionRequest,
+    target: &ActionTarget,
+    target_state: LifecycleState,
+    status: &str,
+) -> Result<SourceManagementActionReceipt, SourceManagementActionError> {
+    let propagation = signal_engine.as_deref().ok_or_else(|| {
+        SourceManagementActionError::ActionFailed("signal propagation unavailable".to_string())
+    })?;
+    let entity_type = normalize_required_filter(request.input.entity_type.clone());
+    let entity_id = normalize_required_filter(request.input.entity_id.clone());
+    let reason = request
+        .input
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+        .unwrap_or("user_requested");
+    let action_slug = action_slug(request.input.action);
+    let target_lifecycle = lifecycle_state_slug(target_state);
+
+    db.with_transaction(|tx_db| {
+        let tx_conn = tx_db.conn_ref();
+        let current =
+            lifecycle_state_from_slug(&target.lifecycle.lifecycle_state).ok_or_else(|| {
+                format!(
+                    "unknown source lifecycle state: {}",
+                    target.lifecycle.lifecycle_state
+                )
+            })?;
+        LifecycleRepo::record_user_override(tx_conn, &target.lifecycle.file_id, &request.actor_id)
+            .map_err(|error| error.to_string())?;
+        LifecycleRepo::transition(tx_conn, &target.lifecycle.file_id, current, target_state)
+            .map_err(|error| error.to_string())?;
+        let signal_ctx = SignalEmitContext::new(ctx, tx_db, Some(propagation));
+        emit_source_policy_changed(
+            &signal_ctx,
+            WorkspaceSourcePolicyChangedInput {
+                source_handle: &request.input.source_key,
+                policy_action: action_slug,
+                reason,
+                actor: &request.actor_id,
+                entity_type: Some(entity_type.as_str()),
+                entity_id: Some(entity_id.as_str()),
+                policy_receipt_id: None,
+            },
+        )
+        .map_err(|error| error.to_string())
+    })
+    .map_err(SourceManagementActionError::ActionFailed)?;
+
+    Ok(action_receipt(
+        request,
+        status,
+        target_lifecycle,
+        latest_run_for_file(db.conn_ref(), &target.lifecycle.file_id)?,
+    ))
+}
+
+fn action_slug(action: SourceManagementActionKind) -> &'static str {
+    match action {
+        SourceManagementActionKind::Reingest => "reingest",
+        SourceManagementActionKind::Quarantine => "quarantine",
+        SourceManagementActionKind::Relink => "relink",
+        SourceManagementActionKind::Ignore => "ignore",
+        SourceManagementActionKind::Scratchpad => "scratchpad",
+        SourceManagementActionKind::Archive => "archive",
+        SourceManagementActionKind::Delete => "delete",
+    }
 }
 
 fn action_receipt(
@@ -977,16 +1092,28 @@ fn enabled_action_policy() -> SourceManagementActionPolicy {
         reingest_enabled: true,
         quarantine_enabled: true,
         relink_enabled: true,
+        ignore_enabled: true,
+        scratchpad_enabled: true,
+        archive_enabled: true,
+        delete_enabled: true,
         disabled_reason: ACTIONS_READY_REASON.to_string(),
     }
 }
 
 fn source_actions_for(lifecycle: &LifecycleRow) -> SourceManagementSourceActions {
     let can_quarantine = lifecycle.lifecycle_state != "quarantined";
+    let already_ignored = lifecycle.lifecycle_state == "ignored";
+    let already_scratchpad = lifecycle.lifecycle_state == "scratchpad";
+    let already_archived = lifecycle.lifecycle_state == "archived";
+    let already_deleted = lifecycle.lifecycle_state == "deleted";
     SourceManagementSourceActions {
         can_reingest: true,
         can_quarantine,
         can_relink: true,
+        can_ignore: !already_ignored,
+        can_scratchpad: !already_scratchpad,
+        can_archive: !already_archived,
+        can_delete: !already_deleted,
         disabled_reason: if can_quarantine {
             ACTIONS_READY_REASON
         } else {

--- a/src-tauri/src/services/workspace_ingestion/graph.rs
+++ b/src-tauri/src/services/workspace_ingestion/graph.rs
@@ -887,7 +887,13 @@ fn build_audit_gaps(
                     }
                     if matches!(
                         lifecycle.lifecycle_state.as_str(),
-                        "rejected" | "quarantined" | "superseded"
+                        "rejected"
+                            | "quarantined"
+                            | "superseded"
+                            | "ignored"
+                            | "scratchpad"
+                            | "archived"
+                            | "deleted"
                     ) {
                         gaps.push(claim_gap(ClaimGapInput {
                             category: "excluded_file_has_active_workspace_claim",

--- a/src-tauri/src/services/workspace_ingestion/lifecycle.rs
+++ b/src-tauri/src/services/workspace_ingestion/lifecycle.rs
@@ -17,8 +17,8 @@ use crate::entity::EntityType;
 use super::contracts::{FileIdentity, WorkspaceCategory, WorkspaceFileKind};
 use super::pipeline::EntityRef;
 
-/// Seven-state lifecycle per wave plan §Goal + cycle 2 amendment
-/// (`pending_entity_assignment`).
+/// Source lifecycle per wave plan §Goal + cycle 2 amendment
+/// (`pending_entity_assignment`) plus W5 source-management policy states.
 ///
 /// State-machine transitions that will trigger `contracts::SignalEmitter`
 /// calls in W2/W3:
@@ -46,6 +46,10 @@ pub enum LifecycleState {
     Superseded,
     Rejected,
     Quarantined,
+    Ignored,
+    Scratchpad,
+    Archived,
+    Deleted,
 }
 
 /// Audit record of a user correction that bypassed automated lifecycle
@@ -376,6 +380,10 @@ fn is_valid_transition(from: LifecycleState, to: LifecycleState) -> bool {
             )
             | (LifecycleState::Ingested, LifecycleState::Superseded)
             | (_, LifecycleState::Quarantined)
+            | (_, LifecycleState::Ignored)
+            | (_, LifecycleState::Scratchpad)
+            | (_, LifecycleState::Archived)
+            | (_, LifecycleState::Deleted)
             | (LifecycleState::Rejected, LifecycleState::Pending)
     )
 }
@@ -389,10 +397,14 @@ pub fn lifecycle_state_slug(state: LifecycleState) -> &'static str {
         LifecycleState::Superseded => "superseded",
         LifecycleState::Rejected => "rejected",
         LifecycleState::Quarantined => "quarantined",
+        LifecycleState::Ignored => "ignored",
+        LifecycleState::Scratchpad => "scratchpad",
+        LifecycleState::Archived => "archived",
+        LifecycleState::Deleted => "deleted",
     }
 }
 
-fn lifecycle_state_from_slug(slug: &str) -> Option<LifecycleState> {
+pub fn lifecycle_state_from_slug(slug: &str) -> Option<LifecycleState> {
     match slug {
         "pending" => Some(LifecycleState::Pending),
         "pending_entity_assignment" => Some(LifecycleState::PendingEntityAssignment),
@@ -401,6 +413,10 @@ fn lifecycle_state_from_slug(slug: &str) -> Option<LifecycleState> {
         "superseded" => Some(LifecycleState::Superseded),
         "rejected" => Some(LifecycleState::Rejected),
         "quarantined" => Some(LifecycleState::Quarantined),
+        "ignored" => Some(LifecycleState::Ignored),
+        "scratchpad" => Some(LifecycleState::Scratchpad),
+        "archived" => Some(LifecycleState::Archived),
+        "deleted" => Some(LifecycleState::Deleted),
         _ => None,
     }
 }

--- a/src-tauri/src/services/workspace_ingestion/signals.rs
+++ b/src-tauri/src/services/workspace_ingestion/signals.rs
@@ -368,6 +368,10 @@ pub fn source_policy_action_code(action: &str) -> &'static str {
     match action.trim() {
         "allow" | "allowed" | "enable" | "enabled" | "restore" | "restored" => "enabled",
         "deny" | "denied" | "disable" | "disabled" | "quarantine" | "quarantined" => "disabled",
+        "ignore" | "ignored" => "ignored",
+        "scratchpad" => "scratchpad",
+        "archive" | "archived" => "archived",
+        "delete" | "deleted" => "deleted",
         "category" | "category_changed" | "recategorized" => "category_changed",
         _ => "updated",
     }

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -3,7 +3,14 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use dailyos_lib::abilities::provenance::source::EntityId;
+use dailyos_lib::abilities::provenance::trust::claim_trust_band_from_score;
 use dailyos_lib::abilities::registry::McpExposure;
+use dailyos_lib::abilities::source_management_ledger::contracts::{
+    SourceManagementActionInput, SourceManagementActionKind, SourceManagementActionRequest,
+    SourceManagementLedgerInput, SourceManagementLedgerPrivacyProfile,
+    SourceManagementLedgerReadRequest,
+};
+use dailyos_lib::abilities::trust::TrustBand;
 use dailyos_lib::abilities::workspace_graph::contracts::{
     WorkspaceGraphInput, WorkspaceGraphPrivacyProfile, WorkspaceGraphReadRequest,
     WorkspaceGraphResponse,
@@ -16,21 +23,17 @@ use dailyos_lib::bridges::mcp::McpAbilityBridge;
 use dailyos_lib::bridges::tauri::{TauriAbilityBridge, TauriTestInvokeContext};
 #[cfg(feature = "test-harness")]
 use dailyos_lib::bridges::{BridgeSurface, McpSessionId};
-#[cfg(feature = "test-harness")]
 use dailyos_lib::db::claims::{ClaimSensitivity, TemporalScope};
 use dailyos_lib::db::{ActionDb, DbAccount};
 use dailyos_lib::entity::EntityType;
 #[cfg(feature = "test-harness")]
 use dailyos_lib::intelligence::provider::ReplayProvider;
-#[cfg(feature = "test-harness")]
 use dailyos_lib::services::claims::{
     commit_claim, load_entity_context_claims_active_for_surface, ClaimProposal, CommittedClaim,
 };
+use dailyos_lib::services::context::{ClaimDismissalSurface, FixedClock, SeedableRng};
 #[cfg(feature = "test-harness")]
-use dailyos_lib::services::context::{
-    ClaimDismissalSurface, EntityContextClaimReadFuture, EntityContextClaimReadHandle, FixedClock,
-    SeedableRng,
-};
+use dailyos_lib::services::context::{EntityContextClaimReadFuture, EntityContextClaimReadHandle};
 use dailyos_lib::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
 use dailyos_lib::services::mcp_v2::actor_policy::{ToolGrant, ToolRateLimit};
 use dailyos_lib::services::mcp_v2::contracts::{
@@ -52,11 +55,14 @@ use dailyos_lib::services::workspace_ingestion::registry::WorkspaceSourceRegistr
 use dailyos_lib::services::workspace_ingestion::runs::IngestionMode;
 use dailyos_lib::services::workspace_ingestion::signals::WorkspaceSignalEmitter;
 use dailyos_lib::services::workspace_ingestion::wiring;
+use dailyos_lib::services::{
+    source_management_ledger::{apply_source_management_action, read_source_management_ledger},
+    trust_recompute::recompute_claim_trust_for_subject,
+};
 use parking_lot::Mutex;
 #[cfg(feature = "test-harness")]
 use rusqlite::OpenFlags;
 use rusqlite::{params, Connection};
-#[cfg(feature = "test-harness")]
 use serde_json::json;
 
 #[test]
@@ -569,6 +575,217 @@ async fn context_inclusion_privacy_parity() {
     }
 }
 
+#[test]
+fn trust_band_discipline() {
+    let fixture = Fixture::new();
+    fixture.seed_account("acct-v146-trust", "Trust Account");
+    let now = DateTime::parse_from_rfc3339("2026-05-26T00:00:00Z")
+        .expect("fixed trust time")
+        .with_timezone(&Utc);
+
+    let fresh_claim_id = fixture.commit_validation_claim(
+        "acct-v146-trust",
+        "Fresh source-backed note for Trust Account.",
+        Some(now - Duration::days(1)),
+        now - Duration::days(1),
+        Some("workspace_file:v146-trust-fresh"),
+    );
+    let stale_claim_id = fixture.commit_validation_claim(
+        "acct-v146-trust",
+        "Stale source-backed note for Trust Account.",
+        Some(now - Duration::days(120)),
+        now - Duration::days(120),
+        Some("workspace_file:v146-trust-stale"),
+    );
+    let missing_source_asof_claim_id = fixture.commit_validation_claim(
+        "acct-v146-trust",
+        "Timestamp-unknown note for Trust Account.",
+        None,
+        now - Duration::days(1),
+        Some("workspace_file:v146-trust-missing-source-asof"),
+    );
+
+    let clock = FixedClock::new(now);
+    let rng = SeedableRng::new(146);
+    let external = ExternalClients::default();
+    let ctx =
+        ServiceContext::new_live(&clock, &rng, &external).with_actor("system:v146_validation");
+    let report = recompute_claim_trust_for_subject(
+        &ctx,
+        &ActionDb::from_conn(&fixture.conn),
+        "account",
+        "acct-v146-trust",
+    )
+    .expect("trust recompute");
+    assert_eq!(report.claims_seen, 3);
+    assert_eq!(report.claims_updated, 3);
+    assert_eq!(report.claims_skipped, 0);
+
+    assert_eq!(
+        fixture.claim_trust_band(&fresh_claim_id),
+        TrustBand::LikelyCurrent,
+        "fresh source_asof should survive recompute as likely current"
+    );
+    assert!(
+        matches!(
+            fixture.claim_trust_band(&stale_claim_id),
+            TrustBand::UseWithCaution | TrustBand::NeedsVerification
+        ),
+        "stale source_asof must not render as likely current"
+    );
+    assert!(
+        matches!(
+            fixture.claim_trust_band(&missing_source_asof_claim_id),
+            TrustBand::UseWithCaution | TrustBand::NeedsVerification
+        ),
+        "missing source_asof must not render as likely current"
+    );
+}
+
+#[test]
+fn lifecycle_actions_and_user_correction_round_trip() {
+    let fixture = Fixture::new();
+    fixture.seed_account("acct-v146-life", "Lifecycle Account");
+    let relink_note = fixture.write_account_file(
+        "Lifecycle Account",
+        "lifecycle-relink.md",
+        "Lifecycle relink validation note.",
+    );
+    let relink_receipt = fixture.ingest_account_note(
+        &relink_note,
+        EntityRef {
+            entity_type: EntityType::Account,
+            entity_id: EntityId::new("acct-v146-life".to_string()),
+            entity_name: Some("Lifecycle Account".to_string()),
+        },
+        None,
+    );
+    assert_eq!(
+        context_claim_count(&fixture, "acct-v146-life"),
+        1,
+        "ingested workspace claims should be visible before policy actions"
+    );
+
+    let signal_engine = Arc::new(dailyos_lib::signals::propagation::default_engine());
+    let diagnostic_key = diagnostic_key_for_tests("v146-lifecycle");
+    let relink_key = fixture.source_key_for_lifecycle_state(&diagnostic_key, "ingested");
+
+    let relink = fixture.apply_source_action(
+        Arc::clone(&signal_engine),
+        &diagnostic_key,
+        &relink_key,
+        SourceManagementActionKind::Relink,
+    );
+    assert_eq!(relink.status, "linked");
+    assert_eq!(
+        fixture.source_lifecycle_state(&relink_receipt.file_id),
+        "ingested"
+    );
+    assert_eq!(
+        count(
+            &fixture.conn,
+            "SELECT COUNT(*)
+             FROM document_entity_links
+             WHERE file_id = ?1
+               AND user_override_actor = 'user:v146_validation'",
+            params![&relink_receipt.file_id],
+        ),
+        1,
+        "relink action should record a user override through the link service"
+    );
+
+    let quarantine = fixture.apply_source_action(
+        Arc::clone(&signal_engine),
+        &diagnostic_key,
+        &relink_key,
+        SourceManagementActionKind::Quarantine,
+    );
+    assert_eq!(quarantine.lifecycle_state, "quarantined");
+    assert_eq!(
+        context_claim_count(&fixture, "acct-v146-life"),
+        0,
+        "quarantined workspace source should stop feeding entity context"
+    );
+
+    let policy_note = fixture.write_account_file(
+        "Lifecycle Account",
+        "lifecycle-policy.md",
+        "Lifecycle policy validation note.",
+    );
+    let policy_receipt = fixture.ingest_account_note(
+        &policy_note,
+        EntityRef {
+            entity_type: EntityType::Account,
+            entity_id: EntityId::new("acct-v146-life".to_string()),
+            entity_name: Some("Lifecycle Account".to_string()),
+        },
+        None,
+    );
+    assert_eq!(context_claim_count(&fixture, "acct-v146-life"), 1);
+    let policy_key = fixture.source_key_for_lifecycle_state(&diagnostic_key, "ingested");
+
+    for (action, expected_state) in [
+        (SourceManagementActionKind::Ignore, "ignored"),
+        (SourceManagementActionKind::Scratchpad, "scratchpad"),
+        (SourceManagementActionKind::Archive, "archived"),
+        (SourceManagementActionKind::Delete, "deleted"),
+    ] {
+        let receipt = fixture.apply_source_action(
+            Arc::clone(&signal_engine),
+            &diagnostic_key,
+            &policy_key,
+            action,
+        );
+        assert_eq!(receipt.lifecycle_state, expected_state);
+        assert_eq!(
+            fixture.source_lifecycle_state(&policy_receipt.file_id),
+            expected_state
+        );
+        assert_eq!(
+            context_claim_count(&fixture, "acct-v146-life"),
+            0,
+            "{expected_state} workspace source should stay out of entity context"
+        );
+    }
+
+    let ledger = read_source_management_ledger(
+        &fixture.conn,
+        SourceManagementLedgerReadRequest {
+            input: SourceManagementLedgerInput {
+                schema_version: 1,
+                entity_type: "account".to_string(),
+                entity_id: "acct-v146-life".to_string(),
+                cursor: None,
+                page_size: 25,
+            },
+            privacy_profile: SourceManagementLedgerPrivacyProfile::SurfaceClient,
+        },
+        &diagnostic_key,
+    )
+    .expect("source ledger after lifecycle actions");
+    let states = ledger
+        .sources
+        .iter()
+        .map(|source| source.lifecycle_state.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(states.contains("quarantined"));
+    assert!(states.contains("deleted"));
+
+    let policy_signal_count = count(
+        &fixture.conn,
+        "SELECT COUNT(*)
+         FROM signal_events
+         WHERE signal_type = 'workspace_source_policy_changed'
+           AND entity_type = 'account'
+           AND entity_id = 'acct-v146-life'",
+        [],
+    );
+    assert!(
+        (1..=4).contains(&policy_signal_count),
+        "policy actions should emit at least one invalidating signal; rapid actions may coalesce"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn filesystem_validation_negative_fixtures() {
@@ -973,6 +1190,175 @@ impl Fixture {
             other => panic!("expected inserted context parity claim, got {other:?}"),
         }
     }
+
+    fn commit_validation_claim(
+        &self,
+        account_id: &str,
+        text: &str,
+        source_asof: Option<DateTime<Utc>>,
+        observed_at: DateTime<Utc>,
+        source_ref: Option<&str>,
+    ) -> String {
+        let clock = FixedClock::new(
+            DateTime::parse_from_rfc3339("2026-05-26T00:00:00Z")
+                .expect("fixed time")
+                .with_timezone(&Utc),
+        );
+        let rng = SeedableRng::new(476);
+        let external = ExternalClients::default();
+        let ctx =
+            ServiceContext::new_live(&clock, &rng, &external).with_actor("system:v146_validation");
+        let committed = commit_claim(
+            &ctx,
+            ActionDb::from_conn(&self.conn),
+            ClaimProposal {
+                id: None,
+                expected_claim_version: None,
+                subject_ref: json!({
+                    "kind": "account",
+                    "id": account_id,
+                })
+                .to_string(),
+                claim_type: "user_note".to_string(),
+                field_path: None,
+                topic_key: None,
+                text: text.to_string(),
+                actor: "system:v146_validation".to_string(),
+                data_source: "workspace_file:entity_doc".to_string(),
+                source_ref: source_ref.map(str::to_string),
+                source_asof: source_asof.map(|value| value.to_rfc3339()),
+                observed_at: observed_at.to_rfc3339(),
+                provenance_json: "{}".to_string(),
+                metadata_json: Some(
+                    json!({
+                        "producer": "v146_validation",
+                        "internal_consistency": 1.0,
+                    })
+                    .to_string(),
+                ),
+                thread_id: None,
+                temporal_scope: Some(TemporalScope::State),
+                sensitivity: Some(ClaimSensitivity::Internal),
+                supersedes: None,
+                tombstone: None,
+            },
+        )
+        .expect("commit validation claim");
+
+        match committed {
+            CommittedClaim::Inserted { claim } => claim.id,
+            other => panic!("expected inserted validation claim, got {other:?}"),
+        }
+    }
+
+    fn claim_trust_band(&self, claim_id: &str) -> TrustBand {
+        let trust_score: Option<f64> = self
+            .conn
+            .query_row(
+                "SELECT trust_score FROM intelligence_claims WHERE id = ?1",
+                [claim_id],
+                |row| row.get(0),
+            )
+            .expect("claim trust score");
+        claim_trust_band_from_score(trust_score)
+    }
+
+    fn source_lifecycle_state(&self, file_id: &str) -> String {
+        self.conn
+            .query_row(
+                "SELECT lifecycle_state
+                 FROM workspace_file_lifecycle
+                 WHERE file_id = ?1",
+                [file_id],
+                |row| row.get(0),
+            )
+            .expect("source lifecycle state")
+    }
+
+    fn source_key_for_lifecycle_state(
+        &self,
+        diagnostic_key: &dailyos_lib::services::workspace_ingestion::graph::WorkspaceGraphDiagnosticKey,
+        lifecycle_state: &str,
+    ) -> String {
+        let ledger = read_source_management_ledger(
+            &self.conn,
+            SourceManagementLedgerReadRequest {
+                input: SourceManagementLedgerInput {
+                    schema_version: 1,
+                    entity_type: "account".to_string(),
+                    entity_id: "acct-v146-life".to_string(),
+                    cursor: None,
+                    page_size: 25,
+                },
+                privacy_profile: SourceManagementLedgerPrivacyProfile::SurfaceClient,
+            },
+            diagnostic_key,
+        )
+        .expect("source management ledger");
+        let matches = ledger
+            .sources
+            .iter()
+            .filter(|source| source.lifecycle_state == lifecycle_state)
+            .map(|source| source.source_key.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matches.len(),
+            1,
+            "expected exactly one source in lifecycle state {lifecycle_state}, got {:?}",
+            ledger
+                .sources
+                .iter()
+                .map(|source| source.lifecycle_state.as_str())
+                .collect::<Vec<_>>()
+        );
+        matches[0].clone()
+    }
+
+    fn apply_source_action(
+        &self,
+        signal_engine: Arc<dailyos_lib::signals::propagation::PropagationEngine>,
+        diagnostic_key: &dailyos_lib::services::workspace_ingestion::graph::WorkspaceGraphDiagnosticKey,
+        source_key: &str,
+        action: SourceManagementActionKind,
+    ) -> dailyos_lib::abilities::source_management_ledger::contracts::SourceManagementActionReceipt
+    {
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let ctx =
+            ServiceContext::new_live(&clock, &rng, &external).with_actor("user:v146_validation");
+        apply_source_management_action(
+            &ctx,
+            &ActionDb::from_conn(&self.conn),
+            self.workspace_root.clone(),
+            Some(signal_engine),
+            SourceManagementActionRequest {
+                input: SourceManagementActionInput {
+                    schema_version: 1,
+                    entity_type: "account".to_string(),
+                    entity_id: "acct-v146-life".to_string(),
+                    source_key: source_key.to_string(),
+                    action,
+                    reason: Some("user_requested".to_string()),
+                },
+                actor_id: "user:v146_validation".to_string(),
+            },
+            diagnostic_key,
+        )
+        .expect("source management action")
+    }
+}
+
+fn context_claim_count(fixture: &Fixture, account_id: &str) -> usize {
+    load_entity_context_claims_active_for_surface(
+        ActionDb::from_conn(&fixture.conn),
+        "account",
+        account_id,
+        1,
+        ClaimDismissalSurface::TauriEntityDetail.as_str(),
+    )
+    .expect("entity context claims")
+    .len()
 }
 
 #[cfg(feature = "test-harness")]

--- a/src-tauri/tests/workspace_ingestion_unit.rs
+++ b/src-tauri/tests/workspace_ingestion_unit.rs
@@ -19,7 +19,7 @@ use dailyos_lib::services::workspace_ingestion::lifecycle::LifecycleState;
 // ---- LifecycleState ---------------------------------------------------------
 
 #[test]
-fn lifecycle_state_has_exactly_seven_variants_with_canonical_serde_strings() {
+fn lifecycle_state_has_canonical_serde_strings() {
     let pairs: &[(LifecycleState, &str)] = &[
         (LifecycleState::Pending, "pending"),
         (
@@ -31,12 +31,16 @@ fn lifecycle_state_has_exactly_seven_variants_with_canonical_serde_strings() {
         (LifecycleState::Superseded, "superseded"),
         (LifecycleState::Rejected, "rejected"),
         (LifecycleState::Quarantined, "quarantined"),
+        (LifecycleState::Ignored, "ignored"),
+        (LifecycleState::Scratchpad, "scratchpad"),
+        (LifecycleState::Archived, "archived"),
+        (LifecycleState::Deleted, "deleted"),
     ];
 
     assert_eq!(
         pairs.len(),
-        7,
-        "LifecycleState must have exactly 7 variants"
+        11,
+        "LifecycleState must have exactly 11 variants"
     );
 
     for (state, expected_slug) in pairs {

--- a/tests/v146_validation/run.sh
+++ b/tests/v146_validation/run.sh
@@ -64,7 +64,15 @@ status_for_axis() {
       fi
       ;;
     trust)
-      printf 'blocked\tcargo test --test v146_validation trust_band_discipline\tblocked until the full W5 trust matrix covers recent, stale, pending-review, and reingest-without-freshness cases through real recompute\n'
+      if (
+        cd "$ROOT_DIR"
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation trust_band_discipline >/dev/null &&
+        cargo test --manifest-path src-tauri/Cargo.toml apply_registers_pending_review_source_and_graph_excludes_it --lib >/dev/null
+      ); then
+        printf 'pass\tcargo test --test v146_validation trust_band_discipline + cargo test apply_registers_pending_review_source_and_graph_excludes_it --lib\tfresh, stale, and missing source_asof claims passed through commit_claim plus real trust recompute; pending-review backfill stays claim-free and graph-excluded\n'
+      else
+        printf 'fail\tcargo test --test v146_validation trust_band_discipline + cargo test apply_registers_pending_review_source_and_graph_excludes_it --lib\ttrust-band recompute matrix or pending-review zero-claim evidence failed\n'
+      fi
       ;;
     signals)
       if (
@@ -88,7 +96,14 @@ status_for_axis() {
       fi
       ;;
     lifecycle)
-      printf 'blocked\tcargo test --test v146_validation lifecycle_actions_and_user_correction_round_trip\tblocked because source-management actions currently expose reingest/quarantine/relink only, not ignore/scratchpad or archive/delete\n'
+      if (
+        cd "$ROOT_DIR"
+        cargo test --manifest-path src-tauri/Cargo.toml --test v146_validation lifecycle_actions_and_user_correction_round_trip >/dev/null
+      ); then
+        printf 'pass\tcargo test --test v146_validation lifecycle_actions_and_user_correction_round_trip\trelink, quarantine, ignore, scratchpad, archive, and delete source actions round-tripped through service APIs and suppressed workspace-backed context reads\n'
+      else
+        printf 'fail\tcargo test --test v146_validation lifecycle_actions_and_user_correction_round_trip\tlifecycle action or source-backed context suppression evidence failed\n'
+      fi
       ;;
     filesystem)
       if (

--- a/wp/dailyos/blocks/source-management/render-functions.php
+++ b/wp/dailyos/blocks/source-management/render-functions.php
@@ -13,7 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	if ( function_exists( 'add_action' ) ) {
-		add_action( 'rest_api_init', 'dailyos_source_management_register_routes' );
+		add_action(
+			'rest_api_init',
+			static function (): void {
+				dailyos_source_management_register_routes();
+			}
+		);
 	}
 
 	/**
@@ -50,7 +55,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @return mixed
 	 */
 	function dailyos_source_management_handle_action( mixed $request ): mixed {
-		$params = is_object( $request ) && is_callable( [ $request, 'get_json_params' ] )
+		$params    = is_object( $request ) && is_callable( [ $request, 'get_json_params' ] )
 			? $request->get_json_params()
 			: [];
 		$validated = dailyos_source_management_validate_action_payload( is_array( $params ) ? $params : [] );
@@ -84,7 +89,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		$entity_type = isset( $params['entityType'] ) && is_scalar( $params['entityType'] ) ? strtolower( trim( (string) $params['entityType'] ) ) : '';
 		$entity_id   = isset( $params['entityId'] ) && is_scalar( $params['entityId'] ) ? trim( (string) $params['entityId'] ) : '';
 		$source_key  = isset( $params['sourceKey'] ) && is_scalar( $params['sourceKey'] ) ? trim( (string) $params['sourceKey'] ) : '';
-		if ( ! in_array( $action, [ 'reingest', 'quarantine', 'relink' ], true ) ) {
+		if ( ! in_array( $action, [ 'reingest', 'quarantine', 'relink', 'ignore', 'scratchpad', 'archive', 'delete' ], true ) ) {
 			return new WP_Error( 'dailyos_invalid_source_action', __( 'Source action is unavailable.', 'dailyos' ), [ 'status' => 400 ] );
 		}
 		if ( ! dailyos_source_management_is_entity_type( $entity_type ) || ! dailyos_source_management_is_entity_id( $entity_id ) || ! dailyos_source_management_is_source_key( $source_key ) ) {
@@ -143,7 +148,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		$entity_type = isset( $attributes['entity_type'] ) && is_scalar( $attributes['entity_type'] )
 			? strtolower( trim( (string) $attributes['entity_type'] ) )
 			: '';
-		$entity_id = isset( $attributes['entity_id'] ) && is_scalar( $attributes['entity_id'] )
+		$entity_id   = isset( $attributes['entity_id'] ) && is_scalar( $attributes['entity_id'] )
 			? trim( (string) $attributes['entity_id'] )
 			: '';
 		if ( ! in_array( $entity_type, [ 'account', 'person', 'project' ], true ) ) {
@@ -230,13 +235,13 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		$category  = dailyos_source_management_safe_text( dailyos_source_management_first_string( $source, [ 'category' ], '' ), '', 40 );
 		$lifecycle = dailyos_source_management_lifecycle_label( dailyos_source_management_first_string( $source, [ 'lifecycleState', 'lifecycle_state' ], 'pending' ) );
 		$date      = dailyos_source_management_source_date( $source );
-			$run       = isset( $source['latestRun'] ) && is_array( $source['latestRun'] )
+			$run   = isset( $source['latestRun'] ) && is_array( $source['latestRun'] )
 				? $source['latestRun']
 				: ( isset( $source['latest_run'] ) && is_array( $source['latest_run'] ) ? $source['latest_run'] : [] );
-			$runs      = isset( $source['ingestionRuns'] ) && is_array( $source['ingestionRuns'] )
+			$runs  = isset( $source['ingestionRuns'] ) && is_array( $source['ingestionRuns'] )
 				? $source['ingestionRuns']
 				: ( isset( $source['ingestion_runs'] ) && is_array( $source['ingestion_runs'] ) ? $source['ingestion_runs'] : [] );
-			$trust     = isset( $source['trustBandSummary'] ) && is_array( $source['trustBandSummary'] )
+			$trust = isset( $source['trustBandSummary'] ) && is_array( $source['trustBandSummary'] )
 				? $source['trustBandSummary']
 				: ( isset( $source['trust_band_summary'] ) && is_array( $source['trust_band_summary'] ) ? $source['trust_band_summary'] : [] );
 		$actions   = isset( $source['actions'] ) && is_array( $source['actions'] ) ? $source['actions'] : [];
@@ -249,14 +254,14 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		if ( '' !== $category ) {
 			$out .= dailyos_source_management_meta_item( __( 'Category', 'dailyos' ), $category );
 		}
-		$out .= dailyos_source_management_meta_item( __( 'Date', 'dailyos' ), $date );
+		$out     .= dailyos_source_management_meta_item( __( 'Date', 'dailyos' ), $date );
 			$out .= dailyos_source_management_meta_item( __( 'Run', 'dailyos' ), dailyos_source_management_run_label( $run ) );
 			$out .= '</dl>';
 			$out .= dailyos_source_management_run_history( $runs );
 			$out .= dailyos_source_management_trust_summary( $trust );
 			$out .= '</div>';
 			$out .= dailyos_source_management_actions( $source, $actions );
-		$out .= '</li>';
+		$out     .= '</li>';
 
 		return $out;
 	}
@@ -302,15 +307,15 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @return string
 	 */
 	function dailyos_source_management_action_policy( array $payload ): string {
-		$policy = isset( $payload['actionPolicy'] ) && is_array( $payload['actionPolicy'] )
+		$policy     = isset( $payload['actionPolicy'] ) && is_array( $payload['actionPolicy'] )
 			? $payload['actionPolicy']
 			: ( isset( $payload['action_policy'] ) && is_array( $payload['action_policy'] ) ? $payload['action_policy'] : [] );
 			$reason = dailyos_source_management_first_string( $policy, [ 'disabledReason', 'disabled_reason' ], 'read_only' );
-			if ( '' === $reason ) {
-				return '';
-			}
-			return '<p class="dailyos-source-management__policy">' . esc_html( dailyos_source_management_policy_label( $reason ) ) . '</p>';
+		if ( '' === $reason ) {
+			return '';
 		}
+			return '<p class="dailyos-source-management__policy">' . esc_html( dailyos_source_management_policy_label( $reason ) ) . '</p>';
+	}
 
 		/**
 		 * Render row actions.
@@ -319,24 +324,28 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param array<string, mixed> $actions Action payload.
 		 * @return string
 		 */
-		function dailyos_source_management_actions( array $source, array $actions ): string {
-			$source_key = dailyos_source_management_first_string( $source, [ 'sourceKey', 'source_key' ], '' );
-			$entity     = isset( $source['entity'] ) && is_array( $source['entity'] ) ? $source['entity'] : [];
-			$entity_type = dailyos_source_management_first_string( $entity, [ 'entityType', 'entity_type' ], '' );
-			$entity_id   = dailyos_source_management_first_string( $entity, [ 'entityId', 'entity_id' ], '' );
-			$has_target  = dailyos_source_management_is_source_key( $source_key )
-				&& dailyos_source_management_is_entity_type( $entity_type )
-				&& dailyos_source_management_is_entity_id( $entity_id );
-			$disabled_reason = dailyos_source_management_policy_label(
-				dailyos_source_management_first_string( $actions, [ 'disabledReason', 'disabled_reason' ], '' )
-			);
-			$out  = '<div class="dailyos-source-management__actions" aria-label="' . esc_attr__( 'Source actions', 'dailyos' ) . '">';
-			$out .= dailyos_source_management_action_button( __( 'Re-ingest', 'dailyos' ), 'reingest', $has_target && dailyos_source_management_bool_value( $actions, [ 'canReingest', 'can_reingest' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
-			$out .= dailyos_source_management_action_button( __( 'Quarantine', 'dailyos' ), 'quarantine', $has_target && dailyos_source_management_bool_value( $actions, [ 'canQuarantine', 'can_quarantine' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
-			$out .= dailyos_source_management_action_button( __( 'Re-link', 'dailyos' ), 'relink', $has_target && dailyos_source_management_bool_value( $actions, [ 'canRelink', 'can_relink' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
-			$out .= '</div>';
-			return $out;
-		}
+	function dailyos_source_management_actions( array $source, array $actions ): string {
+		$source_key      = dailyos_source_management_first_string( $source, [ 'sourceKey', 'source_key' ], '' );
+		$entity          = isset( $source['entity'] ) && is_array( $source['entity'] ) ? $source['entity'] : [];
+		$entity_type     = dailyos_source_management_first_string( $entity, [ 'entityType', 'entity_type' ], '' );
+		$entity_id       = dailyos_source_management_first_string( $entity, [ 'entityId', 'entity_id' ], '' );
+		$has_target      = dailyos_source_management_is_source_key( $source_key )
+			&& dailyos_source_management_is_entity_type( $entity_type )
+			&& dailyos_source_management_is_entity_id( $entity_id );
+		$disabled_reason = dailyos_source_management_policy_label(
+			dailyos_source_management_first_string( $actions, [ 'disabledReason', 'disabled_reason' ], '' )
+		);
+		$out             = '<div class="dailyos-source-management__actions" aria-label="' . esc_attr( __( 'Source actions', 'dailyos' ) ) . '">';
+		$out            .= dailyos_source_management_action_button( __( 'Re-ingest', 'dailyos' ), 'reingest', $has_target && dailyos_source_management_bool_value( $actions, [ 'canReingest', 'can_reingest' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Quarantine', 'dailyos' ), 'quarantine', $has_target && dailyos_source_management_bool_value( $actions, [ 'canQuarantine', 'can_quarantine' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Re-link', 'dailyos' ), 'relink', $has_target && dailyos_source_management_bool_value( $actions, [ 'canRelink', 'can_relink' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Ignore', 'dailyos' ), 'ignore', $has_target && dailyos_source_management_bool_value( $actions, [ 'canIgnore', 'can_ignore' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Scratchpad', 'dailyos' ), 'scratchpad', $has_target && dailyos_source_management_bool_value( $actions, [ 'canScratchpad', 'can_scratchpad' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Archive', 'dailyos' ), 'archive', $has_target && dailyos_source_management_bool_value( $actions, [ 'canArchive', 'can_archive' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= dailyos_source_management_action_button( __( 'Delete', 'dailyos' ), 'delete', $has_target && dailyos_source_management_bool_value( $actions, [ 'canDelete', 'can_delete' ] ), $source_key, $entity_type, $entity_id, $disabled_reason );
+		$out            .= '</div>';
+		return $out;
+	}
 
 		/**
 		 * Render an action affordance.
@@ -350,26 +359,26 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param string $reason Disabled reason.
 		 * @return string
 		 */
-		function dailyos_source_management_action_button( string $label, string $action, bool $enabled, string $source_key, string $entity_type, string $entity_id, string $reason ): string {
-			$attrs = [
-				'type'                     => 'button',
-				'class'                    => 'dailyos-source-management__action',
-				'data-dailyos-source-action' => $action,
-				'data-dailyos-source-key'  => $source_key,
-				'data-dailyos-entity-type' => $entity_type,
-				'data-dailyos-entity-id'   => $entity_id,
-			];
-			if ( ! $enabled ) {
-				$attrs['disabled']      = 'disabled';
-				$attrs['aria-disabled'] = 'true';
-				$attrs['title']         = '' === $reason ? __( 'Unavailable', 'dailyos' ) : $reason;
-			}
-			$out = '<button';
-			foreach ( $attrs as $name => $value ) {
-				$out .= ' ' . esc_attr( $name ) . '="' . esc_attr( $value ) . '"';
-			}
-			return $out . '>' . esc_html( $label ) . '</button>';
+	function dailyos_source_management_action_button( string $label, string $action, bool $enabled, string $source_key, string $entity_type, string $entity_id, string $reason ): string {
+		$attrs = [
+			'type'                       => 'button',
+			'class'                      => 'dailyos-source-management__action',
+			'data-dailyos-source-action' => $action,
+			'data-dailyos-source-key'    => $source_key,
+			'data-dailyos-entity-type'   => $entity_type,
+			'data-dailyos-entity-id'     => $entity_id,
+		];
+		if ( ! $enabled ) {
+			$attrs['disabled']      = 'disabled';
+			$attrs['aria-disabled'] = 'true';
+			$attrs['title']         = '' === $reason ? __( 'Unavailable', 'dailyos' ) : $reason;
 		}
+		$out = '<button';
+		foreach ( $attrs as $name => $value ) {
+			$out .= ' ' . esc_attr( $name ) . '="' . esc_attr( $value ) . '"';
+		}
+		return $out . '>' . esc_html( $label ) . '</button>';
+	}
 
 	/**
 	 * Render trust distribution.
@@ -382,17 +391,33 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		if ( 0 === $total ) {
 			return '<p class="dailyos-source-management__trust">' . esc_html__( 'No derived claims', 'dailyos' ) . '</p>';
 		}
-		$likely  = dailyos_source_management_int_value( $trust, [ 'likelyCurrent', 'likely_current' ] );
-		$caution = dailyos_source_management_int_value( $trust, [ 'useWithCaution', 'use_with_caution' ] );
-		$verify  = dailyos_source_management_int_value( $trust, [ 'needsVerification', 'needs_verification' ] );
+		$likely   = dailyos_source_management_int_value( $trust, [ 'likelyCurrent', 'likely_current' ] );
+		$caution  = dailyos_source_management_int_value( $trust, [ 'useWithCaution', 'use_with_caution' ] );
+		$verify   = dailyos_source_management_int_value( $trust, [ 'needsVerification', 'needs_verification' ] );
 		$unscored = dailyos_source_management_int_value( $trust, [ 'unscored' ] );
-		$parts   = [
-			sprintf( _n( '%d likely current', '%d likely current', $likely, 'dailyos' ), $likely ),
-			sprintf( _n( '%d use with caution', '%d use with caution', $caution, 'dailyos' ), $caution ),
-			sprintf( _n( '%d needs verification', '%d needs verification', $verify, 'dailyos' ), $verify ),
+		$parts    = [
+			sprintf(
+				/* translators: %d: number of likely-current claims. */
+				_n( '%d likely current', '%d likely current', $likely, 'dailyos' ),
+				$likely
+			),
+			sprintf(
+				/* translators: %d: number of use-with-caution claims. */
+				_n( '%d use with caution', '%d use with caution', $caution, 'dailyos' ),
+				$caution
+			),
+			sprintf(
+				/* translators: %d: number of needs-verification claims. */
+				_n( '%d needs verification', '%d needs verification', $verify, 'dailyos' ),
+				$verify
+			),
 		];
 		if ( $unscored > 0 ) {
-			$parts[] = sprintf( _n( '%d unscored', '%d unscored', $unscored, 'dailyos' ), $unscored );
+			$parts[] = sprintf(
+				/* translators: %d: number of unscored claims. */
+				_n( '%d unscored', '%d unscored', $unscored, 'dailyos' ),
+				$unscored
+			);
 		}
 		return '<p class="dailyos-source-management__trust">' . esc_html( implode( ', ', $parts ) ) . '</p>';
 	}
@@ -418,7 +443,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @return string
 	 */
 	function dailyos_source_management_kind_label( string $kind ): string {
-		$key = dailyos_source_management_safe_key( $kind, 'workspace_source' );
+		$key    = dailyos_source_management_safe_key( $kind, 'workspace_source' );
 		$labels = [
 			'drive_sync'         => __( 'Drive file', 'dailyos' ),
 			'entity_doc'         => __( 'Entity document', 'dailyos' ),
@@ -439,7 +464,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @return string
 	 */
 	function dailyos_source_management_lifecycle_label( string $state ): string {
-		$key = dailyos_source_management_safe_key( $state, 'pending' );
+		$key    = dailyos_source_management_safe_key( $state, 'pending' );
 		$labels = [
 			'ingested'                  => __( 'Active', 'dailyos' ),
 			'ingesting'                 => __( 'Ingesting', 'dailyos' ),
@@ -448,6 +473,10 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 			'quarantined'               => __( 'Needs review', 'dailyos' ),
 			'rejected'                  => __( 'Rejected', 'dailyos' ),
 			'superseded'                => __( 'Superseded', 'dailyos' ),
+			'ignored'                   => __( 'Ignored', 'dailyos' ),
+			'scratchpad'                => __( 'Scratchpad', 'dailyos' ),
+			'archived'                  => __( 'Archived', 'dailyos' ),
+			'deleted'                   => __( 'Deleted', 'dailyos' ),
 		];
 		return $labels[ $key ] ?? __( 'Pending', 'dailyos' );
 	}
@@ -458,16 +487,16 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @param string $reason Raw reason.
 	 * @return string
 	 */
-		function dailyos_source_management_policy_label( string $reason ): string {
-			$key = dailyos_source_management_safe_key( $reason, 'read_only' );
-			if ( 'already_quarantined' === $key ) {
-				return __( 'Already quarantined', 'dailyos' );
-			}
-			if ( 'write_actions_deferred' === $key ) {
-				return __( 'Read-only until source actions land', 'dailyos' );
-			}
-			return __( 'Read-only', 'dailyos' );
+	function dailyos_source_management_policy_label( string $reason ): string {
+		$key = dailyos_source_management_safe_key( $reason, 'read_only' );
+		if ( 'already_quarantined' === $key ) {
+			return __( 'Already quarantined', 'dailyos' );
 		}
+		if ( 'write_actions_deferred' === $key ) {
+			return __( 'Read-only until source actions land', 'dailyos' );
+		}
+		return __( 'Read-only', 'dailyos' );
+	}
 
 	/**
 	 * Render latest run summary.
@@ -475,23 +504,23 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @param array<string, mixed> $run Latest run.
 	 * @return string
 	 */
-		function dailyos_source_management_run_label( array $run ): string {
-			if ( empty( $run ) ) {
-				return __( 'No runs', 'dailyos' );
+	function dailyos_source_management_run_label( array $run ): string {
+		if ( empty( $run ) ) {
+			return __( 'No runs', 'dailyos' );
 		}
 		$status = dailyos_source_management_safe_text(
 			dailyos_source_management_first_string( $run, [ 'status' ], 'unknown' ),
 			__( 'Unknown', 'dailyos' ),
 			32
 		);
-		$count = dailyos_source_management_int_value( $run, [ 'claimCountProduced', 'claim_count_produced' ] );
+		$count  = dailyos_source_management_int_value( $run, [ 'claimCountProduced', 'claim_count_produced' ] );
 		return sprintf(
-			/* translators: 1: run status, 2: claim count */
+		/* translators: 1: run status, 2: claim count */
 			__( '%1$s, %2$d claims', 'dailyos' ),
 			ucfirst( $status ),
 			$count
-			);
-		}
+		);
+	}
 
 		/**
 		 * Render bounded ingestion run history.
@@ -499,34 +528,34 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param array<int, mixed> $runs Ingestion run payloads.
 		 * @return string
 		 */
-		function dailyos_source_management_run_history( array $runs ): string {
-			$items = [];
-			foreach ( $runs as $run ) {
-				if ( ! is_array( $run ) ) {
-					continue;
-				}
-				$items[] = dailyos_source_management_run_label( $run );
-				if ( count( $items ) >= 5 ) {
-					break;
-				}
+	function dailyos_source_management_run_history( array $runs ): string {
+		$items = [];
+		foreach ( $runs as $run ) {
+			if ( ! is_array( $run ) ) {
+				continue;
 			}
-			if ( empty( $items ) ) {
-				return '';
+			$items[] = dailyos_source_management_run_label( $run );
+			if ( count( $items ) >= 5 ) {
+				break;
 			}
-			$out = '<ol class="dailyos-source-management__runs" aria-label="' . esc_attr__( 'Ingestion run history', 'dailyos' ) . '">';
-			foreach ( $items as $item ) {
-				$out .= '<li>' . esc_html( $item ) . '</li>';
-			}
-			$out .= '</ol>';
-			return $out;
 		}
+		if ( empty( $items ) ) {
+			return '';
+		}
+		$out = '<ol class="dailyos-source-management__runs" aria-label="' . esc_attr( __( 'Ingestion run history', 'dailyos' ) ) . '">';
+		foreach ( $items as $item ) {
+			$out .= '<li>' . esc_html( $item ) . '</li>';
+		}
+		$out .= '</ol>';
+		return $out;
+	}
 
 		/**
 		 * Render source date.
-	 *
-	 * @param array<string, mixed> $source Source payload.
-	 * @return string
-	 */
+		 *
+		 * @param array<string, mixed> $source Source payload.
+		 * @return string
+		 */
 	function dailyos_source_management_source_date( array $source ): string {
 		$raw = dailyos_source_management_first_string( $source, [ 'sourceAsof', 'source_asof' ], '' );
 		if ( '' === $raw ) {
@@ -539,7 +568,7 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		if ( function_exists( 'wp_date' ) ) {
 			return wp_date( 'M j, Y', $timestamp );
 		}
-		return date( 'M j, Y', $timestamp );
+		return gmdate( 'M j, Y', $timestamp );
 	}
 
 	/**
@@ -566,14 +595,14 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 	 * @param array<int, string>   $keys Candidate keys.
 	 * @return int
 	 */
-		function dailyos_source_management_int_value( array $payload, array $keys ): int {
-			foreach ( $keys as $key ) {
-				if ( isset( $payload[ $key ] ) && is_numeric( $payload[ $key ] ) ) {
-					return max( 0, (int) $payload[ $key ] );
-				}
+	function dailyos_source_management_int_value( array $payload, array $keys ): int {
+		foreach ( $keys as $key ) {
+			if ( isset( $payload[ $key ] ) && is_numeric( $payload[ $key ] ) ) {
+				return max( 0, (int) $payload[ $key ] );
 			}
-			return 0;
 		}
+		return 0;
+	}
 
 		/**
 		 * Pick the first boolean value.
@@ -582,14 +611,14 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param array<int, string>   $keys Candidate keys.
 		 * @return bool
 		 */
-		function dailyos_source_management_bool_value( array $payload, array $keys ): bool {
-			foreach ( $keys as $key ) {
-				if ( isset( $payload[ $key ] ) ) {
-					return true === $payload[ $key ] || 1 === $payload[ $key ] || '1' === $payload[ $key ];
-				}
+	function dailyos_source_management_bool_value( array $payload, array $keys ): bool {
+		foreach ( $keys as $key ) {
+			if ( isset( $payload[ $key ] ) ) {
+				return true === $payload[ $key ] || 1 === $payload[ $key ] || '1' === $payload[ $key ];
 			}
-			return false;
 		}
+		return false;
+	}
 
 		/**
 		 * Validate an opaque source action key.
@@ -597,9 +626,9 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param string $value Candidate key.
 		 * @return bool
 		 */
-		function dailyos_source_management_is_source_key( string $value ): bool {
-			return 1 === preg_match( '/^source:v1:[A-Za-z0-9_-]{16,160}$/', $value );
-		}
+	function dailyos_source_management_is_source_key( string $value ): bool {
+		return 1 === preg_match( '/^source:v1:[A-Za-z0-9_-]{16,160}$/', $value );
+	}
 
 		/**
 		 * Validate an entity type.
@@ -607,9 +636,9 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param string $value Candidate entity type.
 		 * @return bool
 		 */
-		function dailyos_source_management_is_entity_type( string $value ): bool {
-			return in_array( $value, [ 'account', 'person', 'project' ], true );
-		}
+	function dailyos_source_management_is_entity_type( string $value ): bool {
+		return in_array( $value, [ 'account', 'person', 'project' ], true );
+	}
 
 		/**
 		 * Validate an entity id.
@@ -617,23 +646,23 @@ if ( ! function_exists( 'dailyos_source_management_render' ) ) {
 		 * @param string $value Candidate entity id.
 		 * @return bool
 		 */
-		function dailyos_source_management_is_entity_id( string $value ): bool {
-			return 1 === preg_match( '/^[A-Za-z0-9:_-]{1,160}$/', $value );
-		}
+	function dailyos_source_management_is_entity_id( string $value ): bool {
+		return 1 === preg_match( '/^[A-Za-z0-9:_-]{1,160}$/', $value );
+	}
 
 		/**
 		 * Sanitize display text and reject path-like values.
-	 *
-	 * @param mixed  $value Candidate value.
-	 * @param string $fallback Fallback.
-	 * @param int    $max_length Maximum output length.
-	 * @return string
-	 */
+		 *
+		 * @param mixed  $value Candidate value.
+		 * @param string $fallback Fallback.
+		 * @param int    $max_length Maximum output length.
+		 * @return string
+		 */
 	function dailyos_source_management_safe_text( mixed $value, string $fallback, int $max_length = 120 ): string {
 		if ( ! is_scalar( $value ) ) {
 			return $fallback;
 		}
-		$text = preg_replace( '/\s+/', ' ', trim( strip_tags( (string) $value ) ) ) ?? '';
+		$text = preg_replace( '/\s+/', ' ', trim( wp_strip_all_tags( (string) $value ) ) ) ?? '';
 		if ( '' === $text || str_contains( $text, '/' ) || str_contains( $text, '\\' ) ) {
 			return $fallback;
 		}

--- a/wp/dailyos/includes/class-dailyos-markdown-sanitizer.php
+++ b/wp/dailyos/includes/class-dailyos-markdown-sanitizer.php
@@ -13,6 +13,7 @@ namespace DailyOS;
  * Sanitizes already-rendered preview HTML before it reaches the browser.
  */
 final class DailyOS_Markdown_Sanitizer {
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- DOMDocument exposes camelCase properties.
 	public const LOCAL_ASSET_PLACEHOLDER = '[local asset blocked]';
 	public const REMOTE_ASSET_PLACEHOLDER = '[remote asset blocked]';
 
@@ -332,7 +333,10 @@ final class DailyOS_Markdown_Sanitizer {
 	 * @return string
 	 */
 	private function clean_class_list( string $value ): string {
-		$tokens = preg_split( '/\s+/', trim( $value ) ) ?: [];
+		$tokens = preg_split( '/\s+/', trim( $value ) );
+		if ( false === $tokens ) {
+			$tokens = [];
+		}
 		$allowed = [];
 		foreach ( $tokens as $token ) {
 			if ( 1 === preg_match( '/^dailyos-markdown-preview(?:__(?:[a-z0-9_-]+)|--(?:[a-z0-9_-]+))?$/', $token ) ) {

--- a/wp/dailyos/tests/MarkdownSanitizerTest.php
+++ b/wp/dailyos/tests/MarkdownSanitizerTest.php
@@ -38,6 +38,7 @@ final class DailyOS_MarkdownSanitizerTest extends TestCase {
 			'foreign'      => [ '<foreignObject><body onload=alert(1)></body></foreignObject>', [ 'foreignObject', 'onload', 'alert(1)' ] ],
 			'style_attr'   => [ '<p style="background:url(javascript:alert(1))">x</p>', [ 'style=', 'javascript:', 'alert(1)' ] ],
 			'style_tag'    => [ '<style>@import url(http://example.invalid/style.css)</style>', [ '<style', '@import', 'example.invalid' ] ],
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- Sanitizer fixture intentionally includes a dangerous stylesheet link.
 			'link'         => [ '<link rel="stylesheet" href="http://example.invalid/style.css">', [ '<link', 'example.invalid' ] ],
 			'object'       => [ '<object data="http://example.invalid/payload"></object>', [ '<object', 'example.invalid' ] ],
 			'embed'        => [ '<embed src="http://example.invalid/payload">', [ '<embed', 'example.invalid' ] ],

--- a/wp/dailyos/tests/blocks/SourceManagementBlockTest.php
+++ b/wp/dailyos/tests/blocks/SourceManagementBlockTest.php
@@ -60,7 +60,7 @@ final class DailyOS_SourceManagementBlockTest extends TestCase {
 				],
 				'sources'      => [
 					[
-							'sourceKey'        => 'source:v1:abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-',
+						'sourceKey'        => 'source:v1:abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-',
 						'sourceHandle'     => 'source_opaque_123',
 						'file_id'          => 'pathhash-alpha',
 						'link_id'          => 'link-alpha',
@@ -70,38 +70,42 @@ final class DailyOS_SourceManagementBlockTest extends TestCase {
 						'sourceKind'       => 'mcp_placement',
 						'lifecycleState'   => 'quarantined',
 						'category'         => 'notes',
-							'sourceAsof'       => '2026-05-24T10:00:00Z',
-							'entity'           => [
-								'entityType' => 'account',
-								'entityId'   => 'acct-test-001',
-							],
-							'latestRun'        => [
+						'sourceAsof'       => '2026-05-24T10:00:00Z',
+						'entity'           => [
+							'entityType' => 'account',
+							'entityId'   => 'acct-test-001',
+						],
+						'latestRun'        => [
+							'status'             => 'success',
+							'claimCountProduced' => 2,
+						],
+						'ingestionRuns'    => [
+							[
 								'status'             => 'success',
 								'claimCountProduced' => 2,
 							],
-							'ingestionRuns'    => [
-								[
-									'status'             => 'success',
-									'claimCountProduced' => 2,
-								],
-								[
-									'status'             => 'failed',
-									'claimCountProduced' => 0,
-								],
+							[
+								'status'             => 'failed',
+								'claimCountProduced' => 0,
 							],
-							'trustBandSummary' => [
+						],
+						'trustBandSummary' => [
 							'total'             => 3,
 							'likelyCurrent'     => 1,
 							'useWithCaution'    => 1,
 							'needsVerification' => 1,
 							'unscored'          => 0,
 						],
-							'actions'          => [
-								'canReingest'    => true,
-								'canQuarantine'  => true,
-								'canRelink'      => true,
-								'disabledReason' => '',
-							],
+						'actions'          => [
+							'canReingest'    => true,
+							'canQuarantine'  => true,
+							'canRelink'      => true,
+							'canIgnore'      => true,
+							'canScratchpad'  => true,
+							'canArchive'     => true,
+							'canDelete'      => true,
+							'disabledReason' => '',
+						],
 					],
 				],
 			]
@@ -118,7 +122,15 @@ final class DailyOS_SourceManagementBlockTest extends TestCase {
 			$this->assertStringContainsString( 'Re-ingest', $html );
 			$this->assertStringContainsString( 'Quarantine', $html );
 			$this->assertStringContainsString( 'Re-link', $html );
+			$this->assertStringContainsString( 'Ignore', $html );
+			$this->assertStringContainsString( 'Scratchpad', $html );
+			$this->assertStringContainsString( 'Archive', $html );
+			$this->assertStringContainsString( 'Delete', $html );
 			$this->assertStringContainsString( 'data-dailyos-source-action="reingest"', $html );
+			$this->assertStringContainsString( 'data-dailyos-source-action="ignore"', $html );
+			$this->assertStringContainsString( 'data-dailyos-source-action="scratchpad"', $html );
+			$this->assertStringContainsString( 'data-dailyos-source-action="archive"', $html );
+			$this->assertStringContainsString( 'data-dailyos-source-action="delete"', $html );
 			$this->assertStringContainsString( 'data-dailyos-source-key="source:v1:abcdefghijklmnopqrstuvwxyzABCDEF0123456789_-"', $html );
 			$this->assertStringNotContainsString( 'source_opaque_123', $html );
 		$this->assertStringNotContainsString( 'pathhash-alpha', $html );

--- a/wp/dailyos/tests/bootstrap.php
+++ b/wp/dailyos/tests/bootstrap.php
@@ -754,6 +754,19 @@ namespace {
 		}
 	}
 
+	if ( ! function_exists( '_n' ) ) {
+		function _n( string $single, string $plural, int $number, string $domain = 'default' ): string {
+			unset( $domain );
+			return 1 === $number ? $single : $plural;
+		}
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( string $text ): string {
+			return strip_tags( $text );
+		}
+	}
+
 	if ( ! function_exists( 'add_settings_error' ) ) {
 		function add_settings_error( string $setting, string $code, string $message, string $type = 'error' ): void {
 			$GLOBALS['dailyos_test_settings_errors'][ $setting ][] = [


### PR DESCRIPTION
## Linear ticket

DOS-476

## Summary

Closes the W5 trust and lifecycle release-gate gaps for v1.4.5 workspace memory by wiring source-management lifecycle policy actions through service APIs and validating real trust/context behavior.

## What changed

- Added source-management lifecycle actions for ignore, scratchpad, archive, and delete.
- Routed lifecycle actions through `services::source_management_ledger`, recording user overrides, transitioning workspace source lifecycle, and emitting privacy-safe `workspace_source_policy_changed` signals.
- Suppressed active workspace-backed claims from context readers when their backing workspace source is rejected, quarantined, superseded, ignored, scratchpad, archived, or deleted.
- Updated workspace graph audit exclusion handling and lifecycle slug serialization for the new states.
- Exposed the new actions in the WordPress source-management block with opaque source-key payloads.
- Closed the v146 trust and lifecycle validation axes with real `commit_claim`, trust recompute, and source action round-trip coverage.
- Cleaned up WordPress lint/plugin-check blockers surfaced by the whole-plugin PR gate.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (if frontend changes)
- [x] Manual verification: `bash tests/v146_validation/run.sh all`
- [x] Manual verification: `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] Manual verification: `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] Manual verification: `/Users/jamesgiroux/Documents/dailyos-repo/wp/dailyos/vendor/bin/phpunit --no-coverage --filter DailyOS_SourceManagementBlockTest`
- [x] Manual verification: `/Users/jamesgiroux/Documents/dailyos-repo/wp/dailyos/vendor/bin/phpunit --no-coverage`
- [x] Manual verification: `/Users/jamesgiroux/Documents/dailyos-repo/wp/dailyos/vendor/bin/phpcs -q --warning-severity=0`
- [x] Manual verification: `bash scripts/check_ability_inventory.sh`
- [x] Manual verification: `git diff --check`

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: N/A

**Exemption rationale**:

N/A. This PR touches service-layer source lifecycle, claim filtering, signal emission, and source-management rendering, so the security-auditor path is required.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Claim/source retraction for quarantined or deleted workspace sources remains deferred until the account/Glean claim producer lifecycle lane is coordinated. This PR only invalidates and suppresses reads.

## Notes for review

- No claim retraction, source purge, filesystem delete, account/Glean producer, or signal bus semantic changes are included.
- `workspace_source_policy_changed` uses existing service signal APIs and may coalesce during rapid sequential source actions.
- External `codex review` stalled with no output and was terminated. Manual bounded L2 over the changed files found no blocking issues; the commit carries `L2-status: not-run-acknowledged` for formal-runner accuracy.
