### PR TITLE
docs: reconcile v1.4.7 MCP plan

### DIFF
--- a/.docs/plans/v1.4.7-w1-foundation/dos-168-l0-plan.md
+++ b/.docs/plans/v1.4.7-w1-foundation/dos-168-l0-plan.md
@@ -1,0 +1,295 @@
+# DOS-168 — MCP v2 ability/service gateway + actor policy + auth + audit — L0 plan packet
+
+**Wave:** v1.4.7 W1-A
+**Lane spec:** [DOS-168](https://linear.app/a8c/issue/DOS-168)
+**Wave plan:** `.docs/plans/v1.4.7-waves.md` §"Agent W1-A — DOS-168"
+**Authoring discipline:** scoped tight; cycle-2 same-shape findings driven by my substrate-grep errors → cycle-3 grounds every claim with the verified path. Cycle-2 architectural questions resolved via small W0 amendment (~30 LOC + ADR-0102 cycle-7 text) folded into this packet as a precondition deliverable.
+
+## Cycle-7 changelog (2026-05-20) — close cycle-6 NEW HIGHs via substrate landing
+
+Cycle-6 verdicts: challenge **BLOCK**; architect / CSO / devex **NEEDS-CHANGES**. 3 convergent NEW HIGH: (a) per-response nonce refresh + transport envelope shape (CSO + challenge + architect MED); (b) nonce ledger lifecycle gaps (issued_at/expires_at, fail-closed) (architect MED + challenge HIGH + CSO MED); (c) L6-3 handler docs NOT actually landed (devex HIGH + challenge) — taxonomy.rs was still a stub despite my packet claim.
+
+**Substrate landed BEFORE cycle-7 dispatch (per "stop the shape-only is a trap" pattern):**
+
+1. **`services/mcp_v2/contracts.rs`** — `OpaqueNonce` newtype + `request_nonce: OpaqueNonce` on `McpToolRequestEnvelope` + `next_request_nonce: OpaqueNonce` on `McpToolResponseEnvelope` + parity tests (`opaque_nonce_wire_is_transparent_string` + updated 4 envelope parity tests). 27/27 contracts tests pass.
+2. **ADR-0102 cycle-9 amendment** — §C.bis.refresh (per-response nonce refresh; seed at pairing, fresh nonce per response, asymmetric flow), §C.bis.schema (full ledger DDL with `issued_at`/`expires_at`/`consumed_at` + 3 indexes + atomic consume SQL), §C.bis.fail-closed (consumed nonce stays consumed even on downstream failure — fail-closed against TCP-reset replay attack), §C.bis.sweep (background sweep cadence + grace window).
+3. **`services/mcp_v2/taxonomy.rs`** — actual `TaxonomyCatalog` trait + `TaxonomyError::HandlerCatalogMismatch` (architect cycle-6 LOW: catalog-neutral naming, NOT `HandlerYamlMismatch`) + ~130 lines of rustdoc with concrete Side::Read no-cursor example + concrete Side::Write required-cursor example + composite-mutation example + cursor-shape-per-service table (claim_id → CommittedClaim.new_claim_id at services/claims.rs:209; signal_id → emit* String return at services/signals.rs:46-106; action_id → services::actions::*). cargo check clean.
+
+Cycle-7 packet changes:
+
+1. **§1 #1 gateway flow narrative** updated to use the new request envelope shape: Gate 0 verifies HMAC over (payload + `envelope.request_nonce`); calls `auth::verify_and_consume_nonce(client_id, envelope.request_nonce)` per ADR-0102 §C.bis.refresh. On success, gateway invokes handler; on response, calls `auth::issue_next_nonce(client_id)` → returns `next_request_nonce` in response envelope.
+2. **AC-2** unchanged structurally (decision order preserved); Gate 0 references new `verify_and_consume_nonce`.
+3. **AC-6** mutation_cursor convention: SHOULD-with-warning (NOT MUST-fail per devex cycle-6 MED). Side::Write without cursor → Suite-S `mcp_write_handler_missing_cursor` signal + audit row written without cursor field. Forced MUST-fail (dev-mode validator that rejects test fixtures) filed as separate W1.5 ticket.
+4. **AC-7 reject signal durability** (challenge cycle-6 MED): `emit_signal` for `McpInvocationRejected` uses the emit-or-log pattern; failure → fallback warning log + Suite-S alert `mcp_reject_signal_emit_failed`. No forensic blind spot.
+5. **AC-11 + AC-12 + AC-5** unchanged (already correct per cycle 6).
+6. **Migration v243 schema reflects ADR-0102 §C.bis.schema**: full DDL with `nonce, client_id, issued_at, expires_at, consumed_at` + 3 indexes + atomic consume predicate + background sweep + 1h grace window.
+7. **L6-3 substrate-truth verified**: taxonomy.rs now contains `TaxonomyCatalog` trait + rustdoc; not a stub.
+
+Cycle-7 net delta: ~25 lines packet + 60 LOC code (contracts.rs OpaqueNonce + envelope amendments + tests) + 130 LOC code (taxonomy.rs trait + rustdoc) + 100 lines ADR cycle-9 amendment. Cumulative cycles 1→7: 151 → 296 LOC packet (+145 over 7 cycles, well within the K-in `<80/cycle` discipline target).
+
+---
+
+## Cycle-6 changelog (2026-05-20) — L6 decisions folded in
+
+User L6 verdict (3 structural decisions) folded in this cycle:
+
+**L6-1 (replay guard) = nonce ledger.** Per ADR-0102 §C cycle-8 amendment (this cycle): every MCP message MUST carry a server-issued `request_nonce` signed in the HMAC; server stores recently-seen nonces in `mcp_transport_nonce_ledger` (v243-shifted-up to v244 — see slot reallocation below); replay attempts within window → `ToolError::BadParams { detail: "nonce_replayed" }`. Mirrors `services::surface_nonce::verify_and_consume` pattern verbatim. Closes cycle-5 CSO HIGH.
+
+**L6-2 (reject audit) = drop `internal_reject_reason`.** AC-6 narrows: audit append happens ONLY on handler success. Auth-state rejections (`PairingRevoked` / `ExposureForbidden` / `Unauthorized` / `ConversationRevoked`) emit Suite-S signal `mcp_invocation_rejected` (per ADR-0115 NonPiiMetadata) carrying `client_id` (if manifest resolved) or `<unresolved>` plus the reject reason. No audit row for rejects. Closes cycle-5 challenge HIGH + architect MED. Removes the AC-6 vs handler-success-precondition contradiction.
+
+**L6-3 (handler docs) = rustdoc on TaxonomyCatalog trait.** Cursor convention documented as rustdoc on `TaxonomyCatalog` trait in `services/mcp_v2/taxonomy.rs`. ~30 lines: trait-level overview + per-method examples (`Ok(json!({..., "mutation_cursor": {"claim_id": 42}}))`); naming conventions; allowed cursor ID shapes (UUID, integer, opaque hash; NEVER PII per AC-6). `cargo doc` surfaces it for handler authors. Closes cycle-5 devex HIGH.
+
+Cycle-6 packet edits:
+
+1. **AC-2 + §1 #1 + AC-12** add nonce check as Gate 0 (BEFORE PairingRevoked): `auth::verify_transport_hmac(payload, sig, presented_nonce)` verifies HMAC AND checks/consumes nonce; failure → `ToolError::BadParams { detail: "invalid_signature" }` OR `{ detail: "nonce_replayed" }`. Identical wall-clock floor via `sleep_until(start + 10ms)` to prevent timing oracle.
+2. **AC-6 reworded** (L6-2): "Handler success precedes audit append. On rejection, NO audit row is written; instead a `SignalType::McpInvocationRejected` is emitted (NonPiiMetadata; payload: `client_id_or_unresolved`, `reject_reason`). Audit detail JSON: `{client_id, conversation_handle, tool_name, params_hash, response_hash, mutation_cursor?}` — `internal_reject_reason` field REMOVED (per L6-2; rejections handled via SignalType not audit). Outbox path unchanged for JSONL append failures on success-rows."
+3. **AC-7 extended**: registers TWO new SignalTypes — `McpToolInvoked` (existing) + `McpInvocationRejected` (new). Both NonPiiMetadata per ADR-0115. Same 5-touchpoint wiring.
+4. **AC-11 + AC-12** unchanged structurally (Zeroizing wrapper, 10ms floor preserved); applies to nonce-check path too.
+5. **§14 + taxonomy.rs**: trait gets rustdoc per L6-3. Concrete examples for handler authors.
+6. **Migration slot reallocation**: insert v243 for nonce ledger; bump original v243 (rate-limit ledger + audit outbox) → v244.
+   - **v241** `mcp_client_manifest` (unchanged)
+   - **v242** `mcp_conversation_handle` (unchanged: `(handle, client_id, mint_at, last_touched_at, revoked_at)` per cycle-3 binding)
+   - **v243** `mcp_transport_nonce_ledger` (`nonce, client_id, consumed_at`; UNIQUE composite on `(nonce, client_id)`; index for cleanup; window = 5 minutes)
+   - **v244** `mcp_tool_call_ledger` + `mcp_audit_outbox` (was v243)
+7. **ADR-0102 §C cycle-8 amendment** (this cycle) documents the nonce ledger requirement: 5-minute window, `services::surface_nonce` precedent, BadParams variants. Lands in Deliverable 0 alongside cycle-7.
+
+Cycle-6 net delta: +30 lines packet + 1 substrate landing (nonce ledger spec) + 1 ADR amendment.
+
+---
+
+## Cycle-5 changelog (2026-05-20)
+
+Cycle-4 verdicts: codex challenge **BLOCK**; architect / CSO / devex **NEEDS-CHANGES**. **Unanimous (4/4)** on two issues: (i) §1 #1 still contradicted AC-2 on the absent-grant branch (3rd cycle hitting the same propagation gap); (ii) `ServiceMutationCursor` was claimed as landed but `rg` finds no such type in `contracts.rs` (and the substrate citations for `CommittedClaim.claim_id` and `services::signals::publish -> SignalId` were wrong — actual shapes are `CommittedClaim { claim, new_claim_id }` and `services::signals::emit*` returning `String`). 3/4 on namespace collision lint not credible (script absent, paths wrong: `src/mcp/main.rs` should be `src-tauri/src/mcp/main.rs`, W1-B YAML doesn't exist yet). 2/3 on AC-12 ±5ms ceiling not portable on macOS/Linux CI.
+
+Cycle-5 changes (all surgical, all substrate-verified via `rg` before writing):
+
+1. **§1 #1 absent-grant branch fixed** (4/4 convergent). Narrative now reads: "absent grant OR non-Invocable exposure → `ExposureForbidden { tool_name }`; grant present AND invocable, but `scopes_required.is_subset(scopes_granted)` false → `Unauthorized { missing_scope }`." Matches AC-2 verbatim. Grep-validated: `rg 'absent grant' dos-168-l0-plan.md` returns only the matching new wording.
+2. **ServiceMutationCursor REMOVED from Deliverable 0 / W0 amendment scope** (4/4 convergent). The `McpToolHandler::invoke` W0-frozen trait signature does NOT change. Cursor enforcement happens at the gateway level via JSON inspection: gateway extracts `result_value.get("mutation_cursor")` after handler success for `Side::Write` handlers. If absent for `Side::Write`, gateway logs a Suite-S warning `mcp_write_handler_missing_cursor` (forensic alert; handler effects preserved) and proceeds to audit append with `mutation_cursor` field absent in detail JSON. The cursor convention is documented in W1-A `taxonomy.rs` `TaxonomyCatalog` trait docs (Side::Write handlers SHOULD populate cursor). No new W0 type added.
+3. **Substrate citations corrected** (architect HIGH + devex HIGH + CSO MED). `CommittedClaim` is at `services/claims.rs:209` with `new_claim_id` field (not `claim_id`); `services::signals::emit*` returns `String` (at `services/signals.rs:46-106`), not `publish -> SignalId`. AC-6 cursor format: `mutation_cursor: serde_json::Value` (typed-less, IDs only — no payloads per CSO MED). Convention documented in taxonomy.rs trait docs.
+4. **Namespace collision CI REMOVED from W1-A scope** (3/4 convergent). Filed as separate Linear ticket "v1.4.7 W1.5 — MCP v2 namespace collision CI" (Maintenance project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`). The CI lint requires W1-B YAML which doesn't exist yet AND clean reading of the legacy tool list at `src-tauri/src/mcp/main.rs:715-730` (challenge cycle-4 cited path is correct). Cycle-4 §7 + AC-10 reference + §11 entry all dropped.
+5. **AC-12 timing floor reworked** (2/3 — challenge + CSO). Drop ±5ms ceiling (not portable). Gateway uses `tokio::time::sleep_until(start + Duration::from_millis(10))` before returning ANY `Unauthorized` / `ExposureForbidden` / `PairingRevoked` / `ConversationRevoked` error. Test asserts both missing-client and invalid-HMAC branches return after `>= 10ms` wall-clock; no upper bound. Identical error shape constraint preserved (uniform JSON keys).
+6. **AC-11 key custody spelled out** (CSO not-closed). `auth::verify_transport_hmac` wraps loaded key in `Zeroizing<[u8; 32]>` from the `zeroize` crate; per `Zeroize` Drop impl the buffer is wiped on function exit. (NOT the line 623 derivation; correct precedent is `SecretBytes32` at `src/surface_runtime/hmac.rs:643`.) Test asserts `verify_transport_hmac` does not retain key reference past function return.
+7. **AC-6 internal reject reason** (architect MED). Audit detail JSON includes `internal_reject_reason: Option<String>` carrying machine-readable cause (`absent_grant`, `non_invocable`, `missing_scope:<scope>`, `invalid_hmac`, `pairing_revoked`, `conversation_revoked`) for forensic ordering. Wire shape stays merged — caller sees only the typed `ToolError`. No leak.
+8. **AC-5 ledger pruning order** (challenge tightening). Explicit transaction order: `BEGIN IMMEDIATE` → `DELETE FROM mcp_tool_call_ledger WHERE client_id = ?1 AND tool_name = ?2 AND called_at < (?3 - window_seconds_ms)` → `SELECT COUNT(*) FROM mcp_tool_call_ledger WHERE client_id = ?1 AND tool_name = ?2` → if `count >= max_calls` ROLLBACK + return `RateLimited`; else `INSERT INTO mcp_tool_call_ledger VALUES (?1, ?2, ?3)` → `COMMIT`.
+9. **`mcp_audit_outbox` access control** (CSO MED). Same access pattern as JSONL audit log per ADR-0094: operator-only via existing audit inspection paths (`get_audit_log_records` / `export_audit_log` Tauri commands). No separate CLI / no MCP exposure of outbox contents. Outbox is forensic only.
+10. **AC-6 mutation_cursor cap** (devex MED). `mutation_cursor` JSON field max depth 4, max byte size 2 KiB (uniform with existing `MCP_INVOCATION_CACHE_ENTRY_BYTE_CAP / 5` budget at `bridges/mcp.rs`). Test asserts oversize → gateway logs warning + truncates to placeholder `"truncated_oversize"` in audit detail; handler effects preserved.
+11. **DX note added** (devex MED). 10ms response floor on auth-state errors adds latency vs sub-ms paths. Acceptable security tradeoff (prevents client_id enumeration). Hosts amortize via successful-result caching.
+
+Cycle-5 packet net delta: +35 lines. Cumulative cycle 1→5: 151 → ~253. Cycle-5 is the convergence cycle; no new scope, only AC + narrative tightening + 1 ticket spinoff.
+
+---
+
+## Cycle-4 changelog (2026-05-20)
+
+Cycle-3 verdicts: codex challenge **BLOCK** (1 NEW HIGH AC-2 + 2 MED; cycle-2 "STILL-OPEN" findings were all about Deliverable 0 not having landed yet); architect **NEEDS-CHANGES** (7/7 closed; 1 NEW HIGH AC-2; 1 MED wave-plan-stale); CSO **NEEDS-CHANGES** (2 STILL-OPEN due to Deliverable 0 unlanded + 1 unverified-floor; 3 NEW MED + 1 LOW); devex **NEEDS-CHANGES** (4/4 packet-level closed; 1 NEW HIGH "Deliverable 0 must actually land" + 1 NEW HIGH mutation_cursor + 1 MED fixture realism).
+
+Convergent NEW HIGH (3/4): AC-2 internal inconsistency between §1 #1 and the AC body on `Unauthorized` vs `ExposureForbidden` branching. **All cycle-3 "STILL-OPEN" findings about Deliverable 0 are now closed by substrate landing** — `contracts.rs` carries `ExposureForbidden` variant + golden parity test; ADR-0102 carries cycle-7 amendment (§C.bis + §D.bis); wave plan stale text fixed at lines 85, 453, 467.
+
+Cycle-4 changes:
+
+1. **Deliverable 0 has landed in this same branch** (closes the 4/4 "shape-only is a trap" finding). Substrate-truth, not packet promise. Cycle-4 reviewers can grep `ExposureForbidden` in `contracts.rs` + read ADR-0102 cycle-7 amendment + verify wave plan lines 85/453/467 carry the new text.
+2. **AC-2 reworded to architect's recommended decision order** (closes convergent NEW HIGH). Decision order: (i) `revoked_at.is_some()` → `PairingRevoked`; (ii) absent grant OR `exposure != Invocable` → `ExposureForbidden { tool_name }`; (iii) grant present + invocable but `scopes_required.is_subset(scopes_granted)` false → `Unauthorized { missing_scope }`; (iv) caller-asserted scope/conversation_id in params → `BadParams`. §1 #1 narrative aligned.
+3. **AC-12 timing oracle gains numeric floor** (CSO MED): floor = 10ms minimum response time on `Unauthorized` failure paths (missing-client + invalid-HMAC); tolerance = ± 5ms jitter ceiling. Test asserts measured wall-clock floor is `>= 10ms - 5ms = 5ms` for both branches. Implementation: gateway uses `tokio::time::sleep_until(start + 10ms)` before returning either error.
+4. **AC-11 transport key uses `Zeroizing<[u8; 32]>`** (CSO MED): per existing `surface_runtime/hmac.rs:623` precedent — Rust drop is insufficient for transient key material. `auth::verify_transport_hmac` borrows the key inside `Zeroizing` wrapper; on function exit the buffer is zeroized.
+5. **mcp_tool_call_ledger pruning + composite index** (challenge MED): v243 migration adds `idx_mcp_tool_call_ledger_client_tool_called ON (client_id, tool_name, called_at)` + same-transaction prune step in the rate-limit reservation: `DELETE FROM mcp_tool_call_ledger WHERE client_id = ?1 AND tool_name = ?2 AND called_at < ?3 - window_seconds_ms` before the `BEGIN IMMEDIATE` insert.
+6. **mutation_cursor specified per service** (devex HIGH + challenge MED): for `Side::Write` handlers, the gateway requires the handler's `Ok(value)` payload to carry a `mutation_cursor: ServiceMutationCursor` field. `ServiceMutationCursor` is a tagged enum: `Claim { claim_id: ClaimId }`, `Signal { signal_id: SignalId }`, `Action { action_id: ActionId }`, `Multi(Vec<ServiceMutationCursor>)` — handlers route through `services::claims::commit_claim` (returns `CommittedClaim { claim_id: ClaimId, ... }` per `services/claims.rs:204`), `services::signals::publish` (returns `SignalId` per `services/signals.rs:46-106`), or `services::actions::*` (returns `ActionId`). For `Side::Read` handlers, `mutation_cursor` is omitted from the audit detail (no mutation happened). New W0 type added in cycle-4 substrate landing: `ServiceMutationCursor` in `services/mcp_v2/contracts.rs` (small additive type, sibling to `ToolError`).
+7. **Legacy coexistence interim guard** (CSO MED): **SUPERSEDED by cycle-5 #4** — the namespace collision CI is moved out of W1-A scope (script doesn't exist; cross-wave dep on W1-B YAML; path was wrong: `src/mcp/main.rs` should be `src-tauri/src/mcp/main.rs`). Filed as separate Linear ticket "v1.4.7 W1.5 — MCP v2 namespace collision CI" in Maintenance project. AC-10 records the spinoff.
+8. **AC-3b fixture realism** (devex MED): cross-client test fixture uses two real paired `McpClientId`s minted via the pairing handshake (not synthetic strings), and a real `OpaqueConversationHandle` minted under client A presented by client B.
+9. **Wave-plan stale text fixed and verified in same commit** (architect MED): lines 85, 453, 467 now carry the dedicated-variant language per ADR-0102 cycle-7 amendment.
+
+Cycle-4 packet net delta: +20 lines (198 → ~218). Tight; cycle-4 is convergence cycle, not new scope.
+
+---
+
+## Cycle-3 changelog (2026-05-20)
+
+Cycle-2 verdicts: codex challenge **BLOCK** (1 STILL-OPEN HIGH + 2 NEW HIGH + 2 MED); architect **NEEDS-CHANGES** (2 STILL-OPEN + 3 NEW HIGH + 2 MED); CSO **NEEDS-CHANGES** (0 STILL-OPEN + 3 MED + 1 LOW); devex **BLOCK** (2 STILL-OPEN HIGH + 3 NEW HIGH + 2 MED). Convergent: sentinel-scope-on-Unauthorized (3/4), `bridges/mcp.rs:737` misidentified (2/4 — confirmed factually as test fixture), audit wire envelope mutation (2/4 — confirmed factually as W0 violation), handle client_id binding gap (2/4).
+
+Cycle-3 changes:
+
+1. **W0 amendment commit added as Deliverable 0** (Class N — 3/4 convergent + Class O — 2/4 convergent). Lands BEFORE W1-A body. Two changes to `src-tauri/src/services/mcp_v2/contracts.rs`:
+   - New `ToolError::ExposureForbidden { tool_name: ScopedName }` variant. Same shape as `PairingRevoked`/`ConversationRevoked` per ADR-0102 §C — auth-state classes that do not abuse `Scope` newtype. New parity test added.
+   - `OpaqueConversationHandle` wire shape unchanged (still opaque string); server-side binding spec amended in ADR-0102 §D — handles bind to `client_id` at mint time, resolve by `(client_id, handle)`, cross-client presentation returns `ConversationRevoked`. Wire layer stays compatible.
+   ADR-0102 §C/§D cycle-7 amendment text drafted as part of this commit (~6 lines added to ADR-0102).
+2. **§1 #8 bridges/mcp.rs change REMOVED** (Class Q — 2/4, factually confirmed). The `todo!()` at `src/bridges/mcp.rs:737` is inside `provenance_actor_for_test` (`#[cfg(test)] mod tests`), not production routing. There is no production `Actor::McpClient` arm in `bridges/mcp.rs` to wire in W1-A. Test fixture is filled by W2+ when the first `Actor::McpClient`-using handler ships parity tests.
+3. **Audit wire envelope mutation REMOVED** (Class R — 2/4, factually confirmed). `audit_outbox_pending` warning no longer surfaces on `McpToolResponseEnvelope` (W0 frozen with only `conversation_handle` + `result`). Outbox state stays behind `audit.rs` — operator-visible only (Suite-S regression alert when outbox row count > 0).
+4. **Audit signature corrected** (Class S — 1/4, factually confirmed). `AuditLogger::append_with_actor(event: &str, actor: &Actor, fields: AuditFields)`. `event = "mcp.tool_invoked"` is the SEPARATE arg; `AuditFields { category: "security", detail: {...}, wp_user_id: None, wp_user_hash: None, request_id: Some(...) }` carries the structured payload. `audit_log.rs:325` already documents that McpClient routes through this path with `wp_user_id/hash = None`.
+5. **AC-2 reworded** (Class N closure): non-Invocable exposure returns `ToolError::ExposureForbidden { tool_name }` (W0 amendment, item 1 above). No sentinel scope. Missing scope still returns `ToolError::Unauthorized { missing_scope }`.
+6. **Handle migration shape updated** (Class O closure): v242 schema is `mcp_conversation_handle { handle, client_id, mint_at, last_touched_at, revoked_at }` with composite unique on `(handle, client_id)`. Resolve takes `(client_id, handle)`; mismatch → `ConversationRevoked`. AC-3b adds explicit cross-client rejection test.
+7. **Migration filename clarified** (Class T — architect HIGH #3): registered `version` field is authoritative. Filenames mirror version with no offset: `241_mcp_client_manifest.sql`, `242_mcp_conversation_handle.sql`, `243_mcp_rate_limit_and_audit_outbox.sql`. The `migration-filename-version-offset` solution doc applies to a different convention; cited here only as a discipline reminder, not as offset guidance.
+8. **W1-A/W1-B taxonomy seam restructured** (Class V — architect MED): W1-A defines the CATALOG INTERFACE in `taxonomy.rs` (validation function signature + binding contract). W1-B owns YAML LOADING + boot validation invocation. W1-A no longer dispatches off W1-B-owned YAML at runtime; the binding is purely a registry-time validation seam.
+9. **Manifest lookup is indexed** (Class U — architect MED): per-dispatch DB query is `SELECT * FROM mcp_tool_grant WHERE client_id = ? AND tool_name = ?` (indexed composite key), NOT `tool_grants: Vec<ToolGrant>` full-load. Manifest struct holds one resolved `ToolGrant` per call, not the full vector.
+10. **AC-6 audit-required emit-or-log caveat addressed** (Class W — challenge MED): if JSONL append fails AND outbox insert also fails, gateway returns `ToolError::Internal { trace_id }` to caller (handler effects preserved but caller is warned via Internal error), emits Suite-S alert `mcp_audit_double_failure` for operator action. Documented as a documented degradation path per the cited emit-or-log caveat.
+11. **Mid-call revocation audit state** (Class X — challenge MED): if revocation lands between manifest load and handler return, audit row's `detail` includes `revocation_state: "revoked_during_invocation"` per ADR-0102 §C.
+12. **Key custody AC added** (Class Y — CSO MED): transport key loaded from keychain for ONE HMAC verification per dispatch and dropped after; gateway state never caches the raw key. Test asserts `Manifest` struct contains `KeychainRef`, not raw bytes.
+13. **Timing oracle AC added** (Class Z — CSO LOW): missing-client and invalid-HMAC return the same `ToolError::Unauthorized` shape with the same response timing (bounded by a uniform sleep floor). Test asserts both paths return the same wall-clock-floor.
+14. **AC-6 temporal ordering note added** (Class AA — devex MED): audit is post-commit attribution, not source-of-order truth. AC-6 detail carries mutation cursor IDs (e.g., `claim_id`, `signal_seq`) so audit ordering can be reconstructed from substrate even when audit timestamp != mutation timestamp.
+15. **Taxonomy mismatch returns structured error** (Class BB — devex MED): boot-time mismatch returns `TaxonomyError::HandlerYamlMismatch { handler, yaml }` to the registry init path; operator-friendly error message + operator-init suggested fix. No `panic!()`.
+16. **Wave plan stale text fixed** (Class G — devex HIGH): doc-only edit to `.docs/plans/v1.4.7-waves.md:451+467` removing `Unauthorized { missing_scope: "valid_conversation" }`, lands in same commit as W0 amendment.
+
+Cycle-3 packet net delta from cycle-2: +60 lines (151 → 184 → ~245). Most of the delta is the changelog above + AC tightening + the W0 amendment specification. Not in cycle-2's "5+ net-new findings per cycle / 80+ line revision" diminishing-returns range.
+
+---
+
+## Deliverable 0 — W0 amendment commit (precondition)
+
+Lands BEFORE W1-A body (own commit, own L2 cycle). Files (all already landed in this branch as of cycle-3/cycle-6 substrate work):
+
+- `src-tauri/src/services/mcp_v2/contracts.rs` — `ToolError::ExposureForbidden { tool_name: ScopedName }` variant + golden parity test (`tool_error_exposure_forbidden_wire_shape`). LANDED.
+- `.docs/decisions/0102-abilities-as-runtime-contract.md` — cycle-7 amendment (§C.bis sentinel-scope ExposureForbidden + §D.bis handle client_id binding) + cycle-8 amendment (§C.bis.replay nonce ledger per L6-1 user verdict). LANDED.
+- `.docs/plans/v1.4.7-waves.md` — stale `Unauthorized { missing_scope: "valid_conversation" }` text fixed at lines 85 + 451 + 467. LANDED.
+
+Total: ~45 LOC code + ~50 lines doc. All grep-verified against substrate before cycle-6 dispatch.
+
+---
+
+## 1. What this lane ships (W1-A body, lands AFTER Deliverable 0)
+
+1. **`src-tauri/src/services/mcp_v2/gateway.rs`** — `Gateway::handle_tool_call(envelope: McpToolRequestEnvelope) -> McpToolResponseEnvelope`. Per-dispatch flow (matches AC-2 verbatim): **Gate 0a** `auth::verify_transport_hmac(payload, sig)` — HMAC failure → `ToolError::BadParams { detail: "invalid_signature" }`. **Gate 0b** `auth::verify_and_consume_nonce(client_id, envelope.request_nonce)` per ADR-0102 §C.bis.refresh (cycle-9 amendment) — atomic SQL `UPDATE mcp_transport_nonce_ledger SET consumed_at = ?now WHERE client_id = ?c AND nonce = ?n AND consumed_at IS NULL AND expires_at >= ?now`; on `rowsAffected = 0` reject with `{ detail: "nonce_replayed" }` (row consumed) or `{ detail: "invalid_signature" }` (row absent/expired — uniform shape). Fail-closed: consumed nonce stays consumed even on downstream failure. Then: `auth::load_client_record(client_id)` → reject if `revoked_at.is_some()` (→ `PairingRevoked`); `auth::resolve_tool_grant(client_id, tool_name)` (indexed lookup, single row) → **absent grant OR `grant.exposure != Invocable` → `ExposureForbidden { tool_name }`**; **grant present AND invocable but `tool.description().scopes_required.is_subset(grant.scopes_granted)` false → `Unauthorized { missing_scope }`**; `auth::resolve_or_mint_handle(client_id, envelope.conversation_handle)` (mismatch → `ConversationRevoked`); enforce rate limit BEFORE dispatch via atomic ledger insert (AC-5 explicit tx order); construct `McpActor::Client`; dispatch via registered `McpToolHandler`; on success → extract `mutation_cursor` from `result_value.get("mutation_cursor")` for `Side::Write` (Suite-S warning if absent for Write — SHOULD not MUST per AC-6); → `audit::write(event, fields, actor)` via emit-or-log path (handler effects preserved on audit failure); emit `SignalType::McpToolInvoked`; **call `auth::issue_next_nonce(client_id)` to mint fresh nonce** → return `next_request_nonce` in response envelope. On any auth-state rejection (BadParams from Gate 0a/0b, PairingRevoked, ExposureForbidden, Unauthorized, ConversationRevoked): NO audit row written; emit `SignalType::McpInvocationRejected` via emit-or-log helper (failure → fallback log + Suite-S alert `mcp_reject_signal_emit_failed` per AC-7); gateway calls `tokio::time::sleep_until(start + Duration::from_millis(10))` for AC-12 timing parity; mint fresh nonce on response anyway (so client can recover).
+2. **`src-tauri/src/services/mcp_v2/auth.rs`** — `pair_client(handshake) -> McpClientId` (mirrors `services::surface_pairing` + `services::surface_session_keychain` per ADR-0102 §C); `load_client_record(client_id) -> ClientRecord`; `resolve_tool_grant(client_id, tool_name) -> Option<ToolGrant>` (indexed query); `verify_transport_hmac(payload, sig)` (loads key for one verify, drops); `resolve_or_mint_handle(client_id, presented) -> OpaqueConversationHandle` (mint on None; resolve by `(client_id, handle)`; mismatch → `ConversationRevoked`); `revoke_handle / revoke_client` admin paths.
+3. **`src-tauri/src/services/mcp_v2/audit.rs`** — `write(event, actor, params, response_or_error, request_id)`. Computes keyed HMAC-SHA256 hashes per ADR-0102 §C. Calls `AuditLogger::append_with_actor(event = "mcp.tool_invoked", actor = &Actor::McpClient { .. }, fields = AuditFields { category: "security", detail: serde_json!({client_id, conversation_handle, tool_name, params_hash, response_hash, revocation_state?, mutation_cursor?}), wp_user_id: None, wp_user_hash: None, request_id: Some(...) })`. On JSONL append failure → insert into `mcp_audit_outbox` table. On outbox failure → return `ToolError::Internal { trace_id }` to caller + emit Suite-S `mcp_audit_double_failure` alert.
+4. **`src-tauri/src/services/mcp_v2/actor_policy.rs`** — `ClientRecord -> AbilityPolicy` projection consumed by gateway. Per ADR-0102 §B asymmetry, `Actor::McpClient` carries no scopes; this module owns the projection.
+5. **`src-tauri/src/services/mcp_v2/taxonomy.rs`** — W1-A defines the CATALOG INTERFACE only: `pub trait TaxonomyCatalog { fn validate_against_handlers(&self, handlers: &[&dyn McpToolHandler]) -> Result<(), TaxonomyError> }` + `TaxonomyError::HandlerYamlMismatch { handler: ScopedName, yaml: Option<ScopedName> }`. W1-B fills the YAML loader and invokes `validate_against_handlers` at boot.
+6. **`src-tauri/src/signals/policy_registry.rs`** — adds `SignalType::McpToolInvoked` at 5 sites per ADR-0115: enum variant; `from_name`; `canonical_name`; known-names const; `policy_for` returning `SignalPolicy::local_observation + NonPiiMetadata`. Payload: `tool_name`, `client_id`, `conversation_handle`. NO raw params/response. Suite S invariant.
+7. **`src-tauri/src/migrations.rs`** — FOUR migrations in v241–v244 (cycle-6 added v243 nonce ledger per L6-1; original v243 rate-limit + audit-outbox shifted to v244). Latest registered is v240 at `migrations.rs:927`; filename mirrors version with no offset:
+   - **v241** `241_mcp_client_manifest.sql` — `mcp_client_manifest (client_id, paired_at, revoked_at, transport_key_ref)` + `mcp_tool_grant (client_id, tool_name, scopes_granted_json, exposure, rate_limit_max, rate_limit_window_secs)` with index `idx_mcp_tool_grant_client_tool ON (client_id, tool_name)`.
+   - **v242** `242_mcp_conversation_handle.sql` — `mcp_conversation_handle (handle, client_id, mint_at, last_touched_at, revoked_at)` with `UNIQUE(handle, client_id)` + `idx_mcp_conversation_handle_lookup ON (client_id, handle)`.
+   - **v243** (cycle-6 NEW per L6-1; cycle-7 schema completed per ADR-0102 §C.bis.schema) `243_mcp_transport_nonce_ledger.sql` — `mcp_transport_nonce_ledger (nonce TEXT, client_id TEXT, issued_at INTEGER, expires_at INTEGER, consumed_at INTEGER NULL)` with `UNIQUE(nonce, client_id)` + `idx_mcp_nonce_lookup ON (client_id, nonce)` + `idx_mcp_nonce_consumed ON (consumed_at)` + `idx_mcp_nonce_expires ON (expires_at)`. Window: 5 minutes (`expires_at = issued_at + 5min`) per ADR-0102 §C.bis.refresh. Atomic consume per §C.bis.schema: `UPDATE ... SET consumed_at = ?now WHERE client_id = ?c AND nonce = ?n AND consumed_at IS NULL AND expires_at >= ?now`. Background sweep every 5 min deletes rows where `expires_at < now() - 1 hour` (1h grace per §C.bis.sweep). Fail-closed per §C.bis.fail-closed.
+   - **v244** (was v243) `244_mcp_rate_limit_and_audit_outbox.sql` — `mcp_tool_call_ledger (client_id, tool_name, called_at)` for sliding-window rate accounting (`BEGIN IMMEDIATE` for atomic reservation) + `mcp_audit_outbox (id, event, detail_json, actor_kind, request_id, created_at, drained_at)` forensic store.
+8. **`src-tauri/scripts/check_mcp_tool_handler_allowlist.sh`** — CI lint forbidding direct DB writes from `services/mcp_v2/handlers/*.rs`. Acknowledged porous per `docs/solutions/architecture-patterns/capability-boundary-needs-crate-split-not-grep-2026-05-18.md`; structural enforcement filed as a separate maintenance ticket if a real bypass surfaces in W2+.
+
+## 2. Coexistence with legacy MCP
+
+The wave plan §W1-A explicitly admits coexistence: v2 introduces a v2-paired ingress for clients that opt into the ADR-0102 §C contract; legacy `src/mcp/main.rs` + `src/bridges/mcp.rs:402` continue serving `Actor::Agent` (pre-pairing substrate). The two paths route by `Actor` variant at the abilities-runtime layer (per ADR-0102 §F `AbilityPolicy.allowed_actors`).
+
+The challenge HIGH "every MCP-originated invocation must pass §C four gates" applies forward — to v1.4.7-introduced ingress. Legacy is grandfathered; retirement is a separate Linear ticket (filed at L0 close).
+
+**W1-A does NOT touch legacy code paths.** The `Actor::McpClient` test fixture in `src/bridges/mcp.rs:737` is filled by W2+ when first handler ships its parity test; production legacy code (`mcp/main.rs:1379` rmcp stdio serving) stays unchanged.
+
+**W1-A does NOT ship:** per-tool handler bodies (handlers/*.rs placeholders untouched); tool taxonomy YAML (W1-B); MCP write allowlist extension (W4); new `Actor::McpClient` enum variant or `McpClientId` / `OpaqueConversationHandle` newtypes (W0 already shipped in `abilities-runtime/src/abilities/registry.rs:124,153,441`); new pairing transport design (mirrors surface_pairing).
+
+## 3. Frozen substrate citations (W0 + W0-amendment + ADRs)
+
+- **W0 contracts (`src-tauri/src/services/mcp_v2/contracts.rs`)** — `ToolDescription`, `Side`, `ScopedName`, `Scope`, `ParamSpec`, `ReturnSpec`, `ToolExample`, `Page<T>`, `OpaqueConversationHandle` (wire envelope, opaque string), `McpClientId`, `McpActor::Client`, `McpToolRequestEnvelope` (no granted_scopes — gateway hydrates), `McpToolResponseEnvelope` (frozen: `conversation_handle` + `result`; no audit warnings), `McpToolResult`, `McpToolHandler` trait, `ToolError` (Deliverable 0 adds `ExposureForbidden`).
+- **`abilities-runtime/src/abilities/registry.rs:106-153,441-480`** — `Actor::McpClient`, `McpClientId`, `OpaqueConversationHandle` runtime types.
+- **`abilities-runtime/src/inventory.rs:63,412-433,611,679`** — `ActorKind::McpClient` discriminator + `AbilityActor::project()` Agent+Invocable → McpClient.
+- **`src/audit_log.rs:47,149,325`** — `AuditRecord`, `AuditFields`, `AuditLogger::append_with_actor(event, actor, fields)` (event SEPARATE arg). McpClient explicitly noted at line 350-354.
+- **ADR-0102 §C/§D/§E + cycle-7 amendment (Deliverable 0)** — four-gate trust contract, handle lifecycle with client_id binding, scope namespace.
+- **ADR-0094** — JSONL append-only audit substrate.
+- **ADR-0111 §8** — SurfaceClient pairing precedent.
+- **ADR-0115** — signal registration discipline.
+- **ADR-0128 §6 + §C** — continuity affordance; wire shape defers to ADR-0102 §D.
+
+## 4. K-in citations (present-on-dev)
+
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md` — applied; cycle-3 grounded every claim with a verified path.
+- `docs/solutions/architecture-patterns/emit-or-log-wrapper-silent-error-swallow-class-2026-05-18.md` — audit-required caveat at line 50 addressed via §1 #3 double-failure escalation.
+- `docs/solutions/architecture-patterns/capability-boundary-needs-crate-split-not-grep-2026-05-18.md` — acknowledged porous; structural enforcement filed if W2+ surfaces a bypass.
+- `docs/solutions/conventions/migration-filename-version-offset-2026-05-18.md` — relevant only as filename discipline reminder; v241–v243 do NOT use an offset; `registered version` is authoritative.
+- `docs/solutions/workflow-issues/substrate-only-landing-needs-l0-amendment-2026-05-18.md` — Deliverable 0 W0 amendment satisfies the precedent.
+
+## 5. Per-client substrate format (frozen at L0 cycle 3)
+
+```rust
+// src-tauri/src/services/mcp_v2/auth.rs
+pub struct ClientRecord {
+    pub client_id: McpClientId,
+    pub paired_at: SystemTime,
+    pub revoked_at: Option<SystemTime>,
+    pub transport_key_ref: KeychainRef,        // raw key never in ClientRecord/state
+}
+
+pub struct ToolGrant {                          // resolved per-call via indexed query
+    pub tool_name: ScopedName,
+    pub scopes_granted: Vec<Scope>,
+    pub exposure: McpExposure,
+    pub rate_limit: ToolRateLimit,
+}
+
+pub struct ToolRateLimit { pub max_calls: u32, pub window_seconds: u32 }
+```
+
+Manifest is composed at call time from `ClientRecord` + `Option<ToolGrant>` — never bulk-loaded.
+
+## 6. Acceptance criteria
+
+- **AC-1 Gateway dispatch.** Unknown tool → `ToolError::BadParams { detail: "unknown tool name" }`. Handler dispatch ONLY after AC-2..AC-5 pass.
+- **AC-2 Scope + exposure authorization (cycle-4 decision-order locked).** Per-dispatch, in this exact order: (i) `ClientRecord.revoked_at.is_some()` → `ToolError::PairingRevoked`. (ii) `auth::resolve_tool_grant(client_id, tool_name)` indexed query: absent grant OR `grant.exposure != Invocable` → `ToolError::ExposureForbidden { tool_name }`. (iii) grant present AND invocable, but `tool.description().scopes_required.is_subset(grant.scopes_granted)` is false → `ToolError::Unauthorized { missing_scope }`. (iv) caller-asserted `granted_scopes` or `conversation_id` in `params` → `ToolError::BadParams`. `McpActor::Client` constructed ONLY after manifest resolution (post step iii pass).
+- **AC-3a Handle lifecycle.** First call no handle → mint(client_id), dispatch, return new handle. Subsequent call with handle → resolve `(client_id, handle)`, refresh last_touched_at, dispatch. Expired handle (24h sliding) → silent mint of replacement (transparent). Revoked handle → `ConversationRevoked`. Caller-asserted `conversation_id` in params → `BadParams`.
+- **AC-3b Cross-session + cross-client tests.** (a) New MCP session with same client_id + non-revoked handle → resolves successfully, handler sees same handle. (b) Different client_id presenting another client's handle → `ConversationRevoked` (binding enforcement). Both integration tests required.
+- **AC-4 Pairing revocation.** Per-dispatch `ClientRecord` load → revoked → `PairingRevoked`. Propagates within ≤ 1 call per ADR-0102 §C.
+- **AC-5 Rate limit (cycle-5 tx order).** Atomic reservation via explicit transaction sequence: `BEGIN IMMEDIATE` → `DELETE FROM mcp_tool_call_ledger WHERE client_id=?1 AND tool_name=?2 AND called_at < (?3 - window_seconds_ms)` (prune) → `SELECT COUNT(*) FROM mcp_tool_call_ledger WHERE client_id=?1 AND tool_name=?2` → if `count >= max_calls` ROLLBACK + return `RateLimited { retry_after_seconds }`; else `INSERT INTO mcp_tool_call_ledger VALUES (?1, ?2, ?3)` → `COMMIT`. Key tuple: `(ActorKind::McpClient, McpClientId, ScopedName)` (ledger is MCP-only so ActorKind is implicit; audit + signal carry the full tuple). Concurrent burst test required.
+- **AC-6 Audit append (cycle-6 L6-2: success-only).** Handler success precedes audit append. Gateway calls `AuditLogger::append_with_actor(event="mcp.tool_invoked", actor=&actor, fields=AuditFields::new("security", detail).with_request_id(req_id))`. Detail JSON: `{client_id, conversation_handle, tool_name, params_hash, response_hash, mutation_cursor?, revocation_state?}` — `mutation_cursor` is IDs-only `serde_json::Value` (max depth 4, max 2 KiB; truncate → `"truncated_oversize"`), required for `Side::Write` (handler-filled per `taxonomy.rs` rustdoc), omitted for `Side::Read`; `revocation_state` only present if revocation lands mid-call per ADR-0102 §C. Auth-state rejections do NOT write an audit row — handled via `McpInvocationRejected` signal (AC-7) per L6-2. JSONL append fails → insert into `mcp_audit_outbox` (operator-only access via existing `get_audit_log_records` / `export_audit_log` paths; no MCP exposure, no separate CLI). Outbox insert also fails → `ToolError::Internal { trace_id }` + Suite-S alert `mcp_audit_double_failure`. Raw params/responses NEVER stored. Audit is post-commit attribution, not source-of-order truth.
+- **AC-7 Signal emission (cycle-7 with reject-signal durability).** TWO new `SignalType` variants, both registered at 5 sites per ADR-0115 (variant + `from_name` + `canonical_name` + known-names const + `policy_for`); both `SignalPolicy::local_observation + NonPiiMetadata`: (a) `SignalType::McpToolInvoked` on dispatch success — payload `{tool_name, client_id, conversation_handle}`. (b) `SignalType::McpInvocationRejected` on auth-state rejection — payload `{client_id_or_unresolved, reject_reason, tool_name_or_unresolved}`. Reject-signal emission uses the emit-or-log pattern: on emission failure, fallback to operator warning log + Suite-S alert `mcp_reject_signal_emit_failed` (closes cycle-6 challenge MED — replaces audit forensics for rejects so emission failure cannot become a forensic blind spot). `client_id_or_unresolved` is either the resolved `McpClientId` or the literal `"unresolved"` (Gate 0a/0b failures, missing-client). `tool_name_or_unresolved` always present (even Gate 0 failures echo the envelope's `tool_name`). NO raw params/response in either event.
+- **AC-8 CI gate.** `scripts/check_mcp_tool_handler_allowlist.sh` rejects direct DB writes from `services/mcp_v2/handlers/*.rs`. Wired in CI.
+- **AC-9 Required checks.** `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` green.
+- **AC-10 Legacy coexistence.** Legacy `src-tauri/src/bridges/mcp.rs:402` + `src-tauri/src/mcp/main.rs:1379` continue with `Actor::Agent`; W1-A does NOT touch them. Test fixture at `src-tauri/src/bridges/mcp.rs:737` left `todo!()` (W2+ fills when first McpClient handler ships). Namespace collision CI (was cycle-4 #7) is OUT of W1-A scope per cycle-5 spinoff Linear ticket "v1.4.7 W1.5 — MCP v2 namespace collision CI" (Maintenance project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`).
+- **AC-11 Key custody (cycle-5 spelled out).** `auth::verify_transport_hmac` wraps loaded key bytes in `Zeroizing<[u8; 32]>` from the `zeroize` crate; per `Zeroize` Drop impl the buffer is wiped on function exit. Pattern follows `SecretBytes32` precedent at `src-tauri/src/surface_runtime/hmac.rs:643` (NOT the line 623 key derivation, which is a separate concern). `ClientRecord` never holds raw key bytes — only `KeychainRef`. Tests: (a) `ClientRecord` struct field shape is `KeychainRef`, not `[u8; 32]`; (b) post-call snapshot of stack/heap shows no zeroed-pattern lingering bytes for the loaded key.
+- **AC-12 Timing oracle (cycle-6 expanded for Gate 0).** Gateway calls `tokio::time::sleep_until(start + Duration::from_millis(10))` before returning ANY of: `BadParams { detail: "invalid_signature" }`, `BadParams { detail: "nonce_replayed" }` (Gate 0 failures per L6-1), `PairingRevoked`, `ExposureForbidden`, `Unauthorized`, `ConversationRevoked`. Test asserts measured wall-clock from request entry to error response is `>= 10ms` for ALL branches (missing-client, invalid-HMAC, replayed-nonce, missing-grant, non-invocable, missing-scope, expired-handle, cross-client-handle). NO upper bound assertion (per cycle-4 challenge/CSO portability finding). Identical error-shape constraint preserved: same JSON keys, same JSON-canonical byte length within 16 bytes (BadParams variants distinguishable only by `detail` field content — same shape).
+
+## 7. Test plan
+
+- **Unit**: dispatch, unknown-tool, missing-scope, ExposureForbidden, revoked-pairing, revoked-handle, first-write-mint, expired-handle-replacement, raw-conversation-id-rejection, raw-granted-scopes-rejection, cross-client-handle-rejection.
+- **Integration**: stub `McpToolHandler` proving (a) audit row iff handler success, (b) JSONL fail → outbox path, (c) JSONL+outbox fail → Internal + Suite-S alert, (d) signal payload carries only `tool_name + client_id + conversation_handle`, (e) rate-limit ledger consumes per full tuple atomically, (f) cross-session same-client (AC-3b.a), (g) cross-client rejection (AC-3b.b), (h) revocation within 1 call.
+- **Property**: HMAC canonical-JSON parity for `params_hash`.
+- **Concurrency**: `BEGIN IMMEDIATE` rate-limit burst test.
+- **Timing**: AC-12 oracle test — missing-client vs invalid-HMAC indistinguishable in error shape + bounded floor.
+- **CI lint**: planted direct-conn fixture rejected.
+
+## 8. Security gates (CSO + plan-devex-review at L0 AND L2)
+
+Per ADR-0102 §C four gates + W0 cycle-7 amendment + cycle-3 ACs:
+1. Caller scopes ignored at dispatch (AC-2).
+2. Caller conversation IDs rejected (AC-3a).
+3. Audit hashes keyed HMAC-SHA256, raw data forbidden (AC-6).
+4. Signal no-leak (AC-7).
+5. Atomic pre-dispatch rate limit (AC-5).
+6. Per-dispatch revocation, ≤ 1-call propagation (AC-2 + AC-3a + AC-4).
+7. Per-tool exposure tier enforced via `ExposureForbidden` variant (AC-2 + Deliverable 0).
+8. Handle client_id binding (AC-3b + Deliverable 0).
+9. Key custody — single-verify, no caching (AC-11).
+10. Timing oracle — uniform failure shape (AC-12).
+11. Audit double-failure → Internal + Suite-S alert (AC-6).
+12. Mid-call revocation captured in audit `revocation_state` (AC-6 + ADR-0102 §C).
+
+## 9. Out-of-scope findings → DailyOS Maintenance
+
+L0/L2 findings not bound by AC-1..AC-12 or by named ADR sections file as separate Linear tickets to `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`. Already-identified followups to file at L0 close:
+- "v1.4.7 W1.5 — legacy MCP retirement plan" (ADR-0102 §C forward-application clarification + plan to flip clients to v2 or deprecate the legacy path).
+- "MCP gateway handler crate split" (structural replacement for `check_mcp_tool_handler_allowlist.sh` grep lint when W2+ surfaces a real bypass).
+
+## 10. Open questions
+
+| # | Question | Default | Resolution path |
+|---|---|---|---|
+| Q1 | Rate-limit default budgets | 60/min per (client_id, tool_name); per-client global 600/min | CSO L0 sign-off on this default; tunable in manifest at pairing |
+| Q2 | Forensic outbox drain cadence | On next gateway invocation; if N>100 backlog, drain immediately | architect L0 sign-off |
+
+## 11. Files (W1-A exclusive ownership)
+
+| File | State | Owner |
+|---|---|---|
+| `src-tauri/src/services/mcp_v2/contracts.rs` | Deliverable 0 (W0 amendment: +`ExposureForbidden` variant + parity test) | shared (additive only) |
+| `src-tauri/src/services/mcp_v2/gateway.rs` | W0 placeholder → W1-A body | exclusive |
+| `src-tauri/src/services/mcp_v2/auth.rs` | W0 placeholder → W1-A body | exclusive |
+| `src-tauri/src/services/mcp_v2/audit.rs` | W0 placeholder → W1-A body | exclusive |
+| `src-tauri/src/services/mcp_v2/actor_policy.rs` | W0 placeholder → W1-A body | exclusive |
+| `src-tauri/src/services/mcp_v2/taxonomy.rs` | W0 placeholder → W1-A trait + error type only | exclusive (interface only; W1-B fills loader) |
+| `src-tauri/src/services/mcp_v2/handlers/*.rs` | W0 placeholders | **untouched** |
+| `src-tauri/src/signals/policy_registry.rs` | function-level addition (5 sites) | shared (additive) |
+| `src-tauri/src/migrations.rs` | new v241–v243 entries | shared (additive) |
+| `src-tauri/src/audit_log.rs` + `audit.rs` | **read-only** (reused via `append_with_actor`) | shared |
+| `src-tauri/src/bridges/mcp.rs` | **untouched** (production); test fixture at line 737 untouched | n/a |
+| `src-tauri/scripts/check_mcp_tool_handler_allowlist.sh` | NEW | exclusive |
+| `.docs/decisions/0102-abilities-as-runtime-contract.md` | Deliverable 0 (cycle-7 amendment +6 lines) | shared (additive) |
+| `.docs/plans/v1.4.7-waves.md` | Deliverable 0 (lines 451 + 467 stale-text fix) | shared |
+
+## 12. Depends-on
+
+- W0 (PR #322) — merged ✅.
+- Deliverable 0 — lands as part of this lane's first commit.
+- v1.4.5 frozen contracts — NOT a hard dep for W1-A.
+
+## 13. Definition of Done
+
+§6 AC-1..AC-12 met; L0 unanimous APPROVE on cycle 3; Deliverable 0 commit + W1-A body commit each pass L2; commit-msg `L2-status: passed`; PR opens against `dev` after L2 clears.

--- a/.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md
+++ b/.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md
@@ -1,0 +1,264 @@
+# DOS-175 — MCP v2 W2-A read handlers (account_status) — L0 plan packet
+
+**Wave:** v1.4.7 W2-A (Phase A; Phase B = daily_briefing follow-up)
+**Lane spec:** [DOS-175](https://linear.app/a8c/issue/DOS-175)
+**Wave plan reference:** `.docs/plans/v1.4.7-waves.md` §"Agent W2-A — DOS-175"
+**Depends on:** W1-A (DOS-168 gateway), W1-B (DOS-478 taxonomy), W1.5 (transport)
+**Authoring discipline:** narrow-scoped per K-in lessons; scope confined to wiring one already-authored producer into the W1-A handler seam.
+
+## Cycle-2 changelog (2026-05-21)
+
+Cycle-1 verdicts: all 4 reviewers NEEDS-CHANGES. Convergent findings folded:
+
+1. **Ability name (HIGH architect + codex):** registered name is `"dailyos/account-overview"` not `"account_overview"` (verified `account_overview.rs:84`). Handler dispatches the correct name.
+2. **Catalog↔ability schema gap (HIGH architect):** catalog parameter is `subject: string` per ADR-0083; ability requires `{schema_version: u32, account_id: String}`. Cycle-2: handler does a thin "subject → account_id" passthrough + `schema_version` injection. Full resolver deferred as Phase-A.1.
+3. **Sync/async runtime bridge (HIGH devex + MED architect):** wrap the sync `gateway.dispatch(...)` in `transport.rs::call_tool` with `tokio::task::spawn_blocking(...)`. Handler holds a `tokio::runtime::Handle` captured at registration; inside `spawn_blocking` (a blocking-pool thread, not a tokio worker), `self.runtime.block_on(...)` is safe. No W1-A trait change.
+4. **Don't invent actor projection (MED architect):** use existing `services/mcp_v2/actor_policy.rs::project_actor`.
+5. **Wave-scope reconciliation (HIGH consult):** cycle-2 scopes to **`account_status` only**. `daily_briefing` moves to Phase B (separate sub-ticket of DOS-175, fired after L4 demo lands). Wave plan amendment filed separately.
+6. **AC/test consistency (MED):** AC-9 exercises only `account_status` end-to-end; cross-tool rejection test removed (single-tool scope obviates it).
+7. **ADR-0083 vocabulary leak (LOW devex):** catalog "recent signals" → "recent updates and changes". Included in AC.
+8. **K-in expansion:** `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` is the relevant prior solution; `account_overview.rs:268` already invokes `prompt_input_sensitivity_allowed` internally on the OUTPUT side of the boundary, so no handler-layer gate needed. §2 cites it.
+
+## 0. Threat topology
+
+`local-to-local single-user`. Claude Desktop on the same machine, same user, loopback stdio MCP transport. Per `engineering-ladder.md` §"Threat-topology framing" + memory `feedback_local_to_local_security_overreach_primary_concern`: reviewers do NOT enforce multi-actor gates, principal differentiation, cross-actor poisoning, or scope-gated redaction of data the user already has filesystem access to. Invariants that survive the topology test: compile correctness, crate boundaries, sensitivity rendering already done in the producer (ADR-0108), indirect-prompt-injection containment from third-party document content (ADR-0093).
+
+## 1. What this unblocks
+
+End-to-end demo: user pairs Claude Desktop against `dailyos-mcp-v2`, asks "give me an account overview for Acme", Claude routes to `dailyos.read.account_status`, the W2-A handler invokes `dailyos/account-overview` against the same `AbilityRegistry` the Tauri UI uses, substrate response returns. This is the v1.4.7 W2-A Phase-A bar — first observable MCP product surface against real DailyOS substrate, comparable side-by-side with Glean's output for the same prompt.
+
+Phase-B (`daily_briefing`) is filed as a sub-ticket of DOS-175 and dispatched once Phase-A is validated in Claude Desktop. The 8 catalog slots without aligned producers are out of scope for W2-A entirely — they require new producer abilities and belong to W3+.
+
+## 2. Substrate path (K-in confirmation)
+
+`docs/solutions/` + `.docs/decisions/` grep — substrate present, no reinvention:
+
+- **`AbilityRegistry`** — single global static at `abilities-runtime/src/abilities/registry.rs:838`. No parallel legacy registry.
+- **`crate::abilities` shim** — `src-tauri/src/abilities/mod.rs:3` is `pub use abilities_runtime::abilities::*;`. Tauri commands and MCP bridges consume the same re-export.
+- **`invoke_registry_json`** — shared async dispatch core. Called by Tauri (`bridges/tauri.rs:217`), legacy MCP (`bridges/mcp.rs:411-422`), and now W2-A.
+- **`McpAbilityBridge::invoke_ability`** at `bridges/mcp.rs:385-430` — canonical pattern for "(actor, ability_name, input_json) → AbilityResponseJson". W2-A handler reuses this pattern.
+- **`services/mcp_v2/actor_policy.rs::project_actor`** at line 68 — projects `McpClientId + ToolGrant + Option<OpaqueConversationHandle>` to `abilities_runtime::Actor::McpClient`.
+- **ADR-0102 §C.bis** — abilities-as-runtime contract; `mcp_exposure`, `allowed_actors`, attribute amendments.
+- **ADR-0108 + ADR-0125** — claim-sensitivity rendering; producers render sensitivity before returning. The `account_overview` producer invokes `prompt_input_sensitivity_allowed` at `account_overview.rs:268`. Handler is a thin JSON wrapper.
+- **`docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md`** — centralized sensitivity gate in `services/claims.rs` enumerable across all 5 prompt-channel readers. `account_overview` is on the OUTPUT side and already gated; no fresh OUTPUT-side gate needed in the handler.
+- **W1-A handler seam** — `services/mcp_v2/gateway.rs:155` (`handlers: HashMap<ScopedName, Arc<dyn McpToolHandler>>`), `:177` (`register`), `:271` (`dispatch`). Scaffolding `services/mcp_v2/handlers/` exists; we add `tool_account_status.rs` (no placeholder for it today).
+- **`McpToolHandler` trait** — `services/mcp_v2/contracts.rs:341`: sync `invoke(&self, &McpActor, params: Value) -> Result<Value, ToolError>`.
+
+## 3. Architecture
+
+### 3.1 Handler shape
+
+```rust
+pub struct AccountStatusHandler {
+    description: ToolDescription,
+    registry: &'static AbilityRegistry,
+    workspace_readers: McpWorkspaceReaders,
+    runtime: tokio::runtime::Handle,
+}
+```
+
+- `registry`: captured at construction from `AbilityRegistry::global_checked()`.
+- `workspace_readers`: `McpWorkspaceReaders::from_action_db(db)` per `bridges/mcp.rs:53` — needed so `ServiceContext` has readers attached, otherwise `account_overview` produces empty output.
+- `runtime`: `tokio::runtime::Handle::current()` captured during `register_v147_handlers` (called from inside the rmcp tokio runtime context).
+
+### 3.2 Async/sync bridge — spawn_blocking at transport boundary
+
+The architectural fix folds at `transport.rs::call_tool` (rmcp's async entry), NOT at each handler:
+
+```rust
+// services/mcp_v2/transport.rs::V2ServerHandler::call_tool (existing async fn)
+let gateway = self.gateway.clone();
+let envelope = build_envelope(...);
+let result = tokio::task::spawn_blocking(move || gateway.dispatch(envelope))
+    .await
+    .map_err(|join_err| McpError::internal_error(format!("blocking task panic: {join_err}"), None))?;
+```
+
+Effects:
+- `gateway.dispatch` (sync) + `handler.invoke` (sync) now run on a tokio blocking-pool thread, NOT a tokio worker thread.
+- Inside `handler.invoke`, `self.runtime.block_on(async_ability_call)` is safe: we're on a blocking-pool thread, the runtime worker pool is free, `block_on` blocks the current thread while the future runs on the worker pool.
+- No nested-runtime panic.
+- No W1-A trait change. Single-line edit at the transport boundary.
+
+### 3.3 Ability dispatch within the handler
+
+Mirrors `bridges/mcp.rs:391-422`:
+
+```rust
+fn invoke(&self, actor: &McpActor, params: Value) -> Result<Value, ToolError> {
+    let McpActor::Client { client_id, conversation_handle, granted_scopes } = actor else {
+        return Err(ToolError::Unauthorized { reason: "unsupported actor variant".into() });
+    };
+    // Synthesize a ToolGrant from the already-resolved McpActor scopes
+    // (gateway already validated grant before dispatch).
+    let synthetic_grant = ToolGrant::synthetic_from_actor(client_id, granted_scopes);
+    let runtime_actor = project_actor(client_id, &synthetic_grant, conversation_handle.as_ref());
+
+    self.runtime.block_on(async {
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let services = self.workspace_readers
+            .attach_to(ServiceContext::new_live(&clock, &rng, &external).with_actor(MCP_ACTOR_LABEL));
+        let invocation = InvocationContext {
+            actor: BridgeActor::Agent,
+            mode: ExecutionMode::Live,
+            surface: BridgeSurface::McpTool,
+            claim_dismissal_surface: ClaimDismissalSurface::McpTool,
+            dry_run: false,
+            confirmation: None,
+            confirmation_store: None,
+        };
+        let resolved_input = build_account_overview_input(params)?;
+        let response = invoke_registry_json(
+            self.registry,
+            &services,
+            None,  // intelligence provider — not needed for read-only path
+            None,  // tracer — W2-A no per-invocation tracing (W3 adds it)
+            invocation,
+            "dailyos/account-overview",  // registered ability name
+            resolved_input,
+        )
+        .await
+        .map_err(map_invoke_error_to_tool_error)?;
+        Ok(response.data)
+    })
+}
+```
+
+Note: actor variant naming in the destructure follows the existing `McpActor::Client { client_id, conversation_handle, granted_scopes }` enum at `contracts.rs:267`. The `ToolGrant::synthetic_from_actor` helper is new — small constructor that wraps the actor's granted_scopes into the existing `ToolGrant` shape. **Open question Q1** (§7): does an equivalent synthetic-grant helper already exist that I should reuse instead of authoring a new one?
+
+### 3.4 Input translation — subject → account_id
+
+Catalog declares the parameter as `subject: string` per ADR-0083 product-vocabulary. The ability requires `{schema_version: 1, account_id: String}`. Cycle-1 handler does a thin translation:
+
+```rust
+fn build_account_overview_input(params: Value) -> Result<Value, ToolError> {
+    let subject = params.get("subject")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::BadParams { reason: "missing 'subject' parameter".into() })?
+        .trim();
+    if subject.is_empty() {
+        return Err(ToolError::BadParams { reason: "'subject' must be non-empty".into() });
+    }
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "account_id": subject,
+    }))
+}
+```
+
+Phase-A.1 sub-ticket: replace this passthrough with a real subject-to-account_id resolver (fuzzy match on account name / handle index). Cycle-1 passthrough means the demo works for any `account_id` the user types verbatim (matches the substrate's account_id field).
+
+### 3.5 Registration helper
+
+New `services/mcp_v2/handlers/registration.rs`:
+
+```rust
+pub fn register_v147_handlers(
+    gateway: &mut Gateway,
+    catalog: &Arc<dyn TaxonomyCatalog>,
+    db: Arc<ParkingMutex<ActionDb>>,
+) -> Result<(), RegistrationError> {
+    let registry = AbilityRegistry::global_checked()
+        .map_err(RegistrationError::AbilityRegistry)?;
+    let workspace_readers = McpWorkspaceReaders::from_action_db(db);
+    let runtime = tokio::runtime::Handle::current();
+
+    let account_status_name = ScopedName::parse("dailyos.read.account_status")?;
+    let description = catalog.description_for(&account_status_name)
+        .ok_or(RegistrationError::CatalogEntryMissing(account_status_name.clone()))?
+        .clone();
+    gateway.register(Arc::new(AccountStatusHandler::new(
+        description,
+        registry,
+        workspace_readers,
+        runtime,
+    )));
+    Ok(())
+}
+```
+
+Called from `mcp_v2/main.rs::run_serve` between `gateway.set_taxonomy(catalog.clone())` and `gateway.seal()`. The `db` arg is the existing `Arc<Mutex<ActionDb>>` the binary already constructs via `open_conn(db_path)`.
+
+### 3.6 Ability attribute amendment
+
+**`account_overview` (`abilities-runtime/src/abilities/account_overview.rs:84`):**
+
+```rust
+#[ability(
+    name = "dailyos/account-overview",
+    category = Read,
+-   allowed_actors = [User, SurfaceClient],
++   allowed_actors = [User, SurfaceClient, McpClient],
+    mcp_exposure = Invocable,
+    ...
+)]
+```
+
+Consistency fix — ability already declared `Invocable`; adding `McpClient` to the allowlist makes the declaration reachable. Local-to-local single-user topology, no fresh CSO escalation.
+
+### 3.7 Output translation
+
+`AbilityResponseJson.data` is already sensitivity-rendered by the producer (`account_overview.rs:268` + ADR-0108). Handler returns `response.data` verbatim. No re-rendering, no redaction layer in the handler.
+
+## 4. Out-of-scope (explicit deferrals)
+
+These are filed as sub-tickets of DOS-175 (Phase B+) or W3+ tickets, NOT path-α maintenance:
+
+1. **Phase B — `dailyos.read.daily_briefing`** → wraps `get_daily_briefing`. Requires DOS-624 amendment apply (already authored, just needs the actor + exposure attribute change applied) and `tool_briefing.rs` body filled in. Dispatched after Phase-A L4 demo validates harness end-to-end.
+2. **Phase A.1 — subject→account_id resolver.** Cycle-1 passthrough works for users who know their account_id slug; real resolver requires name/handle index work.
+3. **`dailyos.read.meeting_briefing`** — producer mapping ambiguous (DOS-624 §3.4 timing-floor + uniform-unavailable shape may itself be over-engineered for local-to-local single-user per memory `feedback_local_to_local_security_overreach`). Defer; revisit DOS-624 §3.4 framing when wave-plan amendment lands.
+4. **Other 7 slots** — no producer ability exists; W3+ work.
+
+## 5. Acceptance criteria
+
+**AC-1.** `account_overview` ability attribute amended: `allowed_actors` includes `McpClient`. `cargo check --features mcp --lib` + `cargo clippy --features mcp --lib --bin dailyos-mcp-v2 -- -D warnings` green.
+
+**AC-2.** New file `services/mcp_v2/handlers/tool_account_status.rs` exports `AccountStatusHandler` implementing `McpToolHandler` for the `dailyos.read.account_status` scoped name. Dispatches to `"dailyos/account-overview"` ability via `invoke_registry_json` per §3.3. Captures `tokio::runtime::Handle` at construction.
+
+**AC-3.** New file `services/mcp_v2/handlers/registration.rs` exports `register_v147_handlers(gateway, catalog, db) -> Result<(), RegistrationError>`. Called from `mcp_v2/main.rs::run_serve` between `set_taxonomy` and `seal`.
+
+**AC-4.** `services/mcp_v2/transport.rs::V2ServerHandler::call_tool` wraps the `gateway.dispatch(...)` call in `tokio::task::spawn_blocking(...)` per §3.2. Single-line behavioral change; existing tests updated.
+
+**AC-5.** `handlers/mod.rs` updated to export `tool_account_status` + `registration`.
+
+**AC-6.** `Gateway::seal()` succeeds with 1 handler registered against the 10-tool catalog. `validate_catalog_against_handlers` returns the 9 unregistered slugs as a `Vec` (per W1-B AC-7 split — not an `Err`). Test asserts.
+
+**AC-7.** Unit test for `AccountStatusHandler::invoke`: given an `McpActor::Client` stub + `{"subject": "acme"}` params, the handler returns a `Value` matching `AccountOverviewOutput` JSON shape (mocked registry via test-only hook OR hermetic test registry with a seeded fake ability).
+
+**AC-8.** Integration test `tests/dos175_w2a_account_status_test.rs`: subprocess `dailyos-mcp-v2 serve` against a temp DB seeded with one Acme account, pair via stdio, issue `tools/list` (assert `dailyos.read.account_status` present), issue `tools/call` for `dailyos.read.account_status` with `{"subject": "acme"}`, assert response is non-error JSON containing the `account_id`, `as_of`, and `status` fields.
+
+**AC-9.** End-to-end manual smoke (L4): `dailyos-mcp-v2 pair --client-name claude --grant dailyos.read.account_status:dailyos.read.account_status:invocable --format claude-desktop` emits a valid claude_desktop_config.json snippet; after pasting + restarting Claude Desktop, the prompt "give me an account overview for Acme" routes to `dailyos.read.account_status` and returns substrate. Screenshot captured for the Glean comparison.
+
+**AC-10.** Catalog edit at `src-tauri/resources/mcp_v2/tool_descriptions.yaml:24` — replace "recent signals" with "recent updates and changes" per ADR-0083.
+
+**AC-11.** No regression: `cargo check --features mcp --lib`, `cargo clippy --features mcp --lib --bin dailyos-mcp-v2 -- -D warnings`, `cargo test --features mcp` all green.
+
+## 6. Test plan
+
+- **Unit** (`tool_account_status.rs::tests`): mock registry dispatch via thread-local injection or generic registry param; assert subject→input translation, actor projection, and response unwrap. ~40 LOC.
+- **Seal/parity test** (`tests/dos175_w2a_seal_test.rs`): assert `seal()` succeeds with 1 handler + 10 catalog entries; assert `validate_catalog_against_handlers` returns the expected 9-slug `Vec`.
+- **Integration test** (`tests/dos175_w2a_account_status_test.rs`): subprocess + stdio JSON-RPC happy path. Seeded Acme account; assert response shape.
+- **No cross-tool tests in cycle-1** (single-tool scope obviates).
+- **No concurrent burst tests** (deferred — memory `feedback_local_to_local_security_overreach`).
+
+## 7. Open questions for L0 reviewers (cycle 2)
+
+**Q1.** Does a synthetic `ToolGrant` helper already exist somewhere I should reuse, or do I author `ToolGrant::synthetic_from_actor` fresh? Either way trivial; flag if I'm missing a precedent.
+
+**Q2.** Defer per-session provenance cache to Phase B. V1 bridge maintains a `(InvocationId → RenderedProvenance)` map for detail-pane lookups; Claude Desktop's text rendering doesn't need this. Cycle-2 stance: defer.
+
+## 8. Reviewer dispatch (cycle 2)
+
+Same panel: `/codex challenge`, architect, `/plan-devex-review`, `/codex consult`. K-in mandatory. Unanimous APPROVE required.
+
+**Reviewer instructions for cycle 2:** focus on whether the cycle-1 findings (numbered 1-7 in the changelog) are addressed. Avoid re-litigating settled topology framing. Surface any genuinely new architectural issues only.
+
+## 9. Definition of done
+
+1. Cycle-2 unanimous L0 APPROVE
+2. AC-1 through AC-11 validated with real data
+3. L2 (codex review + code-reviewer + architect) unanimous APPROVE on the diff, bounded by AC
+4. L4 manual smoke (AC-9) executed: Claude Desktop returns substrate for "give me an account overview for Acme"; screenshot captured for Glean comparison
+5. Phase B (daily_briefing) filed as DOS-175 sub-ticket, ready for next session

--- a/.docs/plans/v1.4.7-w1-foundation/dos-478-l0-plan.md
+++ b/.docs/plans/v1.4.7-w1-foundation/dos-478-l0-plan.md
@@ -1,0 +1,227 @@
+# DOS-478 — MCP v2 tool taxonomy + host-selection contract — L0 plan packet
+
+**Wave:** v1.4.7 W1-B (parallel to W1-A)
+**Lane spec:** [DOS-478](https://linear.app/a8c/issue/DOS-478)
+**Wave plan reference:** `.docs/plans/v1.4.7-waves.md` §"Agent W1-B — DOS-478"
+**Authoring discipline:** narrow-scoped per K-in lessons; substrate gaps file as separate Linear tickets.
+
+## Cycle-4 changelog (2026-05-20)
+
+Cycle-3 verdicts: CEO APPROVE ✅; challenge + architect + devex NEEDS-CHANGES. Convergent 3/3 cleanup: YAML `expected_response_shape` must be `expectedResponseShape` (ToolExample is `#[serde(rename_all = "camelCase")]` per contracts.rs:177); architect + challenge agree. Plus AC-7 test wording + storage normalization + public API + nested deny_unknown_fields.
+
+Cycle-4 fixes:
+
+1. **YAML examples casing matches ToolExample camelCase** (3/3 convergent). Sample YAML uses `expectedResponseShape` (not `expected_response_shape`). Direct deserialization to `Vec<ToolExample>` succeeds. No `YamlToolExample` DTO needed; ToolExample's existing camelCase serde rename handles wire shape.
+
+2. **AC-7 test wording split** (challenge cleanup). Test plan now reads:
+   - `seal()` handler→catalog: stub set with EXTRA handler not in catalog → `Err(HandlerCatalogMismatch { handler, catalog_entry: None, nearest_candidate: Some(closest) })`
+   - `validate_catalog_against_handlers(handlers)` catalog→handler: stub set missing one catalog tool → returns `Vec<ScopedName>{ missing_tool }` (NOT an error; production logs this)
+
+3. **Catalog storage normalization** (architect minor). Storage is `HashMap<ScopedName, (ToolDescription, SelectionFixtures)>` (tuple, not split maps). Public accessor: `pub fn description_for(name: &ScopedName) -> Option<&ToolDescription>`, `pub fn fixtures_for(name: &ScopedName) -> Option<&SelectionFixtures>`.
+
+4. **Public conversion API** (devex). All accessors explicit `pub`: `pub fn into_description_and_fixtures(self) -> (ToolDescription, SelectionFixtures)` on YamlToolEntry; `pub fn description_for/fixtures_for/entries_with_fixtures` on YamlTaxonomyCatalog.
+
+5. **Nested deny_unknown_fields** (devex). `SelectionFixtures`, `PromptFixture`, `AdjacentFixture` all carry `#[serde(deny_unknown_fields)]`. Test asserts unknown nested field rejects load.
+
+## Cycle-3 changelog (2026-05-20)
+
+Cycle-2 verdicts: all 4 reviewers NEEDS-CHANGES. **Convergent (3/4 challenge + architect + devex):** YAML entry shape doesn't fit frozen `ToolDescription` contract — I added `selection_fixtures` + omitted required `examples`; AC-8 deny_unknown_fields conflicts. **Plus**: CEO product-vocabulary tightening; challenge AC-7 bidirectional-validation; architect `nearest_candidate` field needs explicit W1-A enum amendment.
+
+Cycle-3 fixes:
+
+1. **`YamlToolEntry` DTO + conversion** (3/4 convergent — challenge + architect + devex). Cycle-2 conflated wire YAML and frozen `ToolDescription`. Cycle-3 splits:
+   - `YamlToolEntry` (NEW DTO with `#[serde(deny_unknown_fields)]`): all `ToolDescription` fields verbatim (including required `examples: Vec<ToolExample>` per contracts.rs:5) PLUS `selection_fixtures: SelectionFixtures` (new struct for DOS-481 fixture stubs).
+   - `pub struct SelectionFixtures { positive: Vec<PromptFixture>, negative_broad_corpus: Vec<PromptFixture>, negative_adjacent_tool: Vec<AdjacentFixture> }` — separate type not in W0 contracts.
+   - `impl YamlToolEntry { fn into_description_and_fixtures(self) -> (ToolDescription, SelectionFixtures) }` — splits at load time.
+   - `YamlTaxonomyCatalog` stores `HashMap<ScopedName, (ToolDescription, SelectionFixtures)>`.
+   - `examples` field added to every YAML sample (mandatory per ToolDescription). Sample updated in §1.
+
+2. **Bidirectional registry validation** (challenge HIGH AC-7). The W1-A `validate_against_handlers(handlers: &[...])` validates handler→catalog. Cycle-3 also adds `validate_catalog_against_handlers(handlers: &[...]) -> Vec<ScopedName>` returning catalog entries with no matching handler (NOT an error in production where W2-W4 handlers haven't shipped yet; emit operator-log warning so handler authors see what's pending). `Gateway::seal()` in production calls handler→catalog only (forward direction; an unknown handler is a typo). Test `dos478_taxonomy_catalog_test` uses BOTH directions on a stub set — handler→catalog detects extra/wrong handler; catalog→handler detects pending tools (logs, doesn't fail).
+
+3. **`HandlerCatalogMismatch.nearest_candidate` W1-A enum amendment** (architect). Cycle-3 additively extends the W1-A variant: `HandlerCatalogMismatch { handler, catalog_entry, nearest_candidate: Option<ScopedName> }`. Same shape-amendment precedent as W0 cycle-7 amendments (additive optional field; no consumers break). Update W1-A `taxonomy.rs` in this W1-B branch.
+
+4. **Product-vocabulary discipline in AC-4 + AC-6** (CEO NEEDS-CHANGES). Cycle-3 AC-4 + AC-6 forbid `dailyos.*` substrings AND system identifiers in `when_to_call` / `when_NOT_to_call` natural-language fields. Tool identifiers MAY only appear in structured `selection_fixtures.*.expected_tool` fields. Test asserts the natural-language fields contain no `dailyos.` substring + no `Read|SubmitCorrection|Write|McpClient|etc.` system terms.
+
+5. **AC-8 unknown-field rejection is on `YamlToolEntry`, not `ToolDescription`**. The wire DTO uses `serde(deny_unknown_fields)`; `ToolDescription` is unchanged. Conversion strips `selection_fixtures` before producing `ToolDescription`.
+
+## Cycle-2 changelog (2026-05-20)
+
+Cycle-1 verdicts: all 4 reviewers NEEDS-CHANGES (codex challenge, architect, plan-ceo-review, plan-devex-review). 13 findings; 5 convergent (3+/4):
+1. Tool inventory ambiguous (challenge + ceo + architect) — fixed by §5 exact required-name table
+2. `TaxonomyError` needs parse/invalid variants (challenge + architect + devex) — fixed by §1 #2 expanded variant list + Display impl
+3. Fixture density (challenge + ceo) — ADR-0128 §B requires ≥ 2 positive + ≥ 2 negative per tool; fixed by AC-5 update + per-entry YAML fixture-stub fields
+4. `Gateway::seal()` pattern (architect + devex) — fixed by Q2 resolution + AC-7
+5. AC-4 weak (ceo + challenge) — ADR-0128 needs BOTH broad-corpus AND adjacent-wrong-tool; fixed by AC-4 split
+
+Plus 8 singletons all folded: Side serialization (`SubmitCorrection` not `Submit`); YAML hardening (duplicate-name + unknown-field rejection); cross-conversation continuity in description discipline; Result not panic (matches W1-A); `TaxonomyError::Display` spec'd; nearest-candidate suggestions for typo DX; local-dev FS override env-gated; exact per-tool scope mapping.
+
+## 1. What this lane ships
+
+W1-A already shipped the typed substrate (commit `45b3f53d` + `228a17f3`):
+- `src-tauri/src/services/mcp_v2/contracts.rs` — `ToolDescription`, `ScopedName`, `Scope`, `Side` (`Read | SubmitCorrection | Write` — note: NOT `Submit`), `ParamSpec`, `ReturnSpec`, `ToolExample`
+- `src-tauri/src/services/mcp_v2/taxonomy.rs` — `TaxonomyCatalog` trait + `TaxonomyError::HandlerCatalogMismatch` + handler-author cursor rustdoc (~130 lines)
+
+W1-B fills:
+
+1. **`src-tauri/resources/mcp_v2/tool_descriptions.yaml`** (NEW) — version-controlled catalog, parsed via `YamlToolEntry` DTO (NOT directly as `ToolDescription` — see cycle-3 fix #1). Entry shape:
+   ```yaml
+   - name: dailyos.read.account_status
+     side: Read                     # verbatim "Read" | "SubmitCorrection" | "Write"
+     summary: "Returns current state of an account the user works with."
+     when_to_call: |
+       When the user asks about a specific account they have a working
+       relationship with — status, recent signals, open commitments,
+       champion engagement, contract state. The assistant persists
+       context across conversations and updates as work evolves; the
+       host model can rely on this for cross-conversation continuity.
+     when_NOT_to_call: |
+       Do NOT call for accounts the user has no working relationship
+       with — this surface is for the user's personal working
+       understanding of their professional world, not broad enterprise
+       or web corpus search. Use enterprise search, web search, or
+       Glean for broad corpus lookups. Do NOT call for org-wide policy
+       or how-to questions.
+     scopes_required: [dailyos.read.account_status]
+     parameters:
+       - { name: subject, schema: { type: string }, required: true, description: "Account name or handle" }
+     returns:
+       schema: { type: object, additionalProperties: false }
+       description: "Account status payload with claim attribution + freshness per ADR-0105"
+     examples:                                    # required per ToolDescription (contracts.rs:5); camelCase per ToolExample serde rename (contracts.rs:177)
+       - prompt: "What's going on with Acme?"
+         invocation: { name: dailyos.read.account_status, arguments: { subject: acme } }
+         expectedResponseShape: { account_id: <opaque>, status: <enum>, as_of: <iso8601> }
+     selection_fixtures:                          # additive DTO field; consumed by DOS-481 W5-A; stripped before ToolDescription
+       positive:
+         - { prompt: "What's going on with Acme?", expected_tool: dailyos.read.account_status }
+         - { prompt: "How are things looking with the Hooli deal?", expected_tool: dailyos.read.account_status }
+       negative_broad_corpus:
+         - { prompt: "Search the web for SaaS pricing benchmarks", expected_tool_class: external }
+         - { prompt: "What's the company's vacation policy?", expected_tool_class: external }
+       negative_adjacent_tool:
+         - { prompt: "What did I write about the Q1 readout?", expected_tool: dailyos.search.workspace_memory }
+   ```
+   Note: natural-language fields (`summary`, `when_to_call`, `when_NOT_to_call`) MUST NOT contain `dailyos.` substrings or system identifiers (`Read | SubmitCorrection | Write | McpClient | ToolError | ...`). Tool identifiers appear only in structured `selection_fixtures.*.expected_tool` field (per AC-4/AC-6 cycle-3 #4). The sample above conforms.
+
+2. **`src-tauri/src/services/mcp_v2/taxonomy.rs` extensions** — W1-A shipped the trait; W1-B fills the loader implementation. Adds:
+   - `TaxonomyError` new variants per cycle-1 architect + challenge + devex: `ParseFailed { error: String }`, `InvalidName { name: String, reason: String }`, `InvalidScope { tool: ScopedName, scope: Scope }`, `DuplicateName { name: ScopedName }`, `SideMismatch { handler: ScopedName, expected: Side, actual: Side }`, `FixtureCoverage { tool: ScopedName, missing: &'static str }`
+   - `impl std::fmt::Display for TaxonomyError` — operator-readable messages with concrete fix suggestions per devex cycle-1 #2+#4 (nearest-candidate suggestions on `HandlerCatalogMismatch` typos)
+   - `pub struct YamlTaxonomyCatalog { entries: HashMap<ScopedName, (ToolDescription, SelectionFixtures)> }` (cycle-4 #3 tuple-normalized)
+   - `pub fn description_for(&self, name: &ScopedName) -> Option<&ToolDescription>` + `pub fn fixtures_for(&self, name: &ScopedName) -> Option<&SelectionFixtures>` + `pub fn entries_with_fixtures(&self) -> impl Iterator<Item=(&ScopedName, &ToolDescription, &SelectionFixtures)>` (cycle-4 #4 explicit pub API)
+   - `pub fn load_embedded() -> Result<YamlTaxonomyCatalog, TaxonomyError>` — reads embedded YAML via `include_str!`
+   - `pub fn load_from_path(path: &Path) -> Result<YamlTaxonomyCatalog, TaxonomyError>` — env-gated dev override (cycle-1 devex #5; mirrors `src-tauri/src/presets/loader.rs` precedent)
+   - `impl TaxonomyCatalog for YamlTaxonomyCatalog { ... }` — `validate_against_handlers` returns `Result<(), TaxonomyError>` (NOT panic; cycle-1 devex #1)
+
+3. **Gateway integration** — additive line-bounded edits to `gateway.rs`:
+   - `pub fn set_taxonomy(&mut self, catalog: Arc<dyn TaxonomyCatalog>)` — register the catalog reference
+   - `pub fn seal(&self) -> Result<(), TaxonomyError>` — called by `main.rs` after `Gateway::register()` calls complete; invokes `catalog.validate_against_handlers(&self.handlers_as_slice())` and returns the error structured (NOT panic per cycle-1 devex resolution Q3)
+   - main.rs (or wherever Gateway is instantiated in production) MUST call `gateway.seal()?` after registration; missing `seal()` is a startup logic error operators detect via integration test.
+
+4. **`src-tauri/tests/dos478_taxonomy_catalog_test.rs`** (NEW) — integration tests covering AC-1..AC-10.
+
+## 2. What this lane does NOT ship
+
+- Per-tool handler bodies (W2/W3/W4 scope).
+- Host-selection eval harness (W5-A / DOS-481 scope; this lane ships fixture STUBS in YAML, DOS-481 implements the eval runner against them).
+- ADR-0128 changes (already amended in W0 commit 45b3f53d).
+- Production signal bus wiring (W1.5 path-α from W1-A).
+
+## 3. Frozen substrate citations
+
+- **W0 contracts (`contracts.rs` frozen at commit `45b3f53d` + cycle-7/8/9 amendments)**: `ToolDescription`, `Side` (Read | SubmitCorrection | Write — verbatim variant names), `ScopedName`, `Scope`, `ParamSpec`, `ReturnSpec`, `ToolExample`, `CANONICAL_NAMESPACE = "dailyos"`, `Verb` enum (Read | Write | Submit | Search | List | Get | Prepare).
+- **W1-A taxonomy.rs (committed `228a17f3`)**: `TaxonomyCatalog` trait + handler-author rustdoc.
+- **ADR-0102 §E** — scope namespace freeze.
+- **ADR-0128 §3 + §6 + cycle-7 §B amendment** — tool descriptions are product copy; cross-conversation continuity named as affordance; host-selection eval (DOS-481) requires ≥ 2 positive + ≥ 2 negative fixtures per tool with broad-corpus AND adjacent-wrong-tool negatives.
+- **ADR-0083** — product vocabulary discipline (warm + specific + self-evident; no system terms).
+- **`src-tauri/src/presets/loader.rs`** — embedded + filesystem-override precedent for dev-iteration ergonomics (cycle-1 devex #5).
+
+## 4. K-in citations (present-on-dev)
+
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md` — grep substrate; cycle-2 cites W1-A trait + W0 contracts by file:line.
+- `docs/solutions/architecture-patterns/capability-boundary-needs-crate-split-not-grep-2026-05-18.md` — fail-fast boot via structured `Result` is the structural pattern (cycle-1 devex #1).
+
+## 5. Frozen tool inventory (10 entries — cycle-2 #1)
+
+The catalog ships entries for EXACTLY these 10 tool names. AC-1 enforces the count + identity:
+
+| # | Tool name | Side | Scopes required | Owner wave |
+|---|---|---|---|---|
+| 1 | `dailyos.read.account_status` | Read | `dailyos.read.account_status` | W2 (out-of-scope handler — discovery surface from DOS-172 ranked entity lookup) |
+| 2 | `dailyos.read.daily_briefing` | Read | `dailyos.read.daily_briefing` | W2-A (DOS-175) |
+| 3 | `dailyos.read.meeting_briefing` | Read | `dailyos.read.meeting_briefing` | W2-A (DOS-175) |
+| 4 | `dailyos.read.portfolio_attention` | Read | `dailyos.read.portfolio_attention` | W2-C (DOS-173) |
+| 5 | `dailyos.search.workspace_memory` | Read | `read.workspace_graph` (v1.4.5 grandfathered) | W3-A (DOS-479) |
+| 6 | `dailyos.read.workspace_source_provenance` | Read | `dailyos.read.workspace_source_provenance` | W3-A (DOS-479) |
+| 7 | `dailyos.write.place_document` | Write | `write.workspace_place_document` (v1.4.5 grandfathered) | W3-B (DOS-480) |
+| 8 | `dailyos.submit.note` | SubmitCorrection | `dailyos.submit.note` | W4-A (DOS-167) |
+| 9 | `dailyos.submit.action` | SubmitCorrection | `dailyos.submit.action` | W4-B (DOS-169) |
+| 10 | `dailyos.submit.action_status` | SubmitCorrection | `dailyos.submit.action_status` | W4-C (DOS-170) |
+
+Note: pagination/list surface (DOS-172) is a discovery refinement applied across read tools, NOT a separate tool name. The frozen 10 is the surface for v1.4.7. Future tools amend the catalog at their own L0.
+
+## 6. Acceptance criteria (cycle-2 tightened)
+
+- **AC-1 Inventory + load.** `YamlTaxonomyCatalog::load_embedded()` succeeds; resulting catalog has EXACTLY the 10 entries from §5 (assert by name + count). Extra or missing entries → test failure.
+- **AC-2 Naming convention + Side serialization.** Every entry `name` matches regex `^dailyos\.(read|write|submit|search|list|get|prepare)\.[a-z][a-z0-9_]*$`. Every entry `side` deserializes to `Side::Read | Side::SubmitCorrection | Side::Write` — YAML strings use verbatim variant names (cycle-1 architect #4). Wrong YAML `side: Submit` → `TaxonomyError::ParseFailed`.
+- **AC-3 Scope mapping exact** (cycle-1 challenge #2). Each entry's `scopes_required` matches the §5 table verbatim. Test asserts per-tool: catalog scope set equals expected scope set (NOT just "in allowlist").
+- **AC-4 Displacement framing in product vocabulary** (cycle-1 ceo + challenge convergent + cycle-2 ceo tightening). Every entry's `when_NOT_to_call` MUST contain BOTH (a) at least one broad-corpus keyword: `broad`, `enterprise search`, `web search`, `Glean`, `corpus`; AND (b) at least one adjacent-tool framing in PRODUCT LANGUAGE: `different surface`, `not for ... — use ... for`, `personal working`, or natural-language reference to the alternative. **AC-4 ALSO forbids**: substring `dailyos.` AND system identifiers (`Read|SubmitCorrection|Write|McpClient|ToolError|McpToolHandler|Gateway|Scope`) in `when_to_call` / `when_NOT_to_call` natural-language fields per cycle-2 CEO. Tool identifiers appear ONLY in structured `selection_fixtures.*.expected_tool` field.
+- **AC-5 Fixture coverage** (cycle-1 ceo + challenge convergent). Every entry has `selection_fixtures`: `positive` with ≥ 2 entries, `negative_broad_corpus` with ≥ 2 entries, `negative_adjacent_tool` with ≥ 1 entry (≥ 2 if the tool has an adjacent counterpart in §5; the `dailyos.write.place_document` lone-write tool may have only 1). DOS-481 W5-A will consume these fixtures to run the host-selection eval. `TaxonomyError::FixtureCoverage` on shortfall.
+- **AC-6 Continuity affordance in product vocabulary** (cycle-1 ceo #5 + cycle-2 ceo tightening). Every Read entry's `when_to_call` MUST mention continuity using one of: `cross-conversation`, `persists context`, `updates as work evolves`, `working understanding ... over time`. Per ADR-0128 §6 named-affordance contract. Same vocabulary discipline as AC-4 — no `dailyos.` substrings, no system identifiers.
+- **AC-7 Boot validation via `Gateway::seal()` returning `Result`** (cycle-1 architect #2 + devex #1; cycle-2 challenge + architect). `main.rs` calls `gateway.seal()?` after registration. Production `seal()` runs ONLY handler→catalog validation (an unknown handler is a typo blocking startup). Mismatch → `Err(TaxonomyError::HandlerCatalogMismatch { handler, catalog_entry, nearest_candidate: Option<ScopedName> })` per devex #4. No `panic!()`. Catalog→handler validation is a SEPARATE method `validate_catalog_against_handlers(handlers) -> Vec<ScopedName>` (returns pending tools; W2-W4 land them one-by-one); production logs the list as operator info, doesn't fail boot. **W1-A taxonomy.rs `HandlerCatalogMismatch` variant additively extended** with `nearest_candidate: Option<ScopedName>` field (this lane lands the additive amendment).
+- **AC-8 YAML hardening** (cycle-1 challenge #4). Loader rejects: duplicate `name` entries (`DuplicateName`), unknown YAML fields (serde deny_unknown_fields), empty `summary` / `when_to_call` / `when_NOT_to_call`. Per-failure test asserts the specific variant.
+- **AC-9 `TaxonomyError::Display` operator-readable** (cycle-1 devex #2). Each variant's `Display` impl includes: what failed, where (handler name or YAML position), suggested fix. Tests assert the message contains the suggestion substring.
+- **AC-10 Local-dev FS override** (cycle-1 devex #5). `YamlTaxonomyCatalog::load_from_path(path: &Path)` reads YAML from filesystem; production uses `load_embedded()`. Env-gate via `DAILYOS_MCP_TAXONOMY_PATH`; mirrors `src/presets/loader.rs` precedent. Override never active in release builds.
+- **AC-11 Required checks.** `cargo clippy --lib -- -D warnings && cargo test && pnpm tsc --noEmit` green. `cargo test dos478_taxonomy_catalog_test` passes (AC-1..AC-10 covered).
+
+## 7. Files owned (W1-B)
+
+| File | State | Owner |
+|---|---|---|
+| `src-tauri/resources/mcp_v2/tool_descriptions.yaml` | NEW (10 entries) | exclusive |
+| `src-tauri/src/services/mcp_v2/taxonomy.rs` | W1-A shipped trait; W1-B adds variants + Display + YamlTaxonomyCatalog + load_embedded + load_from_path | shared (additive) |
+| `src-tauri/src/services/mcp_v2/gateway.rs` | additive — `set_taxonomy` + `seal` | shared (line-bounded additive) |
+| `src-tauri/src/lib.rs` (or main.rs equivalent) | additive — call `gateway.seal()?` after registration | shared (line-bounded additive; verify exact path at L1) |
+| `src-tauri/tests/dos478_taxonomy_catalog_test.rs` | NEW | exclusive |
+| `src-tauri/Cargo.toml` | additive — `serde_yaml = "0.9"` | shared (additive) |
+
+## 8. Test plan (covers AC-1..AC-10)
+
+- **load_embedded + 10 entries** (AC-1): assert count + name set equals §5.
+- **naming + side serialization** (AC-2): per-entry regex match; positive YAML `side: Submit` → ParseFailed.
+- **scope mapping** (AC-3): per-tool assert scope set == §5 expected.
+- **displacement framing** (AC-4): per-entry assert both keyword groups present in `when_NOT_to_call`.
+- **fixture coverage** (AC-5): per-entry assert positive ≥ 2, negative_broad_corpus ≥ 2, negative_adjacent_tool ≥ 1 (≥ 2 where adjacent exists).
+- **continuity affordance** (AC-6): per Read entry assert continuity keyword in `when_to_call`.
+- **boot validation Result** (AC-7): handler→catalog: stub set covering 10 → `seal()` returns `Ok(())`. EXTRA handler not in catalog → `seal()` returns `Err(HandlerCatalogMismatch { handler: <name>, catalog_entry: None, nearest_candidate: Some(<closest>) })`. **catalog→handler (separate method)**: stub set MISSING one catalog tool → `validate_catalog_against_handlers(handlers)` returns `Vec<ScopedName>{<missing>}` (NOT an error; logs pending; W2-W4 land incrementally).
+- **YAML hardening** (AC-8): duplicate-name YAML → `DuplicateName`; unknown top-level field → `ParseFailed`; empty-when_to_call YAML → `ParseFailed`; **nested unknown field on `SelectionFixtures` / `PromptFixture` / `AdjacentFixture` → `ParseFailed`** (cycle-4 #5 nested deny_unknown_fields).
+- **Display** (AC-9): per-variant assert message contains the suggestion substring.
+- **FS override** (AC-10): `load_from_path(temp_yaml)` succeeds; env var triggers override; release build ignores env.
+
+## 9. Security gates
+
+`/cso` not mandatory (no security-annotated work). `/plan-ceo-review` + `/plan-devex-review` mandatory per wave plan (tool taxonomy IS the product-strategy + DX surface).
+
+## 10. Path-α (file as Maintenance Linear tickets)
+
+- Live host-model selection eval — DOS-481 (W5-A).
+- Per-tool prompt fixture refinement — DOS-481.
+- YAML schema JSON Schema export for IDE tooling — post-v1.4.7.
+- Operator runbook for catalog edits — DX docs, ship with W1-B PR but as separate file.
+
+## 11. Depends-on
+
+- **W1-A merged** (mandatory): YAML loader needs `TaxonomyCatalog` trait + ToolDescription types. W1-A at unanimous L2 APPROVE on branch `v1.4.7-w1-foundation` (commits 45b3f53d → dc80ff86, 11 commits). User-validated PR open is the gating step.
+- v1.4.5 frozen scopes — NOT a hard dep; v1.4.5 grandfathered scope set is a hardcoded allowlist in §5 table.
+
+## 12. Definition of Done
+
+§6 AC-1..AC-11 met; L0 unanimous APPROVE; L2 unanimous APPROVE bounded by AC; commit-msg `L2-status: passed`; PR opens against `dev` after W1-A PR merges (sequential — W1-B depends on W1-A).
+
+## 13. Open questions resolved in cycle 2
+
+| # | Question | Resolution |
+|---|---|---|
+| Q1 | YAML library | `serde_yaml = "0.9"` (cycle-1 architect — matches serde_json ergonomics) |
+| Q2 | Validation hook point | Explicit `Gateway::seal()` after `register()` calls; main.rs calls `gateway.seal()?` (cycle-1 architect #2 + devex #1) |
+| Q3 | Panic vs Result | `Result<(), TaxonomyError>` (cycle-1 devex #1; matches W1-A taxonomy.rs which already shipped no-panic) |
+| Q4 | Embedded vs FS | BOTH: `load_embedded()` (production, `include_str!`) + `load_from_path()` (dev override env-gated, mirrors `src/presets/loader.rs`) (cycle-1 devex #5) |

--- a/.docs/plans/v1.4.7-w1-foundation/dos-624-cso-amendment.md
+++ b/.docs/plans/v1.4.7-w1-foundation/dos-624-cso-amendment.md
@@ -1,0 +1,132 @@
+# DOS-624 — CSO L0 amendment for MCP exposure of daily/meeting briefing intelligence
+
+**Type:** L0 amendment (security-annotated)
+**Wave:** v1.4.7 W2-A predecessor (gates DOS-175 implementation)
+**Lane spec:** [DOS-624](https://linear.app/a8c/issue/DOS-624)
+**Origin:** v1.4.3 carve-out — `get_daily_briefing` shipped as Read-only User actor only. No Agent/MCP exposure without separate CSO-approved L0 amendment. This is that amendment.
+
+## Cycle-2 changelog (2026-05-20)
+
+Cycle-1 verdicts: all 4 NEEDS-CHANGES. **Convergent (2+ reviewers):**
+- **meeting_briefing existence oracle / enumeration** (CSO + challenge)
+- **W3-C two-paths actor_kind tagging is factually wrong** (architect + challenge + devex)
+
+Cycle-2 fixes:
+
+1. **Architect §4 rewrite — actor_kind correctly distinguishes paths** (architect HIGH + challenge + devex convergent). The cycle-1 amendment claimed "both paths write via Actor::McpClient variants distinguishable by actor_kind." Architect correctly flagged: there's only ONE `Actor::McpClient { client_id, conversation_handle }` variant; `audit_log.rs:215` collapses all McpClient invocations to `actor_kind = "mcp_client"`. The W3-C WordPress MCP Adapter path uses `Actor::SurfaceClient { instance, scopes }` per ADR-0111 §8 + ADR-0129 — audit tags `actor_kind = "surface_client"`. So the two paths ARE distinguishable, just by `surface_client` vs `mcp_client`, not by two McpClient variants. §4 corrected.
+
+2. **§4 W3-C policy store correction** (architect HIGH). ADR-0129 §4: WP uses WP capability + WP MCP Adapter allowlist + `SurfaceClient` scopes per ADR-0111 §8. Not `mcp_client_manifest` / `mcp_tool_grant` (which is W1-A direct-path-only). §4 specifies independent policy stores per path; operator grants briefing access in BOTH places independently. No shared manifest schema.
+
+3. **§3 sensitivity gate composition** (architect MED). The cycle-1 §3.1 protection said "Handler MUST filter to caller's read.entity_names scope." Architect correctly flagged this should COMPOSE the existing centralized claim sensitivity gate (ADR-0125 + per-call ClaimSensitivity render in services::claims::render), NOT copy redaction logic. §3.1 rewritten to require DOS-175 handler routes briefing output through the centralized sensitivity render with caller's manifest scopes; no parallel redaction.
+
+4. **meeting_briefing uniform unavailable response in DOS-175 AC** (CSO HIGH + challenge HIGH convergent). Existence-oracle defense: DOS-175 W2-A must include `dailyos.read.meeting_briefing(meeting_id)` returning a uniform `{status: "unavailable"}` typed result for ALL of: nonexistent meeting_id, manifest scope insufficient for entity_names, filtered by sensitivity, stale beyond freshness threshold. This pushes the "object resolution hygiene" into W2-A AC explicitly. CSO Q2 conditional sign-off requires this.
+
+5. **CSO #2 audit coverage for unavailable responses** — DOS-175 makes unavailable responses successful typed results (per #4), so the W1-A success-path audit (`audit::write` with `event="mcp.tool_invoked"`) covers them naturally. `params_hash` over `(meeting_id)` fingerprints probing patterns; operator detects via duplicate `params_hash` across many `conversation_handle`s.
+
+6. **Q1 sign-off folded — per-pairing only** (CSO + devex confirm). Default-denied per-pairing grants + revocation are sufficient for v1.4.7. Global policy registry remains path-α (separate ticket: "DOS-? v1.4.7+ MCP global briefing policy registry").
+
+7. **Q2 sign-off folded — manifest scope authorization + uniform unavailable response** (CSO conditional sign-off). Combined gate.
+
+8. **Singleton substrate hardening filed as separate tickets, NOT folded into this amendment** (per `feedback_review_loop_diminishing_returns_means_scope_is_wrong` + `feedback_l2_path_alpha_to_maintenance_project`):
+   - **DOS-? "MCP pairing credential-theft defense"** (challenge #1) — host/client-key binding, one-time pairing codes, short pairing TTL, operator-visible device identity. Real substrate work for v1.4.7+; not blocking this amendment because the post-pairing trust contract already covers replay (per ADR-0102 §C.bis.replay/refresh/schema/fail-closed which CSO independently verified holds).
+   - **DOS-? "MCP per-user global briefing rate-limit budget"** (challenge #4) — path-coalesced anomaly detection across W1-A direct + W3-C WP paths. Substrate work for v1.4.7+.
+   - **DOS-? "MCP scope grant UI: no glob, explicit briefing scope, confirmation copy"** (challenge #5) — operator UI work, post-v1.4.7.
+   - **DOS-? "MCP response_hash side-channel mitigation"** (challenge #2) — per-row salt or security-admin-only fingerprint querying. Substrate work for v1.4.7+.
+   - **DOS-? "MCP operator pairing UX: briefing intelligence section"** (devex #1) — operator-facing docs + manifest UI changes. Post-v1.4.7.
+   - **DOS-? "MCP rate-limit config keys + retry-after surfacing"** (devex #2) — DOS-175 should make `rate_limit_max=60`, `rate_limit_window_secs=3600` discoverable; gateway's `ToolError::RateLimited { retry_after_seconds }` already exists in W1-A so this is documentation + config wiring, not substrate.
+   - **DOS-? "MCP audit dashboard query for briefing replay anomaly detection"** (devex #3) — explicit SQL query schema for operator dashboards.
+   - **DOS-? "MCP two-paths-one-ability operator runbook"** (devex #4) — pre-W2-A docs work; how to grant/revoke each path independently; how to audit both sources via `actor_kind` filter.
+
+   These are real, named, scoped — filed in this amendment rather than folded keeps the amendment as a policy decision (its proper shape) rather than turning it into a substrate-hardening initiative.
+
+---
+
+## 1. What this amendment unblocks (unchanged from cycle 1)
+
+v1.4.7 W2-A (DOS-175) ships two MCP tools wrapping the v1.4.3 `get_daily_briefing` ability:
+- `dailyos.read.daily_briefing` — current-day briefing
+- `dailyos.read.meeting_briefing(meeting_id)` — prep briefing for a specific meeting
+
+The v1.4.3 carve-out blocks them pending this amendment.
+
+## 2. Why MCP exposure is appropriate now (unchanged + CSO verified)
+
+The v1.4.3 carve-out predates v1.4.7 W1-A's MCP trust contract. Pre-W1-A, MCP exposure meant unauthenticated unbounded ability invocation. v1.4.7 W1-A landed (commits `45b3f53d`..`3e5d7155` on `v1.4.7-w1-foundation`; L2 unanimous APPROVE; CSO confirmed in this cycle's review: "No new transport replay vector found. ADR-0102 nonce consume + per-response refresh + fail-closed semantics are implemented in `auth.rs`/`gateway.rs` as described.") Every MCP-originated invocation now passes through:
+
+1. Pairing handshake → server-issued `McpClientId` + operator-set manifest
+2. Transport HMAC-SHA256 signing over canonical-JSON envelope including `request_nonce`; key wrapped in `Zeroizing`
+3. Server-side nonce ledger consume-once + fail-closed (per ADR-0102 §C.bis.replay/refresh/schema/fail-closed)
+4. Server-side manifest scope authorization (caller-asserted scopes rejected)
+5. Per-tool exposure tier (None / MetadataOnly / Invocable; default None)
+6. Per `(McpClientId, ScopedName)` rate limit with atomic BEGIN IMMEDIATE
+7. Audit attribution with keyed HMAC-SHA256 hashes (no raw payloads)
+8. Signal emission via `McpToolInvoked` / `McpInvocationRejected` (NonPiiMetadata)
+
+Pre-W1-A threat model (unauthenticated MCP exposure of personal briefing intelligence) no longer applies.
+
+## 3. Briefing-specific protections (cycle-2 sensitivity gate composed)
+
+Beyond W1-A's universal gates, DOS-175 (W2-A) MUST honor these briefing-specific ACs:
+
+1. **Sensitivity rendering composes the centralized claim sensitivity gate** (cycle-2 fix #3 per architect MED). DOS-175 handler routes briefing output through `services::claims::render` (or the equivalent centralized sensitivity rendering path per ADR-0125 + ADR-0108) using the caller's manifest-resolved scopes. PII-tier claims (file paths, raw entity names, raw claim text in aggregates) redact when caller's manifest does not grant the corresponding read scope (`read.entity_names`). NO parallel redaction logic in the handler.
+
+2. **Per-pairing tool grant default = denied** (unchanged). New pairings receive no briefing access by default. Operator must explicitly grant `dailyos.read.daily_briefing` and `dailyos.read.meeting_briefing` scopes + Invocable exposure tier at pairing time.
+
+3. **Per-invocation rate limit default = 60 calls/hour** (unchanged from cycle 1). Operator-tunable.
+
+4. **Uniform unavailable response for meeting_briefing(meeting_id)** (cycle-2 fix #4 per CSO HIGH + challenge HIGH). DOS-175 handler returns `{status: "unavailable", reason_class: "unavailable"}` (NOT distinguishing nonexistent / scope-insufficient / sensitivity-filtered / stale-beyond-freshness — uniform shape) for ALL of:
+   - meeting_id not in caller's accessible meeting set
+   - meeting exists but scope insufficient for entity_names disclosure
+   - meeting exists, accessible, but ClaimSensitivity gate filters all surfaceable claims
+   - meeting exists but briefing freshness exceeds operator-configured threshold (stale)
+   
+   **Uniform timing floor for unavailable success responses** (cycle-3 CSO normative tightening). The W1-A AC-12 10ms floor applies only to auth-state rejections, NOT to successful typed responses. DOS-175 handler **MUST** call `tokio::time::sleep_until(start + Duration::from_millis(20))` (20ms or greater; not "recommended" — required) before returning ANY `{status: "unavailable"}` response, regardless of which internal branch (nonexistent / scope-insufficient / sensitivity-filtered / stale) produced it. **Concurrent burst test required: p95 latency across all 4 unavailable branches MUST be within ± 5ms of each other** (burst of ≥ 200 calls under concurrent load, asserted in `tests/dos175_meeting_briefing_existence_oracle_test.rs`). Closes CSO cycle-2 + cycle-3 enumeration-via-latency findings.
+
+5. **Audit covers unavailable responses** (cycle-2 fix #5 per CSO #2). Because unavailable is a successful typed result, W1-A's success-path audit naturally fingerprints it via `params_hash` over `(meeting_id)`. Operators detect probing via duplicate `params_hash` across many `conversation_handle`s. No new audit substrate needed.
+
+## 4. Coordination with v1.4.2 W3-C WordPress MCP Adapter (cycle-2 corrected)
+
+Per cycle-2 fix #1 + #2 (architect HIGH convergent):
+
+- **Both paths consume the SAME ability** (`get_daily_briefing`). Producer/renderer split per ADR-0130 supports surface-agnostic producer abilities.
+- **Different actor classes, distinguishable in audit**:
+  - W1-A direct path (Claude Desktop / Cursor / other agents over loopback HTTP or stdio MCP) → `Actor::McpClient { client_id, conversation_handle }` → audit `actor_kind = "mcp_client"`
+  - W3-C WP MCP Adapter path (WordPress block + adapter) → `Actor::SurfaceClient { instance, scopes }` per ADR-0111 §8 + ADR-0129 §4 → audit `actor_kind = "surface_client"`
+- **Different policy stores per path** (cycle-2 fix #2):
+  - W1-A direct: `mcp_client_manifest` + `mcp_tool_grant` rows (v241 migration; loaded by `services::mcp_v2::auth`)
+  - W3-C WP: WP capability + WP MCP Adapter allowlist + `SurfaceClient` scope grants per ADR-0111 §8
+  - Operator MUST grant briefing access in BOTH places independently — no shared manifest schema, no implicit propagation.
+- **No duplicate audit rows** — each invocation through either path writes ONE audit row attributed to its respective Actor variant; the audit log's `actor_kind` field distinguishes the source.
+- **Operator runbook for two-paths coordination** filed as separate ticket (cycle-2 fix #8 — "DOS-? MCP two-paths-one-ability operator runbook").
+
+## 5. Audit + signal payload changes (NONE required) (unchanged)
+
+This amendment adds no new audit event types, no new signal types, no new claim types. The W1-A substrate handles briefing invocations identically to any other tool. The amendment is a scope decision, not a substrate change.
+
+## 6. Acceptance
+
+- **CSO L0 sign-off** on this amendment (Q1 + Q2 cycle-1 sign-offs folded per cycle-2 fix #6 + #7).
+- **No code changes in this amendment** — scope/policy only. Implementation lands in DOS-175 (W2-A).
+- **W2-A DOS-175 L0 packet** (separate) MUST cite this amendment as predecessor + enumerate §3 ACs in its own AC (especially #1 sensitivity-gate composition + #4 uniform unavailable response + #5 audit fingerprinting).
+
+## 7. Spinoff Linear tickets (cycle-2 fix #8 filed list)
+
+Filed to DailyOS Maintenance project (`b8e6aea4-d47e-4f3a-b03d-a05bec914aeb`) per path-α discipline:
+
+- "MCP pairing credential-theft defense" (challenge #1; substrate)
+- "MCP per-user global briefing rate-limit budget" (challenge #4; substrate)
+- "MCP scope grant UI: no glob, explicit briefing scope, confirmation copy" (challenge #5; UX)
+- "MCP response_hash side-channel mitigation" (challenge #2; substrate)
+- "MCP operator pairing UX: briefing intelligence section" (devex #1; docs + UI)
+- "MCP rate-limit config keys + retry-after surfacing" (devex #2; docs + DOS-175 AC reference)
+- "MCP audit dashboard query for briefing replay anomaly detection" (devex #3; ops dashboards)
+- "MCP two-paths-one-ability operator runbook" (devex #4; pre-W2-A docs)
+
+## 8. Open questions — none remaining (CSO Q1 + Q2 signed off in cycle 1+2; cycle-2 folded)
+
+## 9. Reviewer dispatch (cycle 2)
+
+- **CSO** (mandatory primary) — verify Q1 + Q2 sign-offs folded correctly + new §3 #4 uniform unavailable response is sufficient existence-oracle defense
+- **/codex challenge** (adversarial) — verify the 8 spinoff tickets actually capture the cycle-1 findings adequately; nothing dropped that should block
+- **architect-reviewer** (substrate) — verify cycle-2 fix #1+#2 actor_kind framing + #3 sensitivity composition match ADR-0111/0125/0129/0130
+- **/plan-devex-review** (DX) — verify cycle-2 fix #8 ticket-filing-vs-folding split is the right call vs cycle-1 ask

--- a/.docs/plans/v1.4.7-w1-foundation/dos-mcp-transport-l0-plan.md
+++ b/.docs/plans/v1.4.7-w1-foundation/dos-mcp-transport-l0-plan.md
@@ -1,0 +1,309 @@
+# v1.4.7 — MCP v2 Transport Ingress (rmcp ServerHandler → Gateway) — L0 plan packet
+
+**Wave:** v1.4.7 W1.5 (post-W1-A + W1-B; pre-W2 handlers)
+**Linear ticket:** TBD (mint after L0 approve)
+**Scope:** local-to-local same-machine only. No remote MCP transport in scope. Trust boundary is "same user on this machine."
+**Authoring discipline:** narrow-scoped per K-in lessons.
+
+## Cycle-5 changelog (2026-05-21)
+
+Cycle-4 verdicts: architect APPROVE, challenge NEEDS-CHANGES, CSO BLOCK, devex BLOCK. CSO + devex convergent on per-envelope HMAC client-incompatibility for standard MCP clients (Claude Desktop, Cursor don't compute HMAC); devex provided the concrete fix.
+
+**Cycle-5 architectural commit (user-directed):** Option A — startup identity is the auth boundary for stdio; transport self-signs internally. Scope explicitly local-to-local same-machine. No remote MCP transport in v1.4.7.
+
+Cycle-5 fixes:
+
+1. **Trust model differentiated by transport class.** Stdio transport (Claude Desktop, Cursor): auth = env-asserted startup identity. Per-envelope HMAC + nonce ledger = transport-internal hygiene (consistent with W1-A substrate; zero attacker value for this transport class given the local-to-local scope). WP adapter (v1.4.2 W3-C) + custom SDK clients: per-envelope HMAC authenticates the middleware/SDK to the gateway (real client auth at the envelope boundary). Gateway substrate unchanged — it always verifies HMAC + consumes nonce; the transport decides where the trust boundary lives.
+
+2. **Transport self-signs internally** (devex BLOCK fix). `tools/call` accepts normal MCP tool params from Claude Desktop / Cursor (no `_dailyos_*` keys in `arguments`). Transport reads `verified_client_id` + transport_key (process-held) + assigns request_nonce (from W1-A preissue ledger), constructs `McpToolRequestEnvelope`, signs with JCS canonicalization, calls `Gateway::handle_tool_call`. `_dailyos_envelope` and `_dailyos_signature` are NOT exposed in public `tools/list` input_schema.
+
+3. **Scope statement: local-to-local same-machine** (user direction). Documented in §0 scope. The /proc/<pid>/environ exposure (challenge + CSO cycle-4) is acceptable because any attacker who can read it is already same-user same-machine and has access to ~/.dailyos/keychain etc. env-wipe via `std::env::remove_var` reworded as best-effort in-process hygiene (limits subsequent `getenv` reads in same process), not a /proc mitigation.
+
+4. **AC-3 add public `message` field** (devex cycle-4). rmcp::Error carries both `code` + `data.kind` + a short human-readable `message` so MCP clients can render a meaningful error.
+
+5. **AC-6 input_schema clean** — only handler params + `_dailyos_*` excluded (devex cycle-4 + transport self-signs).
+
+6. **Cursor compatibility — `"type": "stdio"`** (devex cycle-4). `pair --format claude-desktop` snippet includes `"type": "stdio"` for Cursor compatibility (harmless for Claude Desktop).
+
+7. **JCS hardening** (challenge + CSO cycle-4). Duplicate-key rejection at all object levels; I-JSON-compatible values; golden fixtures expanded to cover ASCII + Unicode (no normalization) + escape sequences + nested arrays/objects + floats + nulls + integer edge cases. Fixtures shipped for SDK authors of WP adapter / custom SDK clients (real auth path).
+
+8. **claude_desktop_config.json file perms note** (challenge cycle-4). `pair --format claude-desktop` stderr warning extended: "Recommend `chmod 600` on claude_desktop_config.json; the transport_key is in the env block." Soft guidance — local-to-local scope means file perms are advisory, not load-bearing.
+
+9. **`McpToolRequestEnvelope` has no client_id** (devex cycle-4 confirmed). Transport passes `verified_client_id` as the `asserted_client_id` argument to `Gateway::handle_tool_call` (existing W1-A API). Envelope shape is unchanged.
+
+10. **Documented trust-model softening for stdio** in §11 DoD. W1-A's "every call HMAC-verified" claim still technically true, but for stdio transport the HMAC is self-signed by the same process that holds the key. Honest framing in proof bundle.
+
+## 0. Scope statement
+
+**In scope:** local stdio MCP transport (Claude Desktop, Cursor, custom local SDK clients) on the same machine as the dailyos-mcp-v2 binary. Trust boundary: same user on this machine.
+
+**Out of scope:** remote MCP transport (HTTP/TLS to external clients). Out-of-machine attackers. Cross-user attackers on the same machine (multi-tenant systems). Network-attached MCP servers. If you have a remote-MCP threat model, this lane is the wrong substrate.
+
+## 1. What this lane ships
+
+The MCP v2 Gateway (W1-A) has no transport ingress — it's a Rust function nobody can call over the wire. Legacy `dailyos-mcp` uses `rmcp::ServerHandler` on stdio. This lane bridges `rmcp` to the v2 `Gateway` so standard MCP clients (Claude Desktop, Cursor, custom) invoke v2 tools through the W1-A trust contract under the §0 scope.
+
+### Architecture: env-asserted startup identity, transport-internal signing
+
+Each `dailyos-mcp-v2` stdio process serves one verified pairing for its lifetime. Identity is asserted via environment variables at process startup; per-call envelopes are constructed + signed BY THE TRANSPORT itself, then dispatched via `Gateway::handle_tool_call` which verifies HMAC + consumes nonce as substrate hygiene.
+
+```
+1. pair CLI emits config snippet → operator pastes into claude_desktop_config.json
+2. Claude Desktop spawns `dailyos-mcp-v2 serve` with env vars set
+3. Subprocess startup:
+     a. Read DAILYOS_MCP_CLIENT_ID + DAILYOS_MCP_TRANSPORT_KEY from env
+     b. Look up mcp_client_manifest row for client_id; verify exists + not revoked
+     c. Read transport_key from keychain via row.keychain_ref; cross-check
+        against env-asserted key (Zeroizing comparison, constant-time)
+     d. Store verified_client_id + transport_key in V2ServerHandler
+     e. Best-effort: std::env::remove_var on env vars (limits subsequent
+        in-process getenv reads; does NOT scrub /proc/<pid>/environ — see §0 scope)
+     f. Begin serving rmcp::ServerHandler
+4. Standard MCP `initialize`/`get_info` handshake
+5. `tools/list` returns registered handlers FILTERED by mcp_tool_grant rows
+   for verified_client_id where exposure = Invocable. input_schema exposes
+   only handler-defined params (no _dailyos_* keys).
+6. `tools/call` flow:
+     a. Receive { name, arguments } — normal MCP shape, no _dailyos_* keys
+     b. Transport assigns request_nonce (W1-A preissue path)
+     c. Transport constructs McpToolRequestEnvelope { tool_name=name,
+        request_nonce, params=arguments, conversation_handle, tool_grant_id }
+     d. Transport canonicalizes envelope via RFC 8785 JCS; signs with
+        process-held transport_key using HMAC-SHA256
+     e. Transport calls Gateway::handle_tool_call(conn, &verified_client_id,
+        envelope, signature)
+     f. Gateway substrate (W1-A, unchanged): verify HMAC, consume nonce,
+        check manifest scope grant, dispatch handler, audit, signal-emit
+     g. Transport unwraps response envelope into rmcp::CallToolResult
+7. Process exit = session end; no persistent state
+```
+
+### Deliverable 1: `src-tauri/src/services/mcp_v2/transport.rs` (NEW)
+
+```rust
+pub struct V2ServerHandler {
+    gateway: Arc<Gateway>,
+    catalog: Arc<dyn TaxonomyCatalog>,
+    db: Arc<Mutex<ActionDb>>,
+    verified_client_id: McpClientId,                  // immutable, set at construction
+    transport_key: Zeroizing<[u8; 32]>,               // process-held; signs envelopes internally
+    server_info: ServerInfo,
+}
+
+impl V2ServerHandler {
+    /// Constructed AFTER successful env-assertion + manifest lookup +
+    /// keychain cross-check in main.rs. Construction failure exits the
+    /// process before the rmcp service runs.
+    pub fn from_verified_pairing(
+        gateway: Arc<Gateway>,
+        catalog: Arc<dyn TaxonomyCatalog>,
+        db: Arc<Mutex<ActionDb>>,
+        verified_client_id: McpClientId,
+        transport_key: Zeroizing<[u8; 32]>,
+    ) -> Self { ... }
+}
+
+impl rmcp::ServerHandler for V2ServerHandler {
+    fn get_info(&self) -> ServerInfo { ... }                   // mirrors legacy
+    async fn list_tools(...) -> Result<ListToolsResult, McpError> { ... }
+    async fn call_tool(...) -> Result<CallToolResult, McpError> { ... }
+    // Internal: construct + sign envelope from request before gateway dispatch
+}
+```
+
+### Deliverable 2: `src-tauri/src/mcp_v2/main.rs` (NEW binary `dailyos-mcp-v2`)
+
+```bash
+dailyos-mcp-v2 serve [--legacy-config-path <p>]   # stdio MCP server
+dailyos-mcp-v2 pair --client-name <s>             # pair a new client
+                    --grant <tool>:<scope1,scope2>:<exposure>  # repeatable
+                    [--format json|claude-desktop]
+dailyos-mcp-v2 unpair --client-id <id>             # revoke a pairing
+```
+
+### Deliverable 3: `pair --format claude-desktop` output
+
+```json
+{
+  "mcpServers": {
+    "<client-name>": {
+      "type": "stdio",
+      "command": "<resolved-absolute-path>",
+      "args": ["serve"],
+      "env": {
+        "DAILYOS_MCP_CLIENT_ID": "mcp_client_<hex>",
+        "DAILYOS_MCP_TRANSPORT_KEY": "<hex>"
+      }
+    }
+  }
+}
+```
+
+Stderr (never stdout):
+```
+WARNING: DAILYOS_MCP_TRANSPORT_KEY printed ONCE. Record it now — there is
+no recovery. Re-pair via 'unpair --client-id <id>' then 'pair' regenerates
+a new key.
+
+Recommended: chmod 600 on claude_desktop_config.json — the env block
+contains the transport_key. (Same-user same-machine threat model; advisory
+only.)
+```
+
+## 2. What this lane does NOT ship
+
+- Per-tool handlers (W2 / W3 / W4)
+- Remote MCP transport (HTTP/TLS) — §0 out-of-scope for v1.4.7
+- MCP v1 deprecation — legacy binary stays per W1-A AC-10
+- Production `BusSignalEmitter` (separate W1.5 lane)
+- Operator pairing UI beyond CLI (post-v1.4.7)
+- `client_label` schema column for pair-by-name revoke (separate ticket)
+
+## 3. Frozen substrate citations
+
+- `rmcp = "0.1"` already in Cargo.toml; legacy precedent at `src/mcp/main.rs:973-1031` + `:1312-1379`
+- W1-A `Gateway::handle_tool_call(conn, &asserted_client_id, envelope, signature)` — dispatch entry, unchanged
+- W1-A `auth::pair_client`, `auth::load_client_record`, `auth::verify_transport_hmac`, `auth::verify_and_consume_and_preissue` — all reused; no parallel paths
+- W1-A keychain via `keychain_ref` in `mcp_client_manifest` — env-asserted key cross-checked here
+- W1-A `mcp_transport_nonce_ledger` — request_nonce ledger consumed per envelope
+- W1-B `YamlTaxonomyCatalog::description_for` (will move to trait per §4)
+- W1-B `Gateway::seal()`
+- ADR-0128 §B — MCP as product surface
+- ADR-0102 §C.bis.replay/refresh — per-envelope HMAC + nonce
+
+## 4. K-in + substrate extensions
+
+- **K-in**: grep `docs/solutions/` + `.docs/decisions/`. Legacy `dailyos-mcp` is the rmcp precedent.
+- **`TaxonomyCatalog` trait extension**: add `fn description_for(&self, name: &ScopedName) -> Option<&ToolDescription>`. One-line additive.
+
+## 5. Acceptance criteria (cycle-5 normative)
+
+- **AC-1 rmcp::ServerHandler implemented.** `V2ServerHandler` implements `get_info`, `list_tools`, `call_tool`. No custom JSON-RPC methods. Standard MCP clients work without modification.
+- **AC-2 Transport self-signs.** `tools/call` receives normal MCP `{ name, arguments }`. Transport (NOT client) constructs `McpToolRequestEnvelope` with `tool_name = name`, `params = arguments`, assigns `request_nonce` from W1-A ledger, signs with process-held `transport_key` over JCS canonicalization. No `_dailyos_*` keys exposed in public input_schema.
+- **AC-3 ToolError → rmcp::Error closed-matrix mapping** including public human-readable `message`.
+
+   | ToolError | rmcp::Error code | data.kind | message (public) | log fields (server-side) |
+   |---|---|---|---|---|
+   | `Unauthorized { missing_scope }` | -32600 invalid_request | `unauthorized` | "tool requires scope your pairing lacks" | client_id, tool_name, missing_scope |
+   | `BadParams { detail }` | -32602 invalid_params | `bad_params` | "tool params are malformed" | client_id, tool_name, detail (server-side only) |
+   | `RateLimited { retry_after_seconds }` | -32099 custom | `rate_limited` | "too many calls; retry later" | client_id, tool_name, retry_after_seconds |
+   | `ExposureForbidden { tool_name }` | -32601 method_not_found | `exposure_forbidden` | "tool is not exposed to your pairing" | client_id, tool_name |
+   | `PairingRevoked` | -32600 invalid_request | `pairing_revoked` | "pairing has been revoked" | client_id |
+   | `ConversationRevoked` | -32600 invalid_request | `conversation_revoked` | "conversation has been revoked" | client_id, conversation_handle |
+   | `NotFound { resource }` | -32601 method_not_found | `not_found` | "requested resource not found" | client_id, tool_name, resource (opaque ID) |
+   | `UpstreamFailure { detail }` | -32603 internal_error | `upstream_failure` | "upstream system failure; try again later" | trace_id (opaque); detail server-side only |
+   | `Internal { trace_id }` | -32603 internal_error | `internal` | "internal error" | trace_id |
+
+   Test asserts every variant; CI lint fails on orphan variant.
+- **AC-4 Boot logs.** Format: `mcp_v2 boot: pairing <client_id> verified, 0 handlers registered, 10 catalog entries pending. tools/list will return empty for this build. Expected for W1.5 transport-only.` Strict mode env: `DAILYOS_MCP_V2_REQUIRE_HANDLERS=1` fails boot if no handlers registered.
+- **AC-5 `pair` CLI:**
+  - `dailyos-mcp-v2 pair --client-name <s> --grant <tool>:<scope1>[,<scope2>...]:<invocable|metadata-only> [--grant ...] [--format json|claude-desktop]`
+  - `--format claude-desktop` → snippet includes `"type": "stdio"` (Cursor compat) + env block (client_id + transport_key). **`command` field MUST be an absolute path** resolved via `std::env::current_exe()` (cycle-5 devex finding: GUI-launched Claude Desktop / Cursor don't reliably inherit shell PATH; bare binary names fail to spawn)
+  - Stderr warnings: key-printed-once + chmod 600 advisory (§0 scope acknowledgment)
+  - No name-based re-pair (substrate gap filed separately)
+- **AC-6 `tools/list` filtered + composed description.** Returns only registered handlers WHOSE `mcp_tool_grant` row for `verified_client_id` has `exposure = Invocable`. Each `rmcp::Tool` carries:
+  - `name` = catalog entry name (ScopedName)
+  - `description` = `format!("{summary}\n\nWhen to call:\n{when_to_call}\n\nWhen NOT to call:\n{when_not_to_call}")`
+  - `input_schema` = JSON Schema for handler params from `ToolDescription.parameters`. **Excludes `_dailyos_*` keys** (transport self-signs; client doesn't construct them).
+- **AC-7 Legacy `dailyos-mcp` unchanged.** Build matrix verifies both binaries compile + bin paths don't collide.
+- **AC-8 Integration tests** (cover AC-1..AC-14):
+  - Unit: `V2ServerHandler::call_tool` direct invocation with stub handler
+  - **Subprocess test**: spawn `dailyos-mcp-v2 serve` with env; perform full MCP `initialize` → `tools/list` → `tools/call` over stdin/stdout; assert stdout protocol-only (per legacy `src/mcp/main.rs:1312` precedent)
+  - Subprocess negative tests: missing env → exit 1; unknown client_id → exit 1; revoked pairing → exit 1; keychain mismatch → exit 1; tools/call with replay of consumed nonce → BadParams (W1-A substrate via gateway)
+- **AC-10 Required checks.** `cargo build --features mcp --bin dailyos-mcp-v2` clean. `cargo clippy --features mcp -- -D warnings` clean. `cargo test --features mcp` passes including subprocess + JCS golden tests.
+- **AC-11 Legacy executable identity guardrail.** `serve --legacy-config-path <p>` refuses to start if config claims v2-owned tools AND points (via filesystem canonicalization following symlinks) at the legacy `dailyos-mcp` binary. Error message includes resolved-path + suggested remediation. Hardlinks/copies acknowledged limitation; binary self-ID `--version-id` fallback filed as separate ticket.
+- **AC-12 Startup env-assertion** (replaces cycle-3 identify ACs).
+  1. Read `DAILYOS_MCP_CLIENT_ID` + `DAILYOS_MCP_TRANSPORT_KEY` from env (into Zeroizing buffers). Missing → exit 1 with operator-readable error.
+  2. Look up `mcp_client_manifest` row. Not found → exit 1.
+  3. Revoked → exit 1.
+  4. Read transport_key from keychain via `row.keychain_ref`; constant-time compare against env-asserted key (Zeroizing). Mismatch → exit 1.
+  5. **Best-effort env-wipe**: `unsafe { std::env::remove_var }` on both env vars BEFORE spawning the rmcp service / any threads. Documented as best-effort in-process hygiene — does NOT scrub `/proc/<pid>/environ` (which retains the initial exec environment for process lifetime per Linux kernel behavior). Acceptable under §0 scope (same-user same-machine threat model; attacker reading /proc already has keychain access).
+  6. Construct `V2ServerHandler::from_verified_pairing` and begin serving.
+- **AC-13 Per-envelope replay protection via W1-A substrate.** `tools/call` calls `Gateway::handle_tool_call` which invokes `auth::verify_transport_hmac` + `auth::verify_and_consume_and_preissue`. Replay (consumed nonce) → BadParams. **Note**: for stdio transport, HMAC verification + nonce consumption are transport-internal hygiene (the same process signs and verifies via the same key). Real client auth for stdio is the startup env-assertion (AC-12). For WP adapter / SDK transports, HMAC + nonce remain real client-to-gateway authentication.
+- **AC-14 RFC 8785 JCS canonicalization with hardened spec + golden fixtures.**
+  - Duplicate-key rejection at all object levels (UnknownField / DuplicateKey error)
+  - I-JSON-compatible values only (no NaN, no Infinity, no -0, no excessive precision)
+  - Golden fixtures shipped in `src-tauri/tests/fixtures/jcs_envelope_*.json` covering:
+    - ASCII text
+    - Unicode (BMP + surrogate pairs)
+    - Escape sequences (`\n`, `\t`, `\\`, `ÿ`)
+    - Nested objects (depth 5)
+    - Arrays (mixed types)
+    - Integer edge cases (0, -0 rejection, max safe int, negative)
+    - Floats (0.1, 1e10, 1e-10)
+    - Null values
+    - Empty object / empty array
+    - Duplicate-key rejection (input + expected error)
+
+## 6. Files owned
+
+| File | State | Owner |
+|---|---|---|
+| `src-tauri/src/services/mcp_v2/transport.rs` | NEW | exclusive |
+| `src-tauri/src/services/mcp_v2/taxonomy.rs` | additive — `description_for` to trait | shared (one-line) |
+| `src-tauri/src/services/mcp_v2/mod.rs` | additive — `pub mod transport;` | shared (one-line) |
+| `src-tauri/src/mcp_v2/main.rs` | NEW (binary with serve / pair / unpair) | exclusive |
+| `src-tauri/Cargo.toml` | additive — `[[bin]]` block for `dailyos-mcp-v2` | shared (additive) |
+| `src-tauri/tests/dos_mcp_transport_test.rs` | NEW | exclusive |
+| `src-tauri/tests/dos_mcp_transport_subprocess_test.rs` | NEW | exclusive |
+| `src-tauri/tests/fixtures/jcs_envelope_*.json` | NEW (10 golden fixtures per AC-14) | exclusive |
+
+## 7. Test plan (per-AC)
+
+- AC-1: get_info shape assertion
+- AC-2: wrapper construction unit test (transport builds envelope from MCP request params, signs, dispatches)
+- AC-3: for-each ToolError variant assert code + message + data.kind + log fields; CI lint enforces no orphan
+- AC-4: subprocess boot stderr parse against exact format
+- AC-5: subprocess pair invocation asserts stdout JSON parseable + "type": "stdio" present + `command` field is an absolute path that resolves to an executable file + stderr warnings + DB rows present
+- AC-6: subprocess pair with grant for A not B; tools/list returns [A] with composed description, no _dailyos_* in input_schema
+- AC-7: build matrix asserts both binaries compile
+- AC-8: full subprocess MCP handshake test; stdout protocol-only assertion
+- AC-10: CI
+- AC-11: synthetic config triggers refusal with expected error text
+- AC-12: subprocess negative tests per failure mode; env-wipe verified via in-process getenv (NOT /proc — acknowledged limitation)
+- AC-13: replay test asserts second tools/call with same envelope nonce → BadParams from gateway
+- AC-14: golden fixture round-trip tests across all 10 fixtures; duplicate-key fixture asserts error
+
+## 8. Security gates
+
+`/cso` mandatory. Cycle-5 must verify the local-to-local same-machine scope statement (§0) makes the env-asserted identity model acceptable, AND that the trust-model differentiation (stdio = internal hygiene; WP/SDK = real auth) is documented honestly without misleading W1-A's "every call HMAC-verified" framing.
+
+## 9. Path-α (separate Linear tickets)
+
+- `client_label` schema for pair-by-name revoke (cycle-2)
+- `dailyos-mcp-v2 migrate-config` subcommand (AC-11 error reference)
+- Binary self-identification via `--version-id` (AC-11 challenge cycle-3)
+- Per-process keychain ACL gating transport_key reads (post-v1.4.7 hardening)
+- Loopback HTTP transport (Phase 2 — out of §0 scope for v1.4.7)
+- Tauri operator pairing UI (post-v1.4.7)
+- MCP client SDK code samples + JCS reference implementations
+
+## 10. Depends-on
+
+- W1-A merged (PR #347): Gateway + auth + nonce ledger + keychain substrate
+- W1-B merged (PR #347): YamlTaxonomyCatalog + Gateway::seal
+- rmcp crate already in deps
+
+## 11. Definition of Done
+
+§5 AC-1..AC-14 met. L0 unanimous APPROVE. L2 unanimous APPROVE bounded by AC. Commit-msg `L2-status: passed`. Pushed to PR #347. CI green including subprocess + JCS golden tests.
+
+**Trust-model honest framing in proof bundle:** W1-A claims "every Gateway::handle_tool_call verifies HMAC + consumes nonce" — that remains true. For stdio transport, the signer IS the verifier (same process holds the key). The real client auth is the startup env-assertion + keychain cross-check (AC-12). For non-stdio transports (WP adapter, SDK clients), the HMAC verification authenticates the external signer to the gateway. Both transport classes share the same gateway substrate; their trust boundaries are at different points.
+
+## 12. Open questions resolved
+
+| # | Question | Resolution |
+|---|---|---|
+| Q1 | rmcp wrapper format | DELETED (cycle-5: transport self-signs internally; no `_dailyos_*` in client params) |
+| Q2 | pair CLI argparse | clap |
+| Q3 | empty handler set at boot | warning + strict-mode env |
+| Q4 | HTTP transport | path-α (§0 scope out for v1.4.7) |
+| Q5 (NEW) | trust-model class | Differentiated by transport: stdio = startup identity + internal hygiene; WP/SDK = per-envelope HMAC real auth |
+| Q6 (NEW) | local-to-local same-machine scope | locked in §0 (user direction) |
+
+## 13. Reviewer dispatch
+
+- **CSO** (mandatory; verify local-to-local scope statement + honest trust framing)
+- **/codex challenge** (adversarial within scope; out-of-scope vectors documented)
+- **architect-reviewer** (V2ServerHandler shape; transport-internal signing seam)
+- **/plan-devex-review** (Claude Desktop + Cursor compatibility; client integration UX)

--- a/.docs/plans/v1.4.7-waves.html
+++ b/.docs/plans/v1.4.7-waves.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>v1.4.7 MCP Server v2 · DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body data-tint="eucalyptus" data-active-page="planning">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="v1.4.7-waves.html" data-active="true">v1.4.7 MCP</a>
+    <a href="abilities-runtime-producer-remediation-waves.html">Runtime Producers</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · v1.4.7 · MCP Server v2</p>
+  <h1 class="plans-title">Make DailyOS the headless personal intelligence surface.</h1>
+  <p class="plans-kicker">Claude Desktop and other MCP hosts should reach DailyOS for the user's working context, not stale exports or raw search.</p>
+  <p class="plans-lede">
+    This is the re-baselined v1.4.7 plan after the runtime producer remediation detour.
+    The remediation work is merged and restored DailyOS's ability to answer from claim-backed runtime evidence.
+    v1.4.7 remains open: the remaining job is to finish MCP v2 as the direct headless surface over that runtime.
+  </p>
+  <div class="plans-meta">
+    <span>Re-baselined: 2026-05-26</span>
+    <span>Status: active, not complete</span>
+    <span>Canonical project: <a href="https://linear.app/a8c/project/v147-mcp-server-v2-abilities-first-6e12027c36c9">Linear v1.4.7</a></span>
+    <span>Markdown source: <a href="v1.4.7-waves.md">v1.4.7-waves.md</a></span>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="where-we-landed">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reconciliation</p>
+    <h2 id="where-we-landed" class="plans-section-title">Producer remediation is merged; v1.4.7 is not done.</h2>
+    <p class="plans-section-lede">
+      The project veered because MCP could call the runtime but the runtime was underfed. That became a runtime-producer remediation wave.
+      The detour fixed the blocking substrate problem and should now be treated as a dependency that v1.4.7 consumes.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Track</th>
+        <th>Current state</th>
+        <th>Evidence</th>
+        <th>Plan consequence</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Runtime producer remediation</td>
+        <td>Done enough for v1.4.7 to proceed</td>
+        <td>PRs #366, #375, #390 and related briefing/context fixes merged</td>
+        <td>Consume the runtime output. Do not reopen account-shaped bypass work.</td>
+      </tr>
+      <tr>
+        <td>MCP v2 foundation</td>
+        <td>Partially landed</td>
+        <td>W0 and gateway/taxonomy/account-status work merged; missing packets recovered from backup branch</td>
+        <td>Recover docs, reconcile Linear, continue W2/W3/W4/W5 under v1.4.7.</td>
+      </tr>
+      <tr>
+        <td>Workspace MCP overlap</td>
+        <td>Partially landed through v1.4.5 release-gate work</td>
+        <td>Placement and context parity PRs landed against v1.4.5 validation work</td>
+        <td>Map those PRs to v1.4.7 tickets where they satisfy MCP surface acceptance criteria.</td>
+      </tr>
+      <tr>
+        <td>Daily and meeting briefing MCP tools</td>
+        <td>Not complete</td>
+        <td>Catalog entries exist, but direct handlers are not the completed release surface yet</td>
+        <td>Keep this in v1.4.7 as the next ability-backed read slice.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="recovered-plans">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Recovered planning packets</p>
+    <h2 id="recovered-plans" class="plans-section-title">The missing MCP local plan was markdown, not HTML.</h2>
+    <p class="plans-section-lede">
+      Repo history showed no separate v1.4.7 MCP HTML plan. The missing local work was a markdown L0 packet set on
+      <code>backup-v147-w1-foundation-pre-rebuild</code>. It has been restored under <code>.docs/plans/v1.4.7-w1-foundation/</code>.
+    </p>
+  </header>
+
+  <ul class="plans-related">
+    <li><strong><a href="v1.4.7-w1-foundation/dos-168-l0-plan.md">DOS-168 L0 packet</a>:</strong> MCP v2 gateway, actor policy, auth, audit, and local-to-local trust model.</li>
+    <li><strong><a href="v1.4.7-w1-foundation/dos-478-l0-plan.md">DOS-478 L0 packet</a>:</strong> tool taxonomy, host-selection contract, YAML catalog, and fixture discipline.</li>
+    <li><strong><a href="v1.4.7-w1-foundation/dos-mcp-transport-l0-plan.md">MCP transport L0 packet</a>:</strong> rmcp transport into the gateway, scoped to local same-user stdio clients.</li>
+    <li><strong><a href="v1.4.7-w1-foundation/dos-175-l0-plan.md">DOS-175 L0 packet</a>:</strong> ability-backed read handler phase A for account status.</li>
+    <li><strong><a href="v1.4.7-w1-foundation/dos-624-cso-amendment.md">DOS-624 CSO amendment</a>:</strong> briefing-specific MCP exposure policy and existence-oracle protections.</li>
+  </ul>
+</section>
+
+<section class="plans-section" aria-labelledby="wave-overview">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave shape</p>
+    <h2 id="wave-overview" class="plans-section-title">Finish the original v1.4.7 scope on top of the repaired runtime.</h2>
+    <p class="plans-section-lede">
+      The original waves stay valid. Their implementation order changes only where merged runtime or workspace-memory work has already satisfied part of a ticket.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Wave</th>
+        <th>Linear scope</th>
+        <th>Status after reconciliation</th>
+        <th>Next action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>W0 · Foundation</td>
+        <td>PR #322 plus ADR-0102 / ADR-0128 amendments</td>
+        <td>Done</td>
+        <td>Keep as historical base.</td>
+      </tr>
+      <tr>
+        <td>W1 · Contract and policy</td>
+        <td>DOS-168, DOS-478, transport ingress</td>
+        <td>Mostly done</td>
+        <td>DOS-478 reconciled; transport traceability recorded as historical W1.5 evidence.</td>
+      </tr>
+      <tr>
+        <td>W2 · Ability-backed reads</td>
+        <td>DOS-175, DOS-172, DOS-173, DOS-624</td>
+        <td>Partially done</td>
+        <td>Complete daily/meeting briefing handlers, ranked discovery, and portfolio attention.</td>
+      </tr>
+      <tr>
+        <td>W3 · Workspace memory tools</td>
+        <td>DOS-479, DOS-480, DOS-171</td>
+        <td>Partially satisfied by v1.4.5 release-gate PRs</td>
+        <td>DOS-480 is satisfied by the merged placement handler path; finish search, provenance, and resources.</td>
+      </tr>
+      <tr>
+        <td>W4 · Controlled feedback and writes</td>
+        <td>DOS-167, DOS-169, DOS-170</td>
+        <td>Open</td>
+        <td>Implement service-backed note, action, and action-status tools with receipts and signals.</td>
+      </tr>
+      <tr>
+        <td>W5 · Evaluation and release gate</td>
+        <td>DOS-481, DOS-482</td>
+        <td>Open</td>
+        <td>Run host-selection and end-to-end Claude Desktop validation against production-shaped data.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section plans-section-callouts" aria-label="Re-baseline rules">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">No runtime bypass</h3>
+      <p class="callout-prose">MCP v2 tools must consume abilities or approved services. Generated JSON, markdown exports, and legacy snapshots are not authority paths.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Catalog is not completion</h3>
+      <p class="callout-prose">A tool may exist in <code>tool_descriptions.yaml</code> before its handler is registered. Linear closure requires live handler, gateway registration, tests, and host-safe output.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Use production only locally</h3>
+      <p class="callout-prose">L4 comparison can use the encrypted local production database, but fixtures and committed artifacts must stay synthetic and source-safe.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="tool-state">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Tool state</p>
+    <h2 id="tool-state" class="plans-section-title">The catalog is ahead of registered behavior.</h2>
+    <p class="plans-section-lede">
+      This table is the working reconciliation target. A tool is not done merely because it has taxonomy copy.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Tool</th>
+        <th>Ticket</th>
+        <th>State</th>
+        <th>Done requires</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>dailyos.read.account_status</code></td>
+        <td>DOS-175 phase A</td>
+        <td>Done enough for prompt comparison</td>
+        <td>Keep runtime projection and subject resolution covered.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.read.daily_briefing</code></td>
+        <td>DOS-175 phase B + DOS-624</td>
+        <td>Open</td>
+        <td>Registered handler, centralized sensitivity rendering, uniform unavailable behavior where needed.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.read.meeting_briefing</code></td>
+        <td>DOS-175 phase B + DOS-624</td>
+        <td>Open</td>
+        <td>Registered handler, existence-oracle protection, source-safe meeting evidence.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.read.portfolio_attention</code></td>
+        <td>DOS-173</td>
+        <td>Open</td>
+        <td>Ability-backed ranking over trust, freshness, open loops, and salience where available.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.search.workspace_memory</code></td>
+        <td>DOS-479</td>
+        <td>Open or partial</td>
+        <td>Source-aware search through v1.4.5 workspace graph, not arbitrary file search.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.read.workspace_source_provenance</code></td>
+        <td>DOS-479</td>
+        <td>Open or partial</td>
+        <td>Privacy-rendered source/provenance view with sensitivity policy and no raw path leaks.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.write.place_document</code></td>
+        <td>DOS-480</td>
+        <td>Done on <code>dev</code></td>
+        <td>Registered handler reaches workspace ingestion, commits a workspace-file claim, and projects into the workspace graph.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.submit.note</code></td>
+        <td>DOS-167</td>
+        <td>Open</td>
+        <td>Claim/source service receipt, actor attribution, signal emission, correction lifecycle.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.submit.action</code></td>
+        <td>DOS-169</td>
+        <td>Open</td>
+        <td>Internal action creation through services with receipt and invalidation.</td>
+      </tr>
+      <tr>
+        <td><code>dailyos.submit.action_status</code></td>
+        <td>DOS-170</td>
+        <td>Open</td>
+        <td>Status update through services with receipt and signal propagation.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="acceptance">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Acceptance</p>
+    <h2 id="acceptance" class="plans-section-title">The release gate is the DailyOS-vs-Glean comparison.</h2>
+    <p class="plans-section-lede">
+      W5 closes only when Claude Desktop can use DailyOS MCP v2 for a real personal-working-context prompt and produce an answer that is at least fact-parity with Glean while adding DailyOS's runtime judgment: trust, freshness, provenance, source caveats, actions, and current local context.
+    </p>
+  </header>
+
+  <ul class="plans-related">
+    <li><strong>Prompt:</strong> executive briefing for an account, including overview, commercial status, current risks and wins, stakeholders/champions, and top priorities.</li>
+    <li><strong>DailyOS must win honestly:</strong> it should not read generated JSON/markdown artifacts, stale snapshots, or raw schema bypasses to beat Glean.</li>
+    <li><strong>Evidence breadth:</strong> local DB evidence, Glean-derived source claims, actions, meetings, transcripts, and workspace sources should flow through runtime-backed sections where available.</li>
+    <li><strong>Caveat behavior:</strong> missing or insufficient evidence must become an explicit section caveat, not confident wrong prose.</li>
+    <li><strong>Host-selection behavior:</strong> Claude Desktop should choose DailyOS for personal working context and avoid DailyOS for broad corpus/web questions.</li>
+  </ul>
+</section>
+
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">Source material.</h2>
+  </header>
+  <ul class="plans-related">
+    <li><strong><a href="v1.4.7-waves.md">v1.4.7-waves.md</a></strong> Original MCP Server v2 wave plan and issue mapping.</li>
+    <li><strong><a href="abilities-runtime-producer-remediation-waves.html">abilities-runtime-producer-remediation-waves.html</a></strong> Runtime producer remediation detour consumed by v1.4.7.</li>
+    <li><strong><a href="abilities-runtime-producer-audit-2026-05-23.md">abilities-runtime-producer-audit-2026-05-23.md</a></strong> Audit that found the underfed runtime problem.</li>
+    <li><strong><a href="intelligence-generation-contract-waves.html">intelligence-generation-contract-waves.html</a></strong> Adjacent refresh/generation contract plan for Glean and local producers.</li>
+  </ul>
+</section>
+
+<div class="finis">
+  <div class="finis-mark">W0 · W1 · W2 · W3 · W4 · W5</div>
+  <div class="finis-date">v1.4.7 MCP Server v2 · 2026-05-26</div>
+  <div class="finis-caption">The runtime is repaired; the headless surface still needs to ship.</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Restores the missing v1.4.7 MCP planning packets from the backup branch.
- Adds an HTML v1.4.7 re-baseline plan that records the runtime producer remediation detour and the current MCP v2 handler reality.
- Clarifies that taxonomy/catalog entries are not completion unless a live handler is registered and tested.

## Validation

- Docs-only change; no runtime validation run.
- Linear v1.4.7 project and affected issues were reconciled separately.

## §4 Security

security_auditor_invoked: false

Exemption ID: docs-only

Exemption rationale: This PR only restores planning documents and adds a planning HTML page. It does not change runtime code, prompts, services, migrations, actor policy, sensitivity policy, or MCP configuration.

## Notes

This intentionally excludes bulky recovered review transcripts; the durable plan packets are committed, and the review artifacts remain recoverable from `backup-v147-w1-foundation-pre-rebuild` if needed.
