### PR TITLE
Fix intelligence refresh claim lifecycle

### DIFF
--- a/src-tauri/src/db/data_lifecycle.rs
+++ b/src-tauri/src/db/data_lifecycle.rs
@@ -393,6 +393,10 @@ pub struct PurgeReport {
     #[serde(default)]
     pub account_fact_recompute_jobs_enqueued: usize,
     #[serde(default)]
+    pub generated_projection_claims_withdrawn: usize,
+    #[serde(default)]
+    pub generated_projection_recompute_jobs_enqueued: usize,
+    #[serde(default)]
     pub technical_footprint_fields_cleared: usize,
     #[serde(default)]
     pub enrichment_commitments_deleted: usize,
@@ -926,6 +930,8 @@ pub fn purge_source(db: &ActionDb, source: DataSource) -> Result<PurgeReport, Db
         let mut account_fact_claims_withdrawn = 0usize;
         let mut account_schema_facts_cleared = 0usize;
         let mut account_fact_recompute_jobs_enqueued = 0usize;
+        let mut generated_projection_claims_withdrawn = 0usize;
+        let mut generated_projection_recompute_jobs_enqueued = 0usize;
         let mut technical_footprint_fields_cleared = 0usize;
         let mut enrichment_commitments_deleted = 0usize;
         let mut account_products_deleted = 0usize;
@@ -951,6 +957,20 @@ pub fn purge_source(db: &ActionDb, source: DataSource) -> Result<PurgeReport, Db
                     account_schema_facts_cleared = account_fact_purge.schema_facts_cleared;
                     account_fact_recompute_jobs_enqueued =
                         account_fact_purge.recompute_jobs_enqueued;
+                }
+
+                if table_exists(tx, "intelligence_claims") {
+                    let projection_purge =
+                        crate::services::intelligence::purge_glean_generated_projection_claims_for_source_purge(
+                            &ctx,
+                            tx,
+                        )
+                        .map_err(|e| {
+                            format!("purge Glean generated projection claims failed: {e}")
+                        })?;
+                    generated_projection_claims_withdrawn = projection_purge.claims_withdrawn;
+                    generated_projection_recompute_jobs_enqueued =
+                        projection_purge.recompute_jobs_enqueued;
                 }
 
                 if table_exists(tx, "entity_assessment") {
@@ -1061,6 +1081,8 @@ pub fn purge_source(db: &ActionDb, source: DataSource) -> Result<PurgeReport, Db
             account_fact_claims_withdrawn,
             account_schema_facts_cleared,
             account_fact_recompute_jobs_enqueued,
+            generated_projection_claims_withdrawn,
+            generated_projection_recompute_jobs_enqueued,
             technical_footprint_fields_cleared,
             enrichment_commitments_deleted,
             account_products_deleted,

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -598,6 +598,13 @@ impl EnrichmentProducer {
         matches!(self, EnrichmentProducer::Glean)
     }
 
+    pub(crate) fn projection_data_source(self) -> &'static str {
+        match self {
+            EnrichmentProducer::Glean => "glean",
+            EnrichmentProducer::Pty => "ai_enrichment",
+        }
+    }
+
     fn materialization_label(self) -> &'static str {
         match self {
             EnrichmentProducer::Glean => "Glean",
@@ -1085,6 +1092,7 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                 &db,
                 input,
                 intel,
+                parsed.producer,
                 if is_background_priority(request.priority) {
                     None
                 } else {
@@ -1107,9 +1115,14 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     &ctx,
                     tx,
                     &state.signals.engine,
-                    &input.entity_type,
-                    &input.entity_id,
-                    prepared.intelligence(),
+                    crate::services::intelligence::EnrichmentAssessmentUpsert {
+                        entity_type: &input.entity_type,
+                        entity_id: &input.entity_id,
+                        intel: prepared.intelligence(),
+                        projection_intel: prepared.projection_intelligence(),
+                        projection_data_source: parsed.producer.projection_data_source(),
+                        cleared_dimensions: prepared.cleared_dimensions(),
+                    },
                 )
             }) {
                 log::warn!(
@@ -1855,6 +1868,7 @@ fn run_parallel_enrichment(
                         write_progressive_dimension(
                             &input.entity_id,
                             &input.entity_type,
+                            input.relationship.as_deref(),
                             &combined,
                         );
                         #[allow(
@@ -1981,7 +1995,12 @@ fn run_parallel_enrichment(
 /// Opens a short-lived DB connection, reads existing entity_assessment, merges the
 /// new combined state, and writes back. Non-fatal on error — the committed
 /// enrichment persistence path is the authoritative write.
-fn write_progressive_dimension(entity_id: &str, entity_type: &str, combined: &IntelligenceJson) {
+fn write_progressive_dimension(
+    entity_id: &str,
+    entity_type: &str,
+    relationship: Option<&str>,
+    combined: &IntelligenceJson,
+) {
     let db = match crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())) {
         Ok(db) => db,
         Err(e) => {
@@ -1994,6 +2013,27 @@ fn write_progressive_dimension(entity_id: &str, entity_type: &str, combined: &In
         }
     };
 
+    let merged =
+        prepare_progressive_dimension_snapshot(&db, entity_id, entity_type, relationship, combined);
+
+    let clock = crate::services::context::SystemClock;
+    let rng = crate::services::context::SystemRng;
+    let ext = crate::services::context::ExternalClients::default();
+    let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
+    if let Err(e) = crate::services::intelligence::upsert_assessment_snapshot(&ctx, &db, &merged) {
+        log::warn!("[I575] Progressive write failed for {}: {}", entity_id, e);
+    } else {
+        log::debug!("[I575] Progressive write succeeded for {}", entity_id,);
+    }
+}
+
+pub(crate) fn prepare_progressive_dimension_snapshot(
+    db: &crate::db::ActionDb,
+    entity_id: &str,
+    entity_type: &str,
+    relationship: Option<&str>,
+    combined: &IntelligenceJson,
+) -> IntelligenceJson {
     // Progressive writes within a single enrichment cycle use simple dimension
     // merge, NOT reconciliation. Reconciliation happens at the final write.
     let existing = db.get_entity_intelligence(entity_id).ok().flatten();
@@ -2020,15 +2060,13 @@ fn write_progressive_dimension(entity_id: &str, entity_type: &str, combined: &In
     merged.entity_type = entity_type.to_string();
     merged.enriched_at = chrono::Utc::now().to_rfc3339();
 
-    let clock = crate::services::context::SystemClock;
-    let rng = crate::services::context::SystemRng;
-    let ext = crate::services::context::ExternalClients::default();
-    let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-    if let Err(e) = crate::services::intelligence::upsert_assessment_snapshot(&ctx, &db, &merged) {
-        log::warn!("[I575] Progressive write failed for {}: {}", entity_id, e);
-    } else {
-        log::debug!("[I575] Progressive write succeeded for {}", entity_id,);
-    }
+    crate::intelligence::dimension_prompts::clear_inapplicable_dimension_fields(
+        &mut merged,
+        entity_type,
+        relationship,
+    );
+
+    merged
 }
 
 /// Legacy monolithic PTY enrichment — single prompt, 30s timeout.
@@ -2192,12 +2230,22 @@ fn run_consistency_repair_retry(
 #[derive(Debug, Clone)]
 pub struct PreparedEnrichment {
     intelligence: IntelligenceJson,
+    projection_intelligence: IntelligenceJson,
     side_writes: EnrichmentSideWrites,
+    cleared_dimensions: Vec<&'static str>,
 }
 
 impl PreparedEnrichment {
     pub fn intelligence(&self) -> &IntelligenceJson {
         &self.intelligence
+    }
+
+    pub fn projection_intelligence(&self) -> &IntelligenceJson {
+        &self.projection_intelligence
+    }
+
+    pub fn cleared_dimensions(&self) -> &[&'static str] {
+        &self.cleared_dimensions
     }
 
     pub fn into_intelligence(self) -> IntelligenceJson {
@@ -2218,6 +2266,100 @@ struct MalformedSuppressionAudit {
     caller_context: &'static str,
 }
 
+fn filter_suppressed_risks_and_wins(
+    db: &crate::db::ActionDb,
+    input: &EnrichmentInput,
+    intel: &mut IntelligenceJson,
+    mut side_writes: Option<&mut EnrichmentSideWrites>,
+) {
+    use crate::db::intelligence_feedback::SuppressionDecision;
+    use crate::intelligence::canonicalization::{item_hash as canonical_item_hash, ItemKind};
+
+    let pre_risk_count = intel.risks.len();
+    intel.risks.retain(|risk| {
+        let item_key = Some(risk.text.as_str());
+        let hash = canonical_item_hash(ItemKind::Risk, &risk.text);
+        match db.is_suppressed(
+            &input.entity_id,
+            "risks",
+            item_key,
+            Some(&hash),
+            risk.item_source.as_ref().map(|s| s.sourced_at.as_str()),
+        ) {
+            SuppressionDecision::Suppressed { .. } => false,
+            SuppressionDecision::NotSuppressed => true,
+            SuppressionDecision::Malformed { record_id, reason } => {
+                log::error!(
+                    "[is_suppressed] malformed tombstone {:?} for entity {} field risks; \
+                     failing closed: {:?}",
+                    record_id,
+                    input.entity_id,
+                    reason
+                );
+                if let Some(writes) = side_writes.as_deref_mut() {
+                    writes
+                        .malformed_suppression_audits
+                        .push(MalformedSuppressionAudit {
+                            record_id: record_id.0,
+                            reason: format!("{:?}", reason),
+                            field_key: "risks",
+                            caller_context: "intel_queue.compose_enrichment_intelligence.risks",
+                        });
+                }
+                false
+            }
+        }
+    });
+
+    let pre_win_count = intel.recent_wins.len();
+    intel.recent_wins.retain(|win| {
+        let item_key = Some(win.text.as_str());
+        let hash = canonical_item_hash(ItemKind::Win, &win.text);
+        match db.is_suppressed(
+            &input.entity_id,
+            "recentWins",
+            item_key,
+            Some(&hash),
+            win.item_source.as_ref().map(|s| s.sourced_at.as_str()),
+        ) {
+            SuppressionDecision::Suppressed { .. } => false,
+            SuppressionDecision::NotSuppressed => true,
+            SuppressionDecision::Malformed { record_id, reason } => {
+                log::error!(
+                    "[is_suppressed] malformed tombstone {:?} for entity {} field recentWins; \
+                     failing closed: {:?}",
+                    record_id,
+                    input.entity_id,
+                    reason
+                );
+                if let Some(writes) = side_writes.as_deref_mut() {
+                    writes
+                        .malformed_suppression_audits
+                        .push(MalformedSuppressionAudit {
+                            record_id: record_id.0,
+                            reason: format!("{:?}", reason),
+                            field_key: "recentWins",
+                            caller_context:
+                                "intel_queue.compose_enrichment_intelligence.recentWins",
+                        });
+                }
+                false
+            }
+        }
+    });
+
+    let risks_suppressed = pre_risk_count - intel.risks.len();
+    let wins_suppressed = pre_win_count - intel.recent_wins.len();
+    if risks_suppressed > 0 || wins_suppressed > 0 {
+        log::info!(
+            "[I645] Suppression filter for {}: {} risks, {} wins removed",
+            input.entity_id,
+            risks_suppressed,
+            wins_suppressed,
+        );
+    }
+}
+
 /// Phase 3: Compose enrichment results for DB-first persistence.
 /// This phase prepares the intelligence payload and records deferred side
 /// writes that the caller applies in the same transaction as the DB upsert.
@@ -2227,15 +2369,17 @@ pub fn compose_enrichment_intelligence(
     db: &crate::db::ActionDb,
     input: &EnrichmentInput,
     intel: &IntelligenceJson,
+    producer: EnrichmentProducer,
     ai_config: Option<&AiModelConfig>,
 ) -> Result<PreparedEnrichment, String> {
-    compose_enrichment_intelligence_payload(db, input, intel, ai_config)
+    compose_enrichment_intelligence_payload(db, input, intel, producer, ai_config)
 }
 
 pub(crate) fn compose_enrichment_intelligence_payload(
     db: &crate::db::ActionDb,
     input: &EnrichmentInput,
     intel: &IntelligenceJson,
+    producer: EnrichmentProducer,
     ai_config: Option<&AiModelConfig>,
 ) -> Result<PreparedEnrichment, String> {
     // Source-aware reconciliation + preserve user-edited fields
@@ -2319,88 +2463,7 @@ pub(crate) fn compose_enrichment_intelligence_payload(
     // Fail-closed: if we cannot open the feedback DB to check suppression,
     // drop risks/wins for this round rather than writing potentially-tombstoned
     // items. One lost enrichment round is recoverable; tombstone resurrection is not.
-    {
-        use crate::db::intelligence_feedback::SuppressionDecision;
-        use crate::intelligence::canonicalization::{item_hash as canonical_item_hash, ItemKind};
-
-        let pre_risk_count = final_intel.risks.len();
-        final_intel.risks.retain(|risk| {
-            let item_key = Some(risk.text.as_str());
-            let hash = canonical_item_hash(ItemKind::Risk, &risk.text);
-            match db.is_suppressed(
-                &input.entity_id,
-                "risks",
-                item_key,
-                Some(&hash),
-                risk.item_source.as_ref().map(|s| s.sourced_at.as_str()),
-            ) {
-                SuppressionDecision::Suppressed { .. } => false,
-                SuppressionDecision::NotSuppressed => true,
-                SuppressionDecision::Malformed { record_id, reason } => {
-                    log::error!(
-                        "[is_suppressed] malformed tombstone {:?} for entity {} field risks; \
-                         failing closed: {:?}",
-                        record_id,
-                        input.entity_id,
-                        reason
-                    );
-                    side_writes
-                        .malformed_suppression_audits
-                        .push(MalformedSuppressionAudit {
-                            record_id: record_id.0,
-                            reason: format!("{:?}", reason),
-                            field_key: "risks",
-                            caller_context: "intel_queue.compose_enrichment_intelligence.risks",
-                        });
-                    false
-                }
-            }
-        });
-        let pre_win_count = final_intel.recent_wins.len();
-        final_intel.recent_wins.retain(|win| {
-            let item_key = Some(win.text.as_str());
-            let hash = canonical_item_hash(ItemKind::Win, &win.text);
-            match db.is_suppressed(
-                &input.entity_id,
-                "recentWins",
-                item_key,
-                Some(&hash),
-                win.item_source.as_ref().map(|s| s.sourced_at.as_str()),
-            ) {
-                SuppressionDecision::Suppressed { .. } => false,
-                SuppressionDecision::NotSuppressed => true,
-                SuppressionDecision::Malformed { record_id, reason } => {
-                    log::error!(
-                        "[is_suppressed] malformed tombstone {:?} for entity {} field recentWins; \
-                         failing closed: {:?}",
-                        record_id,
-                        input.entity_id,
-                        reason
-                    );
-                    side_writes
-                        .malformed_suppression_audits
-                        .push(MalformedSuppressionAudit {
-                            record_id: record_id.0,
-                            reason: format!("{:?}", reason),
-                            field_key: "recentWins",
-                            caller_context:
-                                "intel_queue.compose_enrichment_intelligence.recentWins",
-                        });
-                    false
-                }
-            }
-        });
-        let risks_suppressed = pre_risk_count - final_intel.risks.len();
-        let wins_suppressed = pre_win_count - final_intel.recent_wins.len();
-        if risks_suppressed > 0 || wins_suppressed > 0 {
-            log::info!(
-                "[I645] Suppression filter for {}: {} risks, {} wins removed",
-                input.entity_id,
-                risks_suppressed,
-                wins_suppressed,
-            );
-        }
-    }
+    filter_suppressed_risks_and_wins(db, input, &mut final_intel, Some(&mut side_writes));
 
     // Merge computed health dimensions with LLM narrative.
     // The algorithmic engine provides score/band/dimensions/confidence;
@@ -2425,28 +2488,112 @@ pub(crate) fn compose_enrichment_intelligence_payload(
     // Reconcile user-entered facts with AI-inferred values.
     // User-edited fields (source weight 1.0) override AI guesses.
     if input.entity_type == "account" {
-        if let Ok(Some(account)) = db.get_account(&input.entity_id) {
-            if let Some(user_arr) = account.arr {
-                let cc = final_intel
-                    .contract_context
-                    .get_or_insert_with(Default::default);
-                if cc.current_arr != Some(user_arr) {
-                    log::info!(
-                        "[intel_queue] Overriding AI currentArr ({:?}) with user ARR ({}) for {}",
-                        cc.current_arr,
-                        user_arr,
-                        input.entity_id,
-                    );
-                    cc.current_arr = Some(user_arr);
-                }
-            }
+        apply_confirmed_account_facts_to_enrichment_projection(db, input, &mut final_intel, true);
+    }
+
+    let cleared_dimensions =
+        crate::intelligence::dimension_prompts::clear_inapplicable_dimension_fields(
+            &mut final_intel,
+            &input.entity_type,
+            input.relationship.as_deref(),
+        );
+    if !cleared_dimensions.is_empty() {
+        log::debug!(
+            "IntelProcessor: cleared skipped dimensions for {} {}: {:?}",
+            input.entity_type,
+            input.entity_id,
+            cleared_dimensions
+        );
+    }
+
+    let mut projection_intelligence = if producer.is_glean() {
+        intel.clone()
+    } else {
+        final_intel.clone()
+    };
+    if producer.is_glean() {
+        apply_deterministic_projection_repairs(db, input, &mut projection_intelligence);
+        if input.entity_type == "account" {
+            apply_confirmed_account_facts_to_enrichment_projection(
+                db,
+                input,
+                &mut projection_intelligence,
+                false,
+            );
         }
+        filter_suppressed_risks_and_wins(db, input, &mut projection_intelligence, None);
+        crate::intelligence::dimension_prompts::clear_inapplicable_dimension_fields(
+            &mut projection_intelligence,
+            &input.entity_type,
+            input.relationship.as_deref(),
+        );
     }
 
     Ok(PreparedEnrichment {
         intelligence: final_intel,
+        projection_intelligence,
         side_writes,
+        cleared_dimensions,
     })
+}
+
+fn apply_confirmed_account_facts_to_enrichment_projection(
+    db: &crate::db::ActionDb,
+    input: &EnrichmentInput,
+    intel: &mut IntelligenceJson,
+    create_missing_contract_context: bool,
+) {
+    let Ok(Some(account)) = db.get_account(&input.entity_id) else {
+        return;
+    };
+    let Some(user_arr) = account.arr else {
+        return;
+    };
+    let contract_context = if create_missing_contract_context {
+        Some(intel.contract_context.get_or_insert_with(Default::default))
+    } else {
+        intel.contract_context.as_mut()
+    };
+    let Some(contract_context) = contract_context else {
+        return;
+    };
+    if contract_context.current_arr != Some(user_arr) {
+        log::info!(
+            "[intel_queue] Overriding AI currentArr ({:?}) with user ARR ({}) for {}",
+            contract_context.current_arr,
+            user_arr,
+            input.entity_id,
+        );
+        contract_context.current_arr = Some(user_arr);
+    }
+}
+
+fn apply_deterministic_projection_repairs(
+    db: &crate::db::ActionDb,
+    input: &EnrichmentInput,
+    projection_intel: &mut IntelligenceJson,
+) {
+    if input.entity_type != "account" && input.entity_type != "project" {
+        return;
+    }
+    let Ok(facts) =
+        crate::intelligence::build_fact_context(db, &input.entity_id, &input.entity_type)
+    else {
+        return;
+    };
+    let initial_report = crate::intelligence::check_consistency(projection_intel, &facts);
+    let repaired_intel =
+        crate::intelligence::apply_deterministic_repairs(projection_intel, &initial_report, &facts);
+    let unresolved_report = crate::intelligence::check_consistency(&repaired_intel, &facts);
+    let mut repaired_intel = repaired_intel;
+    repaired_intel.consistency_status = Some(crate::intelligence::status_from_reports(
+        &initial_report,
+        &unresolved_report,
+    ));
+    repaired_intel.consistency_findings =
+        crate::intelligence::merge_fixed_flags(&initial_report, &unresolved_report);
+    repaired_intel.consistency_checked_at = Some(Utc::now().to_rfc3339());
+    *projection_intel = repaired_intel;
 }
 
 pub fn apply_enrichment_side_writes(
@@ -3753,6 +3900,7 @@ mod tests {
         let claim = load_single_trust_claim(&db, account_id);
 
         let (freshness, reason) = freshness_context_for_claim(
+            &db,
             Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
             &claim,
         )
@@ -3782,6 +3930,7 @@ mod tests {
         let claim = load_single_trust_claim(&db, account_id);
 
         let (freshness, reason) = freshness_context_for_claim(
+            &db,
             Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
             &claim,
         )
@@ -4508,6 +4657,174 @@ mod tests {
             Some("Prior narrative")
         );
         assert!(fresh.risks.is_empty());
+    }
+
+    #[test]
+    fn compose_enrichment_clears_skipped_dimension_fields_after_reconciliation() {
+        let db = crate::db::test_utils::test_db();
+        let entity_id = "person-skipped-dimensions";
+        let existing = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: entity_id.to_string(),
+            entity_type: "person".to_string(),
+            enriched_at: "2026-05-20T00:00:00Z".to_string(),
+            executive_assessment: Some("Prior person summary.".to_string()),
+            health: Some(crate::intelligence::io::AccountHealth::default()),
+            contract_context: Some(crate::intelligence::io::ContractContext::default()),
+            success_metrics: Some(vec![crate::intelligence::io::SuccessMetric {
+                name: "Legacy account metric".to_string(),
+                target: Some("100%".to_string()),
+                current: Some("80%".to_string()),
+                status: Some("stale".to_string()),
+                owner: None,
+            }]),
+            product_adoption: Some(crate::intelligence::io::AdoptionSignals::default()),
+            support_health: Some(crate::intelligence::io::SupportHealth::default()),
+            gong_call_summaries: vec![crate::intelligence::io::GongCallSummary {
+                title: "Legacy account call".to_string(),
+                date: "2026-05-19".to_string(),
+                participants: vec!["Generic Person".to_string()],
+                key_topics: "Legacy account-only summary".to_string(),
+                sentiment: "neutral".to_string(),
+            }],
+            nps_csat: Some(crate::intelligence::io::SatisfactionData::default()),
+            ..Default::default()
+        };
+        db.upsert_entity_intelligence(&existing)
+            .expect("seed existing person intelligence");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = EnrichmentInput {
+            workspace: dir.path().to_path_buf(),
+            entity_dir: dir.path().to_path_buf(),
+            entity_id: entity_id.to_string(),
+            entity_type: "person".to_string(),
+            prompt: String::new(),
+            file_manifest: Vec::new(),
+            file_count: 0,
+            computed_health: None,
+            entity_name: "Generic Person".to_string(),
+            relationship: Some("internal".to_string()),
+            intelligence_context: None,
+            active_preset: None,
+        };
+        let incoming = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: entity_id.to_string(),
+            entity_type: "person".to_string(),
+            enriched_at: "2026-05-21T00:00:00Z".to_string(),
+            executive_assessment: Some("Fresh person summary.".to_string()),
+            ..Default::default()
+        };
+
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("compose person enrichment");
+        let final_intel = prepared.intelligence();
+
+        assert_eq!(
+            final_intel.executive_assessment.as_deref(),
+            Some("Fresh person summary.")
+        );
+        assert!(
+            final_intel.health.is_none(),
+            "commercial health must not survive person refresh"
+        );
+        assert!(
+            final_intel.contract_context.is_none(),
+            "contract context must not survive person refresh"
+        );
+        assert!(
+            final_intel.success_metrics.is_none(),
+            "value-success metrics must not survive person refresh"
+        );
+        assert!(
+            final_intel.product_adoption.is_none(),
+            "account-only product adoption must not survive person refresh"
+        );
+        assert!(
+            final_intel.support_health.is_none(),
+            "account-only support health must not survive person refresh"
+        );
+        assert!(
+            final_intel.gong_call_summaries.is_empty(),
+            "account-only call summaries must not survive person refresh"
+        );
+        assert!(
+            final_intel.nps_csat.is_none(),
+            "account-only satisfaction data must not survive person refresh"
+        );
+    }
+
+    #[test]
+    fn progressive_snapshot_clears_skipped_dimension_fields_before_write() {
+        let db = crate::db::test_utils::test_db();
+        let entity_id = "person-progressive-skipped-dimensions";
+        let existing = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: entity_id.to_string(),
+            entity_type: "person".to_string(),
+            enriched_at: "2026-05-20T00:00:00Z".to_string(),
+            health: Some(crate::intelligence::io::AccountHealth::default()),
+            product_adoption: Some(crate::intelligence::io::AdoptionSignals::default()),
+            support_health: Some(crate::intelligence::io::SupportHealth::default()),
+            gong_call_summaries: vec![crate::intelligence::io::GongCallSummary {
+                title: "Legacy account call".to_string(),
+                date: "2026-05-19".to_string(),
+                participants: vec!["Generic Person".to_string()],
+                key_topics: "Legacy account-only summary".to_string(),
+                sentiment: "neutral".to_string(),
+            }],
+            nps_csat: Some(crate::intelligence::io::SatisfactionData::default()),
+            ..Default::default()
+        };
+        db.upsert_entity_intelligence(&existing)
+            .expect("seed existing person intelligence");
+        let combined = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: entity_id.to_string(),
+            entity_type: "person".to_string(),
+            enriched_at: "2026-05-21T00:00:00Z".to_string(),
+            executive_assessment: Some("Progressive person summary.".to_string()),
+            ..Default::default()
+        };
+
+        let progressive = prepare_progressive_dimension_snapshot(
+            &db,
+            entity_id,
+            "person",
+            Some("internal"),
+            &combined,
+        );
+
+        assert_eq!(
+            progressive.executive_assessment.as_deref(),
+            Some("Progressive person summary.")
+        );
+        assert!(
+            progressive.health.is_none(),
+            "progressive snapshots must not persist skipped commercial health"
+        );
+        assert!(
+            progressive.product_adoption.is_none(),
+            "progressive snapshots must not persist account-only product adoption"
+        );
+        assert!(
+            progressive.support_health.is_none(),
+            "progressive snapshots must not persist account-only support health"
+        );
+        assert!(
+            progressive.gong_call_summaries.is_empty(),
+            "progressive snapshots must not persist account-only call summaries"
+        );
+        assert!(
+            progressive.nps_csat.is_none(),
+            "progressive snapshots must not persist account-only satisfaction data"
+        );
     }
 
     #[test]

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -562,6 +562,67 @@ pub struct EnrichmentComplete {
     pub wall_clock_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QueueRefreshFailure {
+    entity_id: String,
+    stage: &'static str,
+    error: String,
+}
+
+impl QueueRefreshFailure {
+    fn new(entity_id: &str, stage: &'static str, error: impl Into<String>) -> Self {
+        Self {
+            entity_id: entity_id.to_string(),
+            stage,
+            error: error.into(),
+        }
+    }
+}
+
+fn queue_worker_final_status_payloads(
+    completed_count: usize,
+    failures: &[QueueRefreshFailure],
+    manual: bool,
+) -> Vec<serde_json::Value> {
+    if let Some(first_failure) = failures.first() {
+        let message = if completed_count > 0 {
+            "Some insight refreshes failed"
+        } else {
+            "Insight refresh failed"
+        };
+        let error = if failures.len() == 1 {
+            first_failure.error.clone()
+        } else {
+            format!(
+                "{} refreshes failed; first failure: {}",
+                failures.len(),
+                first_failure.error
+            )
+        };
+        return vec![serde_json::json!({
+            "phase": "failed",
+            "message": message,
+            "count": failures.len(),
+            "completedCount": completed_count,
+            "manual": manual,
+            "entityId": first_failure.entity_id,
+            "stage": first_failure.stage,
+            "error": error,
+        })];
+    }
+
+    if completed_count == 0 {
+        return Vec::new();
+    }
+
+    vec![serde_json::json!({
+        "phase": "completed",
+        "message": "Insights updated",
+        "count": completed_count,
+        "manual": manual,
+    })]
+}
+
 /// Context gathered from the DB (held briefly, then released before PTY).
 /// Public so manual enrichment commands can reuse the split-lock pattern.
 #[derive(Clone)]
@@ -1049,6 +1110,8 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
         drop(_permit);
 
         // Phase 3 + 4: Write results and emit events for each entity
+        let mut finalized_count = 0usize;
+        let mut finalization_failures = Vec::new();
         for (request, input, parsed) in &results {
             let intel = &parsed.intel;
             // Check for anomalies in the enrichment output
@@ -1078,6 +1141,11 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
             )) {
                 Ok(db) => db,
                 Err(e) => {
+                    finalization_failures.push(QueueRefreshFailure::new(
+                        &request.entity_id,
+                        "open_db",
+                        e.to_string(),
+                    ));
                     log::warn!(
                         "IntelProcessor: failed to open DB for {} persistence: {}",
                         request.entity_id,
@@ -1101,6 +1169,11 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
             ) {
                 Ok(composition) => composition,
                 Err(e) => {
+                    finalization_failures.push(QueueRefreshFailure::new(
+                        &request.entity_id,
+                        "compose",
+                        e.clone(),
+                    ));
                     log::warn!(
                         "IntelProcessor: failed to write results for {}: {}",
                         request.entity_id,
@@ -1125,6 +1198,11 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     },
                 )
             }) {
+                finalization_failures.push(QueueRefreshFailure::new(
+                    &request.entity_id,
+                    "write_results",
+                    e.clone(),
+                ));
                 log::warn!(
                     "IntelProcessor: failed to persist DB assessment for {}: {}",
                     request.entity_id,
@@ -1144,6 +1222,11 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     producer: parsed.producer,
                 },
             ) {
+                finalization_failures.push(QueueRefreshFailure::new(
+                    &request.entity_id,
+                    "finalize",
+                    e.clone(),
+                ));
                 log::warn!(
                     "IntelProcessor: failed to finalize enrichment for {}: {}",
                     request.entity_id,
@@ -1151,6 +1234,7 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                 );
                 continue;
             }
+            finalized_count += 1;
 
             log::info!(
                 "IntelProcessor: completed {} ({} risks, {} wins)",
@@ -1161,19 +1245,17 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
         }
 
         // Emit completion status for frontend indicator
-        #[allow(
-            clippy::let_underscore_must_use,
-            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-        )]
-        let _ = app.emit(
-            "background-work-status",
-            serde_json::json!({
-                "phase": "completed",
-                "message": "Insights updated",
-                "count": results.len(),
-                "manual": batch_has_manual,
-            }),
-        );
+        for payload in queue_worker_final_status_payloads(
+            finalized_count,
+            &finalization_failures,
+            batch_has_manual,
+        ) {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = app.emit("background-work-status", payload);
+        }
     }
 }
 
@@ -3661,6 +3743,34 @@ mod tests {
         let (clock, rng, external) = trust_ctx_parts();
         let ctx = ServiceContext::test_live(&clock, &rng, &external);
         f(&ctx)
+    }
+
+    #[test]
+    fn queue_worker_final_status_reports_finalize_failures_instead_of_success() {
+        let failures = vec![QueueRefreshFailure::new(
+            "account-finalize-failed",
+            "finalize",
+            "visible side effects failed",
+        )];
+
+        let payloads = queue_worker_final_status_payloads(0, &failures, true);
+
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["phase"], "failed");
+        assert_eq!(payloads[0]["manual"], true);
+        assert_eq!(payloads[0]["entityId"], "account-finalize-failed");
+        assert_eq!(payloads[0]["stage"], "finalize");
+        assert_eq!(payloads[0]["error"], "visible side effects failed");
+    }
+
+    #[test]
+    fn queue_worker_final_status_counts_only_finalized_successes() {
+        let payloads = queue_worker_final_status_payloads(2, &[], false);
+
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0]["phase"], "completed");
+        assert_eq!(payloads[0]["count"], 2);
+        assert_eq!(payloads[0]["manual"], false);
     }
 
     fn seed_trust_account(db: &crate::db::ActionDb, account_id: &str) {

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -597,6 +597,26 @@ impl EnrichmentProducer {
     fn is_glean(self) -> bool {
         matches!(self, EnrichmentProducer::Glean)
     }
+
+    fn materialization_label(self) -> &'static str {
+        match self {
+            EnrichmentProducer::Glean => "Glean",
+            EnrichmentProducer::Pty => "PTY",
+        }
+    }
+
+    fn side_effect_producer(
+        self,
+    ) -> crate::services::enrichment_side_effects::EnrichmentSideEffectProducer {
+        match self {
+            EnrichmentProducer::Glean => {
+                crate::services::enrichment_side_effects::EnrichmentSideEffectProducer::Glean
+            }
+            EnrichmentProducer::Pty => {
+                crate::services::enrichment_side_effects::EnrichmentSideEffectProducer::Pty
+            }
+        }
+    }
 }
 
 /// Parsed enrichment output from one model response section.
@@ -2668,43 +2688,27 @@ pub fn run_enrichment_post_commit_side_effects(
 
     if input.entity_type == "account" {
         let ctx = state.live_service_context();
-        let (commitment_source_label, signal_source, product_source) = match producer {
-            EnrichmentProducer::Glean => (
-                format!("glean_enrichment:{}", input.entity_id),
-                "glean",
-                "glean",
-            ),
-            EnrichmentProducer::Pty => (
-                format!("pty_enrichment:{}", input.entity_id),
-                "ai_enrichment",
-                "ai_inference",
-            ),
-        };
-        if let Err(error) =
-            crate::services::enrichment_side_effects::sync_account_enrichment_side_effects(
-                &ctx,
-                db,
-                state.signals.engine.as_ref(),
-                &input.entity_id,
-                final_intel,
-                crate::services::enrichment_side_effects::EnrichmentSideEffectSource {
-                    commitment_source_label: &commitment_source_label,
-                    signal_source,
-                    product_source,
-                },
-            )
-        {
+        let sync_result =
+            crate::services::enrichment_side_effects::sync_account_enrichment_side_effects_for_producer(
+            &ctx,
+            db,
+            state.signals.engine.as_ref(),
+            &input.entity_id,
+            final_intel,
+            producer.side_effect_producer(),
+        );
+        if let Err(error) = sync_result {
             log::warn!(
                 "IntelProcessor: enrichment side-effect sync failed for {}: {}",
                 input.entity_id,
                 error
             );
-            if producer.is_glean() {
-                return Err(format!(
-                    "Glean enrichment side-effect sync failed for {}: {}",
-                    input.entity_id, error
-                ));
-            }
+            return Err(format!(
+                "{} enrichment side-effect sync failed for {}: {}",
+                producer.materialization_label(),
+                input.entity_id,
+                error
+            ));
         }
     }
 
@@ -2819,8 +2823,9 @@ pub(crate) fn run_enrichment_finalize_post_commit(
         }
         FinalizeMode::TrustRecompute => EnrichmentProducer::Pty,
     };
-    let is_glean_producer = side_effect_producer.is_glean();
-    if is_glean_producer {
+    let materialize_visible_side_effects_before_export =
+        !matches!(mode, FinalizeMode::TrustRecompute);
+    if materialize_visible_side_effects_before_export {
         run_enrichment_post_commit_side_effects(
             state.as_ref(),
             input,
@@ -2851,7 +2856,7 @@ pub(crate) fn run_enrichment_finalize_post_commit(
     }
 
     fenced_write_enrichment_intelligence(db, &input.entity_dir, intel);
-    if !is_glean_producer {
+    if !materialize_visible_side_effects_before_export {
         run_enrichment_post_commit_side_effects(
             state.as_ref(),
             input,

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -556,6 +556,9 @@ pub struct EnrichmentComplete {
     pub succeeded: u32,
     pub failed: u32,
     pub failed_dimensions: Vec<String>,
+    pub total_dimensions: u32,
+    pub applicable_total: u32,
+    pub skipped_dimensions: Vec<String>,
     pub wall_clock_ms: u64,
 }
 
@@ -1702,13 +1705,34 @@ fn run_parallel_enrichment(
 
     let is_incremental = ctx.prior_intelligence.is_some();
     let overall_start = Instant::now();
-    let total_dimensions = DIMENSION_NAMES.len() as u32;
+    let applicability = dimension_prompts::dimension_applicability(
+        &input.entity_type,
+        input.relationship.as_deref(),
+    );
+    let total_dimensions = applicability.applicable.len() as u32;
+    let canonical_total_dimensions = DIMENSION_NAMES.len() as u32;
+    let skipped_dimensions: Vec<String> = applicability
+        .skipped
+        .iter()
+        .map(|dimension| (*dimension).to_string())
+        .collect();
+
+    if total_dimensions == 0 {
+        return Err(format!(
+            "No applicable dimensions for {} ({})",
+            input.entity_id, input.entity_type
+        ));
+    }
 
     // Channel for receiving dimension results as they complete
     let (tx, rx) = std::sync::mpsc::channel();
 
     // Spawn one thread per dimension
     for &dimension in DIMENSION_NAMES {
+        if !applicability.applicable.contains(&dimension) {
+            continue;
+        }
+
         let dim_prompt = dimension_prompts::build_dimension_prompt(
             dimension,
             &input.entity_name,
@@ -1846,9 +1870,11 @@ fn run_parallel_enrichment(
 
     let total_ms = overall_start.elapsed().as_millis();
     log::info!(
-        "[I574] Parallel enrichment: {}/6 dimensions succeeded in {}ms",
+        "[I574] Parallel enrichment: {}/{} applicable dimensions succeeded in {}ms (skipped: {:?})",
         succeeded,
-        total_ms
+        total_dimensions,
+        total_ms,
+        skipped_dimensions,
     );
 
     // Emit completion event
@@ -1865,13 +1891,19 @@ fn run_parallel_enrichment(
                 succeeded,
                 failed: failed_dims.len() as u32,
                 failed_dimensions: failed_dims,
+                total_dimensions: canonical_total_dimensions,
+                applicable_total: total_dimensions,
+                skipped_dimensions,
                 wall_clock_ms: total_ms as u64,
             },
         );
     }
 
     if succeeded == 0 {
-        return Err("All 6 dimensions failed".to_string());
+        return Err(format!(
+            "All {} applicable dimensions failed",
+            total_dimensions
+        ));
     }
 
     // Extract inferred relationships from the combined raw output

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -2850,12 +2850,14 @@ pub fn run_enrichment_post_commit_side_effects(
                 input.entity_id,
                 error
             );
-            return Err(format!(
-                "{} enrichment side-effect sync failed for {}: {}",
-                producer.materialization_label(),
-                input.entity_id,
-                error
-            ));
+            if producer.is_glean() {
+                return Err(format!(
+                    "{} enrichment side-effect sync failed for {}: {}",
+                    producer.materialization_label(),
+                    input.entity_id,
+                    error
+                ));
+            }
         }
     }
 

--- a/src-tauri/src/intelligence/dimension_prompts.rs
+++ b/src-tauri/src/intelligence/dimension_prompts.rs
@@ -30,6 +30,60 @@ pub const DIMENSION_NAMES: &[&str] = &[
     "engagement_signals",
 ];
 
+/// Dimension selection for a specific entity refresh.
+///
+/// The six canonical dimensions still define the complete account shape, but
+/// non-account entities should not be asked to synthesize account-only fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DimensionApplicability {
+    pub applicable: Vec<&'static str>,
+    pub skipped: Vec<&'static str>,
+}
+
+pub fn dimension_applicability(
+    entity_type: &str,
+    relationship: Option<&str>,
+) -> DimensionApplicability {
+    let applicable: Vec<&'static str> = DIMENSION_NAMES
+        .iter()
+        .copied()
+        .filter(|dimension| is_dimension_applicable(dimension, entity_type, relationship))
+        .collect();
+    let skipped: Vec<&'static str> = DIMENSION_NAMES
+        .iter()
+        .copied()
+        .filter(|dimension| !applicable.contains(dimension))
+        .collect();
+    DimensionApplicability {
+        applicable,
+        skipped,
+    }
+}
+
+pub fn is_dimension_applicable(
+    dimension: &str,
+    entity_type: &str,
+    relationship: Option<&str>,
+) -> bool {
+    let entity_type = entity_type.to_ascii_lowercase();
+    let relationship = relationship.unwrap_or_default().trim().to_ascii_lowercase();
+    let is_account = entity_type == "account";
+    let is_project = entity_type == "project";
+    let is_person = entity_type == "person";
+    let is_commercial_excluded_relationship = matches!(
+        relationship.as_str(),
+        "internal" | "employee" | "partner" | "vendor"
+    );
+
+    match dimension {
+        "core_assessment" => true,
+        "engagement_signals" => true,
+        "commercial_financial" => is_account && !is_commercial_excluded_relationship,
+        "stakeholder_champion" | "strategic_context" | "value_success" => is_account || is_project,
+        _ => !is_person,
+    }
+}
+
 // =============================================================================
 // PTY dimension prompt builder
 // =============================================================================
@@ -100,6 +154,7 @@ pub fn build_dimension_prompt(
         "Return ONLY a JSON object — no other text before or after. \
          The JSON must conform exactly to this schema:\n\n",
     );
+    prompt.push_str(PROMPT_QUALITY_RULES);
     prompt.push_str(&dimension_json_schema(dimension, entity_type, ctx));
 
     // Source attribution instructions
@@ -242,6 +297,7 @@ pub fn build_glean_dimension_prompt(
          parseable by `JSON.parse()`.\n\n",
     );
     prompt.push_str("The JSON object must have these fields:\n\n");
+    prompt.push_str(PROMPT_QUALITY_RULES);
     prompt.push_str(&dimension_json_schema(dimension, entity_type, ctx));
 
     // Source attribution for Glean
@@ -757,11 +813,18 @@ RECONCILIATION RULES:\n\
 - Items tagged [user_correction] are SACRED — include them verbatim in your output, never modify or drop\n\
 - Items tagged [transcript] are personal observations — preserve even if you have no corroborating data\n\
 - If your data CONTRADICTS an existing item, include BOTH with \"discrepancy\": true on yours\n\
-- Tag every item with \"itemSource\": {\"source\": \"glean_crm|glean_zendesk|glean_gong|glean_chat\", \"confidence\": 0.7-0.9, \"sourcedAt\": \"ISO timestamp\", \"reference\": \"data source name\"}\n\n\
+- Tag every item with \"itemSource\": {\"source\": \"glean_crm|glean_zendesk|glean_gong|glean_chat\", \"confidence\": 0.8, \"sourcedAt\": \"ISO timestamp\", \"reference\": \"data source name\"}\n\n\
 ACCOUNT TRUTH rules:\n\
 - Fields marked \"(source: Salesforce, fact)\" or \"(source: user, fact)\" are ground truth. Do not contradict them.\n\
 - Fields marked \"(source: user, fact \u{2014} do not reassign)\" are explicitly locked by the user. Never change the assignment.\n\
 - You may add context, evidence, or assessments about these fields but do not change the underlying value.\n\n";
+
+const PROMPT_QUALITY_RULES: &str = "\
+## Quality Rules\n\n\
+- Prefer empty arrays or null over unsupported claims.\n\
+- If evidence is stale or timing is unknown, say so in the relevant unknowns or narrative field instead of sounding current.\n\
+- Do not write generic summaries. Every sentence should add a concrete source-grounded fact, risk, opportunity, or unknown.\n\
+- Do not invent commercial state, stakeholder sentiment, product usage, or relationship strength from metadata alone.\n\n";
 
 /// Inject source-tagged existing intelligence items into the prompt.
 ///
@@ -900,7 +963,7 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
         "core_assessment" => {
             s.push_str(
                 r#"  "executiveAssessment": "2-4 paragraphs. P1: one-sentence verdict. P2: top risk. P3: biggest opportunity. P4 (optional): key unknowns. Max 250 words.",
-  "risks": [{"text": "full risk paragraph (multi-sentence)", "headline": "punchy 1-liner ≤80 chars — the triage card heading", "evidence": "supporting detail: named people, timelines, data points (optional)", "urgency": "critical|watch|low", "kindLabel": "specific label like 'Renewal drag · compliance gap' or 'Active friction · unresolved' or 'Expansion window · question unanswered'", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
+  "risks": [{"text": "full risk paragraph (multi-sentence)", "headline": "punchy 1-liner under 80 chars, used as the triage card heading", "evidence": "supporting detail: named people, timelines, data points (optional)", "urgency": "critical|watch|low", "kindLabel": "specific label like 'Renewal drag / compliance gap' or 'Active friction / unresolved'", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
   "recentWins": [{"text": "verifiable win", "impact": "high|medium|low", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
   "pullQuote": "One impactful sentence — the single most important thing about this account right now. Written as an editorial pull quote, not a summary. Max 30 words.",
   "currentState": {
@@ -913,7 +976,7 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
         }
         "stakeholder_champion" => {
             s.push_str(
-                r#"  "stakeholderInsights": [{"name": "full name", "role": "job title", "assessment": "1-2 sentences about engagement", "engagement": "high|medium|low|unknown", "verified": "true ONLY when the assessment is grounded in an actual customer-conversation transcript; false when the assessment is inferred from meeting attendance or metadata alone", "verifiedSource": "meeting|glean|user or null when verified=false", "verifiedAt": "ISO date of verification or null when verified=false", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
+                r#"  "stakeholderInsights": [{"name": "full name", "role": "job title", "assessment": "1-2 sentences about engagement", "engagement": "high|medium|low|unknown", "verified": false, "verifiedSource": null, "verifiedAt": null, "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
   "coverageAssessment": {"roleFillRate": 0.0, "gaps": ["missing role"], "covered": ["filled role"], "level": "strong|adequate|thin|critical"},
   "organizationalChanges": [{"changeType": "departure|hire|promotion|reorg|role_change", "person": "name", "from": "...", "to": "...", "detectedAt": "ISO date", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
   "internalTeam": [{"name": "...", "role": "RM|AE|TAM|Division Lead|etc", "source": "glean|user|crm"}],
@@ -934,9 +997,9 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
             } else {
                 s.push_str(
                     r#"  "health": {
-    "score": "0-100", "band": "green|yellow|red", "source": "computed",
-    "confidence": "0.0-1.0",
-    "trend": {"direction": "improving|stable|declining|volatile", "rationale": "1 sentence", "timeframe": "30d|90d", "confidence": "0.0-1.0"},
+    "score": 72.0, "band": "green", "source": "computed",
+    "confidence": 0.7,
+    "trend": {"direction": "stable", "rationale": "1 sentence", "timeframe": "30d", "confidence": 0.7},
     "recommendedActions": ["specific next action"]
   },
 "#,
@@ -949,7 +1012,7 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
   "blockers": [{"description": "...", "owner": "...", "since": "ISO date", "impact": "critical|high|moderate|low"}],
   "productClassification": {
     "products": [
-      {"type": "cms|analytics", "tier": "enhanced|signature|standard|basic|premier|unknown|null", "arr": 0.0, "billingTerms": "annual|monthly|multi_year|null"}
+      {"type": "cms", "tier": "enhanced", "arr": 0.0, "billingTerms": "annual"}
     ]
   }
 "#,
@@ -964,7 +1027,7 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
                 s.push_str(
                     r#"
   "competitiveContext": [{"competitor": "name", "threatLevel": "displacement|evaluation|mentioned|incumbent", "context": "1 sentence", "detectedAt": "ISO date or null", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
-  "strategicPriorities": [{"priority": "short name, ≤80 chars", "status": "active|exploring|evaluating|paused|completed|at_risk", "owner": "short party name only — e.g. 'Chris Anderson & Diego Martinez' or 'Globex commercial team'. NOT a rationale.", "timeline": "short phrase only — e.g. 'Ongoing', 'Q2 2026', 'Beta March 2026'. NOT a rationale.", "context": "optional one sentence (≤180 chars) of rationale explaining why this matters or how it's evolving; leave null if you'd have nothing new to add beyond the priority name"}],
+  "strategicPriorities": [{"priority": "short name under 80 chars", "status": "active|exploring|evaluating|paused|completed|at_risk", "owner": "short party name only, not a rationale", "timeline": "short phrase only, not a rationale", "context": "optional one sentence under 180 chars of rationale, or null"}],
   "marketContext": [{"title": "short title (e.g. 'DORA compliance + SOC 2 Type II')", "body": "1-3 sentence narrative explaining why this regulatory/market/compliance force shapes this account's buying, renewal, or usage decisions", "category": "regulatory|market|geopolitical|compliance|industry|other", "effectiveDate": "ISO date or null", "itemSource": {"source": "...", "confidence": 0.7, "sourcedAt": "...", "reference": "..."}}],
   "regulatoryContext": [{"standard": "DORA|SOC_2_TYPE_II|HIPAA|GDPR|CUSTOM (or other framework name)", "status": "required|in_progress|met|gap — use 'gap' when the customer has signalled a compliance need that is not yet satisfied", "evidence": "one sentence of concrete evidence from the transcript/email/Glean source", "sourceReference": "meeting id, email id, or Glean document URI — null if not available", "detectedAt": "ISO date of first detection", "itemSource": {"source": "...", "confidence": 0.85, "sourcedAt": "...", "reference": "..."}}]
 "#,
@@ -1035,6 +1098,98 @@ mod tests {
             recent_captures: "Win: reduced churn 20%".to_string(),
             ..Default::default()
         }
+    }
+
+    fn schema_json(schema: &str) -> &str {
+        schema
+            .trim()
+            .strip_prefix("```json")
+            .expect("dimension schema should use a json fence")
+            .trim()
+            .strip_suffix("```")
+            .expect("dimension schema should close its fence")
+            .trim()
+    }
+
+    #[test]
+    fn dimension_applicability_skips_account_only_dimensions_for_people() {
+        let applicability = dimension_applicability("person", Some("internal"));
+
+        assert_eq!(
+            applicability.applicable,
+            vec!["core_assessment", "engagement_signals"]
+        );
+        assert_eq!(
+            applicability.skipped,
+            vec![
+                "stakeholder_champion",
+                "commercial_financial",
+                "strategic_context",
+                "value_success"
+            ]
+        );
+    }
+
+    #[test]
+    fn dimension_applicability_keeps_account_shape_for_customer_accounts() {
+        let applicability = dimension_applicability("account", Some("customer"));
+
+        assert_eq!(applicability.applicable, DIMENSION_NAMES);
+        assert!(applicability.skipped.is_empty());
+    }
+
+    #[test]
+    fn dimension_applicability_preserves_partner_account_context_dimensions() {
+        let applicability = dimension_applicability("account", Some("partner"));
+
+        assert_eq!(
+            applicability.applicable,
+            vec![
+                "core_assessment",
+                "stakeholder_champion",
+                "strategic_context",
+                "value_success",
+                "engagement_signals"
+            ]
+        );
+        assert_eq!(applicability.skipped, vec!["commercial_financial"]);
+    }
+
+    #[test]
+    fn dimension_schema_examples_are_valid_json() {
+        let ctx = make_ctx();
+
+        for dimension in DIMENSION_NAMES {
+            let schema = dimension_json_schema(dimension, "account", &ctx);
+            serde_json::from_str::<serde_json::Value>(schema_json(&schema))
+                .unwrap_or_else(|err| panic!("{dimension} schema should parse as JSON: {err}"));
+        }
+    }
+
+    #[test]
+    fn dimension_prompts_include_quality_rules_for_local_and_glean() {
+        let ctx = make_ctx();
+        let local_prompt = build_dimension_prompt(
+            "core_assessment",
+            "Test Account",
+            "account",
+            None,
+            &ctx,
+            false,
+            None,
+        );
+        let glean_prompt = build_glean_dimension_prompt(
+            "core_assessment",
+            "Test Account",
+            "account",
+            None,
+            &ctx,
+            false,
+            None,
+        );
+
+        assert!(local_prompt.contains("Prefer empty arrays or null over unsupported claims"));
+        assert!(glean_prompt.contains("Prefer empty arrays or null over unsupported claims"));
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/src/intelligence/dimension_prompts.rs
+++ b/src-tauri/src/intelligence/dimension_prompts.rs
@@ -343,6 +343,7 @@ pub fn merge_dimension_into(
     dimension: &str,
     partial: &IntelligenceJson,
 ) -> Result<(), String> {
+    merge_refreshed_fields(existing, partial);
     match dimension {
         "core_assessment" => {
             if partial.executive_assessment.is_some() {
@@ -354,25 +355,29 @@ pub fn merge_dimension_into(
             if partial.current_state.is_some() {
                 existing.current_state = partial.current_state.clone();
             }
-            if !partial.risks.is_empty() {
+            if !partial.risks.is_empty() || field_was_refreshed(partial, "risks") {
                 existing.risks = partial.risks.clone();
             }
-            if !partial.recent_wins.is_empty() {
+            if !partial.recent_wins.is_empty() || field_was_refreshed(partial, "recentWins") {
                 existing.recent_wins = partial.recent_wins.clone();
             }
         }
 
         "stakeholder_champion" => {
-            if !partial.stakeholder_insights.is_empty() {
+            if !partial.stakeholder_insights.is_empty()
+                || field_was_refreshed(partial, "stakeholderInsights")
+            {
                 existing.stakeholder_insights = partial.stakeholder_insights.clone();
             }
             if partial.coverage_assessment.is_some() {
                 existing.coverage_assessment = partial.coverage_assessment.clone();
             }
-            if !partial.organizational_changes.is_empty() {
+            if !partial.organizational_changes.is_empty()
+                || field_was_refreshed(partial, "organizationalChanges")
+            {
                 existing.organizational_changes = partial.organizational_changes.clone();
             }
-            if !partial.internal_team.is_empty() {
+            if !partial.internal_team.is_empty() || field_was_refreshed(partial, "internalTeam") {
                 existing.internal_team = partial.internal_team.clone();
             }
             // relationship_depth is stakeholder-adjacent
@@ -391,10 +396,12 @@ pub fn merge_dimension_into(
             if partial.agreement_outlook.is_some() {
                 existing.agreement_outlook = partial.agreement_outlook.clone();
             }
-            if !partial.expansion_signals.is_empty() {
+            if !partial.expansion_signals.is_empty()
+                || field_was_refreshed(partial, "expansionSignals")
+            {
                 existing.expansion_signals = partial.expansion_signals.clone();
             }
-            if !partial.blockers.is_empty() {
+            if !partial.blockers.is_empty() || field_was_refreshed(partial, "blockers") {
                 existing.blockers = partial.blockers.clone();
             }
             // Product classification from Glean
@@ -407,23 +414,30 @@ pub fn merge_dimension_into(
             if partial.company_context.is_some() {
                 existing.company_context = partial.company_context.clone();
             }
-            if !partial.competitive_context.is_empty() {
+            if !partial.competitive_context.is_empty()
+                || field_was_refreshed(partial, "competitiveContext")
+            {
                 existing.competitive_context = partial.competitive_context.clone();
             }
-            if !partial.strategic_priorities.is_empty() {
+            if !partial.strategic_priorities.is_empty()
+                || field_was_refreshed(partial, "strategicPriorities")
+            {
                 existing.strategic_priorities = partial.strategic_priorities.clone();
             }
-            if !partial.market_context.is_empty() {
+            if !partial.market_context.is_empty() || field_was_refreshed(partial, "marketContext") {
                 existing.market_context = partial.market_context.clone();
             }
             // Merge regulatory items emitted by strategic_context.
-            if !partial.regulatory_context.is_empty() {
+            if !partial.regulatory_context.is_empty()
+                || field_was_refreshed(partial, "regulatoryContext")
+            {
                 existing.regulatory_context = partial.regulatory_context.clone();
             }
         }
 
         "value_success" => {
-            if !partial.value_delivered.is_empty() {
+            if !partial.value_delivered.is_empty() || field_was_refreshed(partial, "valueDelivered")
+            {
                 existing.value_delivered = partial.value_delivered.clone();
             }
             if partial.success_metrics.is_some() {
@@ -450,7 +464,9 @@ pub fn merge_dimension_into(
             if partial.support_health.is_some() {
                 existing.support_health = partial.support_health.clone();
             }
-            if !partial.gong_call_summaries.is_empty() {
+            if !partial.gong_call_summaries.is_empty()
+                || field_was_refreshed(partial, "gongCallSummaries")
+            {
                 existing.gong_call_summaries = partial.gong_call_summaries.clone();
             }
             if partial.nps_csat.is_some() {
@@ -464,6 +480,25 @@ pub fn merge_dimension_into(
     }
 
     Ok(())
+}
+
+fn field_was_refreshed(intel: &IntelligenceJson, field: &str) -> bool {
+    intel
+        .refreshed_fields
+        .iter()
+        .any(|candidate| candidate == field)
+}
+
+fn merge_refreshed_fields(existing: &mut IntelligenceJson, partial: &IntelligenceJson) {
+    for field in &partial.refreshed_fields {
+        if !existing
+            .refreshed_fields
+            .iter()
+            .any(|candidate| candidate == field)
+        {
+            existing.refreshed_fields.push(field.clone());
+        }
+    }
 }
 
 /// Clear fields for dimensions that should not apply to this entity shape.
@@ -1564,6 +1599,31 @@ mod tests {
         // Should NOT wipe because partial is empty
         assert_eq!(existing.executive_assessment, Some("Existing".to_string()));
         assert_eq!(existing.risks.len(), 1);
+    }
+
+    #[test]
+    fn merge_explicit_empty_refreshed_array_clears_existing_items() {
+        let mut existing = empty_intel();
+        existing.risks = vec![super::super::io::IntelRisk {
+            render_policy: None,
+            claim_id: None,
+            text: "Existing risk".to_string(),
+            source: None,
+            urgency: "critical".to_string(),
+            item_source: None,
+            headline: None,
+            evidence: None,
+            kind_label: None,
+            discrepancy: None,
+        }];
+
+        let mut partial = empty_intel();
+        partial.refreshed_fields = vec!["risks".to_string()];
+
+        merge_dimension_into(&mut existing, "core_assessment", &partial).unwrap();
+
+        assert!(existing.risks.is_empty());
+        assert!(existing.refreshed_fields.contains(&"risks".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/intelligence/dimension_prompts.rs
+++ b/src-tauri/src/intelligence/dimension_prompts.rs
@@ -30,6 +30,8 @@ pub const DIMENSION_NAMES: &[&str] = &[
     "engagement_signals",
 ];
 
+pub(crate) const ACCOUNT_ONLY_ENGAGEMENT_FIELDS_CLEAR: &str = "account_only_engagement_fields";
+
 /// Dimension selection for a specific entity refresh.
 ///
 /// The six canonical dimensions still define the complete account shape, but
@@ -462,6 +464,84 @@ pub fn merge_dimension_into(
     }
 
     Ok(())
+}
+
+/// Clear fields for dimensions that should not apply to this entity shape.
+///
+/// Reconciliation preserves missing fields by design, so non-applicable
+/// dimensions need an explicit clear after a refresh changes entity shape or
+/// relationship context.
+pub fn clear_inapplicable_dimension_fields(
+    intel: &mut IntelligenceJson,
+    entity_type: &str,
+    relationship: Option<&str>,
+) -> Vec<&'static str> {
+    let applicability = dimension_applicability(entity_type, relationship);
+    let mut cleared = applicability.skipped;
+    for dimension in &cleared {
+        clear_dimension_fields(intel, dimension);
+    }
+    if !entity_type.eq_ignore_ascii_case("account") {
+        clear_account_only_engagement_fields(intel);
+        cleared.push(ACCOUNT_ONLY_ENGAGEMENT_FIELDS_CLEAR);
+    }
+    cleared
+}
+
+fn clear_dimension_fields(intel: &mut IntelligenceJson, dimension: &str) {
+    match dimension {
+        "core_assessment" => {
+            intel.executive_assessment = None;
+            intel.pull_quote = None;
+            intel.current_state = None;
+            intel.risks.clear();
+            intel.recent_wins.clear();
+        }
+        "stakeholder_champion" => {
+            intel.stakeholder_insights.clear();
+            intel.coverage_assessment = None;
+            intel.organizational_changes.clear();
+            intel.internal_team.clear();
+            intel.relationship_depth = None;
+        }
+        "commercial_financial" => {
+            intel.health = None;
+            intel.contract_context = None;
+            intel.agreement_outlook = None;
+            intel.expansion_signals.clear();
+            intel.blockers.clear();
+            intel.product_classification = None;
+        }
+        "strategic_context" => {
+            intel.company_context = None;
+            intel.competitive_context.clear();
+            intel.strategic_priorities.clear();
+            intel.market_context.clear();
+            intel.regulatory_context.clear();
+        }
+        "value_success" => {
+            intel.value_delivered.clear();
+            intel.success_metrics = None;
+            intel.success_plan_signals = None;
+            intel.open_commitments = None;
+        }
+        "engagement_signals" => {
+            intel.meeting_cadence = None;
+            intel.email_responsiveness = None;
+            intel.product_adoption = None;
+            intel.support_health = None;
+            intel.gong_call_summaries.clear();
+            intel.nps_csat = None;
+        }
+        _ => {}
+    }
+}
+
+fn clear_account_only_engagement_fields(intel: &mut IntelligenceJson) {
+    intel.product_adoption = None;
+    intel.support_health = None;
+    intel.gong_call_summaries.clear();
+    intel.nps_csat = None;
 }
 
 // =============================================================================
@@ -1083,6 +1163,9 @@ fn dimension_json_schema(dimension: &str, entity_type: &str, ctx: &IntelligenceC
 
 #[cfg(test)]
 mod tests {
+    use super::super::io::{
+        AdoptionSignals, CadenceAssessment, GongCallSummary, SatisfactionData, SupportHealth,
+    };
     use super::*;
 
     fn empty_intel() -> IntelligenceJson {
@@ -1136,6 +1219,34 @@ mod tests {
 
         assert_eq!(applicability.applicable, DIMENSION_NAMES);
         assert!(applicability.skipped.is_empty());
+    }
+
+    #[test]
+    fn clear_inapplicable_fields_reports_account_only_engagement_clears_for_people() {
+        let mut intel = empty_intel();
+        intel.product_adoption = Some(AdoptionSignals::default());
+        intel.support_health = Some(SupportHealth::default());
+        intel.gong_call_summaries = vec![GongCallSummary {
+            title: "Account QBR".to_string(),
+            date: "2026-05-22".to_string(),
+            participants: vec!["account team".to_string()],
+            key_topics: "account usage".to_string(),
+            sentiment: "neutral".to_string(),
+        }];
+        intel.nps_csat = Some(SatisfactionData::default());
+        intel.meeting_cadence = Some(CadenceAssessment::default());
+
+        let cleared = clear_inapplicable_dimension_fields(&mut intel, "person", Some("internal"));
+
+        assert!(cleared.contains(&ACCOUNT_ONLY_ENGAGEMENT_FIELDS_CLEAR));
+        assert!(intel.product_adoption.is_none());
+        assert!(intel.support_health.is_none());
+        assert!(intel.gong_call_summaries.is_empty());
+        assert!(intel.nps_csat.is_none());
+        assert!(
+            intel.meeting_cadence.is_some(),
+            "person engagement cadence remains applicable"
+        );
     }
 
     #[test]

--- a/src-tauri/src/intelligence/dimension_prompts.rs
+++ b/src-tauri/src/intelligence/dimension_prompts.rs
@@ -306,7 +306,7 @@ pub fn build_glean_dimension_prompt(
     prompt.push_str(
         "\nFor every array item, include an `\"itemSource\"` object:\n\
          ```json\n\
-         \"itemSource\": { \"source\": \"glean_crm|glean_zendesk|glean_gong|glean_chat|transcript\", \
+         \"itemSource\": { \"source\": \"glean_crm|glean_zendesk|glean_gong|glean_chat\", \
          \"confidence\": 0.9, \"sourcedAt\": \"2026-03-15T00:00:00Z\", \
          \"reference\": \"Salesforce opportunity\" }\n\
          ```\n\n",

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -178,11 +178,26 @@ impl GleanIntelligenceProvider {
 
         let overall_start = Instant::now();
         let is_incremental = ctx.prior_intelligence.is_some();
-        let total_dimensions = DIMENSION_NAMES.len() as u32;
+        let applicability = dimension_prompts::dimension_applicability(entity_type, relationship);
+        let total_dimensions = applicability.applicable.len() as u32;
+        let canonical_total_dimensions = DIMENSION_NAMES.len() as u32;
+        let skipped_dimensions: Vec<String> = applicability
+            .skipped
+            .iter()
+            .map(|dimension| (*dimension).to_string())
+            .collect();
 
-        // Build 6 dimension prompts
+        if total_dimensions == 0 {
+            return Err(format!(
+                "No applicable Glean dimensions for {} ({})",
+                entity_name, entity_type
+            ));
+        }
+
+        // Build dimension prompts for the dimensions that apply to this entity.
         let prompts: Vec<(String, String)> = DIMENSION_NAMES
             .iter()
+            .filter(|dim| applicability.applicable.contains(dim))
             .map(|dim| {
                 let prompt = dimension_prompts::build_glean_dimension_prompt(
                     dim,
@@ -198,10 +213,11 @@ impl GleanIntelligenceProvider {
             .collect();
 
         log::info!(
-            "[I574] Glean parallel enrichment for {} ({}) — {} dimensions, incremental={}",
+            "[I574] Glean parallel enrichment for {} ({}) — {}/{} applicable dimensions, incremental={}",
             entity_name,
             entity_type,
             prompts.len(),
+            canonical_total_dimensions,
             is_incremental,
         );
 
@@ -213,8 +229,9 @@ impl GleanIntelligenceProvider {
 
         // Use tokio::sync::mpsc channel to receive dimension results as they
         // complete, enabling progressive DB writes and event emission.
-        let (tx, mut rx) =
-            tokio::sync::mpsc::channel::<(String, Result<IntelligenceJson, String>)>(6);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, Result<IntelligenceJson, String>)>(
+            prompts.len().max(1),
+        );
         let mut wrote_debug_file = false;
 
         for (dim_name, prompt) in prompts {
@@ -276,7 +293,7 @@ impl GleanIntelligenceProvider {
                             reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                         )]
                         let _ = sender
-                            .send((dim_name, Err("timed out after 30s".to_string())))
+                            .send((dim_name, Err("timed out after 240s".to_string())))
                             .await;
                         return;
                     }
@@ -416,10 +433,12 @@ impl GleanIntelligenceProvider {
 
         let total_ms = overall_start.elapsed().as_millis();
         log::info!(
-            "[I574] Glean parallel: {}/6 dimensions succeeded for {} in {}ms (failed: {:?})",
+            "[I574] Glean parallel: {}/{} applicable dimensions succeeded for {} in {}ms (skipped: {:?}, failed: {:?})",
             succeeded,
+            total_dimensions,
             entity_name,
             total_ms,
+            skipped_dimensions,
             failed_dims,
         );
 
@@ -437,6 +456,9 @@ impl GleanIntelligenceProvider {
                     succeeded,
                     failed: failed_dims.len() as u32,
                     failed_dimensions: failed_dims.clone(),
+                    total_dimensions: canonical_total_dimensions,
+                    applicable_total: total_dimensions,
+                    skipped_dimensions: skipped_dimensions.clone(),
                     wall_clock_ms: total_ms as u64,
                 },
             );
@@ -474,7 +496,12 @@ impl GleanIntelligenceProvider {
                             "entity_type": entity_type,
                             "succeeded": succeeded,
                             "failed": failed_dims.len(),
-                            "failed_dimensions": failed_dims,
+                            "failed_dimensions": failed_dims.clone(),
+                            "required_failed_dimensions": failed_dims.clone(),
+                            "optional_failed_dimensions": Vec::<String>::new(),
+                            "total_dimensions": canonical_total_dimensions,
+                            "applicable_total": total_dimensions,
+                            "skipped_dimensions": skipped_dimensions.clone(),
                             "wall_clock_ms": total_ms,
                         }),
                     );
@@ -496,6 +523,11 @@ impl GleanIntelligenceProvider {
                             "succeeded": succeeded,
                             "failed": failed_dims.len(),
                             "failed_dimensions": failed_dims.clone(),
+                            "required_failed_dimensions": failed_dims.clone(),
+                            "optional_failed_dimensions": Vec::<String>::new(),
+                            "total_dimensions": canonical_total_dimensions,
+                            "applicable_total": total_dimensions,
+                            "skipped_dimensions": skipped_dimensions.clone(),
                             "wall_clock_ms": total_ms,
                             "will_fall_back": succeeded == 0,
                         }),
@@ -505,7 +537,10 @@ impl GleanIntelligenceProvider {
         }
 
         if succeeded == 0 {
-            return Err(format!("All 6 Glean dimensions failed for {}", entity_name));
+            return Err(format!(
+                "All {} applicable Glean dimensions failed for {}",
+                total_dimensions, entity_name
+            ));
         }
 
         // Set metadata on combined result.

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -407,7 +407,12 @@ impl GleanIntelligenceProvider {
 
                         // Progressive DB write + event emission
                         if let Some(handle) = app_handle {
-                            write_progressive_glean_dimension(entity_id, entity_type, &combined);
+                            write_progressive_glean_dimension(
+                                entity_id,
+                                entity_type,
+                                relationship,
+                                &combined,
+                            );
                             #[allow(
                                 clippy::let_underscore_must_use,
                                 reason = "intentional best-effort discard; preserves existing non-blocking behavior"
@@ -1077,6 +1082,7 @@ fn extract_domains_for_glean_enrichment(_intel: &mut IntelligenceJson) {
 fn write_progressive_glean_dimension(
     entity_id: &str,
     entity_type: &str,
+    relationship: Option<&str>,
     combined: &IntelligenceJson,
 ) {
     let db = match crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())) {
@@ -1091,32 +1097,13 @@ fn write_progressive_glean_dimension(
         }
     };
 
-    // Progressive writes within a single enrichment cycle use simple dimension
-    // merge, NOT reconciliation. Reconciliation is for cross-cycle merges
-    // (e.g., Glean refresh on top of existing PTY data). Within one cycle,
-    // the combined state is authoritative — just overlay it on existing.
-    let existing = db.get_entity_intelligence(entity_id).ok().flatten();
-    let mut merged = if let Some(mut existing) = existing {
-        for dim in crate::intelligence::dimension_prompts::DIMENSION_NAMES {
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            let _ = crate::intelligence::dimension_prompts::merge_dimension_into(
-                &mut existing,
-                dim,
-                combined,
-            );
-        }
-        existing
-    } else {
-        combined.clone()
-    };
-
-    merged.entity_id = entity_id.to_string();
-    merged.entity_type = entity_type.to_string();
-    // dos259-grandfathered: progressive-write enrichment timestamp; migrates to ctx.clock.now() when W2-A lands ServiceContext.
-    merged.enriched_at = chrono::Utc::now().to_rfc3339();
+    let merged = crate::intel_queue::prepare_progressive_dimension_snapshot(
+        &db,
+        entity_id,
+        entity_type,
+        relationship,
+        combined,
+    );
 
     let clock = crate::services::context::SystemClock;
     let rng = crate::services::context::SystemRng;

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -1171,6 +1171,7 @@ pub fn reconcile_enrichment(
 ) -> IntelligenceJson {
     let mut result = existing.clone();
     let dismissed = &existing.dismissed_items;
+    let refreshed_fields = new_output.refreshed_fields.clone();
 
     // Helper: check if a vec field (or any of its items' sub-fields) has user edits.
     // When a user edits an individual field like stakeholderInsights[0].engagement,
@@ -1182,6 +1183,8 @@ pub fn reconcile_enrichment(
             e.field_path == field_name || e.field_path.starts_with(&format!("{}[", field_name))
         })
     };
+    let field_refreshed =
+        |field_name: &str| -> bool { refreshed_fields.iter().any(|field| field == field_name) };
 
     // --- Vec fields: source-aware item reconciliation ---
     // Skip reconciliation for fields with user edits — preserve_user_edits
@@ -1192,7 +1195,9 @@ pub fn reconcile_enrichment(
     // against existing pty_synthesis items would wipe them all. Reconcile only
     // when the new output actually has data, or when existing is also empty
     // (nothing to preserve).
-    if !has_user_edits("risks") && (!new_output.risks.is_empty() || existing.risks.is_empty()) {
+    if !has_user_edits("risks")
+        && (field_refreshed("risks") || !new_output.risks.is_empty() || existing.risks.is_empty())
+    {
         result.risks = reconcile_vec_items(
             &existing.risks,
             &new_output.risks,
@@ -1204,7 +1209,9 @@ pub fn reconcile_enrichment(
     }
 
     if !has_user_edits("recentWins")
-        && (!new_output.recent_wins.is_empty() || existing.recent_wins.is_empty())
+        && (field_refreshed("recentWins")
+            || !new_output.recent_wins.is_empty()
+            || existing.recent_wins.is_empty())
     {
         result.recent_wins = reconcile_vec_items(
             &existing.recent_wins,
@@ -1223,7 +1230,9 @@ pub fn reconcile_enrichment(
     result.stakeholder_insights = new_output.stakeholder_insights;
 
     if !has_user_edits("valueDelivered")
-        && (!new_output.value_delivered.is_empty() || existing.value_delivered.is_empty())
+        && (field_refreshed("valueDelivered")
+            || !new_output.value_delivered.is_empty()
+            || existing.value_delivered.is_empty())
     {
         result.value_delivered = reconcile_vec_items(
             &existing.value_delivered,
@@ -1236,7 +1245,9 @@ pub fn reconcile_enrichment(
     }
 
     if !has_user_edits("competitiveContext")
-        && (!new_output.competitive_context.is_empty() || existing.competitive_context.is_empty())
+        && (field_refreshed("competitiveContext")
+            || !new_output.competitive_context.is_empty()
+            || existing.competitive_context.is_empty())
     {
         result.competitive_context = reconcile_vec_items(
             &existing.competitive_context,
@@ -1253,7 +1264,9 @@ pub fn reconcile_enrichment(
     // prior regulatory/market items that user corrections or earlier
     // enrichments accumulated.
     if !has_user_edits("marketContext")
-        && (!new_output.market_context.is_empty() || existing.market_context.is_empty())
+        && (field_refreshed("marketContext")
+            || !new_output.market_context.is_empty()
+            || existing.market_context.is_empty())
     {
         result.market_context = reconcile_vec_items(
             &existing.market_context,
@@ -1266,7 +1279,8 @@ pub fn reconcile_enrichment(
     }
 
     if !has_user_edits("organizationalChanges")
-        && (!new_output.organizational_changes.is_empty()
+        && (field_refreshed("organizationalChanges")
+            || !new_output.organizational_changes.is_empty()
             || existing.organizational_changes.is_empty())
     {
         result.organizational_changes = reconcile_vec_items(
@@ -1280,7 +1294,9 @@ pub fn reconcile_enrichment(
     }
 
     if !has_user_edits("expansionSignals")
-        && (!new_output.expansion_signals.is_empty() || existing.expansion_signals.is_empty())
+        && (field_refreshed("expansionSignals")
+            || !new_output.expansion_signals.is_empty()
+            || existing.expansion_signals.is_empty())
     {
         result.expansion_signals = reconcile_vec_items(
             &existing.expansion_signals,
@@ -1298,7 +1314,7 @@ pub fn reconcile_enrichment(
             (&existing.open_commitments, &new_output.open_commitments)
         {
             // Non-destructive-empty: if new dimension returned empty, keep existing.
-            if !new_oc.is_empty() || existing_oc.is_empty() {
+            if field_refreshed("openCommitments") || !new_oc.is_empty() || existing_oc.is_empty() {
                 let reconciled = reconcile_vec_items(
                     existing_oc,
                     new_oc,
@@ -1355,23 +1371,24 @@ pub fn reconcile_enrichment(
     // Non-source-attributed vecs: strategic_priorities, internal_team, blockers, gong_call_summaries
     // These already use an "only-overwrite-if-non-empty" guard via the is_empty checks below,
     // which preserves existing values when the dimension returns nothing.
-    if !new_output.strategic_priorities.is_empty() {
+    if field_refreshed("strategicPriorities") || !new_output.strategic_priorities.is_empty() {
         result.strategic_priorities = new_output.strategic_priorities;
     }
-    if !new_output.internal_team.is_empty() {
+    if field_refreshed("internalTeam") || !new_output.internal_team.is_empty() {
         result.internal_team =
             reconcile_internal_team(&existing.internal_team, &new_output.internal_team);
     }
-    if !new_output.blockers.is_empty() {
+    if field_refreshed("blockers") || !new_output.blockers.is_empty() {
         result.blockers = new_output.blockers;
     }
-    if !new_output.gong_call_summaries.is_empty() {
+    if field_refreshed("gongCallSummaries") || !new_output.gong_call_summaries.is_empty() {
         result.gong_call_summaries = new_output.gong_call_summaries;
     }
 
     // Carry forward user_edits and dismissed_items from existing
     result.user_edits = existing.user_edits;
     result.dismissed_items = existing.dismissed_items;
+    result.refreshed_fields = refreshed_fields;
 
     // Update metadata
     result.enriched_at = new_output.enriched_at;
@@ -1583,6 +1600,53 @@ mod provider_trait_tests {
             p.current_model(ModelTier::Extraction).as_str(),
             "glean-chat"
         );
+    }
+}
+
+#[cfg(test)]
+mod reconciliation_tests {
+    use super::*;
+    use crate::intelligence::io::{IntelRisk, IntelligenceJson, ItemSource};
+
+    #[test]
+    fn explicit_empty_refreshed_risks_remove_existing_glean_items() {
+        let existing = IntelligenceJson {
+            risks: vec![
+                IntelRisk {
+                    text: "Stale Glean risk".to_string(),
+                    urgency: "watch".to_string(),
+                    item_source: Some(ItemSource {
+                        source: "glean_crm".to_string(),
+                        confidence: 0.9,
+                        sourced_at: "2026-05-20T00:00:00Z".to_string(),
+                        reference: Some("CRM fixture".to_string()),
+                    }),
+                    ..Default::default()
+                },
+                IntelRisk {
+                    text: "Local transcript risk".to_string(),
+                    urgency: "watch".to_string(),
+                    item_source: Some(ItemSource {
+                        source: "pty_synthesis".to_string(),
+                        confidence: 0.5,
+                        sourced_at: "2026-05-19T00:00:00Z".to_string(),
+                        reference: Some("local fixture".to_string()),
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let new_output = IntelligenceJson {
+            refreshed_fields: vec!["risks".to_string()],
+            ..Default::default()
+        };
+
+        let result = reconcile_enrichment(existing, new_output, &["glean_crm"]);
+
+        assert_eq!(result.risks.len(), 1);
+        assert_eq!(result.risks[0].text, "Local transcript risk");
+        assert!(result.refreshed_fields.contains(&"risks".to_string()));
     }
 }
 

--- a/src-tauri/src/intelligence/io.rs
+++ b/src-tauri/src/intelligence/io.rs
@@ -928,6 +928,12 @@ pub struct IntelligenceJson {
     pub source_file_count: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_manifest: Vec<SourceManifestEntry>,
+    /// Top-level response fields explicitly present in the latest parsed model output.
+    ///
+    /// This is runtime-only metadata used to distinguish an omitted field from an
+    /// explicit empty array during partial refreshes.
+    #[serde(skip)]
+    pub refreshed_fields: Vec<String>,
 
     /// Prose assessment: account situation / project status / relationship brief.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/intelligence/prompts.rs
+++ b/src-tauri/src/intelligence/prompts.rs
@@ -3325,6 +3325,50 @@ fn extract_balanced_json_object(candidate: &str) -> Option<&str> {
     None
 }
 
+fn response_refreshed_fields(json_str: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) else {
+        return Vec::new();
+    };
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    object
+        .keys()
+        .filter_map(|key| canonical_response_field_name(key))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn canonical_response_field_name(field: &str) -> Option<&'static str> {
+    match field {
+        "executiveAssessment" => Some("executiveAssessment"),
+        "pullQuote" => Some("pullQuote"),
+        "health" | "healthScore" | "healthTrend" => Some("health"),
+        "risks" => Some("risks"),
+        "recommendedActions" => Some("recommendedActions"),
+        "recentWins" => Some("recentWins"),
+        "currentState" => Some("currentState"),
+        "competitiveContext" => Some("competitiveContext"),
+        "strategicPriorities" => Some("strategicPriorities"),
+        "marketContext" => Some("marketContext"),
+        "regulatoryContext" => Some("regulatoryContext"),
+        "organizationalChanges" => Some("organizationalChanges"),
+        "internalTeam" => Some("internalTeam"),
+        "blockers" => Some("blockers"),
+        "contractContext" => Some("contractContext"),
+        "expansionSignals" => Some("expansionSignals"),
+        "agreementOutlook" | "renewalOutlook" | "renewal_outlook" => Some("agreementOutlook"),
+        "valueDelivered" => Some("valueDelivered"),
+        "successMetrics" => Some("successMetrics"),
+        "openCommitments" => Some("openCommitments"),
+        "stakeholderInsights" => Some("stakeholderInsights"),
+        "companyContext" => Some("companyContext"),
+        "gongCallSummaries" => Some("gongCallSummaries"),
+        _ => None,
+    }
+}
+
 /// Try to parse the response as JSON format. Returns None if it fails.
 fn try_parse_json_response(
     response: &str,
@@ -3334,6 +3378,7 @@ fn try_parse_json_response(
     manifest: &[SourceManifestEntry],
 ) -> Option<IntelligenceJson> {
     let json_str = extract_json_from_response(response)?;
+    let refreshed_fields = response_refreshed_fields(json_str);
 
     // Validate structure and run anomaly detection before deserialization
     if let Err(e) = super::validation::validate_intelligence_response(json_str) {
@@ -3408,6 +3453,7 @@ fn try_parse_json_response(
         enriched_at: Utc::now().to_rfc3339(),
         source_file_count,
         source_manifest: manifest.to_vec(),
+        refreshed_fields,
         executive_assessment: ai_resp.executive_assessment,
         pull_quote: ai_resp.pull_quote,
         risks: ai_resp
@@ -4252,6 +4298,25 @@ Some trailing text"#;
         assert_eq!(readiness.prep_items.len(), 2);
         let ctx = intel.company_context.unwrap();
         assert_eq!(ctx.industry.as_deref(), Some("Technology"));
+    }
+
+    #[test]
+    fn test_parse_json_response_tracks_explicit_empty_refreshed_fields() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "risks": [],
+  "stakeholderInsights": []
+}"#;
+
+        let intel = parse_intelligence_response(response, "acme", "account", 2, vec![])
+            .expect("should parse JSON");
+
+        assert!(intel.risks.is_empty());
+        assert!(intel.stakeholder_insights.is_empty());
+        assert!(intel.refreshed_fields.contains(&"risks".to_string()));
+        assert!(intel
+            .refreshed_fields
+            .contains(&"stakeholderInsights".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/intelligence/prompts.rs
+++ b/src-tauri/src/intelligence/prompts.rs
@@ -2612,12 +2612,19 @@ struct AiIntelResponse {
     expansion_signals: Vec<super::io::ExpansionSignal>,
     #[serde(default)]
     agreement_outlook: Option<super::io::AgreementOutlook>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_product_classification"
+    )]
+    product_classification: Option<super::io::ProductClassification>,
     #[serde(default)]
     support_health: Option<super::io::SupportHealth>,
     #[serde(default)]
     product_adoption: Option<super::io::AdoptionSignals>,
     #[serde(default)]
     nps_csat: Option<super::io::SatisfactionData>,
+    #[serde(default, deserialize_with = "deserialize_gong_call_summaries")]
+    gong_call_summaries: Vec<super::io::GongCallSummary>,
     #[serde(default)]
     source_attribution: Option<std::collections::HashMap<String, Vec<String>>>,
     /// Success plan signals synthesized from aggregate context.
@@ -2702,7 +2709,7 @@ struct AiOpenCommitment {
     source: Option<String>,
     #[serde(default)]
     status: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_item_source")]
     item_source: Option<ItemSource>,
 }
 
@@ -2806,6 +2813,10 @@ struct AiRisk {
     /// Specific kind label (e.g. "Renewal drag · compliance gap").
     #[serde(default)]
     kind_label: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_item_source")]
+    item_source: Option<ItemSource>,
+    #[serde(default)]
+    discrepancy: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2816,6 +2827,10 @@ struct AiWin {
     source: Option<String>,
     #[serde(default)]
     impact: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_item_source")]
+    item_source: Option<ItemSource>,
+    #[serde(default)]
+    discrepancy: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2847,6 +2862,10 @@ struct AiStakeholder {
     verified_source: Option<String>,
     #[serde(default)]
     verified_at: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_item_source")]
+    item_source: Option<ItemSource>,
+    #[serde(default)]
+    discrepancy: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2859,6 +2878,10 @@ struct AiValue {
     source: Option<String>,
     #[serde(default)]
     impact: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_item_source")]
+    item_source: Option<ItemSource>,
+    #[serde(default)]
+    discrepancy: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2881,6 +2904,209 @@ struct AiCompanyContext {
     headquarters: Option<String>,
     #[serde(default)]
     additional_context: Option<String>,
+}
+
+fn deserialize_optional_item_source<'de, D>(deserializer: D) -> Result<Option<ItemSource>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(
+        value.and_then(|value| match serde_json::from_value::<ItemSource>(value) {
+            Ok(source) => Some(source),
+            Err(e) => {
+                log::warn!(
+                    "Ignoring malformed itemSource in intelligence response: {}",
+                    e
+                );
+                None
+            }
+        }),
+    )
+}
+
+fn deserialize_optional_product_classification<'de, D>(
+    deserializer: D,
+) -> Result<Option<super::io::ProductClassification>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    match serde_json::from_value::<super::io::ProductClassification>(value.clone()) {
+        Ok(classification) => Ok(Some(classification)),
+        Err(e) => {
+            log::warn!(
+                "Falling back to tolerant productClassification parsing: {}",
+                e
+            );
+            Ok(parse_product_classification_value(&value))
+        }
+    }
+}
+
+fn parse_product_classification_value(
+    value: &serde_json::Value,
+) -> Option<super::io::ProductClassification> {
+    let products = value.get("products")?.as_array()?;
+    let products = products
+        .iter()
+        .filter_map(|product| {
+            let obj = product.as_object()?;
+            let type_ = string_field(obj, "type");
+            let tier = string_field(obj, "tier");
+            let arr = obj.get("arr").and_then(number_or_money_string);
+            let billing_terms = string_field(obj, "billingTerms");
+
+            if type_.is_none() && tier.is_none() && arr.is_none() && billing_terms.is_none() {
+                None
+            } else {
+                Some(super::io::ProductInfo {
+                    type_,
+                    tier,
+                    arr,
+                    billing_terms,
+                })
+            }
+        })
+        .collect();
+
+    Some(super::io::ProductClassification { products })
+}
+
+fn deserialize_gong_call_summaries<'de, D>(
+    deserializer: D,
+) -> Result<Vec<super::io::GongCallSummary>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+
+    match serde_json::from_value::<Vec<super::io::GongCallSummary>>(value.clone()) {
+        Ok(summaries) => Ok(summaries),
+        Err(e) => {
+            log::warn!("Falling back to tolerant gongCallSummaries parsing: {}", e);
+            Ok(parse_gong_call_summaries_value(&value))
+        }
+    }
+}
+
+fn parse_gong_call_summaries_value(value: &serde_json::Value) -> Vec<super::io::GongCallSummary> {
+    value
+        .as_array()
+        .map(|summaries| {
+            summaries
+                .iter()
+                .filter_map(|summary| {
+                    let obj = summary.as_object()?;
+                    let title = string_field(obj, "title")?;
+                    let date = string_field(obj, "date")?;
+                    let key_topics = string_or_string_array_field(obj, "keyTopics")?;
+                    let sentiment =
+                        string_field(obj, "sentiment").unwrap_or_else(|| "neutral".to_string());
+                    let participants = string_array_field(obj, "participants");
+
+                    Some(super::io::GongCallSummary {
+                        title,
+                        date,
+                        participants,
+                        key_topics,
+                        sentiment,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn string_field(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    obj.get(key)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn string_array_field(obj: &serde_json::Map<String, serde_json::Value>, key: &str) -> Vec<String> {
+    match obj.get(key) {
+        Some(serde_json::Value::Array(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+        Some(serde_json::Value::String(value)) if !value.trim().is_empty() => {
+            vec![value.trim().to_string()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn string_or_string_array_field(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<String> {
+    match obj.get(key) {
+        Some(serde_json::Value::String(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Some(serde_json::Value::Array(values)) => {
+            let joined = values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .join("; ");
+            if joined.is_empty() {
+                None
+            } else {
+                Some(joined)
+            }
+        }
+        _ => None,
+    }
+}
+
+fn number_or_money_string(value: &serde_json::Value) -> Option<f64> {
+    if let Some(number) = value.as_f64() {
+        return Some(number);
+    }
+
+    let raw = value.as_str()?.trim().to_ascii_lowercase();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let (number, multiplier) = if let Some(stripped) = raw.strip_suffix('k') {
+        (stripped, 1_000.0)
+    } else if let Some(stripped) = raw.strip_suffix('m') {
+        (stripped, 1_000_000.0)
+    } else {
+        (raw.as_str(), 1.0)
+    };
+
+    let cleaned = number
+        .chars()
+        .filter(|ch| ch.is_ascii_digit() || *ch == '.')
+        .collect::<String>();
+    if cleaned.is_empty() {
+        None
+    } else {
+        cleaned.parse::<f64>().ok().map(|value| value * multiplier)
+    }
 }
 
 /// Parse Claude's intelligence response into an IntelligenceJson.
@@ -3119,7 +3345,17 @@ fn try_parse_json_response(
         return None;
     }
 
-    let ai_resp: AiIntelResponse = serde_json::from_str(json_str).ok()?;
+    let ai_resp: AiIntelResponse = match serde_json::from_str(json_str) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            log::warn!(
+                "Intelligence response JSON deserialization failed for {}: {}",
+                entity_id,
+                e
+            );
+            return None;
+        }
+    };
 
     let current_state = ai_resp.current_state.map(|cs| CurrentState {
         working: cs.working,
@@ -3186,8 +3422,8 @@ fn try_parse_json_response(
                 headline: r.headline,
                 evidence: r.evidence,
                 kind_label: r.kind_label,
-                item_source: None,
-                discrepancy: None,
+                item_source: r.item_source,
+                discrepancy: r.discrepancy,
             })
             .collect(),
         recent_wins: ai_resp
@@ -3199,8 +3435,8 @@ fn try_parse_json_response(
                 text: w.text,
                 source: w.source,
                 impact: w.impact,
-                item_source: None,
-                discrepancy: None,
+                item_source: w.item_source,
+                discrepancy: w.discrepancy,
             })
             .collect(),
         current_state,
@@ -3220,8 +3456,8 @@ fn try_parse_json_response(
                 verified: s.verified,
                 verified_source: s.verified_source,
                 verified_at: s.verified_at,
-                item_source: None,
-                discrepancy: None,
+                item_source: s.item_source,
+                discrepancy: s.discrepancy,
             })
             .collect(),
         value_delivered: ai_resp
@@ -3234,8 +3470,8 @@ fn try_parse_json_response(
                 statement: v.statement,
                 source: v.source,
                 impact: v.impact,
-                item_source: None,
-                discrepancy: None,
+                item_source: v.item_source,
+                discrepancy: v.discrepancy,
             })
             .collect(),
         next_meeting_readiness,
@@ -3316,12 +3552,12 @@ fn try_parse_json_response(
         contract_context: ai_resp.contract_context,
         expansion_signals: ai_resp.expansion_signals,
         agreement_outlook: ai_resp.agreement_outlook,
-        product_classification: None,
+        product_classification: ai_resp.product_classification,
         support_health: ai_resp.support_health,
         product_adoption: ai_resp.product_adoption,
         nps_csat: ai_resp.nps_csat,
         source_attribution: ai_resp.source_attribution,
-        gong_call_summaries: Vec::new(),
+        gong_call_summaries: ai_resp.gong_call_summaries,
         success_plan_signals: ai_resp.success_plan_signals,
         domains: Vec::new(),
         dismissed_items: Vec::new(),
@@ -4016,6 +4252,176 @@ Some trailing text"#;
         assert_eq!(readiness.prep_items.len(), 2);
         let ctx = intel.company_context.unwrap();
         assert_eq!(ctx.industry.as_deref(), Some("Technology"));
+    }
+
+    #[test]
+    fn test_parse_json_response_preserves_item_sources_and_discrepancies() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "risks": [
+    {
+      "text": "Renewal timing is uncertain",
+      "urgency": "watch",
+      "itemSource": {"source": "glean_crm", "confidence": 0.9, "sourcedAt": "2026-03-15T00:00:00Z", "reference": "Salesforce opportunity"},
+      "discrepancy": true
+    }
+  ],
+  "recentWins": [
+    {
+      "text": "Usage expanded in the support team",
+      "impact": "medium",
+      "itemSource": {"source": "glean_gong", "confidence": 0.8, "sourcedAt": "2026-03-12T00:00:00Z", "reference": "customer call"},
+      "discrepancy": false
+    }
+  ],
+  "stakeholderInsights": [
+    {
+      "name": "Jordan Lee",
+      "role": "VP Operations",
+      "assessment": "Active executive sponsor.",
+      "engagement": "high",
+      "itemSource": {"source": "transcript", "confidence": 0.8, "sourcedAt": "2026-03-10T00:00:00Z", "reference": "QBR"},
+      "discrepancy": true
+    }
+  ],
+  "valueDelivered": [
+    {
+      "date": "2026-03-01",
+      "statement": "Reduced support response time by 20%",
+      "source": "meeting",
+      "impact": "speed",
+      "itemSource": {"source": "transcript", "confidence": 0.8, "sourcedAt": "2026-03-01T00:00:00Z", "reference": "weekly sync"},
+      "discrepancy": false
+    }
+  ]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("should parse JSON with item sources");
+
+        assert_eq!(
+            intel.risks[0].item_source.as_ref().unwrap().source,
+            "glean_crm"
+        );
+        assert_eq!(intel.risks[0].discrepancy, Some(true));
+        assert_eq!(
+            intel.recent_wins[0].item_source.as_ref().unwrap().source,
+            "glean_gong"
+        );
+        assert_eq!(intel.recent_wins[0].discrepancy, Some(false));
+        assert_eq!(
+            intel.stakeholder_insights[0]
+                .item_source
+                .as_ref()
+                .unwrap()
+                .reference
+                .as_deref(),
+            Some("QBR")
+        );
+        assert_eq!(intel.stakeholder_insights[0].discrepancy, Some(true));
+        assert_eq!(
+            intel.value_delivered[0]
+                .item_source
+                .as_ref()
+                .unwrap()
+                .source,
+            "transcript"
+        );
+        assert_eq!(intel.value_delivered[0].discrepancy, Some(false));
+    }
+
+    #[test]
+    fn test_parse_json_response_ignores_malformed_item_source_without_dropping_item() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "risks": [
+    {
+      "text": "Renewal timing is uncertain",
+      "urgency": "watch",
+      "itemSource": {"source": "glean_crm", "confidence": "high"}
+    }
+  ]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("malformed itemSource should not reject the whole response");
+
+        assert_eq!(intel.risks.len(), 1);
+        assert_eq!(intel.risks[0].text, "Renewal timing is uncertain");
+        assert!(intel.risks[0].item_source.is_none());
+    }
+
+    #[test]
+    fn test_parse_json_response_preserves_product_and_gong_fields() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "productClassification": {
+    "products": [
+      {"type": "cms", "tier": "enhanced", "arr": 125000.0, "billingTerms": "annual"}
+    ]
+  },
+  "gongCallSummaries": [
+    {
+      "title": "Renewal planning",
+      "date": "2026-03-15",
+      "participants": ["Jordan Lee"],
+      "keyTopics": "Renewal timing and rollout risks",
+      "sentiment": "neutral"
+    }
+  ]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("should parse JSON with Glean-only fields");
+        let product = &intel.product_classification.unwrap().products[0];
+
+        assert_eq!(product.type_.as_deref(), Some("cms"));
+        assert_eq!(product.tier.as_deref(), Some("enhanced"));
+        assert_eq!(product.arr, Some(125000.0));
+        assert_eq!(product.billing_terms.as_deref(), Some("annual"));
+        assert_eq!(intel.gong_call_summaries.len(), 1);
+        assert_eq!(intel.gong_call_summaries[0].title, "Renewal planning");
+        assert_eq!(
+            intel.gong_call_summaries[0].key_topics,
+            "Renewal timing and rollout risks"
+        );
+    }
+
+    #[test]
+    fn test_parse_json_response_tolerates_malformed_optional_glean_fields() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "productClassification": {
+    "products": [
+      {"type": "cms", "tier": "enhanced", "arr": "$125k", "billingTerms": "annual"}
+    ]
+  },
+  "gongCallSummaries": [
+    {
+      "title": "Renewal planning",
+      "date": "2026-03-15",
+      "participants": "Jordan Lee",
+      "keyTopics": ["Renewal timing", "Rollout risks"],
+      "sentiment": "neutral"
+    }
+  ]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("optional Glean metadata should not reject the whole response");
+        let product = &intel.product_classification.unwrap().products[0];
+
+        assert_eq!(product.type_.as_deref(), Some("cms"));
+        assert_eq!(product.arr, Some(125000.0));
+        assert_eq!(intel.gong_call_summaries.len(), 1);
+        assert_eq!(
+            intel.gong_call_summaries[0].participants,
+            vec!["Jordan Lee".to_string()]
+        );
+        assert_eq!(
+            intel.gong_call_summaries[0].key_topics,
+            "Renewal timing; Rollout risks"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,7 +60,13 @@ pub mod substrate_test_api {
         input: &EnrichmentInput,
         intel: &crate::intelligence::IntelligenceJson,
     ) -> Result<PreparedEnrichment, String> {
-        crate::intel_queue::compose_enrichment_intelligence_payload(db, input, intel, None)
+        crate::intel_queue::compose_enrichment_intelligence_payload(
+            db,
+            input,
+            intel,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
     }
 }
 #[cfg(any(feature = "test-harness", debug_assertions))]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -10695,6 +10695,7 @@ fn load_best_local_projection_corroboration(
                 AND data_source != 'ai_enrichment_progressive'
                 AND data_source != 'glean'
                 AND data_source NOT LIKE 'glean_%'
+                AND trim(data_source) != ''
               ORDER BY strength DESC,
                        coalesce(last_reinforced_at, created_at) DESC,
                        data_source ASC
@@ -10870,7 +10871,9 @@ fn projection_reissue_provenance_data_source(
         "ai" | "ai_enrichment" | "ai_inference" | "pty_synthesis" => {
             crate::abilities::provenance::DataSource::Ai
         }
-        "" => crate::abilities::provenance::DataSource::LegacyUnattributed,
+        "" => crate::abilities::provenance::DataSource::Other(
+            crate::abilities::provenance::SourceName::new("unknown_projection_source"),
+        ),
         other => crate::abilities::provenance::DataSource::Other(
             crate::abilities::provenance::SourceName::new(other),
         ),
@@ -10908,7 +10911,7 @@ fn delete_glean_generated_projection_corroborations_for_source_purge_in_tx(
 ) -> Result<usize, ClaimError> {
     db.conn_ref()
         .execute(
-            "DELETE FROM claim_corroborations
+            "DELETE FROM claim_corroborations -- dos7-allowed: source purge removes corroboration evidence; corroborations have no lifecycle column
               WHERE (
                     data_source = 'glean'
                     OR data_source LIKE 'glean_%'

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -5116,19 +5116,19 @@ fn corroborate_in_tx(
     source_mechanism: Option<&str>,
     now: &str,
 ) -> Result<String, ClaimError> {
-    let existing: Option<(String, f64, i64)> = tx
+    let existing: Option<(String, f64, i64, Option<String>)> = tx
         .conn_ref()
         .query_row(
-            "SELECT id, strength, reinforcement_count
+            "SELECT id, strength, reinforcement_count, source_asof
              FROM claim_corroborations
              WHERE claim_id = ?1 AND data_source = ?2",
             params![claim_id, data_source],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()?;
 
     let id = match existing {
-        Some((id, strength, count)) => {
+        Some((id, strength, count, existing_source_asof)) => {
             let numerator = (count as f64 + 2.0).ln();
             let denominator = (count as f64 + 1.0).ln();
             let increment = if denominator > 0.0 {
@@ -5137,13 +5137,15 @@ fn corroborate_in_tx(
                 1.0
             };
             let new_strength = (strength + increment).min(1.0);
+            let source_asof = newest_source_asof(existing_source_asof.as_deref(), source_asof);
             tx.conn_ref().execute(
                 "UPDATE claim_corroborations
                  SET strength = ?1,
                      reinforcement_count = reinforcement_count + 1,
-                     last_reinforced_at = ?2
-                 WHERE id = ?3",
-                params![new_strength, &now, &id],
+                     last_reinforced_at = ?2,
+                     source_asof = ?3
+                 WHERE id = ?4",
+                params![new_strength, &now, source_asof.as_deref(), &id],
             )?;
             id
         }
@@ -5167,6 +5169,26 @@ fn corroborate_in_tx(
         }
     };
     Ok(id)
+}
+
+fn newest_source_asof(existing: Option<&str>, incoming: Option<&str>) -> Option<String> {
+    match (existing, incoming) {
+        (None, None) => None,
+        (Some(existing), None) => Some(existing.to_string()),
+        (None, Some(incoming)) => Some(incoming.to_string()),
+        (Some(existing), Some(incoming)) => {
+            match (
+                DateTime::parse_from_rfc3339(existing),
+                DateTime::parse_from_rfc3339(incoming),
+            ) {
+                (Ok(existing_time), Ok(incoming_time)) if incoming_time > existing_time => {
+                    Some(incoming.to_string())
+                }
+                (Err(_), Ok(_)) => Some(incoming.to_string()),
+                _ => Some(existing.to_string()),
+            }
+        }
+    }
 }
 
 fn insert_semantic_evidence_in_tx(
@@ -10306,26 +10328,14 @@ pub fn withdraw_email_subject_claims_for_existing_emails(
 /// Runs in the caller's transaction and uses the normal claim lifecycle side
 /// effects: subject claim-version bump, claim-version event, and edge
 /// tombstoning. The claim assertion rows remain for audit.
-pub fn withdraw_glean_account_fact_claims_for_source_purge_in_tx(
+fn withdraw_claim_ids_for_source_purge_in_tx(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
+    claim_ids: Vec<String>,
+    retraction_reason: &str,
 ) -> Result<usize, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
-    let mut stmt = db.conn_ref().prepare(
-        "SELECT ic.id
-           FROM intelligence_claims ic
-          WHERE ic.claim_type = 'account_fact'
-            AND ic.claim_state IN ('active', 'tombstoned', 'dormant')
-            AND json_valid(ic.subject_ref) = 1
-            AND lower(json_extract(ic.subject_ref, '$.kind')) = 'account'
-            AND ic.source_ref LIKE 'glean_account_fact:%'
-          ORDER BY ic.id",
-    )?;
-    let claim_ids = stmt
-        .query_map([], |row| row.get::<_, String>(0))?
-        .collect::<Result<Vec<_>, _>>()?;
-
     let mut withdrawn = 0usize;
     let now = ctx.clock.now().to_rfc3339();
     let actor_kind = VersionActorKind::from_service_actor(ctx.actor);
@@ -10355,9 +10365,9 @@ pub fn withdraw_glean_account_fact_claims_for_source_purge_in_tx(
             "UPDATE intelligence_claims
              SET claim_state = 'withdrawn',
                  surfacing_state = 'dormant',
-                 retraction_reason = coalesce(retraction_reason, 'source_purged:glean')
+                 retraction_reason = coalesce(retraction_reason, ?2)
              WHERE id = ?1",
-            params![claim_id],
+            params![claim_id, retraction_reason],
         )?;
         mark_claim_edges_tombstoned(db, &claim_id, &now)?;
         db.bump_for_subject(&subject)?;
@@ -10377,6 +10387,551 @@ pub fn withdraw_glean_account_fact_claims_for_source_purge_in_tx(
         withdrawn += 1;
     }
     Ok(withdrawn)
+}
+
+pub fn withdraw_generated_projection_claims_for_field_path_roots_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    field_path_roots: &[&str],
+    retraction_reason: &str,
+) -> Result<usize, ClaimError> {
+    if field_path_roots.is_empty() {
+        return Ok(0);
+    }
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT ic.id, coalesce(ic.field_path, '')
+           FROM intelligence_claims ic
+          WHERE ic.claim_state = 'active'
+            AND ic.surfacing_state = 'active'
+            AND json_valid(ic.subject_ref) = 1
+            AND lower(json_extract(ic.subject_ref, '$.kind')) = lower(?1)
+            AND json_extract(ic.subject_ref, '$.id') = ?2
+            AND (
+                ic.source_ref LIKE 'intelligence_projection_source:%'
+                OR (
+                    json_valid(ic.provenance_json) = 1
+                    AND json_extract(ic.provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                )
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_type(ic.metadata_json, '$.legacy_projection_value') IS NOT NULL
+                )
+            )
+          ORDER BY ic.id",
+    )?;
+    let rows = stmt
+        .query_map(params![entity_type, entity_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let claim_ids = rows
+        .into_iter()
+        .filter_map(|(claim_id, field_path)| {
+            field_path_roots
+                .iter()
+                .any(|root| field_path_matches_projection_root(&field_path, root))
+                .then_some(claim_id)
+        })
+        .collect();
+
+    withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, retraction_reason)
+}
+
+fn field_path_matches_projection_root(field_path: &str, root: &str) -> bool {
+    field_path == root
+        || field_path
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('[') || suffix.starts_with('.'))
+}
+
+/// Withdraw account-fact claims whose evidence came through Glean finalization.
+///
+/// Runs in the caller's transaction and uses the normal claim lifecycle side
+/// effects: subject claim-version bump, claim-version event, and edge
+/// tombstoning. The claim assertion rows remain for audit.
+pub fn withdraw_glean_account_fact_claims_for_source_purge_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+) -> Result<usize, ClaimError> {
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT ic.id
+           FROM intelligence_claims ic
+          WHERE ic.claim_type = 'account_fact'
+            AND ic.claim_state IN ('active', 'tombstoned', 'dormant')
+            AND json_valid(ic.subject_ref) = 1
+            AND lower(json_extract(ic.subject_ref, '$.kind')) = 'account'
+            AND ic.source_ref LIKE 'glean_account_fact:%'
+          ORDER BY ic.id",
+    )?;
+    let claim_ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, "source_purged:glean")
+}
+
+/// Withdraw generated projection claims whose item-level evidence came from Glean.
+pub fn withdraw_glean_generated_projection_claims_for_source_purge_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+) -> Result<usize, ClaimError> {
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT ic.id
+           FROM intelligence_claims ic
+          WHERE ic.claim_state IN ('active', 'tombstoned', 'dormant')
+            AND json_valid(ic.subject_ref) = 1
+            AND (
+                ic.data_source = 'glean'
+                OR ic.data_source LIKE 'glean_%'
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_extract(ic.metadata_json, '$.projection_producer') = 'glean'
+                    AND ic.data_source IN ('ai', 'ai_enrichment', 'ai_inference')
+                )
+                OR (
+                    EXISTS (
+                        SELECT 1
+                          FROM claim_corroborations cc
+                         WHERE cc.claim_id = ic.id
+                           AND (
+                               cc.data_source = 'glean'
+                               OR cc.data_source LIKE 'glean_%'
+                           )
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                          FROM claim_corroborations cc_local
+                         WHERE cc_local.claim_id = ic.id
+                           AND cc_local.data_source != 'ai_enrichment_progressive'
+                           AND cc_local.data_source != 'glean'
+                           AND cc_local.data_source NOT LIKE 'glean_%'
+                    )
+                    AND (
+                        ic.data_source = 'ai_enrichment_progressive'
+                        OR (
+                            ic.metadata_json IS NOT NULL
+                            AND json_valid(ic.metadata_json) = 1
+                            AND json_extract(ic.metadata_json, '$.projection_producer') = 'ai_enrichment_progressive'
+                        )
+                    )
+                )
+            )
+            AND (
+                ic.source_ref LIKE 'intelligence_projection_source:%'
+                OR (
+                    json_valid(ic.provenance_json) = 1
+                    AND json_extract(ic.provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                )
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_type(ic.metadata_json, '$.legacy_projection_value') IS NOT NULL
+                )
+            )
+          ORDER BY ic.id",
+    )?;
+    let claim_ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let reissues = load_glean_origin_projection_reissues_for_source_purge(ctx, db)?;
+
+    delete_glean_generated_projection_corroborations_for_source_purge_in_tx(db)?;
+
+    let withdrawn =
+        withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, "source_purged:glean")?;
+    for reissue in reissues {
+        commit_claim(ctx, db, reissue.into_claim_proposal())?;
+    }
+    Ok(withdrawn)
+}
+
+struct GeneratedProjectionClaimReissue {
+    subject_ref: String,
+    claim_type: String,
+    field_path: Option<String>,
+    topic_key: Option<String>,
+    text: String,
+    actor: String,
+    data_source: String,
+    source_asof: Option<String>,
+    observed_at: String,
+    provenance_json: String,
+    metadata_json: Option<String>,
+    temporal_scope: TemporalScope,
+    sensitivity: ClaimSensitivity,
+}
+
+impl GeneratedProjectionClaimReissue {
+    fn into_claim_proposal(self) -> ClaimProposal {
+        ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: self.subject_ref,
+            claim_type: self.claim_type,
+            field_path: self.field_path,
+            topic_key: self.topic_key,
+            text: self.text,
+            actor: self.actor,
+            data_source: self.data_source,
+            source_ref: None,
+            source_asof: self.source_asof,
+            observed_at: self.observed_at,
+            provenance_json: self.provenance_json,
+            metadata_json: self.metadata_json,
+            thread_id: None,
+            temporal_scope: Some(self.temporal_scope),
+            sensitivity: Some(self.sensitivity),
+            supersedes: None,
+            tombstone: None,
+        }
+    }
+}
+
+struct LocalProjectionCorroboration {
+    data_source: String,
+    source_asof: Option<String>,
+    strength: f64,
+}
+
+fn load_glean_origin_projection_reissues_for_source_purge(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+) -> Result<Vec<GeneratedProjectionClaimReissue>, ClaimError> {
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT ic.id
+           FROM intelligence_claims ic
+          WHERE ic.claim_state IN ('active', 'tombstoned', 'dormant')
+            AND json_valid(ic.subject_ref) = 1
+            AND (
+                ic.data_source = 'glean'
+                OR ic.data_source LIKE 'glean_%'
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_extract(ic.metadata_json, '$.projection_producer') = 'glean'
+                    AND ic.data_source IN ('ai', 'ai_enrichment', 'ai_inference')
+                )
+            )
+            AND EXISTS (
+                SELECT 1
+                  FROM claim_corroborations cc_local
+                 WHERE cc_local.claim_id = ic.id
+                   AND cc_local.data_source != 'ai_enrichment_progressive'
+                   AND cc_local.data_source != 'glean'
+                   AND cc_local.data_source NOT LIKE 'glean_%'
+            )
+            AND (
+                ic.source_ref LIKE 'intelligence_projection_source:%'
+                OR (
+                    json_valid(ic.provenance_json) = 1
+                    AND json_extract(ic.provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                )
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_type(ic.metadata_json, '$.legacy_projection_value') IS NOT NULL
+                )
+            )
+          ORDER BY ic.id",
+    )?;
+    let claim_ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut reissues = Vec::new();
+    for claim_id in claim_ids {
+        let Some(claim) = load_claim_by_id(db.conn_ref(), &claim_id)? else {
+            continue;
+        };
+        let Some(local) = load_best_local_projection_corroboration(db, &claim_id)? else {
+            continue;
+        };
+        let observed_at = local
+            .source_asof
+            .clone()
+            .unwrap_or_else(|| ctx.clock.now().to_rfc3339());
+        let provenance_json = projection_reissue_provenance_json(
+            ctx,
+            &claim,
+            &local.data_source,
+            local.source_asof.as_deref(),
+            local.strength,
+            &observed_at,
+        )?;
+        let metadata_json =
+            projection_reissue_metadata_json(claim.metadata_json.as_deref(), &local.data_source)?;
+        reissues.push(GeneratedProjectionClaimReissue {
+            subject_ref: claim.subject_ref,
+            claim_type: claim.claim_type,
+            field_path: claim.field_path,
+            topic_key: claim.topic_key,
+            text: claim.text,
+            actor: claim.actor,
+            data_source: local.data_source,
+            source_asof: local.source_asof,
+            observed_at,
+            provenance_json,
+            metadata_json,
+            temporal_scope: claim.temporal_scope,
+            sensitivity: claim.sensitivity,
+        });
+    }
+    Ok(reissues)
+}
+
+fn load_best_local_projection_corroboration(
+    db: &ActionDb,
+    claim_id: &str,
+) -> Result<Option<LocalProjectionCorroboration>, ClaimError> {
+    db.conn_ref()
+        .query_row(
+            "SELECT data_source, source_asof, strength
+               FROM claim_corroborations
+              WHERE claim_id = ?1
+                AND data_source != 'ai_enrichment_progressive'
+                AND data_source != 'glean'
+                AND data_source NOT LIKE 'glean_%'
+              ORDER BY strength DESC,
+                       coalesce(last_reinforced_at, created_at) DESC,
+                       data_source ASC
+              LIMIT 1",
+            params![claim_id],
+            |row| {
+                Ok(LocalProjectionCorroboration {
+                    data_source: row.get(0)?,
+                    source_asof: row.get(1)?,
+                    strength: row.get(2)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(ClaimError::from)
+}
+
+fn projection_reissue_metadata_json(
+    metadata_json: Option<&str>,
+    projection_producer: &str,
+) -> Result<Option<String>, ClaimError> {
+    let Some(metadata_json) = metadata_json else {
+        return Ok(None);
+    };
+    let mut value = serde_json::from_str::<serde_json::Value>(metadata_json)?;
+    let Some(object) = value.as_object_mut() else {
+        return Ok(None);
+    };
+    object.insert(
+        "projection_producer".to_string(),
+        serde_json::json!(projection_producer),
+    );
+    Ok(Some(serde_json::to_string(&value)?))
+}
+
+fn projection_reissue_provenance_json(
+    ctx: &ServiceContext<'_>,
+    claim: &IntelligenceClaim,
+    data_source: &str,
+    source_asof: Option<&str>,
+    strength: f64,
+    observed_at: &str,
+) -> Result<String, ClaimError> {
+    let subject_value = serde_json::from_str::<serde_json::Value>(&claim.subject_ref)?;
+    let (subject_kind, subject_id) = projection_reissue_subject_parts(&subject_value)?;
+    let subject_ref = projection_reissue_provenance_subject_ref(&subject_kind, &subject_id)?;
+    let subject = crate::abilities::provenance::SubjectAttribution::direct_confident(subject_ref);
+    let observed_at = projection_reissue_timestamp(observed_at).unwrap_or_else(|| ctx.clock.now());
+    let source_asof_timestamp = source_asof.and_then(projection_reissue_timestamp);
+    let provenance_data_source = projection_reissue_provenance_data_source(data_source);
+    let source_identifier = crate::abilities::provenance::SourceIdentifier::Entity {
+        entity_id: crate::abilities::provenance::EntityId::new(subject_id),
+        field: claim.field_path.clone(),
+    };
+    let confidence = if strength.is_finite() {
+        strength.clamp(0.0, 1.0) as f32
+    } else {
+        0.5
+    };
+    let source = crate::abilities::provenance::SourceAttribution::new(
+        provenance_data_source,
+        vec![source_identifier],
+        observed_at,
+        source_asof_timestamp,
+        confidence,
+        None,
+    )
+    .map_err(|error| {
+        ClaimError::Transaction(format!("projection reissue source invalid: {error}"))
+    })?;
+
+    let mut config = crate::abilities::provenance::ProvenanceBuilderConfig::new(
+        "claim_shaped_intelligence_projection",
+        ctx.clock.now(),
+    );
+    config.invocation_id = crate::abilities::provenance::InvocationId::new(uuid::Uuid::new_v4());
+    config.actor = projection_reissue_provenance_actor(&claim.actor);
+    config.mode = ctx.mode.into();
+    config.category = crate::abilities::registry::AbilityCategory::Transform;
+
+    let mut builder = crate::abilities::provenance::ProvenanceBuilder::new(config);
+    builder.set_subject(subject.clone());
+    let source_index = builder.add_source(source);
+    let explanation = crate::abilities::provenance::SanitizedExplanation::new(
+        "Generated projection preserved through surviving local corroboration after source purge.",
+    )
+    .map_err(|error| {
+        ClaimError::Transaction(format!("projection reissue explanation invalid: {error}"))
+    })?;
+    let field_attribution = crate::abilities::provenance::FieldAttribution::llm_synthesis(
+        subject,
+        vec![crate::abilities::provenance::SourceRef::Source { source_index }],
+        crate::abilities::provenance::Confidence::provider_reported(confidence).map_err(
+            |error| {
+                ClaimError::Transaction(format!("projection reissue confidence invalid: {error}"))
+            },
+        )?,
+        Some(explanation),
+    )
+    .map_err(|error| {
+        ClaimError::Transaction(format!(
+            "projection reissue field attribution invalid: {error}"
+        ))
+    })?;
+    builder
+        .attribute_subtree(
+            crate::abilities::provenance::FieldPath::root(),
+            field_attribution,
+        )
+        .map_err(|error| {
+            ClaimError::Transaction(format!("projection reissue attribution failed: {error}"))
+        })?;
+    let output = serde_json::json!({
+        "claimType": claim.claim_type.as_str(),
+        "fieldPath": claim.field_path.as_deref(),
+        "text": claim.text.as_str(),
+        "dataSource": data_source,
+        "sourceRef": null,
+        "sourceAsOf": source_asof,
+    });
+    let output = builder.finalize(output).map_err(|error| {
+        ClaimError::Transaction(format!("projection reissue provenance invalid: {error}"))
+    })?;
+    serde_json::to_string(output.provenance()).map_err(ClaimError::from)
+}
+
+fn projection_reissue_subject_parts(
+    value: &serde_json::Value,
+) -> Result<(String, String), ClaimError> {
+    match subject_ref_from_json(value)? {
+        SubjectRef::Account { id } => Ok(("account".to_string(), id)),
+        SubjectRef::Project { id } => Ok(("project".to_string(), id)),
+        SubjectRef::Person { id } => Ok(("person".to_string(), id)),
+        SubjectRef::Meeting { id } => Ok(("meeting".to_string(), id)),
+        other => Err(ClaimError::SubjectRef(format!(
+            "unsupported generated projection reissue subject: {other:?}"
+        ))),
+    }
+}
+
+fn projection_reissue_provenance_subject_ref(
+    subject_kind: &str,
+    subject_id: &str,
+) -> Result<crate::abilities::provenance::SubjectRef, ClaimError> {
+    match subject_kind {
+        "account" => Ok(crate::abilities::provenance::SubjectRef::Account(
+            subject_id.to_string(),
+        )),
+        "project" => Ok(crate::abilities::provenance::SubjectRef::Project(
+            subject_id.to_string(),
+        )),
+        "person" => Ok(crate::abilities::provenance::SubjectRef::Person(
+            subject_id.to_string(),
+        )),
+        "meeting" => Ok(crate::abilities::provenance::SubjectRef::Meeting(
+            subject_id.to_string(),
+        )),
+        other => Err(ClaimError::SubjectRef(format!(
+            "unsupported projection provenance subject: {other}"
+        ))),
+    }
+}
+
+fn projection_reissue_provenance_data_source(
+    source: &str,
+) -> crate::abilities::provenance::DataSource {
+    match source.trim().to_ascii_lowercase().as_str() {
+        "user" | "user_correction" => crate::abilities::provenance::DataSource::User,
+        "google" | "gmail" | "email" => crate::abilities::provenance::DataSource::Google,
+        "clay" => crate::abilities::provenance::DataSource::Clay,
+        "local_enrichment" | "local_file" | "workspace_file" | "transcript" | "meeting"
+        | "post_meeting" | "calendar" => crate::abilities::provenance::DataSource::LocalEnrichment,
+        "ai" | "ai_enrichment" | "ai_inference" | "pty_synthesis" => {
+            crate::abilities::provenance::DataSource::Ai
+        }
+        "" => crate::abilities::provenance::DataSource::LegacyUnattributed,
+        other => crate::abilities::provenance::DataSource::Other(
+            crate::abilities::provenance::SourceName::new(other),
+        ),
+    }
+}
+
+fn projection_reissue_provenance_actor(actor: &str) -> crate::abilities::provenance::Actor {
+    let actor = actor.trim();
+    if actor.eq_ignore_ascii_case("user") || actor.starts_with("user:") {
+        return crate::abilities::provenance::Actor::User;
+    }
+    if let Some(agent) = actor.strip_prefix("agent:") {
+        return crate::abilities::provenance::Actor::Agent {
+            name: agent.to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+    }
+    crate::abilities::provenance::Actor::System {
+        component: if actor.is_empty() {
+            "intelligence_projection".to_string()
+        } else {
+            actor.to_string()
+        },
+    }
+}
+
+fn projection_reissue_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+}
+
+fn delete_glean_generated_projection_corroborations_for_source_purge_in_tx(
+    db: &ActionDb,
+) -> Result<usize, ClaimError> {
+    db.conn_ref()
+        .execute(
+            "DELETE FROM claim_corroborations
+              WHERE (
+                    data_source = 'glean'
+                    OR data_source LIKE 'glean_%'
+                )
+                AND claim_id IN (
+                    SELECT ic.id
+                      FROM intelligence_claims ic
+                     WHERE (
+                            ic.source_ref LIKE 'intelligence_projection_source:%'
+                            OR (
+                                json_valid(ic.provenance_json) = 1
+                                AND json_extract(ic.provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                            )
+                            OR (
+                                ic.metadata_json IS NOT NULL
+                                AND json_valid(ic.metadata_json) = 1
+                                AND json_type(ic.metadata_json, '$.legacy_projection_value') IS NOT NULL
+                            )
+                        )
+                )",
+            [],
+        )
+        .map_err(ClaimError::from)
 }
 
 pub fn withdraw_tombstones_for(
@@ -16589,6 +17144,53 @@ mod tests {
         .unwrap();
         assert_eq!(recovered_for_surface.len(), 1);
         assert_eq!(recovered_for_surface[0].id, first_id);
+    }
+
+    #[test]
+    fn same_generated_claim_reinforces_existing_claim() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let mut first = proposal("Renewal budget approval is pending with finance");
+        first.actor = "agent:intelligence".to_string();
+        first.data_source = "ai_enrichment".to_string();
+        first.source_ref = Some("intelligence_projection_source:first".to_string());
+        let first_id = inserted_claim_id(commit_claim(&ctx, &db, first).unwrap());
+        update_claim_trust(&db, &first_id, TrustScore(0.85), 1, &ctx).unwrap();
+
+        let mut second = proposal("Renewal budget approval is pending with finance");
+        second.actor = "agent:intelligence".to_string();
+        second.data_source = "glean_crm".to_string();
+        second.source_ref = Some("intelligence_projection_source:second".to_string());
+        second.source_asof = Some("2026-05-03T12:00:00+00:00".to_string());
+        second.provenance_json = serde_json::json!({
+            "source": "generated_projection",
+            "sourceRef": second.source_ref.as_deref(),
+        })
+        .to_string();
+
+        match commit_claim(&ctx, &db, second).unwrap() {
+            CommittedClaim::Reinforced { claim, .. } => assert_eq!(claim.id, first_id),
+            other => panic!("same generated claim should reinforce, got {other:?}"),
+        }
+
+        let active = load_claims_active(&db, SUBJECT, Some("risk")).unwrap();
+        assert_eq!(active.len(), 1);
+        let corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean_crm'
+                    AND source_asof = '2026-05-03T12:00:00+00:00'",
+                params![&first_id],
+                |row| row.get(0),
+            )
+            .expect("corroboration count");
+        assert_eq!(corroboration_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -10446,27 +10446,52 @@ pub struct GeneratedProjectionRefreshWithdrawal<'a> {
     pub entity_id: &'a str,
     pub field_path_roots: &'a [&'a str],
     pub projection_producers: &'a [&'a str],
-    pub retained_claim_keys: &'a [(String, String, String)],
+    pub retained_claim_keys: &'a [(String, String, String, String)],
     pub retraction_reason: &'a str,
+}
+
+pub struct GeneratedProjectionRefreshWithdrawalOutcome {
+    pub withdrawn: usize,
+    pub affected_subjects: Vec<(String, String)>,
 }
 
 pub fn withdraw_generated_projection_claims_for_field_path_roots_by_projection_producer_in_tx(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     input: GeneratedProjectionRefreshWithdrawal<'_>,
-) -> Result<usize, ClaimError> {
+) -> Result<GeneratedProjectionRefreshWithdrawalOutcome, ClaimError> {
     if input.field_path_roots.is_empty() || input.projection_producers.is_empty() {
-        return Ok(0);
+        return Ok(GeneratedProjectionRefreshWithdrawalOutcome {
+            withdrawn: 0,
+            affected_subjects: Vec::new(),
+        });
     }
 
     let mut stmt = db.conn_ref().prepare(
-        "SELECT ic.id, ic.claim_type, coalesce(ic.field_path, ''), ic.text, ic.metadata_json
+        "SELECT ic.id,
+                ic.subject_ref,
+                lower(json_extract(ic.subject_ref, '$.kind')),
+                json_extract(ic.subject_ref, '$.id'),
+                ic.claim_type,
+                coalesce(ic.field_path, ''),
+                ic.text,
+                ic.metadata_json
            FROM intelligence_claims ic
           WHERE ic.claim_state = 'active'
             AND ic.surfacing_state = 'active'
             AND json_valid(ic.subject_ref) = 1
-            AND lower(json_extract(ic.subject_ref, '$.kind')) = lower(?1)
-            AND json_extract(ic.subject_ref, '$.id') = ?2
+            AND (
+                (
+                    lower(json_extract(ic.subject_ref, '$.kind')) = lower(?1)
+                    AND json_extract(ic.subject_ref, '$.id') = ?2
+                )
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND lower(json_extract(ic.metadata_json, '$.projection_origin_subject.kind')) = lower(?1)
+                    AND json_extract(ic.metadata_json, '$.projection_origin_subject.id') = ?2
+                )
+            )
             AND (
                 ic.source_ref LIKE 'intelligence_projection_source:%'
                 OR (
@@ -10488,39 +10513,64 @@ pub fn withdraw_generated_projection_claims_for_field_path_roots_by_projection_p
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
                 row.get::<_, String>(3)?,
-                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, Option<String>>(7)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
+    let mut affected_subjects = HashSet::new();
     let claim_ids = rows
         .into_iter()
-        .filter_map(|(claim_id, claim_type, field_path, text, metadata_json)| {
-            let field_matches = input
-                .field_path_roots
-                .iter()
-                .any(|root| field_path_matches_projection_root(&field_path, root));
-            if !field_matches {
-                return None;
-            }
-            if input.retained_claim_keys.iter().any(
-                |(retained_type, retained_path, retained_text)| {
-                    retained_type == &claim_type
-                        && retained_path == &field_path
-                        && retained_text == &text
-                },
-            ) {
-                return None;
-            }
-            let producer = projection_producer_from_metadata(metadata_json.as_deref())?;
-            input
-                .projection_producers
-                .iter()
-                .any(|candidate| producer.eq_ignore_ascii_case(candidate))
-                .then_some(claim_id)
-        })
+        .filter_map(
+            |(
+                claim_id,
+                subject_ref,
+                subject_kind,
+                subject_id,
+                claim_type,
+                field_path,
+                text,
+                metadata_json,
+            )| {
+                let field_matches = input
+                    .field_path_roots
+                    .iter()
+                    .any(|root| field_path_matches_projection_root(&field_path, root));
+                if !field_matches {
+                    return None;
+                }
+                if input.retained_claim_keys.iter().any(
+                    |(retained_subject, retained_type, retained_path, retained_text)| {
+                        retained_subject == &subject_ref
+                            && retained_type == &claim_type
+                            && retained_path == &field_path
+                            && retained_text == &text
+                    },
+                ) {
+                    return None;
+                }
+                let producer = projection_producer_from_metadata(metadata_json.as_deref())?;
+                if !input
+                    .projection_producers
+                    .iter()
+                    .any(|candidate| producer.eq_ignore_ascii_case(candidate))
+                {
+                    return None;
+                }
+                affected_subjects.insert((subject_kind, subject_id));
+                Some(claim_id)
+            },
+        )
         .collect();
 
-    withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, input.retraction_reason)
+    let withdrawn =
+        withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, input.retraction_reason)?;
+    Ok(GeneratedProjectionRefreshWithdrawalOutcome {
+        withdrawn,
+        affected_subjects: affected_subjects.into_iter().collect(),
+    })
 }
 
 fn projection_producer_from_metadata(metadata_json: Option<&str>) -> Option<String> {
@@ -10816,6 +10866,7 @@ fn projection_reissue_metadata_json(
     let Some(object) = value.as_object_mut() else {
         return Ok(None);
     };
+    object.remove("legacy_projection_value");
     object.insert(
         "projection_producer".to_string(),
         serde_json::json!(projection_producer),

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -10441,6 +10441,98 @@ pub fn withdraw_generated_projection_claims_for_field_path_roots_in_tx(
     withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, retraction_reason)
 }
 
+pub struct GeneratedProjectionRefreshWithdrawal<'a> {
+    pub entity_type: &'a str,
+    pub entity_id: &'a str,
+    pub field_path_roots: &'a [&'a str],
+    pub projection_producers: &'a [&'a str],
+    pub retained_claim_keys: &'a [(String, String, String)],
+    pub retraction_reason: &'a str,
+}
+
+pub fn withdraw_generated_projection_claims_for_field_path_roots_by_projection_producer_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: GeneratedProjectionRefreshWithdrawal<'_>,
+) -> Result<usize, ClaimError> {
+    if input.field_path_roots.is_empty() || input.projection_producers.is_empty() {
+        return Ok(0);
+    }
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT ic.id, ic.claim_type, coalesce(ic.field_path, ''), ic.text, ic.metadata_json
+           FROM intelligence_claims ic
+          WHERE ic.claim_state = 'active'
+            AND ic.surfacing_state = 'active'
+            AND json_valid(ic.subject_ref) = 1
+            AND lower(json_extract(ic.subject_ref, '$.kind')) = lower(?1)
+            AND json_extract(ic.subject_ref, '$.id') = ?2
+            AND (
+                ic.source_ref LIKE 'intelligence_projection_source:%'
+                OR (
+                    json_valid(ic.provenance_json) = 1
+                    AND json_extract(ic.provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                )
+                OR (
+                    ic.metadata_json IS NOT NULL
+                    AND json_valid(ic.metadata_json) = 1
+                    AND json_type(ic.metadata_json, '$.legacy_projection_value') IS NOT NULL
+                )
+            )
+          ORDER BY ic.id",
+    )?;
+    let rows = stmt
+        .query_map(params![input.entity_type, input.entity_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let claim_ids = rows
+        .into_iter()
+        .filter_map(|(claim_id, claim_type, field_path, text, metadata_json)| {
+            let field_matches = input
+                .field_path_roots
+                .iter()
+                .any(|root| field_path_matches_projection_root(&field_path, root));
+            if !field_matches {
+                return None;
+            }
+            if input.retained_claim_keys.iter().any(
+                |(retained_type, retained_path, retained_text)| {
+                    retained_type == &claim_type
+                        && retained_path == &field_path
+                        && retained_text == &text
+                },
+            ) {
+                return None;
+            }
+            let producer = projection_producer_from_metadata(metadata_json.as_deref())?;
+            input
+                .projection_producers
+                .iter()
+                .any(|candidate| producer.eq_ignore_ascii_case(candidate))
+                .then_some(claim_id)
+        })
+        .collect();
+
+    withdraw_claim_ids_for_source_purge_in_tx(ctx, db, claim_ids, input.retraction_reason)
+}
+
+fn projection_producer_from_metadata(metadata_json: Option<&str>) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(metadata_json?).ok()?;
+    value
+        .get("projection_producer")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn field_path_matches_projection_root(field_path: &str, root: &str) -> bool {
     field_path == root
         || field_path

--- a/src-tauri/src/services/enrichment_side_effects.rs
+++ b/src-tauri/src/services/enrichment_side_effects.rs
@@ -18,6 +18,45 @@ pub struct EnrichmentSideEffectSource<'a> {
     pub product_source: &'a str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentSideEffectProducer {
+    Glean,
+    Pty,
+}
+
+pub fn sync_account_enrichment_side_effects_for_producer(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &PropagationEngine,
+    account_id: &str,
+    intel: &IntelligenceJson,
+    producer: EnrichmentSideEffectProducer,
+) -> Result<(), String> {
+    let (commitment_source_label, signal_source, product_source) = match producer {
+        EnrichmentSideEffectProducer::Glean => {
+            (format!("glean_enrichment:{account_id}"), "glean", "glean")
+        }
+        EnrichmentSideEffectProducer::Pty => (
+            format!("pty_enrichment:{account_id}"),
+            "ai_enrichment",
+            "ai_inference",
+        ),
+    };
+
+    sync_account_enrichment_side_effects(
+        ctx,
+        db,
+        engine,
+        account_id,
+        intel,
+        EnrichmentSideEffectSource {
+            commitment_source_label: &commitment_source_label,
+            signal_source,
+            product_source,
+        },
+    )
+}
+
 pub fn sync_account_enrichment_side_effects(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,

--- a/src-tauri/src/services/entity_intelligence/neighborhood.rs
+++ b/src-tauri/src/services/entity_intelligence/neighborhood.rs
@@ -1343,7 +1343,7 @@ mod tests {
                 INSERT INTO people (id, email, name, role, relationship, last_seen, updated_at) VALUES
                     ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
                 INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
-                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
+                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T15:00:00Z');
                 INSERT INTO linked_entities_raw
                     (owner_type, owner_id, entity_id, entity_type, role, source, rule_id, confidence, graph_version, created_at)
                 VALUES
@@ -1380,7 +1380,7 @@ mod tests {
                 INSERT INTO people (id, email, name, role, relationship, last_seen, updated_at) VALUES
                     ('person-1', 'one@example.com', 'Person One', 'Director', 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
                 INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
-                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
+                    ('meeting-1', 'Current Account Sync', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T15:00:00Z');
                 INSERT INTO meeting_entities (meeting_id, entity_id, entity_type, confidence) VALUES
                     ('meeting-1', 'account-1', 'account', 0.95);
                 INSERT INTO linked_entities_raw
@@ -1562,7 +1562,7 @@ mod tests {
                     ('person-ae', 'ae@example.com', 'Commercial Lead', NULL, 'internal', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z'),
                     ('person-associated', 'associated@example.com', 'Associated Person', NULL, 'external', '2026-05-22T00:00:00Z', '2026-05-22T00:00:00Z');
                 INSERT INTO meetings (id, title, meeting_type, start_time, end_time, created_at) VALUES
-                    ('meeting-1', 'Account Review', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T00:00:00Z');
+                    ('meeting-1', 'Account Review', 'customer', '2026-05-22T15:00:00Z', NULL, '2026-05-22T15:00:00Z');
                 INSERT INTO meeting_entities (meeting_id, entity_id, entity_type, confidence) VALUES
                     ('meeting-1', 'account-1', 'account', 0.95);
                 INSERT INTO meeting_attendees (meeting_id, person_id) VALUES

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -13,8 +13,12 @@ use crate::pty::AiUsageContext;
 use crate::services::context::ServiceContext;
 use crate::signals::propagation::PropagationEngine;
 use crate::state::AppState;
+use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
+use sha2::{Digest, Sha256};
 use tauri::Emitter;
+
+const GENERATED_PROJECTION_SOURCE_REF_PREFIX: &str = "intelligence_projection_source:";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EntityIntelligenceProjectionBackfillReport {
@@ -26,6 +30,12 @@ pub struct EntityIntelligenceProjectionBackfillReport {
     pub claims_inserted: usize,
     pub recompute_jobs_enqueued: usize,
     pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GeneratedProjectionSourcePurgeReport {
+    pub claims_withdrawn: usize,
+    pub recompute_jobs_enqueued: usize,
 }
 
 /// Preserve user-confirmed value_delivered items during re-enrichment.
@@ -94,9 +104,10 @@ fn subject_ref_for_entity(entity_type: &str, entity_id: &str) -> Result<String, 
     }
 }
 
-fn projection_metadata(value: serde_json::Value) -> Option<String> {
+fn projection_metadata(value: serde_json::Value, projection_producer: &str) -> Option<String> {
     serde_json::to_string(&serde_json::json!({
         "legacy_projection_value": value,
+        "projection_producer": projection_producer,
     }))
     .ok()
 }
@@ -107,6 +118,297 @@ fn source_asof_from_item_source(
     source
         .map(|item_source| item_source.sourced_at.trim())
         .filter(|sourced_at| !sourced_at.is_empty())
+}
+
+fn projection_claim_data_source(
+    fallback: &str,
+    source: Option<&crate::intelligence::io::ItemSource>,
+) -> String {
+    let fallback = fallback.trim();
+    let source = source
+        .map(|item_source| item_source.source.trim())
+        .filter(|source| !source.is_empty());
+
+    match fallback {
+        "glean" => match source {
+            Some(source) => authorized_glean_projection_data_source(source)
+                .or_else(|| authorized_non_glean_projection_data_source(source))
+                .unwrap_or("ai_enrichment")
+                .to_string(),
+            None => "glean".to_string(),
+        },
+        source if source.starts_with("glean_") => source.to_string(),
+        source => source.to_string(),
+    }
+}
+
+fn authorized_non_glean_projection_data_source(source: &str) -> Option<&'static str> {
+    match source.trim().to_ascii_lowercase().as_str() {
+        "transcript" => Some("transcript"),
+        "meeting" => Some("meeting"),
+        "post_meeting" => Some("post_meeting"),
+        "calendar" => Some("calendar"),
+        "local_file" | "workspace_file" => Some("local_file"),
+        "email" | "gmail" | "google" => Some("email"),
+        "pty_synthesis" => Some("pty_synthesis"),
+        "local_enrichment" => Some("local_enrichment"),
+        "ai" | "ai_enrichment" | "ai_inference" => Some("ai_enrichment"),
+        _ => None,
+    }
+}
+
+fn authorized_glean_projection_data_source(source: &str) -> Option<&'static str> {
+    match source.trim().to_ascii_lowercase().as_str() {
+        "glean" => Some("glean"),
+        "glean_crm" | "glean_salesforce" | "salesforce" => Some("glean_crm"),
+        "glean_zendesk" | "glean_support" | "zendesk" => Some("glean_zendesk"),
+        "glean_gong" | "gong" => Some("glean_gong"),
+        "glean_slack" | "glean_chat" | "slack" => Some("glean_chat"),
+        "glean_p2" | "p2" => Some("glean_p2"),
+        "glean_wordpress" | "wordpress" => Some("glean_wordpress"),
+        "glean_org" | "glean_org_directory" => Some("glean_org_directory"),
+        "glean_documents" | "glean_document" => Some("glean_documents"),
+        source if source.starts_with("glean") => Some("glean"),
+        _ => None,
+    }
+}
+
+fn projection_source_ref(input: &ProjectionClaimInput<'_>) -> Option<String> {
+    let item_source = input.item_source?;
+    let reference = item_source.reference.as_deref()?.trim();
+    if reference.is_empty() {
+        return None;
+    }
+
+    let mut hasher = Sha256::new();
+    for part in [
+        input.subject_ref,
+        input.claim_type,
+        input.field_path,
+        item_source.source.trim(),
+        item_source.sourced_at.trim(),
+        reference,
+    ] {
+        hasher.update(part.as_bytes());
+        hasher.update([0]);
+    }
+    let digest = hasher.finalize();
+    Some(format!(
+        "{GENERATED_PROJECTION_SOURCE_REF_PREFIX}{}",
+        hex::encode(&digest[..16])
+    ))
+}
+
+fn parse_projection_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+}
+
+fn projection_item_confidence(source: Option<&crate::intelligence::io::ItemSource>) -> f32 {
+    let Some(confidence) = source.map(|item_source| item_source.confidence) else {
+        return 0.5;
+    };
+    if confidence.is_finite() {
+        confidence.clamp(0.0, 1.0) as f32
+    } else {
+        0.5
+    }
+}
+
+fn projection_provenance_subject_ref(
+    subject_kind: &str,
+    subject_id: &str,
+) -> Result<crate::abilities::provenance::SubjectRef, String> {
+    match subject_kind {
+        "account" => Ok(crate::abilities::provenance::SubjectRef::Account(
+            subject_id.to_string(),
+        )),
+        "project" => Ok(crate::abilities::provenance::SubjectRef::Project(
+            subject_id.to_string(),
+        )),
+        "person" => Ok(crate::abilities::provenance::SubjectRef::Person(
+            subject_id.to_string(),
+        )),
+        "meeting" => Ok(crate::abilities::provenance::SubjectRef::Meeting(
+            subject_id.to_string(),
+        )),
+        other => Err(format!(
+            "unsupported projection provenance subject: {other}"
+        )),
+    }
+}
+
+fn glean_downstream_for_projection_source(
+    source: &str,
+) -> Option<crate::abilities::provenance::GleanDownstream> {
+    match source.trim().to_ascii_lowercase().as_str() {
+        "glean_crm" | "glean_salesforce" | "salesforce" => {
+            Some(crate::abilities::provenance::GleanDownstream::Salesforce)
+        }
+        "glean_zendesk" | "glean_support" | "zendesk" => {
+            Some(crate::abilities::provenance::GleanDownstream::Zendesk)
+        }
+        "glean_gong" | "gong" => Some(crate::abilities::provenance::GleanDownstream::Gong),
+        "glean_slack" | "glean_chat" | "slack" => {
+            Some(crate::abilities::provenance::GleanDownstream::Slack)
+        }
+        "glean_p2" | "p2" => Some(crate::abilities::provenance::GleanDownstream::P2),
+        "glean_wordpress" | "wordpress" => {
+            Some(crate::abilities::provenance::GleanDownstream::Wordpress)
+        }
+        "glean_org" | "glean_org_directory" => {
+            Some(crate::abilities::provenance::GleanDownstream::OrgDirectory)
+        }
+        "glean_documents" | "glean_document" => {
+            Some(crate::abilities::provenance::GleanDownstream::Documents)
+        }
+        source if source.starts_with("glean") => {
+            Some(crate::abilities::provenance::GleanDownstream::Unknown)
+        }
+        _ => None,
+    }
+}
+
+fn projection_provenance_data_source(source: &str) -> crate::abilities::provenance::DataSource {
+    let normalized = source.trim();
+    if let Some(downstream) = glean_downstream_for_projection_source(normalized) {
+        return crate::abilities::provenance::DataSource::Glean { downstream };
+    }
+    match normalized.to_ascii_lowercase().as_str() {
+        "user" | "user_correction" => crate::abilities::provenance::DataSource::User,
+        "google" | "gmail" | "email" => crate::abilities::provenance::DataSource::Google,
+        "clay" => crate::abilities::provenance::DataSource::Clay,
+        "local_enrichment" | "local_file" | "workspace_file" | "transcript" | "meeting"
+        | "post_meeting" | "calendar" => crate::abilities::provenance::DataSource::LocalEnrichment,
+        "ai" | "ai_enrichment" | "ai_inference" | "pty_synthesis" => {
+            crate::abilities::provenance::DataSource::Ai
+        }
+        "" => crate::abilities::provenance::DataSource::LegacyUnattributed,
+        other => crate::abilities::provenance::DataSource::Other(
+            crate::abilities::provenance::SourceName::new(other),
+        ),
+    }
+}
+
+fn projection_provenance_actor(actor: &str) -> crate::abilities::provenance::Actor {
+    let actor = actor.trim();
+    if actor.eq_ignore_ascii_case("user") || actor.starts_with("user:") {
+        return crate::abilities::provenance::Actor::User;
+    }
+    if let Some(agent) = actor.strip_prefix("agent:") {
+        return crate::abilities::provenance::Actor::Agent {
+            name: agent.to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+    }
+    crate::abilities::provenance::Actor::System {
+        component: if actor.is_empty() {
+            "intelligence_projection".to_string()
+        } else {
+            actor.to_string()
+        },
+    }
+}
+
+fn projection_source_identifier(
+    data_source: &crate::abilities::provenance::DataSource,
+    input: &ProjectionClaimInput<'_>,
+    subject_id: &str,
+    source_asof: Option<DateTime<Utc>>,
+    observed_at: DateTime<Utc>,
+) -> crate::abilities::provenance::SourceIdentifier {
+    if let crate::abilities::provenance::DataSource::Glean { downstream } = data_source {
+        return crate::abilities::provenance::SourceIdentifier::OpaqueGleanSource {
+            downstream: downstream.clone(),
+            opaque_ref: input
+                .item_source
+                .and_then(|source| source.reference.as_deref())
+                .map(str::trim)
+                .filter(|reference| !reference.is_empty())
+                .unwrap_or(input.field_path)
+                .to_string(),
+            cited_as_of: source_asof.unwrap_or(observed_at),
+        };
+    }
+
+    crate::abilities::provenance::SourceIdentifier::Entity {
+        entity_id: crate::abilities::provenance::EntityId::new(subject_id.to_string()),
+        field: Some(input.field_path.to_string()),
+    }
+}
+
+fn projection_provenance_json(
+    ctx: &ServiceContext<'_>,
+    input: &ProjectionClaimInput<'_>,
+    observed_at: &str,
+    source_ref: Option<&str>,
+    claim_data_source: &str,
+) -> Result<String, String> {
+    let (subject_kind, subject_id) = projection_subject_lookup_parts(input.subject_ref)?;
+    let subject_ref = projection_provenance_subject_ref(&subject_kind, &subject_id)?;
+    let subject = crate::abilities::provenance::SubjectAttribution::direct_confident(subject_ref);
+    let observed_at = parse_projection_timestamp(observed_at).unwrap_or_else(|| ctx.clock.now());
+    let source_asof = input.source_asof.and_then(parse_projection_timestamp);
+    let data_source = projection_provenance_data_source(claim_data_source);
+    let source_identifier =
+        projection_source_identifier(&data_source, input, &subject_id, source_asof, observed_at);
+    let source = crate::abilities::provenance::SourceAttribution::new(
+        data_source,
+        vec![source_identifier],
+        observed_at,
+        source_asof,
+        projection_item_confidence(input.item_source),
+        None,
+    )
+    .map_err(|error| format!("projection source provenance invalid: {error}"))?;
+
+    let mut config = crate::abilities::provenance::ProvenanceBuilderConfig::new(
+        "claim_shaped_intelligence_projection",
+        ctx.clock.now(),
+    );
+    config.invocation_id = crate::abilities::provenance::InvocationId::new(uuid::Uuid::new_v4());
+    config.actor = projection_provenance_actor(input.actor);
+    config.mode = ctx.mode.into();
+    config.category = crate::abilities::registry::AbilityCategory::Transform;
+
+    let mut builder = crate::abilities::provenance::ProvenanceBuilder::new(config);
+    builder.set_subject(subject.clone());
+    let source_index = builder.add_source(source);
+    let explanation = crate::abilities::provenance::SanitizedExplanation::new(
+        "Generated projection committed as claim-shaped intelligence.",
+    )
+    .map_err(|error| format!("projection provenance explanation invalid: {error}"))?;
+    let field_attribution = crate::abilities::provenance::FieldAttribution::llm_synthesis(
+        subject,
+        vec![crate::abilities::provenance::SourceRef::Source { source_index }],
+        crate::abilities::provenance::Confidence::provider_reported(projection_item_confidence(
+            input.item_source,
+        ))
+        .map_err(|error| format!("projection provenance confidence invalid: {error}"))?,
+        Some(explanation),
+    )
+    .map_err(|error| format!("projection field provenance invalid: {error}"))?;
+    builder
+        .attribute_subtree(
+            crate::abilities::provenance::FieldPath::root(),
+            field_attribution,
+        )
+        .map_err(|error| format!("projection provenance attribution failed: {error}"))?;
+
+    let output = serde_json::json!({
+        "claimType": input.claim_type,
+        "fieldPath": input.field_path,
+        "text": input.text,
+        "dataSource": claim_data_source,
+        "sourceRef": source_ref,
+        "sourceAsOf": input.source_asof,
+    });
+    let output = builder
+        .finalize(output)
+        .map_err(|error| format!("projection provenance validation failed: {error}"))?;
+    serde_json::to_string(output.provenance())
+        .map_err(|error| format!("projection provenance serialization failed: {error}"))
 }
 
 fn non_empty_join(parts: impl IntoIterator<Item = String>) -> Option<String> {
@@ -366,6 +668,7 @@ struct ProjectionClaimInput<'a> {
     subject_ref: &'a str,
     actor: &'a str,
     data_source: &'a str,
+    item_source: Option<&'a crate::intelligence::io::ItemSource>,
     source_asof: Option<&'a str>,
     claim_type: &'a str,
     field_path: &'a str,
@@ -387,7 +690,15 @@ fn commit_projection_claim(
         return Ok(());
     }
     let historical_backfill = input.data_source == "legacy_intelligence_backfill";
-    let supersedes = match projection_claim_preflight(db, &input, historical_backfill)? {
+    let claim_data_source = projection_claim_data_source(input.data_source, input.item_source);
+    let source_ref = projection_source_ref(&input);
+    let supersedes = match projection_claim_preflight(
+        db,
+        &input,
+        source_ref.as_deref(),
+        &claim_data_source,
+        historical_backfill,
+    )? {
         ProjectionClaimPreflight::ExactActiveClaimAlreadyExists => return Ok(()),
         ProjectionClaimPreflight::Commit { supersedes } => supersedes,
     };
@@ -395,6 +706,13 @@ fn commit_projection_claim(
         .source_asof
         .map(str::to_string)
         .unwrap_or_else(|| ctx.clock.now().to_rfc3339());
+    let provenance_json = projection_provenance_json(
+        ctx,
+        &input,
+        &observed_at,
+        source_ref.as_deref(),
+        &claim_data_source,
+    )?;
     crate::services::claims::commit_claim(
         ctx,
         db,
@@ -407,15 +725,15 @@ fn commit_projection_claim(
             topic_key: None,
             text: input.text.to_string(),
             actor: input.actor.to_string(),
-            data_source: input.data_source.to_string(),
-            source_ref: None,
+            data_source: claim_data_source,
+            source_ref,
             source_asof: input.source_asof.map(str::to_string),
             observed_at,
-            provenance_json: "{}".to_string(),
-            metadata_json: projection_metadata(input.legacy_value),
+            provenance_json,
+            metadata_json: projection_metadata(input.legacy_value, input.data_source),
             thread_id: None,
-            temporal_scope: None,
-            sensitivity: None,
+            temporal_scope: Some(crate::db::claims::TemporalScope::State),
+            sensitivity: Some(crate::db::claims::ClaimSensitivity::Internal),
             supersedes,
             tombstone: None,
         },
@@ -427,6 +745,8 @@ fn commit_projection_claim(
 fn projection_claim_preflight(
     db: &ActionDb,
     input: &ProjectionClaimInput<'_>,
+    target_source_ref: Option<&str>,
+    target_data_source: &str,
     historical_backfill: bool,
 ) -> Result<ProjectionClaimPreflight, String> {
     let target_source_asof = input.source_asof.map(str::to_string);
@@ -444,11 +764,15 @@ fn projection_claim_preflight(
                 AND claim_type = ?3
                 AND coalesce(field_path, '') = coalesce(?4, '')
                 AND text = ?5
-                AND source_ref IS NULL
                 AND (
-                    (source_asof IS NULL AND ?6 IS NULL)
-                    OR source_asof = ?6
+                    (source_ref IS NULL AND ?6 IS NULL)
+                    OR source_ref = ?6
                 )
+                AND (
+                    (source_asof IS NULL AND ?7 IS NULL)
+                    OR source_asof = ?7
+                )
+                AND data_source = ?8
                 AND claim_state = 'active'
                 AND surfacing_state = 'active'
               LIMIT 1",
@@ -458,7 +782,9 @@ fn projection_claim_preflight(
                 input.claim_type,
                 input.field_path,
                 target_text.as_str(),
-                target_source_asof.as_deref()
+                target_source_ref,
+                target_source_asof.as_deref(),
+                target_data_source
             ],
             |row| row.get::<_, i64>(0),
         )
@@ -469,41 +795,7 @@ fn projection_claim_preflight(
         return Ok(ProjectionClaimPreflight::ExactActiveClaimAlreadyExists);
     }
 
-    let supersedes = db
-        .conn_ref()
-        .query_row(
-            "SELECT id
-               FROM intelligence_claims
-              WHERE json_valid(subject_ref) = 1
-                AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
-                AND json_extract(subject_ref, '$.id') = ?2
-                AND claim_type = ?3
-                AND coalesce(field_path, '') = coalesce(?4, '')
-                AND text = ?5
-                AND source_ref IS NULL
-                AND (
-                    (source_asof IS NULL AND ?6 IS NOT NULL)
-                    OR (source_asof IS NOT NULL AND ?6 IS NULL)
-                    OR source_asof != ?6
-                )
-                AND claim_state = 'active'
-                AND surfacing_state = 'active'
-              ORDER BY created_at DESC
-              LIMIT 1",
-            params![
-                kind.as_str(),
-                id.as_str(),
-                input.claim_type,
-                input.field_path,
-                target_text.as_str(),
-                target_source_asof.as_deref()
-            ],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()
-        .map_err(|e| format!("projection supersession preflight failed: {e}"))?;
-
-    if historical_backfill && supersedes.is_none() {
+    if historical_backfill {
         let same_field_exists = db
             .conn_ref()
             .query_row(
@@ -533,7 +825,57 @@ fn projection_claim_preflight(
         }
     }
 
-    Ok(ProjectionClaimPreflight::Commit { supersedes })
+    if input.data_source.trim().eq_ignore_ascii_case("glean") {
+        let superseded_progressive_id = db
+            .conn_ref()
+            .query_row(
+                "SELECT id
+                   FROM intelligence_claims
+                  WHERE json_valid(subject_ref) = 1
+                    AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
+                    AND json_extract(subject_ref, '$.id') = ?2
+                    AND claim_type = ?3
+                    AND coalesce(field_path, '') = coalesce(?4, '')
+                    AND text = ?5
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND (
+                        data_source = 'ai_enrichment_progressive'
+                        OR (
+                            metadata_json IS NOT NULL
+                            AND json_valid(metadata_json) = 1
+                            AND json_extract(metadata_json, '$.projection_producer') = 'ai_enrichment_progressive'
+                        )
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                          FROM claim_corroborations cc_local
+                         WHERE cc_local.claim_id = intelligence_claims.id
+                           AND cc_local.data_source != 'ai_enrichment_progressive'
+                           AND cc_local.data_source != 'glean'
+                           AND cc_local.data_source NOT LIKE 'glean_%'
+                    )
+                  ORDER BY created_at DESC
+                  LIMIT 1",
+                params![
+                    kind.as_str(),
+                    id.as_str(),
+                    input.claim_type,
+                    input.field_path,
+                    target_text.as_str(),
+                ],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|e| format!("projection progressive supersession preflight failed: {e}"))?;
+        if let Some(supersedes) = superseded_progressive_id {
+            return Ok(ProjectionClaimPreflight::Commit {
+                supersedes: Some(supersedes),
+            });
+        }
+    }
+
+    Ok(ProjectionClaimPreflight::Commit { supersedes: None })
 }
 
 fn projection_subject_lookup_parts(subject_ref: &str) -> Result<(String, String), String> {
@@ -572,6 +914,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: None,
                 source_asof: None,
                 claim_type: "entity_summary",
                 field_path: "executiveAssessment",
@@ -589,6 +932,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: None,
                 source_asof: None,
                 claim_type: "entity_summary",
                 field_path: "pullQuote",
@@ -607,6 +951,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: "entity_current_state",
                     field_path: "health",
@@ -625,6 +970,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: "recommendation",
                     field_path: &format!("health.recommendedActions[{idx}]"),
@@ -643,6 +989,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: risk.item_source.as_ref(),
                 source_asof: source_asof_from_item_source(risk.item_source.as_ref()),
                 claim_type: "entity_risk",
                 field_path: &format!("risks[{idx}]"),
@@ -664,6 +1011,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: None,
                 source_asof: None,
                 claim_type: "recommendation",
                 field_path: &format!("recommendedActions[{idx}]"),
@@ -682,6 +1030,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: win.item_source.as_ref(),
                 source_asof: source_asof_from_item_source(win.item_source.as_ref()),
                 claim_type: "entity_win",
                 field_path: &format!("recentWins[{idx}]"),
@@ -701,6 +1050,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: "entity_current_state",
                     field_path: "currentState",
@@ -723,6 +1073,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: None,
                 source_asof: None,
                 claim_type: "entity_current_state",
                 field_path: &format!("strategicPriorities[{idx}]"),
@@ -744,6 +1095,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: None,
                 source_asof: None,
                 claim_type: "entity_risk",
                 field_path: &format!("blockers[{idx}]"),
@@ -763,6 +1115,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: if intel.entity_type == "account" {
                         "company_context"
@@ -789,6 +1142,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: signal.item_source.as_ref(),
                 source_asof: source_asof_from_item_source(signal.item_source.as_ref()),
                 claim_type: "entity_current_state",
                 field_path: &format!("expansionSignals[{idx}]"),
@@ -808,6 +1162,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: "entity_current_state",
                     field_path: "agreementOutlook",
@@ -827,6 +1182,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &subject_ref,
                 actor,
                 data_source,
+                item_source: value.item_source.as_ref(),
                 source_asof: source_asof_from_item_source(value.item_source.as_ref()),
                 claim_type: "value_delivered",
                 field_path: &format!("valueDelivered[{idx}]"),
@@ -849,6 +1205,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: None,
                     source_asof: None,
                     claim_type: "entity_current_state",
                     field_path: &format!("successMetrics[{idx}]"),
@@ -872,6 +1229,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     subject_ref: &subject_ref,
                     actor,
                     data_source,
+                    item_source: commitment.item_source.as_ref(),
                     source_asof: source_asof_from_item_source(commitment.item_source.as_ref()),
                     claim_type: if intel.entity_type == "account" {
                         "commitment"
@@ -902,6 +1260,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 subject_ref: &person_subject_ref,
                 actor,
                 data_source,
+                item_source: insight.item_source.as_ref(),
                 source_asof: source_asof_from_item_source(insight.item_source.as_ref()),
                 claim_type: "stakeholder_engagement",
                 field_path: &format!("stakeholderInsights[{idx}].engagement"),
@@ -922,6 +1281,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                         subject_ref: &subject_ref,
                         actor,
                         data_source,
+                        item_source: None,
                         source_asof: None,
                         claim_type: "company_context",
                         field_path: "companyContext",
@@ -1500,6 +1860,7 @@ pub async fn enrich_entity(
         &db,
         &input,
         &parsed.intel,
+        parsed.producer,
         Some(&ai_config),
     ) {
         Ok(composition) => composition,
@@ -1522,9 +1883,14 @@ pub async fn enrich_entity(
             ctx,
             tx,
             &state.signals.engine,
-            &input.entity_type,
-            &input.entity_id,
-            prepared.intelligence(),
+            EnrichmentAssessmentUpsert {
+                entity_type: &input.entity_type,
+                entity_id: &input.entity_id,
+                intel: prepared.intelligence(),
+                projection_intel: prepared.projection_intelligence(),
+                projection_data_source: parsed.producer.projection_data_source(),
+                cleared_dimensions: prepared.cleared_dimensions(),
+            },
         )
     }) {
         emit_manual_refresh_failed_best_effort(
@@ -1633,33 +1999,56 @@ pub fn upsert_assessment_from_enrichment(
             ctx,
             tx,
             engine,
-            entity_type,
-            entity_id,
-            intel,
+            EnrichmentAssessmentUpsert {
+                entity_type,
+                entity_id,
+                intel,
+                projection_intel: intel,
+                projection_data_source: "ai_enrichment",
+                cleared_dimensions: &[],
+            },
         )
     })
+}
+
+pub(crate) struct EnrichmentAssessmentUpsert<'a> {
+    pub entity_type: &'a str,
+    pub entity_id: &'a str,
+    pub intel: &'a crate::intelligence::IntelligenceJson,
+    pub projection_intel: &'a crate::intelligence::IntelligenceJson,
+    pub projection_data_source: &'a str,
+    pub cleared_dimensions: &'a [&'static str],
 }
 
 pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
     ctx: &ServiceContext<'_>,
     tx: &ActionDb,
     engine: &PropagationEngine,
-    entity_type: &str,
-    entity_id: &str,
-    intel: &crate::intelligence::IntelligenceJson,
+    upsert: EnrichmentAssessmentUpsert<'_>,
 ) -> Result<(), String> {
     ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     // Merge value_delivered — preserve user-confirmed items during re-enrichment.
-    let mut intel = intel.clone();
-    if let Ok(Some(existing)) = tx.get_entity_intelligence(entity_id) {
+    let mut intel = upsert.intel.clone();
+    let mut projection_intel = upsert.projection_intel.clone();
+    if let Ok(Some(existing)) = tx.get_entity_intelligence(upsert.entity_id) {
         merge_user_confirmed_values(&mut intel, &existing);
+        if upsert.projection_data_source != "glean" {
+            merge_user_confirmed_values(&mut projection_intel, &existing);
+        }
     }
     commit_claim_shaped_intelligence_projection(
         ctx,
         tx,
-        &intel,
+        &projection_intel,
         "agent:intelligence",
-        "ai_enrichment",
+        upsert.projection_data_source,
+    )?;
+    withdraw_cleared_dimension_projection_claims(
+        ctx,
+        tx,
+        upsert.entity_type,
+        upsert.entity_id,
+        upsert.cleared_dimensions,
     )?;
     crate::services::derived_state::upsert_entity_intelligence_legacy_snapshot(ctx, tx, &intel)
         .map_err(|e| e.to_string())?;
@@ -1667,39 +2056,51 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
         ctx,
         tx,
         engine,
-        entity_type,
-        entity_id,
+        upsert.entity_type,
+        upsert.entity_id,
         "entity_intelligence_updated",
         "ai_enrichment",
         None,
         0.8,
     )
     .map_err(|e| format!("signal emit failed: {e}"))?;
-    enqueue_projection_claim_recomputes(ctx, tx, &signal_id, entity_type, entity_id, &intel);
+    enqueue_projection_claim_recomputes(
+        ctx,
+        tx,
+        &signal_id,
+        upsert.entity_type,
+        upsert.entity_id,
+        &intel,
+    );
 
     // After enrichment, reconcile AI objectives with user objectives
-    if entity_type == "account" {
-        if let Err(e) = crate::services::success_plans::reconcile_objectives(ctx, tx, entity_id) {
-            log::warn!("Objective reconciliation failed for {entity_id}: {e}");
+    if upsert.entity_type == "account" {
+        if let Err(e) =
+            crate::services::success_plans::reconcile_objectives(ctx, tx, upsert.entity_id)
+        {
+            log::warn!(
+                "Objective reconciliation failed for {}: {e}",
+                upsert.entity_id
+            );
         }
     }
 
     // DOS Work-tab: Best-effort bridge of AI-inferred commitments → Actions.
     // Enrichment write is the source of truth; bridge errors must not fail it.
-    if entity_type == "account" {
+    if upsert.entity_type == "account" {
         if let Some(ref commitments) = intel.open_commitments {
             let sync_result =
                 crate::services::commitment_bridge::intelligence_commitment_ingestion_items(
-                    entity_type,
-                    entity_id,
+                    upsert.entity_type,
+                    upsert.entity_id,
                     commitments,
                 )
                 .and_then(|items| {
                     crate::services::commitment_bridge::sync_ai_commitments_with_ingestion_sources(
                         ctx,
                         tx,
-                        entity_type,
-                        entity_id,
+                        upsert.entity_type,
+                        upsert.entity_id,
                         &items,
                     )
                 });
@@ -1711,11 +2112,13 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
                     summary.skipped_tombstoned,
                     summary.skipped_missing_id,
                     summary.skipped_malformed_id,
-                    entity_type,
-                    entity_id
+                    upsert.entity_type,
+                    upsert.entity_id
                 ),
                 Err(e) => log::warn!(
-                    "commitment_bridge sync failed for {entity_type}:{entity_id} (non-fatal): {e}"
+                    "commitment_bridge sync failed for {}:{} (non-fatal): {e}",
+                    upsert.entity_type,
+                    upsert.entity_id
                 ),
             }
         }
@@ -1769,6 +2172,264 @@ fn enqueue_projection_claim_recomputes(
                 );
             }
         }
+    }
+}
+
+fn withdraw_cleared_dimension_projection_claims(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    cleared_dimensions: &[&'static str],
+) -> Result<usize, String> {
+    let field_path_roots = projection_field_path_roots_for_cleared_dimensions(cleared_dimensions);
+    if field_path_roots.is_empty() {
+        return Ok(0);
+    }
+
+    let withdrawn =
+        crate::services::claims::withdraw_generated_projection_claims_for_field_path_roots_in_tx(
+            ctx,
+            tx,
+            entity_type,
+            entity_id,
+            &field_path_roots,
+            "dimension_not_applicable",
+        )
+        .map_err(|error| format!("withdraw cleared-dimension projection claims failed: {error}"))?;
+    if withdrawn > 0 {
+        log::info!(
+            "intelligence: withdrew {withdrawn} generated projection claim(s) for cleared dimensions on {entity_type}:{entity_id}"
+        );
+    }
+    Ok(withdrawn)
+}
+
+fn projection_field_path_roots_for_cleared_dimensions(
+    cleared_dimensions: &[&'static str],
+) -> Vec<&'static str> {
+    let mut roots = BTreeSet::new();
+    for dimension in cleared_dimensions {
+        let dimension_roots: &[&'static str] = match *dimension {
+            "core_assessment" => &[
+                "executiveAssessment",
+                "pullQuote",
+                "currentState",
+                "risks",
+                "recentWins",
+            ],
+            "stakeholder_champion" => &[
+                "stakeholderInsights",
+                "coverageAssessment",
+                "organizationalChanges",
+                "internalTeam",
+                "relationshipDepth",
+            ],
+            "commercial_financial" => &[
+                "health",
+                "contractContext",
+                "agreementOutlook",
+                "expansionSignals",
+                "blockers",
+                "productClassification",
+            ],
+            "strategic_context" => &[
+                "companyContext",
+                "competitiveContext",
+                "strategicPriorities",
+                "marketContext",
+                "regulatoryContext",
+            ],
+            "value_success" => &[
+                "valueDelivered",
+                "successMetrics",
+                "successPlanSignals",
+                "openCommitments",
+            ],
+            "engagement_signals" => &[
+                "meetingCadence",
+                "emailResponsiveness",
+                "productAdoption",
+                "supportHealth",
+                "gongCallSummaries",
+                "npsCsat",
+            ],
+            crate::intelligence::dimension_prompts::ACCOUNT_ONLY_ENGAGEMENT_FIELDS_CLEAR => &[
+                "productAdoption",
+                "supportHealth",
+                "gongCallSummaries",
+                "npsCsat",
+            ],
+            _ => &[],
+        };
+        roots.extend(dimension_roots.iter().copied());
+    }
+    roots.into_iter().collect()
+}
+
+pub fn purge_glean_generated_projection_claims_for_source_purge(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+) -> Result<GeneratedProjectionSourcePurgeReport, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    let subjects = load_glean_generated_projection_claim_subjects(db)?;
+    let claims_withdrawn =
+        crate::services::claims::withdraw_glean_generated_projection_claims_for_source_purge_in_tx(
+            ctx, db,
+        )
+        .map_err(|e| format!("withdraw Glean generated projection claims failed: {e}"))?;
+
+    let mut recompute_jobs_enqueued = 0usize;
+    if !subjects.is_empty() {
+        for (subject_type, subject_id) in subjects {
+            match enqueue_generated_projection_claim_recompute_in_tx(
+                ctx,
+                db,
+                &subject_type,
+                &subject_id,
+                "glean_source_purge",
+            ) {
+                Ok(true) => recompute_jobs_enqueued += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    record_generated_projection_recompute_failure(
+                        ctx,
+                        db,
+                        &subject_type,
+                        &subject_id,
+                        &error,
+                    );
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    Ok(GeneratedProjectionSourcePurgeReport {
+        claims_withdrawn,
+        recompute_jobs_enqueued,
+    })
+}
+
+fn load_glean_generated_projection_claim_subjects(
+    db: &ActionDb,
+) -> Result<BTreeSet<(String, String)>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT DISTINCT lower(json_extract(subject_ref, '$.kind')),
+                            json_extract(subject_ref, '$.id')
+               FROM intelligence_claims
+              WHERE claim_state IN ('active', 'tombstoned', 'dormant')
+                AND json_valid(subject_ref) = 1
+                AND (
+                    data_source = 'glean'
+                    OR data_source LIKE 'glean_%'
+                    OR (
+                        metadata_json IS NOT NULL
+                        AND json_valid(metadata_json) = 1
+                        AND json_extract(metadata_json, '$.projection_producer') = 'glean'
+                        AND data_source IN ('ai', 'ai_enrichment', 'ai_inference')
+                    )
+                    OR (
+                        EXISTS (
+                            SELECT 1
+                              FROM claim_corroborations cc
+                             WHERE cc.claim_id = intelligence_claims.id
+                               AND (
+                                   cc.data_source = 'glean'
+                                   OR cc.data_source LIKE 'glean_%'
+                               )
+                        )
+                    )
+                )
+                AND (
+                    source_ref LIKE 'intelligence_projection_source:%'
+                    OR (
+                        json_valid(provenance_json) = 1
+                        AND json_extract(provenance_json, '$.ability_name') = 'claim_shaped_intelligence_projection'
+                    )
+                    OR (
+                        metadata_json IS NOT NULL
+                        AND json_valid(metadata_json) = 1
+                        AND json_type(metadata_json, '$.legacy_projection_value') IS NOT NULL
+                    )
+                )",
+        )
+        .map_err(|e| format!("prepare Glean generated projection subject scan failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|e| format!("query Glean generated projection subjects failed: {e}"))?;
+    rows.collect::<Result<BTreeSet<_>, _>>()
+        .map_err(|e| format!("collect Glean generated projection subjects failed: {e}"))
+}
+
+fn enqueue_generated_projection_claim_recompute_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    subject_type: &str,
+    subject_id: &str,
+    reason: &str,
+) -> Result<bool, String> {
+    let source_claim_version = db
+        .current_subject_claim_version(subject_type, subject_id)
+        .map_err(|error| {
+            format!("read {subject_type}:{subject_id} claim version failed: {error}")
+        })?;
+    let payload = serde_json::json!({
+        "reason": reason,
+        "source_claim_version": source_claim_version,
+    })
+    .to_string();
+    let outcome = crate::services::signals::emit_once_for_key(
+        ctx,
+        db,
+        &format!(
+            "generated_projection_claims:{reason}:{subject_type}:{subject_id}:{source_claim_version}"
+        ),
+        subject_type,
+        subject_id,
+        "generated_projection_claims_updated",
+        "claim_projection",
+        Some(&payload),
+        0.8,
+    )
+    .map_err(|error| format!("signal emit failed: {error}"))?;
+    if outcome.coalesced {
+        return Ok(false);
+    }
+
+    crate::services::invalidation_jobs::enqueue_signal_claim_recompute_in_tx(
+        db,
+        &outcome.id,
+        subject_type,
+        subject_id,
+    )?;
+    Ok(true)
+}
+
+fn record_generated_projection_recompute_failure(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    subject_type: &str,
+    subject_id: &str,
+    error: &str,
+) {
+    if let Err(record_error) = crate::services::mutations::record_pipeline_failure(
+        ctx,
+        db,
+        "generated_projection_claims",
+        Some(subject_id),
+        Some(subject_type),
+        "source_purge_recompute_enqueue_failed",
+        Some(error),
+        0,
+    ) {
+        log::warn!(
+            "generated_projection_claims: failed to record recompute enqueue failure for {subject_type}:{subject_id}: {record_error}"
+        );
     }
 }
 
@@ -3133,6 +3794,1101 @@ pub fn get_all_recommended_actions(
     }
 
     Ok(all_actions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+    use crate::db::{AccountType, DbAccount};
+    use crate::intelligence::{IntelRisk, IntelligenceJson, ItemSource};
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use crate::signals::propagation::PropagationEngine;
+    use chrono::TimeZone;
+    use rusqlite::params;
+
+    fn test_ctx<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        ext: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, ext)
+    }
+
+    fn seed_account(db: &ActionDb, account_id: &str) {
+        db.upsert_account(&DbAccount {
+            id: account_id.to_string(),
+            name: format!("Account {account_id}"),
+            account_type: AccountType::Customer,
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+            ..Default::default()
+        })
+        .expect("seed account");
+    }
+
+    fn generated_risk_intel(account_id: &str) -> IntelligenceJson {
+        IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            risks: vec![IntelRisk {
+                render_policy: None,
+                claim_id: None,
+                text: "Renewal owner has not approved the deployment plan.".to_string(),
+                item_source: Some(ItemSource {
+                    source: "glean_crm".to_string(),
+                    confidence: 0.9,
+                    sourced_at: "2026-05-20T10:30:00Z".to_string(),
+                    reference: Some("CRM opportunity fixture".to_string()),
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn upsert_glean_assessment_from_enrichment(
+        ctx: &ServiceContext<'_>,
+        db: &ActionDb,
+        engine: &PropagationEngine,
+        entity_type: &str,
+        entity_id: &str,
+        intel: &IntelligenceJson,
+    ) -> Result<(), String> {
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                ctx,
+                tx,
+                engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type,
+                    entity_id,
+                    intel,
+                    projection_intel: intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+    }
+
+    fn active_generated_risk_count(db: &ActionDb, account_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active generated risk count")
+    }
+
+    fn active_generated_risk_id(db: &ActionDb, account_id: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT id
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1
+                  ORDER BY created_at DESC
+                  LIMIT 1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active generated risk id")
+    }
+
+    fn withdrawn_generated_risk_count(db: &ActionDb, account_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'withdrawn'
+                    AND surfacing_state = 'dormant'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("withdrawn generated risk count")
+    }
+
+    #[test]
+    fn generated_risk_claim_carries_item_source_as_source_asof() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-source";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(42);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &generated_risk_intel(account_id),
+        )
+        .expect("commit generated risk projection");
+
+        let (
+            actor,
+            data_source,
+            source_ref,
+            source_asof,
+            provenance_json,
+            temporal_scope,
+            sensitivity,
+        ): (
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            String,
+            String,
+            String,
+        ) = db
+            .conn_ref()
+            .query_row(
+                "SELECT actor, data_source, source_ref, source_asof, provenance_json, temporal_scope, sensitivity
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .expect("read generated risk claim");
+
+        assert_eq!(actor, "agent:intelligence");
+        assert_eq!(data_source, "glean_crm");
+        assert_eq!(source_asof.as_deref(), Some("2026-05-20T10:30:00Z"));
+        assert_eq!(temporal_scope, "state");
+        assert_eq!(sensitivity, "internal");
+        assert!(
+            source_ref
+                .as_deref()
+                .is_some_and(|value| value.starts_with(GENERATED_PROJECTION_SOURCE_REF_PREFIX)),
+            "generated risk should carry a stable source reference"
+        );
+
+        let provenance: serde_json::Value =
+            serde_json::from_str(&provenance_json).expect("provenance JSON");
+        assert_eq!(provenance["provenance_schema_version"], 1);
+        assert_eq!(
+            provenance["ability_name"],
+            "claim_shaped_intelligence_projection"
+        );
+        assert_eq!(
+            provenance["sources"][0]["data_source"]["glean"]["downstream"],
+            "salesforce"
+        );
+        assert_eq!(
+            provenance["sources"][0]["source_asof"],
+            "2026-05-20T10:30:00Z"
+        );
+        assert!(
+            provenance["field_attributions"]
+                .as_object()
+                .is_some_and(|fields| !fields.is_empty()),
+            "validated provenance envelope should attribute the generated claim"
+        );
+    }
+
+    #[test]
+    fn generated_projection_same_text_new_evidence_reinforces() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-reinforce";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(43);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &generated_risk_intel(account_id),
+        )
+        .expect("commit first generated risk projection");
+        let first_id = active_generated_risk_id(&db, account_id);
+
+        let mut second = generated_risk_intel(account_id);
+        let item_source = second.risks[0]
+            .item_source
+            .as_mut()
+            .expect("risk item source");
+        item_source.sourced_at = "2026-05-21T10:30:00Z".to_string();
+        item_source.reference = Some("CRM opportunity follow-up fixture".to_string());
+
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &second)
+            .expect("commit reinforcing generated risk projection");
+
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+        assert_eq!(
+            active_generated_risk_id(&db, account_id),
+            first_id,
+            "same generated claim with new evidence should reinforce the existing claim"
+        );
+        let corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean_crm'
+                    AND source_asof = '2026-05-21T10:30:00Z'",
+                params![&first_id],
+                |row| row.get(0),
+            )
+            .expect("corroboration count");
+        assert_eq!(corroboration_count, 1);
+    }
+
+    #[test]
+    fn account_only_engagement_clear_maps_to_account_only_projection_roots() {
+        let roots = super::projection_field_path_roots_for_cleared_dimensions(&[
+            crate::intelligence::dimension_prompts::ACCOUNT_ONLY_ENGAGEMENT_FIELDS_CLEAR,
+        ]);
+
+        assert!(roots.contains(&"productAdoption"));
+        assert!(roots.contains(&"supportHealth"));
+        assert!(roots.contains(&"gongCallSummaries"));
+        assert!(roots.contains(&"npsCsat"));
+        assert!(
+            !roots.contains(&"meetingCadence"),
+            "person/project cadence remains applicable when only account-only engagement fields clear"
+        );
+        assert!(
+            !roots.contains(&"emailResponsiveness"),
+            "person/project responsiveness remains applicable when only account-only engagement fields clear"
+        );
+    }
+
+    #[test]
+    fn glean_source_purge_withdraws_generated_projection_claim() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-purge";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(44);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &generated_risk_intel(account_id),
+        )
+        .expect("commit generated risk projection");
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        assert_eq!(active_generated_risk_count(&db, account_id), 0);
+        assert_eq!(withdrawn_generated_risk_count(&db, account_id), 1);
+    }
+
+    #[test]
+    fn glean_source_purge_withdraws_generated_projection_without_source_ref() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-purge-no-ref";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(45);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let mut intel = generated_risk_intel(account_id);
+        intel.risks[0]
+            .item_source
+            .as_mut()
+            .expect("risk item source")
+            .reference = None;
+
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("commit generated risk projection without source ref");
+        let source_ref: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT source_ref
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read generated risk source ref");
+        assert_eq!(source_ref, None);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        assert_eq!(active_generated_risk_count(&db, account_id), 0);
+        assert_eq!(withdrawn_generated_risk_count(&db, account_id), 1);
+    }
+
+    #[test]
+    fn glean_source_purge_withdraws_producer_marked_projection_without_item_source() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-summary-purge-no-item-source";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(46);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            executive_assessment: Some("Glean summary without item-level source.".to_string()),
+            ..Default::default()
+        };
+
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: &intel,
+                    projection_intel: &intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+        .expect("commit Glean producer projection without item source");
+        let (data_source, source_ref, projection_producer): (String, Option<String>, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT data_source,
+                        source_ref,
+                        json_extract(metadata_json, '$.projection_producer')
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read generated summary claim");
+        assert_eq!(data_source, "glean");
+        assert_eq!(source_ref, None);
+        assert_eq!(projection_producer, "glean");
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        let active_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("active summary count");
+        assert_eq!(active_count, 0);
+    }
+
+    #[test]
+    fn generated_projection_does_not_trust_model_supplied_privileged_item_source() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-untrusted-item-source";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(48);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let mut intel = generated_risk_intel(account_id);
+        let item_source = intel.risks[0]
+            .item_source
+            .as_mut()
+            .expect("risk item source");
+        item_source.source = "user_correction".to_string();
+        item_source.reference = Some("model-supplied privileged source".to_string());
+
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: &intel,
+                    projection_intel: &intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+        .expect("commit Glean-produced projection with non-Glean item source");
+        let (data_source, projection_producer): (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT data_source,
+                        json_extract(metadata_json, '$.projection_producer')
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read generated risk claim");
+        assert_eq!(data_source, "ai_enrichment");
+        assert_eq!(projection_producer, "glean");
+
+        let pty_account_id = "acc-generated-risk-untrusted-pty-item-source";
+        seed_account(&db, pty_account_id);
+        let mut pty_intel = generated_risk_intel(pty_account_id);
+        pty_intel.risks[0]
+            .item_source
+            .as_mut()
+            .expect("pty risk item source")
+            .source = "user_correction".to_string();
+        upsert_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            pty_account_id,
+            &pty_intel,
+        )
+        .expect("commit PTY-produced projection with untrusted item source");
+        let pty_data_source: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT data_source
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![pty_account_id],
+                |row| row.get(0),
+            )
+            .expect("read PTY generated risk data source");
+        assert_eq!(pty_data_source, "ai_enrichment");
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        assert_eq!(
+            active_generated_risk_count(&db, account_id),
+            0,
+            "model-supplied privileged source labels must not survive Glean source purge"
+        );
+        assert_eq!(
+            active_generated_risk_count(&db, pty_account_id),
+            1,
+            "Glean source purge should not withdraw local producer projections"
+        );
+    }
+
+    #[test]
+    fn glean_projection_preserves_allowed_non_glean_item_source() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-transcript-source";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(51);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let mut intel = generated_risk_intel(account_id);
+        let item_source = intel.risks[0]
+            .item_source
+            .as_mut()
+            .expect("risk item source");
+        item_source.source = "transcript".to_string();
+        item_source.confidence = 0.8;
+        item_source.reference = Some("meeting transcript fixture".to_string());
+
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("commit generated risk projection with transcript evidence");
+        let (data_source, projection_producer, provenance_json): (String, String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT data_source,
+                        json_extract(metadata_json, '$.projection_producer'),
+                        provenance_json
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read generated risk claim");
+        assert_eq!(data_source, "transcript");
+        assert_eq!(projection_producer, "glean");
+        let provenance: serde_json::Value =
+            serde_json::from_str(&provenance_json).expect("provenance JSON");
+        assert_eq!(provenance["sources"][0]["data_source"], "local_enrichment");
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 0);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 0);
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+    }
+
+    #[test]
+    fn final_glean_projection_supersedes_progressive_projection_with_same_text() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-summary-purge-progressive-glean";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(47);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            executive_assessment: Some(
+                "Glean progressive summary without item-level source.".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        upsert_assessment_snapshot(&ctx, &db, &intel)
+            .expect("commit progressive generated projection");
+        let (claim_id, data_source, projection_producer): (String, String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT id,
+                        data_source,
+                        json_extract(metadata_json, '$.projection_producer')
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read progressive generated summary claim");
+        assert_eq!(data_source, "ai_enrichment_progressive");
+        assert_eq!(projection_producer, "ai_enrichment_progressive");
+
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: &intel,
+                    projection_intel: &intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+        .expect("commit final Glean generated projection");
+        let (active_claim_id, active_data_source, active_projection_producer): (
+            String,
+            String,
+            String,
+        ) = db
+            .conn_ref()
+            .query_row(
+                "SELECT id,
+                        data_source,
+                        json_extract(metadata_json, '$.projection_producer')
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read final active summary claim");
+        assert_ne!(active_claim_id, claim_id);
+        assert_eq!(active_data_source, "glean");
+        assert_eq!(active_projection_producer, "glean");
+        let (progressive_claim_state, progressive_surfacing_state, progressive_superseded_by): (
+            String,
+            String,
+            Option<String>,
+        ) = db
+            .conn_ref()
+            .query_row(
+                "SELECT claim_state, surfacing_state, superseded_by
+                   FROM intelligence_claims
+                  WHERE id = ?1",
+                params![&claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read superseded progressive claim");
+        assert_eq!(progressive_claim_state, "dormant");
+        assert_eq!(progressive_surfacing_state, "dormant");
+        assert_eq!(
+            progressive_superseded_by.as_deref(),
+            Some(active_claim_id.as_str())
+        );
+        let active_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("active summary count after final Glean write");
+        assert_eq!(active_count, 1);
+        let corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("Glean corroboration count");
+        assert_eq!(corroboration_count, 0);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        let active_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("active summary count after purge");
+        assert_eq!(active_count, 0);
+        let withdrawn_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'withdrawn'
+                    AND surfacing_state = 'dormant'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("withdrawn summary count after purge");
+        assert_eq!(withdrawn_count, 1);
+    }
+
+    #[test]
+    fn glean_source_purge_recomputes_local_projection_with_glean_corroboration() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-local-glean-corroboration";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(52);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let intel = generated_risk_intel(account_id);
+
+        upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("commit local generated risk projection");
+        let claim_id = active_generated_risk_id(&db, account_id);
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("reinforce local generated risk projection from Glean");
+
+        assert_eq!(active_generated_risk_id(&db, account_id), claim_id);
+        let glean_corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean_crm'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("Glean corroboration count");
+        assert_eq!(glean_corroboration_count, 1);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 0);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+        let remaining_glean_corroborations: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND (
+                        data_source = 'glean'
+                        OR data_source LIKE 'glean_%'
+                    )",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("remaining Glean corroboration count");
+        assert_eq!(remaining_glean_corroborations, 0);
+    }
+
+    #[test]
+    fn glean_source_purge_preserves_progressive_projection_with_local_corroboration() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-summary-purge-progressive-local";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(49);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            executive_assessment: Some(
+                "Progressive summary with durable local support.".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        upsert_assessment_snapshot(&ctx, &db, &intel)
+            .expect("commit progressive generated projection");
+        let claim_id: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT id
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read progressive generated summary claim");
+
+        upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("reinforce progressive projection from local final write");
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: &intel,
+                    projection_intel: &intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+        .expect("reinforce progressive projection from Glean");
+
+        let local_corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'ai_enrichment'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("local corroboration count");
+        assert_eq!(local_corroboration_count, 1);
+        let glean_corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("Glean corroboration count");
+        assert_eq!(glean_corroboration_count, 1);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 0);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        let active_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE id = ?1
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("active summary count after purge");
+        assert_eq!(active_count, 1);
+        let remaining_glean_corroborations: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("remaining Glean corroboration count");
+        assert_eq!(remaining_glean_corroborations, 0);
+    }
+
+    #[test]
+    fn glean_source_purge_reissues_glean_origin_projection_with_local_corroboration() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-summary-purge-glean-local";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(50);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            executive_assessment: Some("Glean summary with durable local support.".to_string()),
+            ..Default::default()
+        };
+
+        db.with_transaction(|tx| {
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: &intel,
+                    projection_intel: &intel,
+                    projection_data_source: "glean",
+                    cleared_dimensions: &[],
+                },
+            )
+        })
+        .expect("commit Glean-origin generated projection");
+        let claim_id: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT id
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read Glean-origin generated summary claim");
+
+        upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &intel)
+            .expect("reinforce Glean-origin projection from local final write");
+        let local_corroboration_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'ai_enrichment'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("local corroboration count");
+        assert_eq!(local_corroboration_count, 1);
+
+        let report = crate::db::data_lifecycle::purge_source(
+            &db,
+            crate::db::data_lifecycle::DataSource::Glean,
+        )
+        .expect("purge Glean");
+
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        let old_active_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE id = ?1
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("old active summary count after purge");
+        assert_eq!(old_active_count, 0);
+        let (
+            active_claim_id,
+            active_data_source,
+            active_source_ref,
+            active_projection_producer,
+            active_provenance_json,
+        ): (String, String, Option<String>, String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT id,
+                        data_source,
+                        source_ref,
+                        json_extract(metadata_json, '$.projection_producer'),
+                        provenance_json
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_summary'
+                    AND field_path = 'executiveAssessment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("reissued active summary claim");
+        assert_ne!(active_claim_id, claim_id);
+        assert_eq!(active_data_source, "ai_enrichment");
+        assert_eq!(active_source_ref, None);
+        assert_eq!(active_projection_producer, "ai_enrichment");
+        let active_provenance: serde_json::Value =
+            serde_json::from_str(&active_provenance_json).expect("active provenance JSON");
+        assert_eq!(active_provenance["sources"][0]["data_source"], "ai");
+        let remaining_glean_corroborations: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND (
+                        data_source = 'glean'
+                        OR data_source LIKE 'glean_%'
+                    )",
+                params![&claim_id],
+                |row| row.get(0),
+            )
+            .expect("remaining Glean corroboration count");
+        assert_eq!(remaining_glean_corroborations, 0);
+    }
 }
 
 #[cfg(test)]
@@ -6656,7 +8412,7 @@ mod mutation_smoke_tests {
     }
 
     #[test]
-    fn projection_claim_replaces_same_text_when_source_asof_is_repaired() {
+    fn projection_claim_reinforces_same_text_when_source_asof_differs() {
         let db = test_db();
         let account = make_account("acc-projection-source-asof");
         db.upsert_account(&account).unwrap();
@@ -6713,7 +8469,7 @@ mod mutation_smoke_tests {
         .expect("repair projection claim");
 
         let rows = projection_claim_rows(&db, "acc-projection-source-asof");
-        assert_projection_source_asof(&rows, "pullQuote", None);
+        assert_projection_source_asof(&rows, "pullQuote", Some("2026-05-22T12:00:00Z"));
         let active_pull_quote_count = rows
             .iter()
             .filter(|(claim_type, field_path, _, _)| {
@@ -6734,8 +8490,394 @@ mod mutation_smoke_tests {
                 [],
                 |row| row.get(0),
             )
-            .expect("dormant old projection count");
-        assert_eq!(dormant_old_count, 1);
+            .expect("dormant projection count");
+        assert_eq!(dormant_old_count, 0);
+    }
+
+    #[test]
+    fn cleared_dimensions_withdraw_stale_generated_projection_claims() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-cleared-dimension-projection";
+        let account = make_account(account_id);
+        db.upsert_account(&account).unwrap();
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(50);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let prior = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            health: Some(AccountHealth {
+                narrative: Some(
+                    "Commercial health should not survive internal refresh.".to_string(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        super::upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &prior)
+            .expect("seed commercial health projection");
+        let active_before: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active health projection count before clear");
+        assert_eq!(active_before, 1);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut input = make_enrichment_input(account_id, dir.path());
+        input.relationship = Some("internal".to_string());
+        let incoming = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T13:00:00Z".to_string(),
+            executive_assessment: Some(
+                "Internal account context has no commercial health.".to_string(),
+            ),
+            ..Default::default()
+        };
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("compose internal account refresh");
+
+        assert!(
+            prepared
+                .cleared_dimensions()
+                .contains(&"commercial_financial"),
+            "internal account refresh should clear commercial fields"
+        );
+        assert!(prepared.intelligence().health.is_none());
+        db.with_transaction(|tx| {
+            apply_enrichment_side_writes(&ctx, tx, &input, &prepared)?;
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: prepared.intelligence(),
+                    projection_intel: prepared.projection_intelligence(),
+                    projection_data_source: "ai_enrichment",
+                    cleared_dimensions: prepared.cleared_dimensions(),
+                },
+            )
+        })
+        .expect("persist cleared-dimension refresh");
+
+        let active_after: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active health projection count after clear");
+        assert_eq!(active_after, 0);
+        let withdrawn_after: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND claim_state = 'withdrawn'
+                    AND surfacing_state = 'dormant'
+                    AND retraction_reason = 'dimension_not_applicable'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("withdrawn health projection count after clear");
+        assert_eq!(withdrawn_after, 1);
+    }
+
+    #[test]
+    fn partial_glean_projection_does_not_relabel_preserved_local_fields() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-partial-glean-projection";
+        let account = make_account(account_id);
+        db.upsert_account(&account).unwrap();
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(51);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let local = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            health: Some(AccountHealth {
+                narrative: Some(
+                    "Local health posture should remain locally attributed.".to_string(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        super::upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &local)
+            .expect("seed local health projection");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = make_enrichment_input(account_id, dir.path());
+        let incoming = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T13:00:00Z".to_string(),
+            risks: vec![IntelRisk {
+                render_policy: None,
+                claim_id: None,
+                text: "CRM renewal risk requires executive follow-up.".to_string(),
+                item_source: Some(ItemSource {
+                    source: "glean_crm".to_string(),
+                    confidence: 0.86,
+                    sourced_at: "2026-05-22T12:30:00Z".to_string(),
+                    reference: Some("CRM opportunity fixture".to_string()),
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            crate::intel_queue::EnrichmentProducer::Glean,
+            None,
+        )
+        .expect("compose partial Glean refresh");
+
+        assert!(
+            prepared.intelligence().health.is_some(),
+            "legacy snapshot should preserve local health across sparse Glean refresh"
+        );
+        assert!(
+            prepared.projection_intelligence().health.is_none(),
+            "Glean projection should include only fields returned by Glean"
+        );
+        db.with_transaction(|tx| {
+            apply_enrichment_side_writes(&ctx, tx, &input, &prepared)?;
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: prepared.intelligence(),
+                    projection_intel: prepared.projection_intelligence(),
+                    projection_data_source: "glean",
+                    cleared_dimensions: prepared.cleared_dimensions(),
+                },
+            )
+        })
+        .expect("persist partial Glean refresh");
+
+        let persisted = db
+            .get_entity_intelligence(account_id)
+            .expect("read persisted intelligence")
+            .expect("persisted intelligence");
+        assert!(persisted.health.is_some());
+        let glean_health_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND data_source LIKE 'glean%'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active Glean health projection count");
+        assert_eq!(glean_health_count, 0);
+        let local_health_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND data_source = 'ai_enrichment'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active local health projection count");
+        assert_eq!(local_health_count, 1);
+        let risk_data_source: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT data_source
+                   FROM intelligence_claims
+                  WHERE field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active Glean risk projection source");
+        assert_eq!(risk_data_source, "glean_crm");
+    }
+
+    #[test]
+    fn glean_projection_uses_repaired_user_fact_without_preserved_local_fields() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-glean-projection-repaired-fact";
+        let account = make_account(account_id);
+        db.upsert_account(&account).unwrap();
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(52);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let local = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            health: Some(AccountHealth {
+                narrative: Some("Local health must not be relabeled as Glean.".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        super::upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &local)
+            .expect("seed local health projection");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = make_enrichment_input(account_id, dir.path());
+        let incoming = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T13:00:00Z".to_string(),
+            contract_context: Some(ContractContext {
+                contract_type: Some("annual".to_string()),
+                renewal_date: Some("2027-01-01".to_string()),
+                current_arr: Some(1.0),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            crate::intel_queue::EnrichmentProducer::Glean,
+            None,
+        )
+        .expect("compose Glean refresh with corrected account fact");
+
+        assert_eq!(
+            prepared
+                .intelligence()
+                .contract_context
+                .as_ref()
+                .and_then(|context| context.current_arr),
+            Some(100_000.0)
+        );
+        assert_eq!(
+            prepared
+                .projection_intelligence()
+                .contract_context
+                .as_ref()
+                .and_then(|context| context.current_arr),
+            Some(100_000.0),
+            "Glean-generated projection should use repaired account facts"
+        );
+        assert!(
+            prepared.projection_intelligence().health.is_none(),
+            "Glean-generated projection should not relabel preserved local health"
+        );
+
+        db.with_transaction(|tx| {
+            apply_enrichment_side_writes(&ctx, tx, &input, &prepared)?;
+            super::upsert_assessment_from_enrichment_in_active_transaction(
+                &ctx,
+                tx,
+                &engine,
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: account_id,
+                    intel: prepared.intelligence(),
+                    projection_intel: prepared.projection_intelligence(),
+                    projection_data_source: "glean",
+                    cleared_dimensions: prepared.cleared_dimensions(),
+                },
+            )
+        })
+        .expect("persist repaired Glean refresh");
+
+        let contract_text: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT text
+                   FROM intelligence_claims
+                  WHERE field_path = 'contractContext'
+                    AND data_source = 'glean'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active Glean contract projection text");
+        assert!(
+            contract_text.contains("current arr: 100000"),
+            "contract projection text was {contract_text:?}"
+        );
+        let glean_health_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE field_path = 'health'
+                    AND data_source LIKE 'glean%'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active Glean health projection count");
+        assert_eq!(glean_health_count, 0);
     }
 
     #[test]
@@ -7015,8 +9157,14 @@ mod mutation_smoke_tests {
             }],
             ..Default::default()
         };
-        let prepared = compose_enrichment_intelligence_payload(&db, &input, &incoming, None)
-            .expect("compose full path");
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("compose full path");
 
         let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 3, 0, 0, 0).unwrap());
         let rng = SeedableRng::new(42);
@@ -7052,9 +9200,14 @@ mod mutation_smoke_tests {
                 &ctx,
                 tx,
                 &engine,
-                "account",
-                "acc-compose-rollback",
-                prepared.intelligence(),
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: "acc-compose-rollback",
+                    intel: prepared.intelligence(),
+                    projection_intel: prepared.projection_intelligence(),
+                    projection_data_source: "ai_enrichment",
+                    cleared_dimensions: prepared.cleared_dimensions(),
+                },
             )
         });
         if result.is_ok() {
@@ -7204,8 +9357,14 @@ mod mutation_smoke_tests {
             }],
             ..Default::default()
         };
-        let prepared = compose_enrichment_intelligence_payload(&db, &input, &incoming, None)
-            .expect("compose side-write failure input");
+        let prepared = compose_enrichment_intelligence_payload(
+            &db,
+            &input,
+            &incoming,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("compose side-write failure input");
 
         let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 3, 0, 0, 0).unwrap());
         let rng = SeedableRng::new(42);
@@ -7218,9 +9377,14 @@ mod mutation_smoke_tests {
                 &ctx,
                 tx,
                 &engine,
-                "account",
-                "acc-side-write-fails",
-                prepared.intelligence(),
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: "account",
+                    entity_id: "acc-side-write-fails",
+                    intel: prepared.intelligence(),
+                    projection_intel: prepared.projection_intelligence(),
+                    projection_data_source: "ai_enrichment",
+                    cleared_dimensions: prepared.cleared_dimensions(),
+                },
             )
         });
 
@@ -8350,18 +10514,29 @@ mod live_acceptance_tests {
         let db = ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
             .expect("open DB for first enrichment persistence");
         let ctx = state.live_service_context();
-        let first_prepared =
-            compose_enrichment_intelligence(&state, &db, &input, &contradictory, None)
-                .expect("first compose_enrichment_intelligence failed");
+        let first_prepared = compose_enrichment_intelligence(
+            &state,
+            &db,
+            &input,
+            &contradictory,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("first compose_enrichment_intelligence failed");
         db.with_transaction(|tx| {
             apply_enrichment_side_writes(&ctx, tx, &input, &first_prepared)?;
             super::upsert_assessment_from_enrichment_in_active_transaction(
                 &ctx,
                 tx,
                 &state.signals.engine,
-                &input.entity_type,
-                &input.entity_id,
-                first_prepared.intelligence(),
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: &input.entity_type,
+                    entity_id: &input.entity_id,
+                    intel: first_prepared.intelligence(),
+                    projection_intel: first_prepared.projection_intelligence(),
+                    projection_data_source: "ai_enrichment",
+                    cleared_dimensions: first_prepared.cleared_dimensions(),
+                },
             )
         })
         .expect("first enrichment DB persistence failed");
@@ -8409,17 +10584,29 @@ mod live_acceptance_tests {
         let db = ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
             .expect("open DB for second enrichment persistence");
         let ctx = state.live_service_context();
-        let second_prepared = compose_enrichment_intelligence(&state, &db, &input, &clean, None)
-            .expect("second compose_enrichment_intelligence failed");
+        let second_prepared = compose_enrichment_intelligence(
+            &state,
+            &db,
+            &input,
+            &clean,
+            crate::intel_queue::EnrichmentProducer::Pty,
+            None,
+        )
+        .expect("second compose_enrichment_intelligence failed");
         db.with_transaction(|tx| {
             apply_enrichment_side_writes(&ctx, tx, &input, &second_prepared)?;
             super::upsert_assessment_from_enrichment_in_active_transaction(
                 &ctx,
                 tx,
                 &state.signals.engine,
-                &input.entity_type,
-                &input.entity_id,
-                second_prepared.intelligence(),
+                super::EnrichmentAssessmentUpsert {
+                    entity_type: &input.entity_type,
+                    entity_id: &input.entity_id,
+                    intel: second_prepared.intelligence(),
+                    projection_intel: second_prepared.projection_intelligence(),
+                    projection_data_source: "ai_enrichment",
+                    cleared_dimensions: second_prepared.cleared_dimensions(),
+                },
             )
         })
         .expect("second enrichment DB persistence failed");

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -1081,6 +1081,7 @@ fn stage_failure_message(stage: &str) -> &str {
         "pty_permit" => "PTY permit acquisition",
         "pty_enrichment" => "Claude PTY enrichment",
         "write_results" => "result writeback",
+        "finalize" => "refresh finalization",
         "relationship_persist" => "relationship persistence",
         _ => stage,
     }
@@ -1554,10 +1555,10 @@ pub async fn enrich_entity(
             &input.entity_id,
             &input.entity_type,
             &input.entity_name,
-            "relationship_persist",
+            "finalize",
             &e,
         );
-        return Err(manual_refresh_error("relationship_persist", &e));
+        return Err(manual_refresh_error("finalize", &e));
     }
 
     if let Some(app) = app_handle {
@@ -3888,6 +3889,153 @@ mod mutation_smoke_tests {
         }
     }
 
+    fn visible_materialization_commitment_rows(
+        db: &crate::db::ActionDb,
+        account_id: &str,
+    ) -> Vec<(String, String, Option<String>, String)> {
+        let mut stmt = db
+            .conn_ref()
+            .prepare(
+                "SELECT title, owner, target_date, source
+                 FROM captured_commitments
+                 WHERE account_id = ?1
+                 ORDER BY title, owner, coalesce(target_date, ''), source",
+            )
+            .expect("prepare commitment materialization query");
+        stmt.query_map(params![account_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .expect("query commitment materialization")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect commitment materialization")
+    }
+
+    fn visible_materialization_product_rows(
+        db: &crate::db::ActionDb,
+        account_id: &str,
+    ) -> Vec<(String, String, String)> {
+        let mut stmt = db
+            .conn_ref()
+            .prepare(
+                "SELECT name, printf('%.2f', coalesce(arr_portion, -1.0)), source
+                 FROM account_products
+                 WHERE account_id = ?1
+                 ORDER BY name, source",
+            )
+            .expect("prepare product materialization query");
+        stmt.query_map(params![account_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .expect("query product materialization")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect product materialization")
+    }
+
+    fn make_visible_materialization_intel(entity_id: &str) -> IntelligenceJson {
+        IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: entity_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-03T01:00:00Z".to_string(),
+            open_commitments: Some(vec![OpenCommitment {
+                commitment_id: None,
+                description: "Send reliability recap".to_string(),
+                owner: Some("vendor".to_string()),
+                due_date: Some("2026-06-01".to_string()),
+                source: None,
+                status: None,
+                item_source: None,
+                discrepancy: None,
+            }]),
+            product_adoption: Some(AdoptionSignals {
+                feature_adoption: vec!["Core platform: 75%".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn manual_and_queue_refresh_share_materialization_path() {
+        let state = remote_glean_state();
+
+        for (producer, expected_commitment_prefix, expected_product_source) in [
+            (
+                crate::intel_queue::EnrichmentProducer::Pty,
+                "pty_enrichment:",
+                "ai_inference",
+            ),
+            (
+                crate::intel_queue::EnrichmentProducer::Glean,
+                "glean_enrichment:",
+                "glean",
+            ),
+        ] {
+            let entity_id = format!("acc-shared-materialization-{}", expected_product_source);
+            let intel = make_visible_materialization_intel(&entity_id);
+
+            let queue_db = test_db();
+            seed_finalize_account(&queue_db, &entity_id);
+            let queue_dir = tempfile::tempdir().expect("queue tempdir");
+            let queue_input = make_enrichment_input(&entity_id, queue_dir.path());
+            run_enrichment_finalize_post_commit(
+                &state,
+                &queue_db,
+                &queue_input,
+                &intel,
+                &[],
+                FinalizeMode::QueueWorker {
+                    is_background: false,
+                    producer,
+                },
+            )
+            .expect("queue materialization");
+
+            let manual_db = test_db();
+            seed_finalize_account(&manual_db, &entity_id);
+            let manual_dir = tempfile::tempdir().expect("manual tempdir");
+            let manual_input = make_enrichment_input(&entity_id, manual_dir.path());
+            run_enrichment_finalize_post_commit(
+                &state,
+                &manual_db,
+                &manual_input,
+                &intel,
+                &[],
+                FinalizeMode::ManualRefresh { producer },
+            )
+            .expect("manual materialization");
+
+            let queue_commitments = visible_materialization_commitment_rows(&queue_db, &entity_id);
+            assert_eq!(
+                queue_commitments,
+                visible_materialization_commitment_rows(&manual_db, &entity_id),
+                "queue and manual refresh must commit identical visible commitments for {producer:?}"
+            );
+            assert!(
+                queue_commitments
+                    .iter()
+                    .all(|(_, _, _, source)| source.starts_with(expected_commitment_prefix)),
+                "commitment materialization should use producer-owned source labels"
+            );
+
+            let queue_products = visible_materialization_product_rows(&queue_db, &entity_id);
+            assert_eq!(
+                queue_products,
+                visible_materialization_product_rows(&manual_db, &entity_id),
+                "queue and manual refresh must commit identical visible products for {producer:?}"
+            );
+            assert_eq!(
+                queue_products,
+                vec![(
+                    "Core platform".to_string(),
+                    "0.75".to_string(),
+                    expected_product_source.to_string()
+                )],
+                "product materialization should be normalized and producer-owned"
+            );
+        }
+    }
+
     #[test]
     fn glean_queue_and_manual_refresh_share_finalization_side_effects() {
         let state = remote_glean_state();
@@ -3994,54 +4142,53 @@ mod mutation_smoke_tests {
     }
 
     #[test]
-    fn glean_finalize_blocks_export_when_glean_side_effects_fail() {
+    fn materialization_failure_blocks_export_for_visible_generation_side_effects() {
         let state = remote_glean_state();
-        let db = test_db();
-        let entity_id = "acc-finalize-side-effect-failure";
-        seed_finalize_account(&db, entity_id);
-        db.conn_ref()
-            .execute_batch(
-                "CREATE TRIGGER fail_glean_commitment_insert
-                 BEFORE INSERT ON captured_commitments
-                 WHEN NEW.account_id = 'acc-finalize-side-effect-failure'
-                 BEGIN
-                   SELECT RAISE(ABORT, 'forced Glean side effect failure');
-                 END;",
-            )
-            .expect("install side-effect failure trigger");
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = make_enrichment_input(entity_id, dir.path());
-        let mut intel = make_glean_signal_intel(entity_id);
-        intel.open_commitments = Some(vec![OpenCommitment {
-            commitment_id: None,
-            description: "Send lifecycle-safe recap".to_string(),
-            owner: Some("vendor".to_string()),
-            due_date: Some("2026-06-01".to_string()),
-            source: Some("glean".to_string()),
-            status: None,
-            item_source: None,
-            discrepancy: None,
-        }]);
+        for (producer, expected_error) in [
+            (
+                crate::intel_queue::EnrichmentProducer::Glean,
+                "Glean enrichment side-effect sync failed",
+            ),
+            (
+                crate::intel_queue::EnrichmentProducer::Pty,
+                "PTY enrichment side-effect sync failed",
+            ),
+        ] {
+            let db = test_db();
+            let entity_id = format!("acc-finalize-side-effect-failure-{producer:?}");
+            seed_finalize_account(&db, &entity_id);
+            db.conn_ref()
+                .execute_batch(
+                    "CREATE TRIGGER fail_commitment_insert
+                     BEFORE INSERT ON captured_commitments
+                     WHEN NEW.account_id LIKE 'acc-finalize-side-effect-failure-%'
+                     BEGIN
+                       SELECT RAISE(ABORT, 'forced visible materialization failure');
+                     END;",
+                )
+                .expect("install side-effect failure trigger");
+            let dir = tempfile::tempdir().expect("tempdir");
+            let input = make_enrichment_input(&entity_id, dir.path());
+            let intel = make_visible_materialization_intel(&entity_id);
 
-        let result = run_enrichment_finalize_post_commit(
-            &state,
-            &db,
-            &input,
-            &intel,
-            &[],
-            FinalizeMode::ManualRefresh {
-                producer: crate::intel_queue::EnrichmentProducer::Glean,
-            },
-        );
+            let result = run_enrichment_finalize_post_commit(
+                &state,
+                &db,
+                &input,
+                &intel,
+                &[],
+                FinalizeMode::ManualRefresh { producer },
+            );
 
-        assert!(
-            result.is_err_and(|error| error.contains("Glean enrichment side-effect sync failed")),
-            "Glean side-effect failure must stop finalize success"
-        );
-        assert!(
-            !dir.path().join("intelligence.json").exists(),
-            "generated exports must wait until Glean substrate side effects complete"
-        );
+            assert!(
+                result.is_err_and(|error| error.contains(expected_error)),
+                "{producer:?} side-effect failure must stop finalize success"
+            );
+            assert!(
+                !dir.path().join("intelligence.json").exists(),
+                "generated exports must wait until visible materialization completes for {producer:?}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -104,12 +104,23 @@ fn subject_ref_for_entity(entity_type: &str, entity_id: &str) -> Result<String, 
     }
 }
 
-fn projection_metadata(value: serde_json::Value, projection_producer: &str) -> Option<String> {
-    serde_json::to_string(&serde_json::json!({
+fn projection_metadata(
+    value: serde_json::Value,
+    projection_producer: &str,
+    projection_origin_subject: Option<&str>,
+) -> Option<String> {
+    let mut metadata = serde_json::json!({
         "legacy_projection_value": value,
         "projection_producer": projection_producer,
-    }))
-    .ok()
+    });
+    if let (Some(object), Some(origin_subject)) =
+        (metadata.as_object_mut(), projection_origin_subject)
+    {
+        if let Ok(origin_value) = serde_json::from_str::<serde_json::Value>(origin_subject) {
+            object.insert("projection_origin_subject".to_string(), origin_value);
+        }
+    }
+    serde_json::to_string(&metadata).ok()
 }
 
 fn source_asof_from_item_source(
@@ -667,6 +678,7 @@ fn stakeholder_engagement_projection_text(
 
 struct ProjectionClaimInput<'a> {
     subject_ref: &'a str,
+    projection_origin_subject: Option<&'a str>,
     actor: &'a str,
     data_source: &'a str,
     item_source: Option<&'a crate::intelligence::io::ItemSource>,
@@ -731,7 +743,11 @@ fn commit_projection_claim(
             source_asof: input.source_asof.map(str::to_string),
             observed_at,
             provenance_json,
-            metadata_json: projection_metadata(input.legacy_value, input.data_source),
+            metadata_json: projection_metadata(
+                input.legacy_value,
+                input.data_source,
+                input.projection_origin_subject,
+            ),
             thread_id: None,
             temporal_scope: Some(crate::db::claims::TemporalScope::State),
             sensitivity: Some(crate::db::claims::ClaimSensitivity::Internal),
@@ -913,6 +929,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: None,
@@ -931,6 +948,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: None,
@@ -950,6 +968,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -969,6 +988,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -988,6 +1008,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: risk.item_source.as_ref(),
@@ -1010,6 +1031,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: None,
@@ -1029,6 +1051,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: win.item_source.as_ref(),
@@ -1049,6 +1072,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -1072,6 +1096,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: None,
@@ -1094,6 +1119,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: None,
@@ -1114,6 +1140,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -1141,6 +1168,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: signal.item_source.as_ref(),
@@ -1161,6 +1189,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -1181,6 +1210,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &subject_ref,
+                projection_origin_subject: None,
                 actor,
                 data_source,
                 item_source: value.item_source.as_ref(),
@@ -1204,6 +1234,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: None,
@@ -1228,6 +1259,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                 db,
                 ProjectionClaimInput {
                     subject_ref: &subject_ref,
+                    projection_origin_subject: None,
                     actor,
                     data_source,
                     item_source: commitment.item_source.as_ref(),
@@ -1259,6 +1291,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
             db,
             ProjectionClaimInput {
                 subject_ref: &person_subject_ref,
+                projection_origin_subject: Some(&subject_ref),
                 actor,
                 data_source,
                 item_source: insight.item_source.as_ref(),
@@ -1280,6 +1313,7 @@ pub(crate) fn commit_claim_shaped_intelligence_projection(
                     db,
                     ProjectionClaimInput {
                         subject_ref: &subject_ref,
+                        projection_origin_subject: None,
                         actor,
                         data_source,
                         item_source: None,
@@ -2051,7 +2085,7 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
         "agent:intelligence",
         upsert.projection_data_source,
     )?;
-    withdraw_refreshed_projection_claims(
+    let refreshed_projection_withdrawal = withdraw_refreshed_projection_claims(
         ctx,
         tx,
         upsert.entity_type,
@@ -2073,14 +2107,13 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
         0.8,
     )
     .map_err(|e| format!("signal emit failed: {e}"))?;
-    enqueue_projection_claim_recomputes(
-        ctx,
-        tx,
-        &signal_id,
+    let recompute_subjects = projection_claim_recompute_subjects(
         upsert.entity_type,
         upsert.entity_id,
         &intel,
+        &refreshed_projection_withdrawal.affected_subjects,
     );
+    enqueue_projection_claim_recomputes(ctx, tx, &signal_id, recompute_subjects);
 
     // After enrichment, reconcile AI objectives with user objectives
     if upsert.entity_type == "account" {
@@ -2140,20 +2173,8 @@ fn enqueue_projection_claim_recomputes(
     ctx: &ServiceContext<'_>,
     tx: &ActionDb,
     origin_signal_id: &str,
-    entity_type: &str,
-    entity_id: &str,
-    intel: &crate::intelligence::IntelligenceJson,
+    subjects: BTreeSet<(String, String)>,
 ) {
-    let mut subjects = BTreeSet::new();
-    subjects.insert((entity_type.to_string(), entity_id.to_string()));
-    for insight in &intel.stakeholder_insights {
-        if let Some(person_id) = insight.person_id.as_deref() {
-            if !person_id.trim().is_empty() {
-                subjects.insert(("person".to_string(), person_id.to_string()));
-            }
-        }
-    }
-
     for (subject_type, subject_id) in subjects {
         if let Err(error) = crate::services::invalidation_jobs::enqueue_signal_claim_recompute_in_tx(
             tx,
@@ -2184,6 +2205,33 @@ fn enqueue_projection_claim_recomputes(
     }
 }
 
+fn projection_claim_recompute_subjects(
+    entity_type: &str,
+    entity_id: &str,
+    intel: &crate::intelligence::IntelligenceJson,
+    withdrawn_subjects: &[(String, String)],
+) -> BTreeSet<(String, String)> {
+    let mut subjects = BTreeSet::new();
+    subjects.insert((entity_type.to_string(), entity_id.to_string()));
+    for insight in &intel.stakeholder_insights {
+        if let Some(person_id) = insight.person_id.as_deref() {
+            if !person_id.trim().is_empty() {
+                subjects.insert(("person".to_string(), person_id.to_string()));
+            }
+        }
+    }
+    for (subject_type, subject_id) in withdrawn_subjects {
+        if !subject_type.trim().is_empty() && !subject_id.trim().is_empty() {
+            subjects.insert((subject_type.clone(), subject_id.clone()));
+        }
+    }
+    subjects
+}
+
+struct RefreshedProjectionWithdrawal {
+    affected_subjects: Vec<(String, String)>,
+}
+
 fn withdraw_refreshed_projection_claims(
     ctx: &ServiceContext<'_>,
     tx: &ActionDb,
@@ -2191,15 +2239,17 @@ fn withdraw_refreshed_projection_claims(
     entity_id: &str,
     projection_intel: &crate::intelligence::IntelligenceJson,
     projection_data_source: &str,
-) -> Result<usize, String> {
+) -> Result<RefreshedProjectionWithdrawal, String> {
     let roots = refreshed_projection_field_path_roots(projection_intel, projection_data_source);
     let producers = refreshed_projection_producers(projection_data_source);
     if roots.is_empty() || producers.is_empty() {
-        return Ok(0);
+        return Ok(RefreshedProjectionWithdrawal {
+            affected_subjects: Vec::new(),
+        });
     }
-    let retained_claim_keys = projection_claim_retained_keys(projection_intel);
+    let retained_claim_keys = projection_claim_retained_keys(projection_intel)?;
 
-    let withdrawn = crate::services::claims::withdraw_generated_projection_claims_for_field_path_roots_by_projection_producer_in_tx(
+    let withdrawal = crate::services::claims::withdraw_generated_projection_claims_for_field_path_roots_by_projection_producer_in_tx(
         ctx,
         tx,
         crate::services::claims::GeneratedProjectionRefreshWithdrawal {
@@ -2212,12 +2262,15 @@ fn withdraw_refreshed_projection_claims(
         },
     )
     .map_err(|error| format!("withdraw refreshed projection claims failed: {error}"))?;
-    if withdrawn > 0 {
+    if withdrawal.withdrawn > 0 {
         log::info!(
-            "intelligence: withdrew {withdrawn} stale generated projection claim(s) after refreshed projection on {entity_type}:{entity_id}"
+            "intelligence: withdrew {} stale generated projection claim(s) after refreshed projection on {entity_type}:{entity_id}",
+            withdrawal.withdrawn
         );
     }
-    Ok(withdrawn)
+    Ok(RefreshedProjectionWithdrawal {
+        affected_subjects: withdrawal.affected_subjects,
+    })
 }
 
 fn refreshed_projection_producers(projection_data_source: &str) -> &'static [&'static str] {
@@ -2234,6 +2287,10 @@ fn refreshed_projection_field_path_roots(
 ) -> Vec<&'static str> {
     if projection_data_source.trim() != "glean" {
         return all_projection_field_path_roots();
+    }
+
+    if !intel.refreshed_fields.is_empty() {
+        return refreshed_projection_field_path_roots_from_fields(&intel.refreshed_fields);
     }
 
     let mut roots = BTreeSet::new();
@@ -2292,6 +2349,28 @@ fn refreshed_projection_field_path_roots(
     roots.into_iter().collect()
 }
 
+fn refreshed_projection_field_path_roots_from_fields(fields: &[String]) -> Vec<&'static str> {
+    let projection_roots = all_projection_field_path_roots();
+    let mut roots = BTreeSet::new();
+    for field in fields {
+        if let Some(root) = projection_roots
+            .iter()
+            .copied()
+            .find(|root| field_path_matches_projection_root(field, root))
+        {
+            roots.insert(root);
+        }
+    }
+    roots.into_iter().collect()
+}
+
+fn field_path_matches_projection_root(field_path: &str, root: &str) -> bool {
+    field_path == root
+        || field_path
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('[') || suffix.starts_with('.'))
+}
+
 fn all_projection_field_path_roots() -> Vec<&'static str> {
     vec![
         "executiveAssessment",
@@ -2316,22 +2395,42 @@ fn all_projection_field_path_roots() -> Vec<&'static str> {
 
 fn projection_claim_retained_keys(
     intel: &crate::intelligence::IntelligenceJson,
-) -> Vec<(String, String, String)> {
+) -> Result<Vec<(String, String, String, String)>, String> {
     let mut keys = Vec::new();
+    let subject_ref = subject_ref_for_entity(&intel.entity_type, &intel.entity_id)?;
 
     if let Some(summary) = intel.executive_assessment.as_deref() {
-        push_projection_claim_key(&mut keys, "entity_summary", "executiveAssessment", summary);
+        push_projection_claim_key(
+            &mut keys,
+            &subject_ref,
+            "entity_summary",
+            "executiveAssessment",
+            summary,
+        );
     }
     if let Some(pull_quote) = intel.pull_quote.as_deref() {
-        push_projection_claim_key(&mut keys, "entity_summary", "pullQuote", pull_quote);
+        push_projection_claim_key(
+            &mut keys,
+            &subject_ref,
+            "entity_summary",
+            "pullQuote",
+            pull_quote,
+        );
     }
     if let Some(health) = intel.health.as_ref() {
         if let Some(text) = health_projection_text(health) {
-            push_projection_claim_key(&mut keys, "entity_current_state", "health", &text);
+            push_projection_claim_key(
+                &mut keys,
+                &subject_ref,
+                "entity_current_state",
+                "health",
+                &text,
+            );
         }
         for (idx, action) in health.recommended_actions.iter().enumerate() {
             push_projection_claim_key(
                 &mut keys,
+                &subject_ref,
                 "recommendation",
                 &format!("health.recommendedActions[{idx}]"),
                 action,
@@ -2341,6 +2440,7 @@ fn projection_claim_retained_keys(
     for (idx, risk) in intel.risks.iter().enumerate() {
         push_projection_claim_key(
             &mut keys,
+            &subject_ref,
             "entity_risk",
             &format!("risks[{idx}]"),
             &risk.text,
@@ -2350,6 +2450,7 @@ fn projection_claim_retained_keys(
         if let Some(text) = recommended_action_projection_text(action) {
             push_projection_claim_key(
                 &mut keys,
+                &subject_ref,
                 "recommendation",
                 &format!("recommendedActions[{idx}]"),
                 &text,
@@ -2359,6 +2460,7 @@ fn projection_claim_retained_keys(
     for (idx, win) in intel.recent_wins.iter().enumerate() {
         push_projection_claim_key(
             &mut keys,
+            &subject_ref,
             "entity_win",
             &format!("recentWins[{idx}]"),
             &win.text,
@@ -2366,13 +2468,20 @@ fn projection_claim_retained_keys(
     }
     if let Some(state) = intel.current_state.as_ref() {
         if let Some(text) = current_state_projection_text(state) {
-            push_projection_claim_key(&mut keys, "entity_current_state", "currentState", &text);
+            push_projection_claim_key(
+                &mut keys,
+                &subject_ref,
+                "entity_current_state",
+                "currentState",
+                &text,
+            );
         }
     }
     for (idx, priority) in intel.strategic_priorities.iter().enumerate() {
         if let Some(text) = strategic_priority_projection_text(priority) {
             push_projection_claim_key(
                 &mut keys,
+                &subject_ref,
                 "entity_current_state",
                 &format!("strategicPriorities[{idx}]"),
                 &text,
@@ -2381,7 +2490,13 @@ fn projection_claim_retained_keys(
     }
     for (idx, blocker) in intel.blockers.iter().enumerate() {
         if let Some(text) = blocker_projection_text(blocker) {
-            push_projection_claim_key(&mut keys, "entity_risk", &format!("blockers[{idx}]"), &text);
+            push_projection_claim_key(
+                &mut keys,
+                &subject_ref,
+                "entity_risk",
+                &format!("blockers[{idx}]"),
+                &text,
+            );
         }
     }
     if let Some(context) = intel.contract_context.as_ref() {
@@ -2391,13 +2506,20 @@ fn projection_claim_retained_keys(
             } else {
                 "entity_current_state"
             };
-            push_projection_claim_key(&mut keys, claim_type, "contractContext", &text);
+            push_projection_claim_key(
+                &mut keys,
+                &subject_ref,
+                claim_type,
+                "contractContext",
+                &text,
+            );
         }
     }
     for (idx, signal) in intel.expansion_signals.iter().enumerate() {
         if let Some(text) = expansion_signal_projection_text(signal) {
             push_projection_claim_key(
                 &mut keys,
+                &subject_ref,
                 "entity_current_state",
                 &format!("expansionSignals[{idx}]"),
                 &text,
@@ -2406,12 +2528,19 @@ fn projection_claim_retained_keys(
     }
     if let Some(outlook) = intel.agreement_outlook.as_ref() {
         if let Some(text) = agreement_outlook_projection_text(outlook) {
-            push_projection_claim_key(&mut keys, "entity_current_state", "agreementOutlook", &text);
+            push_projection_claim_key(
+                &mut keys,
+                &subject_ref,
+                "entity_current_state",
+                "agreementOutlook",
+                &text,
+            );
         }
     }
     for (idx, value) in intel.value_delivered.iter().enumerate() {
         push_projection_claim_key(
             &mut keys,
+            &subject_ref,
             "value_delivered",
             &format!("valueDelivered[{idx}]"),
             &value.statement,
@@ -2422,6 +2551,7 @@ fn projection_claim_retained_keys(
             if let Some(text) = success_metric_projection_text(metric) {
                 push_projection_claim_key(
                     &mut keys,
+                    &subject_ref,
                     "entity_current_state",
                     &format!("successMetrics[{idx}]"),
                     &text,
@@ -2439,6 +2569,7 @@ fn projection_claim_retained_keys(
                 };
                 push_projection_claim_key(
                     &mut keys,
+                    &subject_ref,
                     claim_type,
                     &format!("openCommitments[{idx}]"),
                     &text,
@@ -2447,10 +2578,12 @@ fn projection_claim_retained_keys(
         }
     }
     for (idx, insight) in intel.stakeholder_insights.iter().enumerate() {
-        if insight.person_id.is_some() {
+        if let Some(person_id) = insight.person_id.as_deref() {
             if let Some(text) = stakeholder_engagement_projection_text(insight) {
+                let person_subject_ref = subject_ref_for_entity("person", person_id)?;
                 push_projection_claim_key(
                     &mut keys,
+                    &person_subject_ref,
                     "stakeholder_engagement",
                     &format!("stakeholderInsights[{idx}].engagement"),
                     &text,
@@ -2461,16 +2594,23 @@ fn projection_claim_retained_keys(
     if intel.entity_type == "account" {
         if let Some(context) = intel.company_context.as_ref() {
             if let Some(text) = company_context_projection_text(context) {
-                push_projection_claim_key(&mut keys, "company_context", "companyContext", &text);
+                push_projection_claim_key(
+                    &mut keys,
+                    &subject_ref,
+                    "company_context",
+                    "companyContext",
+                    &text,
+                );
             }
         }
     }
 
-    keys
+    Ok(keys)
 }
 
 fn push_projection_claim_key(
-    keys: &mut Vec<(String, String, String)>,
+    keys: &mut Vec<(String, String, String, String)>,
+    subject_ref: &str,
     claim_type: &str,
     field_path: &str,
     text: &str,
@@ -2479,6 +2619,7 @@ fn push_projection_claim_key(
         return;
     }
     keys.push((
+        subject_ref.to_string(),
         claim_type.to_string(),
         field_path.to_string(),
         crate::services::claims::normalize_claim_text(text),
@@ -4111,7 +4252,7 @@ mod tests {
     use super::*;
     use crate::db::test_utils::test_db;
     use crate::db::{AccountType, DbAccount};
-    use crate::intelligence::{IntelRisk, IntelligenceJson, ItemSource};
+    use crate::intelligence::{IntelRisk, IntelligenceJson, ItemSource, StakeholderInsight};
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
     use crate::signals::propagation::PropagationEngine;
     use chrono::TimeZone;
@@ -4134,6 +4275,20 @@ mod tests {
             ..Default::default()
         })
         .expect("seed account");
+    }
+
+    fn seed_person(db: &ActionDb, person_id: &str) {
+        db.conn_ref()
+            .execute(
+                "INSERT INTO people (id, email, name, updated_at)
+                 VALUES (?1, ?2, ?3, '2026-05-20T00:00:00Z')",
+                params![
+                    person_id,
+                    format!("{person_id}@example.com"),
+                    format!("Person {person_id}")
+                ],
+            )
+            .expect("seed person");
     }
 
     fn generated_risk_intel(account_id: &str) -> IntelligenceJson {
@@ -4499,6 +4654,175 @@ mod tests {
         assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
         assert_eq!(active_generated_risk_count(&db, account_id), 0);
         assert_eq!(withdrawn_generated_risk_count(&db, account_id), 1);
+    }
+
+    #[test]
+    fn explicit_empty_glean_field_withdraws_stale_projection_claim() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-empty-refresh";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(54);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &generated_risk_intel(account_id),
+        )
+        .expect("commit generated risk projection");
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+
+        let empty_risks_refresh = IntelligenceJson {
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T13:00:00Z".to_string(),
+            refreshed_fields: vec!["risks".to_string()],
+            ..Default::default()
+        };
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &empty_risks_refresh,
+        )
+        .expect("persist explicit empty risks refresh");
+
+        assert_eq!(active_generated_risk_count(&db, account_id), 0);
+        assert_eq!(withdrawn_generated_risk_count(&db, account_id), 1);
+    }
+
+    #[test]
+    fn account_refresh_withdraws_stale_person_subject_stakeholder_projection() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-stakeholder-origin-refresh";
+        let person_id = "person-stale-stakeholder-origin";
+        seed_account(&db, account_id);
+        seed_person(&db, person_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(55);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        let first_refresh = IntelligenceJson {
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            stakeholder_insights: vec![StakeholderInsight {
+                name: "Fixture Stakeholder".to_string(),
+                role: Some("Champion".to_string()),
+                assessment: Some("Actively backing the rollout.".to_string()),
+                engagement: Some("high".to_string()),
+                person_id: Some(person_id.to_string()),
+                ..Default::default()
+            }],
+            refreshed_fields: vec!["stakeholderInsights".to_string()],
+            ..Default::default()
+        };
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &first_refresh,
+        )
+        .expect("commit person-subject stakeholder projection");
+
+        let (active_before, origin_id): (i64, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*),
+                        json_extract(metadata_json, '$.projection_origin_subject.id')
+                   FROM intelligence_claims
+                  WHERE claim_type = 'stakeholder_engagement'
+                    AND field_path = 'stakeholderInsights[0].engagement'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND lower(json_extract(subject_ref, '$.kind')) = 'person'
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![person_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("active stakeholder projection with origin metadata");
+        assert_eq!(active_before, 1);
+        assert_eq!(origin_id, account_id);
+
+        let second_refresh = IntelligenceJson {
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T13:00:00Z".to_string(),
+            refreshed_fields: vec!["stakeholderInsights".to_string()],
+            ..Default::default()
+        };
+        upsert_glean_assessment_from_enrichment(
+            &ctx,
+            &db,
+            &engine,
+            "account",
+            account_id,
+            &second_refresh,
+        )
+        .expect("persist stakeholder refresh without stale person");
+
+        let active_after: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'stakeholder_engagement'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND lower(json_extract(subject_ref, '$.kind')) = 'person'
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![person_id],
+                |row| row.get(0),
+            )
+            .expect("active stakeholder projection count after refresh");
+        assert_eq!(active_after, 0);
+        let withdrawn_after: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM intelligence_claims
+                  WHERE claim_type = 'stakeholder_engagement'
+                    AND claim_state = 'withdrawn'
+                    AND surfacing_state = 'dormant'
+                    AND retraction_reason = 'projection_refreshed'
+                    AND json_valid(subject_ref) = 1
+                    AND lower(json_extract(subject_ref, '$.kind')) = 'person'
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![person_id],
+                |row| row.get(0),
+            )
+            .expect("withdrawn stakeholder projection count after refresh");
+        assert_eq!(withdrawn_after, 1);
+        let person_recompute_jobs: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                   FROM invalidation_jobs
+                  WHERE job_kind = 'claim_recompute'
+                    AND subject_type = 'person'
+                    AND subject_id = ?1",
+                params![person_id],
+                |row| row.get(0),
+            )
+            .expect("person recompute jobs");
+        assert!(
+            person_recompute_jobs >= 1,
+            "withdrawn person-subject projection should enqueue trust recompute"
+        );
     }
 
     #[test]
@@ -5210,14 +5534,16 @@ mod tests {
             active_source_ref,
             active_projection_producer,
             active_provenance_json,
-        ): (String, String, Option<String>, String, String) = db
+            active_metadata_json,
+        ): (String, String, Option<String>, String, String, String) = db
             .conn_ref()
             .query_row(
                 "SELECT id,
                         data_source,
                         source_ref,
                         json_extract(metadata_json, '$.projection_producer'),
-                        provenance_json
+                        provenance_json,
+                        metadata_json
                    FROM intelligence_claims
                   WHERE claim_type = 'entity_summary'
                     AND field_path = 'executiveAssessment'
@@ -5233,6 +5559,7 @@ mod tests {
                         row.get(2)?,
                         row.get(3)?,
                         row.get(4)?,
+                        row.get(5)?,
                     ))
                 },
             )
@@ -5244,6 +5571,17 @@ mod tests {
         let active_provenance: serde_json::Value =
             serde_json::from_str(&active_provenance_json).expect("active provenance JSON");
         assert_eq!(active_provenance["sources"][0]["data_source"], "ai");
+        let active_metadata: serde_json::Value =
+            serde_json::from_str(&active_metadata_json).expect("active metadata JSON");
+        assert_eq!(active_metadata["projection_producer"], "ai_enrichment");
+        assert!(
+            active_metadata.get("legacy_projection_value").is_none(),
+            "reissued local claim metadata must not retain purged Glean projection payload"
+        );
+        assert!(
+            !active_metadata_json.contains("glean"),
+            "reissued local claim metadata must not retain Glean source labels"
+        );
         let remaining_glean_corroborations: i64 = db
             .conn_ref()
             .query_row(
@@ -5514,14 +5852,13 @@ mod mutation_smoke_tests {
             ..Default::default()
         };
 
-        super::enqueue_projection_claim_recomputes(
-            &ctx,
-            &db,
-            &signal_id,
+        let subjects = super::projection_claim_recompute_subjects(
             "account",
             "acc-projection-recompute",
             &intel,
+            &[],
         );
+        super::enqueue_projection_claim_recomputes(&ctx, &db, &signal_id, subjects);
 
         assert_eq!(
             claim_recompute_job_count(&db, "account", "acc-projection-recompute"),

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -143,8 +143,7 @@ fn projection_claim_data_source(
     match fallback {
         "glean" => match source {
             Some(source) => authorized_glean_projection_data_source(source)
-                .or_else(|| authorized_non_glean_projection_data_source(source))
-                .unwrap_or("ai_enrichment")
+                .unwrap_or("glean")
                 .to_string(),
             None => "glean".to_string(),
         },
@@ -4996,7 +4995,7 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .expect("read generated risk claim");
-        assert_eq!(data_source, "ai_enrichment");
+        assert_eq!(data_source, "glean");
         assert_eq!(projection_producer, "glean");
 
         let pty_account_id = "acc-generated-risk-untrusted-pty-item-source";
@@ -5054,7 +5053,7 @@ mod tests {
     }
 
     #[test]
-    fn glean_projection_preserves_allowed_non_glean_item_source() {
+    fn glean_projection_coerces_non_glean_item_source_to_glean_boundary() {
         let db = test_db();
         let engine = PropagationEngine::default();
         let account_id = "acc-generated-risk-transcript-source";
@@ -5089,11 +5088,14 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )
             .expect("read generated risk claim");
-        assert_eq!(data_source, "transcript");
+        assert_eq!(data_source, "glean");
         assert_eq!(projection_producer, "glean");
         let provenance: serde_json::Value =
             serde_json::from_str(&provenance_json).expect("provenance JSON");
-        assert_eq!(provenance["sources"][0]["data_source"], "local_enrichment");
+        assert_eq!(
+            provenance["sources"][0]["data_source"]["glean"]["downstream"],
+            "unknown"
+        );
 
         let report = crate::db::data_lifecycle::purge_source(
             &db,
@@ -5101,9 +5103,9 @@ mod tests {
         )
         .expect("purge Glean");
 
-        assert_eq!(report.generated_projection_claims_withdrawn, 0);
-        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 0);
-        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+        assert_eq!(report.generated_projection_claims_withdrawn, 1);
+        assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
+        assert_eq!(active_generated_risk_count(&db, account_id), 0);
     }
 
     #[test]

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -138,6 +138,7 @@ fn projection_claim_data_source(
             None => "glean".to_string(),
         },
         source if source.starts_with("glean_") => source.to_string(),
+        "" => "ai_enrichment".to_string(),
         source => source.to_string(),
     }
 }
@@ -284,7 +285,7 @@ fn projection_provenance_data_source(source: &str) -> crate::abilities::provenan
         "ai" | "ai_enrichment" | "ai_inference" | "pty_synthesis" => {
             crate::abilities::provenance::DataSource::Ai
         }
-        "" => crate::abilities::provenance::DataSource::LegacyUnattributed,
+        "" => crate::abilities::provenance::DataSource::Ai,
         other => crate::abilities::provenance::DataSource::Other(
             crate::abilities::provenance::SourceName::new(other),
         ),

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -2037,6 +2037,13 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
             merge_user_confirmed_values(&mut projection_intel, &existing);
         }
     }
+    withdraw_cleared_dimension_projection_claims(
+        ctx,
+        tx,
+        upsert.entity_type,
+        upsert.entity_id,
+        upsert.cleared_dimensions,
+    )?;
     commit_claim_shaped_intelligence_projection(
         ctx,
         tx,
@@ -2044,12 +2051,13 @@ pub(crate) fn upsert_assessment_from_enrichment_in_active_transaction(
         "agent:intelligence",
         upsert.projection_data_source,
     )?;
-    withdraw_cleared_dimension_projection_claims(
+    withdraw_refreshed_projection_claims(
         ctx,
         tx,
         upsert.entity_type,
         upsert.entity_id,
-        upsert.cleared_dimensions,
+        &projection_intel,
+        upsert.projection_data_source,
     )?;
     crate::services::derived_state::upsert_entity_intelligence_legacy_snapshot(ctx, tx, &intel)
         .map_err(|e| e.to_string())?;
@@ -2174,6 +2182,307 @@ fn enqueue_projection_claim_recomputes(
             }
         }
     }
+}
+
+fn withdraw_refreshed_projection_claims(
+    ctx: &ServiceContext<'_>,
+    tx: &ActionDb,
+    entity_type: &str,
+    entity_id: &str,
+    projection_intel: &crate::intelligence::IntelligenceJson,
+    projection_data_source: &str,
+) -> Result<usize, String> {
+    let roots = refreshed_projection_field_path_roots(projection_intel, projection_data_source);
+    let producers = refreshed_projection_producers(projection_data_source);
+    if roots.is_empty() || producers.is_empty() {
+        return Ok(0);
+    }
+    let retained_claim_keys = projection_claim_retained_keys(projection_intel);
+
+    let withdrawn = crate::services::claims::withdraw_generated_projection_claims_for_field_path_roots_by_projection_producer_in_tx(
+        ctx,
+        tx,
+        crate::services::claims::GeneratedProjectionRefreshWithdrawal {
+            entity_type,
+            entity_id,
+            field_path_roots: &roots,
+            projection_producers: producers,
+            retained_claim_keys: &retained_claim_keys,
+            retraction_reason: "projection_refreshed",
+        },
+    )
+    .map_err(|error| format!("withdraw refreshed projection claims failed: {error}"))?;
+    if withdrawn > 0 {
+        log::info!(
+            "intelligence: withdrew {withdrawn} stale generated projection claim(s) after refreshed projection on {entity_type}:{entity_id}"
+        );
+    }
+    Ok(withdrawn)
+}
+
+fn refreshed_projection_producers(projection_data_source: &str) -> &'static [&'static str] {
+    match projection_data_source.trim() {
+        "glean" => &["glean"],
+        "ai_enrichment" => &["ai_enrichment"],
+        _ => &[],
+    }
+}
+
+fn refreshed_projection_field_path_roots(
+    intel: &crate::intelligence::IntelligenceJson,
+    projection_data_source: &str,
+) -> Vec<&'static str> {
+    if projection_data_source.trim() != "glean" {
+        return all_projection_field_path_roots();
+    }
+
+    let mut roots = BTreeSet::new();
+    if intel.executive_assessment.is_some() {
+        roots.insert("executiveAssessment");
+    }
+    if intel.pull_quote.is_some() {
+        roots.insert("pullQuote");
+    }
+    if intel.health.is_some() {
+        roots.insert("health");
+    }
+    if !intel.risks.is_empty() {
+        roots.insert("risks");
+    }
+    if !intel.recommended_actions.is_empty() {
+        roots.insert("recommendedActions");
+    }
+    if !intel.recent_wins.is_empty() {
+        roots.insert("recentWins");
+    }
+    if intel.current_state.is_some() {
+        roots.insert("currentState");
+    }
+    if !intel.strategic_priorities.is_empty() {
+        roots.insert("strategicPriorities");
+    }
+    if !intel.blockers.is_empty() {
+        roots.insert("blockers");
+    }
+    if intel.contract_context.is_some() {
+        roots.insert("contractContext");
+    }
+    if !intel.expansion_signals.is_empty() {
+        roots.insert("expansionSignals");
+    }
+    if intel.agreement_outlook.is_some() {
+        roots.insert("agreementOutlook");
+    }
+    if !intel.value_delivered.is_empty() {
+        roots.insert("valueDelivered");
+    }
+    if intel.success_metrics.is_some() {
+        roots.insert("successMetrics");
+    }
+    if intel.open_commitments.is_some() {
+        roots.insert("openCommitments");
+    }
+    if !intel.stakeholder_insights.is_empty() {
+        roots.insert("stakeholderInsights");
+    }
+    if intel.company_context.is_some() {
+        roots.insert("companyContext");
+    }
+
+    roots.into_iter().collect()
+}
+
+fn all_projection_field_path_roots() -> Vec<&'static str> {
+    vec![
+        "executiveAssessment",
+        "pullQuote",
+        "health",
+        "risks",
+        "recommendedActions",
+        "recentWins",
+        "currentState",
+        "strategicPriorities",
+        "blockers",
+        "contractContext",
+        "expansionSignals",
+        "agreementOutlook",
+        "valueDelivered",
+        "successMetrics",
+        "openCommitments",
+        "stakeholderInsights",
+        "companyContext",
+    ]
+}
+
+fn projection_claim_retained_keys(
+    intel: &crate::intelligence::IntelligenceJson,
+) -> Vec<(String, String, String)> {
+    let mut keys = Vec::new();
+
+    if let Some(summary) = intel.executive_assessment.as_deref() {
+        push_projection_claim_key(&mut keys, "entity_summary", "executiveAssessment", summary);
+    }
+    if let Some(pull_quote) = intel.pull_quote.as_deref() {
+        push_projection_claim_key(&mut keys, "entity_summary", "pullQuote", pull_quote);
+    }
+    if let Some(health) = intel.health.as_ref() {
+        if let Some(text) = health_projection_text(health) {
+            push_projection_claim_key(&mut keys, "entity_current_state", "health", &text);
+        }
+        for (idx, action) in health.recommended_actions.iter().enumerate() {
+            push_projection_claim_key(
+                &mut keys,
+                "recommendation",
+                &format!("health.recommendedActions[{idx}]"),
+                action,
+            );
+        }
+    }
+    for (idx, risk) in intel.risks.iter().enumerate() {
+        push_projection_claim_key(
+            &mut keys,
+            "entity_risk",
+            &format!("risks[{idx}]"),
+            &risk.text,
+        );
+    }
+    for (idx, action) in intel.recommended_actions.iter().enumerate() {
+        if let Some(text) = recommended_action_projection_text(action) {
+            push_projection_claim_key(
+                &mut keys,
+                "recommendation",
+                &format!("recommendedActions[{idx}]"),
+                &text,
+            );
+        }
+    }
+    for (idx, win) in intel.recent_wins.iter().enumerate() {
+        push_projection_claim_key(
+            &mut keys,
+            "entity_win",
+            &format!("recentWins[{idx}]"),
+            &win.text,
+        );
+    }
+    if let Some(state) = intel.current_state.as_ref() {
+        if let Some(text) = current_state_projection_text(state) {
+            push_projection_claim_key(&mut keys, "entity_current_state", "currentState", &text);
+        }
+    }
+    for (idx, priority) in intel.strategic_priorities.iter().enumerate() {
+        if let Some(text) = strategic_priority_projection_text(priority) {
+            push_projection_claim_key(
+                &mut keys,
+                "entity_current_state",
+                &format!("strategicPriorities[{idx}]"),
+                &text,
+            );
+        }
+    }
+    for (idx, blocker) in intel.blockers.iter().enumerate() {
+        if let Some(text) = blocker_projection_text(blocker) {
+            push_projection_claim_key(&mut keys, "entity_risk", &format!("blockers[{idx}]"), &text);
+        }
+    }
+    if let Some(context) = intel.contract_context.as_ref() {
+        if let Some(text) = contract_context_projection_text(context) {
+            let claim_type = if intel.entity_type == "account" {
+                "company_context"
+            } else {
+                "entity_current_state"
+            };
+            push_projection_claim_key(&mut keys, claim_type, "contractContext", &text);
+        }
+    }
+    for (idx, signal) in intel.expansion_signals.iter().enumerate() {
+        if let Some(text) = expansion_signal_projection_text(signal) {
+            push_projection_claim_key(
+                &mut keys,
+                "entity_current_state",
+                &format!("expansionSignals[{idx}]"),
+                &text,
+            );
+        }
+    }
+    if let Some(outlook) = intel.agreement_outlook.as_ref() {
+        if let Some(text) = agreement_outlook_projection_text(outlook) {
+            push_projection_claim_key(&mut keys, "entity_current_state", "agreementOutlook", &text);
+        }
+    }
+    for (idx, value) in intel.value_delivered.iter().enumerate() {
+        push_projection_claim_key(
+            &mut keys,
+            "value_delivered",
+            &format!("valueDelivered[{idx}]"),
+            &value.statement,
+        );
+    }
+    if let Some(metrics) = intel.success_metrics.as_ref() {
+        for (idx, metric) in metrics.iter().enumerate() {
+            if let Some(text) = success_metric_projection_text(metric) {
+                push_projection_claim_key(
+                    &mut keys,
+                    "entity_current_state",
+                    &format!("successMetrics[{idx}]"),
+                    &text,
+                );
+            }
+        }
+    }
+    if let Some(commitments) = intel.open_commitments.as_ref() {
+        for (idx, commitment) in commitments.iter().enumerate() {
+            if let Some(text) = open_commitment_projection_text(commitment) {
+                let claim_type = if intel.entity_type == "account" {
+                    "commitment"
+                } else {
+                    "entity_current_state"
+                };
+                push_projection_claim_key(
+                    &mut keys,
+                    claim_type,
+                    &format!("openCommitments[{idx}]"),
+                    &text,
+                );
+            }
+        }
+    }
+    for (idx, insight) in intel.stakeholder_insights.iter().enumerate() {
+        if insight.person_id.is_some() {
+            if let Some(text) = stakeholder_engagement_projection_text(insight) {
+                push_projection_claim_key(
+                    &mut keys,
+                    "stakeholder_engagement",
+                    &format!("stakeholderInsights[{idx}].engagement"),
+                    &text,
+                );
+            }
+        }
+    }
+    if intel.entity_type == "account" {
+        if let Some(context) = intel.company_context.as_ref() {
+            if let Some(text) = company_context_projection_text(context) {
+                push_projection_claim_key(&mut keys, "company_context", "companyContext", &text);
+            }
+        }
+    }
+
+    keys
+}
+
+fn push_projection_claim_key(
+    keys: &mut Vec<(String, String, String)>,
+    claim_type: &str,
+    field_path: &str,
+    text: &str,
+) {
+    if text.trim().is_empty() {
+        return;
+    }
+    keys.push((
+        claim_type.to_string(),
+        field_path.to_string(),
+        crate::services::claims::normalize_claim_text(text),
+    ));
 }
 
 fn withdraw_cleared_dimension_projection_claims(
@@ -4021,6 +4330,67 @@ mod tests {
                 .is_some_and(|fields| !fields.is_empty()),
             "validated provenance envelope should attribute the generated claim"
         );
+    }
+
+    #[test]
+    fn refreshed_glean_projection_withdraws_stale_same_root_claims() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-generated-risk-refresh";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(54);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        let first = generated_risk_intel(account_id);
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &first)
+            .expect("commit first Glean generated risk projection");
+        let first_claim_id = active_generated_risk_id(&db, account_id);
+
+        let mut second = generated_risk_intel(account_id);
+        second.risks[0].text = "Updated CRM renewal risk needs executive follow-up.".to_string();
+        if let Some(source) = second.risks[0].item_source.as_mut() {
+            source.sourced_at = "2026-05-22T13:30:00Z".to_string();
+            source.reference = Some("Updated CRM opportunity fixture".to_string());
+        }
+        upsert_glean_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &second)
+            .expect("commit refreshed Glean generated risk projection");
+
+        assert_eq!(active_generated_risk_count(&db, account_id), 1);
+        let active_text: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT text
+                   FROM intelligence_claims
+                  WHERE claim_type = 'entity_risk'
+                    AND field_path = 'risks[0]'
+                    AND claim_state = 'active'
+                    AND surfacing_state = 'active'
+                    AND json_valid(subject_ref) = 1
+                    AND json_extract(subject_ref, '$.id') = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("active refreshed risk text");
+        assert_eq!(
+            active_text,
+            "updated crm renewal risk needs executive follow-up."
+        );
+
+        let (old_state, old_surface, old_reason): (String, String, Option<String>) = db
+            .conn_ref()
+            .query_row(
+                "SELECT claim_state, surfacing_state, retraction_reason
+                   FROM intelligence_claims
+                  WHERE id = ?1",
+                params![first_claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read first refreshed claim");
+        assert_eq!(old_state, "withdrawn");
+        assert_eq!(old_surface, "dormant");
+        assert_eq!(old_reason.as_deref(), Some("projection_refreshed"));
     }
 
     #[test]
@@ -5901,51 +6271,79 @@ mod mutation_smoke_tests {
     #[test]
     fn materialization_failure_blocks_export_for_visible_generation_side_effects() {
         let state = remote_glean_state();
-        for (producer, expected_error) in [
-            (
-                crate::intel_queue::EnrichmentProducer::Glean,
-                "Glean enrichment side-effect sync failed",
-            ),
-            (
-                crate::intel_queue::EnrichmentProducer::Pty,
-                "PTY enrichment side-effect sync failed",
-            ),
-        ] {
-            let db = test_db();
-            let entity_id = format!("acc-finalize-side-effect-failure-{producer:?}");
-            seed_finalize_account(&db, &entity_id);
-            db.conn_ref()
-                .execute_batch(
-                    "CREATE TRIGGER fail_commitment_insert
-                     BEFORE INSERT ON captured_commitments
-                     WHEN NEW.account_id LIKE 'acc-finalize-side-effect-failure-%'
-                     BEGIN
-                       SELECT RAISE(ABORT, 'forced visible materialization failure');
-                     END;",
-                )
-                .expect("install side-effect failure trigger");
-            let dir = tempfile::tempdir().expect("tempdir");
-            let input = make_enrichment_input(&entity_id, dir.path());
-            let intel = make_visible_materialization_intel(&entity_id);
+        let db = test_db();
+        let entity_id = "acc-finalize-side-effect-failure-glean";
+        seed_finalize_account(&db, entity_id);
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER fail_commitment_insert
+                 BEFORE INSERT ON captured_commitments
+                 WHEN NEW.account_id = 'acc-finalize-side-effect-failure-glean'
+                 BEGIN
+                   SELECT RAISE(ABORT, 'forced visible materialization failure');
+                 END;",
+            )
+            .expect("install side-effect failure trigger");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = make_enrichment_input(entity_id, dir.path());
+        let intel = make_visible_materialization_intel(entity_id);
 
-            let result = run_enrichment_finalize_post_commit(
-                &state,
-                &db,
-                &input,
-                &intel,
-                &[],
-                FinalizeMode::ManualRefresh { producer },
-            );
+        let result = run_enrichment_finalize_post_commit(
+            &state,
+            &db,
+            &input,
+            &intel,
+            &[],
+            FinalizeMode::ManualRefresh {
+                producer: crate::intel_queue::EnrichmentProducer::Glean,
+            },
+        );
 
-            assert!(
-                result.is_err_and(|error| error.contains(expected_error)),
-                "{producer:?} side-effect failure must stop finalize success"
-            );
-            assert!(
-                !dir.path().join("intelligence.json").exists(),
-                "generated exports must wait until visible materialization completes for {producer:?}"
-            );
-        }
+        assert!(
+            result.is_err_and(|error| error.contains("Glean enrichment side-effect sync failed")),
+            "Glean side-effect failure must stop finalize success"
+        );
+        assert!(
+            !dir.path().join("intelligence.json").exists(),
+            "Glean generated exports must wait until visible materialization completes"
+        );
+    }
+
+    #[test]
+    fn pty_side_effect_failure_stays_non_fatal_after_commit() {
+        let state = remote_glean_state();
+        let db = test_db();
+        let entity_id = "acc-finalize-side-effect-failure-pty";
+        seed_finalize_account(&db, entity_id);
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER fail_commitment_insert
+                 BEFORE INSERT ON captured_commitments
+                 WHEN NEW.account_id = 'acc-finalize-side-effect-failure-pty'
+                 BEGIN
+                   SELECT RAISE(ABORT, 'forced visible materialization failure');
+                 END;",
+            )
+            .expect("install side-effect failure trigger");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = make_enrichment_input(entity_id, dir.path());
+        let intel = make_visible_materialization_intel(entity_id);
+
+        run_enrichment_finalize_post_commit(
+            &state,
+            &db,
+            &input,
+            &intel,
+            &[],
+            FinalizeMode::ManualRefresh {
+                producer: crate::intel_queue::EnrichmentProducer::Pty,
+            },
+        )
+        .expect("PTY side-effect failure should remain non-fatal");
+        assert!(
+            dir.path().join("intelligence.json").exists(),
+            "PTY generated exports should continue after non-authoritative side-effect failure"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/trust_recompute.rs
+++ b/src-tauri/src/services/trust_recompute.rs
@@ -400,7 +400,7 @@ fn build_trust_context_for_claim(
     );
     let now = ctx.clock.now();
     let freshness = collect_trust_input(
-        freshness_context_for_claim(now, claim),
+        freshness_context_for_claim(db, now, claim),
         &mut indeterminate_reasons,
     );
     let source_lifecycle = collect_trust_input(
@@ -639,18 +639,17 @@ pub(crate) fn source_lifecycle_for_claim(
 }
 
 pub(crate) fn freshness_context_for_claim(
+    db: &ActionDb,
     now: chrono::DateTime<Utc>,
     claim: &IntelligenceClaim,
 ) -> TrustInput<crate::abilities::trust::FreshnessContext> {
     let mut indeterminate: Option<&'static str> = None;
+    let mut freshest_source_asof = None;
 
     if let Some(source_asof) = claim.source_asof.as_deref() {
         match chrono::DateTime::parse_from_rfc3339(source_asof) {
             Ok(parsed) => {
-                return TrustInput::ok(crate::abilities::trust::FreshnessContext {
-                    timestamp_known: true,
-                    age_days: age_days(now, parsed.with_timezone(&Utc)),
-                });
+                freshest_source_asof = Some(parsed.with_timezone(&Utc));
             }
             Err(e) => {
                 log::warn!(
@@ -660,6 +659,42 @@ pub(crate) fn freshness_context_for_claim(
                 indeterminate = Some("freshness_source_asof_malformed");
             }
         }
+    }
+
+    match freshest_corroboration_source_asof(db, &claim.id) {
+        TrustInput {
+            value: Some(corroboration_source_asof),
+            indeterminate_reason,
+        } => {
+            if freshest_source_asof
+                .map(|current| corroboration_source_asof > current)
+                .unwrap_or(true)
+            {
+                freshest_source_asof = Some(corroboration_source_asof);
+            }
+            if indeterminate_reason.is_some() {
+                indeterminate = indeterminate_reason;
+            }
+        }
+        TrustInput {
+            value: None,
+            indeterminate_reason: Some(reason),
+        } => indeterminate = Some(reason),
+        TrustInput {
+            value: None,
+            indeterminate_reason: None,
+        } => {}
+    }
+
+    if let Some(source_asof) = freshest_source_asof {
+        let value = crate::abilities::trust::FreshnessContext {
+            timestamp_known: true,
+            age_days: age_days(now, source_asof),
+        };
+        return match indeterminate {
+            Some(reason) => TrustInput::indeterminate(value, reason),
+            None => TrustInput::ok(value),
+        };
     }
 
     for (label, fallback) in [
@@ -691,6 +726,66 @@ pub(crate) fn freshness_context_for_claim(
     match indeterminate {
         Some(reason) => TrustInput::indeterminate(value, reason),
         None => TrustInput::ok(value),
+    }
+}
+
+fn freshest_corroboration_source_asof(
+    db: &ActionDb,
+    claim_id: &str,
+) -> TrustInput<Option<chrono::DateTime<Utc>>> {
+    let mut stmt = match db
+        .conn_ref()
+        .prepare("SELECT source_asof FROM claim_corroborations WHERE claim_id = ?1")
+    {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            log::warn!(
+                "TrustRecompute: failed to prepare corroboration freshness read for {claim_id}: {e}"
+            );
+            return TrustInput::indeterminate(None, "freshness_corroboration_prepare_failed");
+        }
+    };
+    let rows = match stmt.query_map(rusqlite::params![claim_id], |row| {
+        row.get::<_, Option<String>>(0)
+    }) {
+        Ok(rows) => rows,
+        Err(e) => {
+            log::warn!(
+                "TrustRecompute: failed to read corroboration freshness for {claim_id}: {e}"
+            );
+            return TrustInput::indeterminate(None, "freshness_corroboration_query_failed");
+        }
+    };
+
+    let mut freshest = None;
+    let mut indeterminate = None;
+    for row in rows {
+        match row {
+            Ok(Some(source_asof)) => match chrono::DateTime::parse_from_rfc3339(&source_asof) {
+                Ok(parsed) => {
+                    let parsed = parsed.with_timezone(&Utc);
+                    if freshest.map(|current| parsed > current).unwrap_or(true) {
+                        freshest = Some(parsed);
+                    }
+                }
+                Err(e) => {
+                    log::warn!(
+                        "TrustRecompute: malformed corroboration source_asof on {claim_id}: {e}"
+                    );
+                    indeterminate = Some("freshness_corroboration_source_asof_malformed");
+                }
+            },
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!("TrustRecompute: malformed corroboration row for {claim_id}: {e}");
+                indeterminate = Some("freshness_corroboration_row_decode_failed");
+            }
+        }
+    }
+
+    match indeterminate {
+        Some(reason) => TrustInput::indeterminate(freshest, reason),
+        None => TrustInput::ok(freshest),
     }
 }
 
@@ -1149,8 +1244,10 @@ mod tests {
     use super::*;
     use crate::db::claims::{ClaimSensitivity, TemporalScope};
     use crate::db::test_utils::test_db;
+    use crate::intelligence::{IntelRisk, IntelligenceJson, ItemSource};
     use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim};
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
+    use crate::signals::propagation::PropagationEngine;
 
     const TS: &str = "2026-05-04T12:00:00+00:00";
 
@@ -1254,6 +1351,117 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("count invalidation jobs")
+    }
+
+    #[test]
+    fn generation_commit_enqueues_trust_recompute() {
+        let db = test_db();
+        let account_id = "acct-generated-trust-recompute";
+        seed_account(&db, account_id);
+        let (clock, rng, ext) = fixed_ctx();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let engine = PropagationEngine::default();
+        let intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: TS.to_string(),
+            risks: vec![IntelRisk {
+                render_policy: None,
+                claim_id: None,
+                text: "Renewal owner has not approved the deployment plan.".to_string(),
+                item_source: Some(ItemSource {
+                    source: "glean_crm".to_string(),
+                    confidence: 0.9,
+                    sourced_at: TS.to_string(),
+                    reference: Some("CRM opportunity fixture".to_string()),
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        crate::services::intelligence::upsert_assessment_from_enrichment(
+            &ctx, &db, &engine, "account", account_id, &intel,
+        )
+        .expect("commit generated intelligence");
+
+        assert_eq!(
+            invalidation_job_count(&db),
+            1,
+            "generated intelligence commits must enqueue trust recompute"
+        );
+    }
+
+    #[test]
+    fn freshness_context_uses_newer_corroboration_source_asof() {
+        let db = test_db();
+        let account_id = "acct-corroboration-freshness";
+        seed_account(&db, account_id);
+        let (clock, rng, ext) = fixed_ctx();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let text = "Renewal owner has not approved the deployment plan.";
+
+        let mut first = claim_proposal("account", account_id, "risk", text);
+        first.data_source = "glean_crm".to_string();
+        first.source_asof = Some("2026-05-01T12:00:00+00:00".to_string());
+        first.observed_at = "2026-05-01T12:00:00+00:00".to_string();
+        let claim_id = inserted_claim_id(commit_claim(&ctx, &db, first).expect("commit claim"));
+
+        let mut second = claim_proposal("account", account_id, "risk", text);
+        second.data_source = "glean_crm".to_string();
+        second.source_asof = Some("2026-05-02T12:00:00+00:00".to_string());
+        second.observed_at = "2026-05-02T12:00:00+00:00".to_string();
+        match commit_claim(&ctx, &db, second).expect("reinforce claim") {
+            CommittedClaim::Reinforced { claim, .. } => assert_eq!(claim.id, claim_id),
+            other => panic!("same claim should reinforce, got {other:?}"),
+        }
+
+        let mut third = claim_proposal("account", account_id, "risk", text);
+        third.data_source = "glean_crm".to_string();
+        third.source_asof = Some("2026-05-03T12:00:00+00:00".to_string());
+        third.observed_at = "2026-05-03T12:00:00+00:00".to_string();
+        match commit_claim(&ctx, &db, third).expect("reinforce claim again") {
+            CommittedClaim::Reinforced { claim, .. } => assert_eq!(claim.id, claim_id),
+            other => panic!("same claim should reinforce again, got {other:?}"),
+        }
+
+        let subject_ref = serde_json::json!({ "kind": "account", "id": account_id }).to_string();
+        let active = crate::services::claims::load_claims_active(&db, &subject_ref, Some("risk"))
+            .expect("load active claim");
+        assert_eq!(active.len(), 1);
+        assert_eq!(
+            active[0].source_asof.as_deref(),
+            Some("2026-05-01T12:00:00+00:00"),
+            "the canonical claim row stays immutable"
+        );
+
+        let corroboration: (Option<String>, i64) = db
+            .conn_ref()
+            .query_row(
+                "SELECT source_asof, reinforcement_count
+                   FROM claim_corroborations
+                  WHERE claim_id = ?1
+                    AND data_source = 'glean_crm'",
+                params![&claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read corroboration");
+        assert_eq!(
+            corroboration.0.as_deref(),
+            Some("2026-05-03T12:00:00+00:00")
+        );
+        assert_eq!(corroboration.1, 2);
+
+        let (freshness, reason) = freshness_context_for_claim(
+            &db,
+            Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap(),
+            &active[0],
+        )
+        .into_parts();
+        assert_eq!(reason, None);
+        assert!(freshness.timestamp_known);
+        assert_eq!(freshness.age_days, 1.0);
     }
 
     #[test]

--- a/src-tauri/src/signals/bus.rs
+++ b/src-tauri/src/signals/bus.rs
@@ -1210,6 +1210,16 @@ mod tests {
     use super::*;
     use crate::db::test_utils::test_db;
 
+    static COALESCING_TEST_LOCK: OnceLock<parking_lot::Mutex<()>> = OnceLock::new();
+
+    fn reset_coalescing_state_for_test() -> parking_lot::MutexGuard<'static, ()> {
+        let guard = COALESCING_TEST_LOCK
+            .get_or_init(|| parking_lot::Mutex::new(()))
+            .lock();
+        *coalescing_state().lock() = CoalescingState::default();
+        guard
+    }
+
     #[test]
     fn test_source_base_weights() {
         assert_eq!(source_base_weight("user_correction"), 1.0);
@@ -1435,7 +1445,7 @@ mod tests {
 
     #[test]
     fn dos237_coalesces_duplicate_entity_signals_inside_window() {
-        *coalescing_state().lock() = CoalescingState::default();
+        let _coalescing_guard = reset_coalescing_state_for_test();
         let db = test_db();
 
         let first = emit_signal(
@@ -1482,7 +1492,7 @@ mod tests {
         //
         // After the fix: rapid transitions on the same meeting collapse to
         // a single signal_events row inside the 500ms window.
-        *coalescing_state().lock() = CoalescingState::default();
+        let _coalescing_guard = reset_coalescing_state_for_test();
         let db = test_db();
 
         let first = emit_signal(
@@ -1536,7 +1546,7 @@ mod tests {
         // Documented ordering: emits land in arrival order. Subscribers
         // that need cross-signal serialization observe both events on the
         // signal_events table ordered by `created_at` ASC.
-        *coalescing_state().lock() = CoalescingState::default();
+        let _coalescing_guard = reset_coalescing_state_for_test();
         let db = test_db();
 
         let prep_id = emit_signal(
@@ -1796,7 +1806,7 @@ mod tests {
     #[test]
     fn dos262_distinct_unknown_signal_types_do_not_coalesce() {
         let _env_guard = fail_improve_env_lock().lock().expect("env lock");
-        *coalescing_state().lock() = CoalescingState::default();
+        let _coalescing_guard = reset_coalescing_state_for_test();
         let tmp = tempfile::tempdir().expect("tempdir");
         let _restore = EnvRestore {
             previous: std::env::var_os("DAILYOS_FAIL_IMPROVE_ROOT"),

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { formatGleanDegradedMessage } from "./useNotifications";
+
+describe("formatGleanDegradedMessage", () => {
+  it("uses applicable dimensions instead of the legacy six-dimension total", () => {
+    expect(
+      formatGleanDegradedMessage({
+        entity_id: "entity-1",
+        entity_type: "person",
+        succeeded: 2,
+        failed: 1,
+        failed_dimensions: ["engagement_signals"],
+        required_failed_dimensions: ["engagement_signals"],
+        optional_failed_dimensions: [],
+        total_dimensions: 6,
+        applicable_total: 3,
+        skipped_dimensions: [
+          "commercial_financial",
+          "strategic_context",
+          "value_success",
+        ],
+        wall_clock_ms: 1200,
+        will_fall_back: false,
+      }),
+    ).toBe(
+      "Glean refresh incomplete (2/3 applicable areas updated; 3 not applicable; 1 need attention) - showing partial results",
+    );
+  });
+
+  it("keeps older payloads readable", () => {
+    expect(
+      formatGleanDegradedMessage({
+        entity_id: "entity-1",
+        entity_type: "account",
+        succeeded: 2,
+        failed: 4,
+        failed_dimensions: [
+          "commercial_financial",
+          "strategic_context",
+          "value_success",
+          "engagement_signals",
+        ],
+        wall_clock_ms: 1200,
+        will_fall_back: false,
+      }),
+    ).toBe(
+      "Glean refresh incomplete (2/6 applicable areas updated; 4 need attention) - showing partial results",
+    );
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -10,18 +10,23 @@ interface SystemStatusPayload {
 }
 
 /**
- * Payload emitted by `GleanProvider` when one or more of the 6 enrichment
+ * Payload emitted by `GleanProvider` when one or more applicable refresh
  * dimensions fail. When `will_fall_back` is true, Glean returned nothing
  * usable and the backend swaps to the legacy PTY enrichment path.
  *
  * Shape defined in src-tauri/src/intelligence/glean_provider.rs (~L412-423).
  */
-interface GleanDegradedPayload {
+export interface GleanDegradedPayload {
   entity_id: string;
   entity_type: string;
   succeeded: number;
   failed: number;
   failed_dimensions: string[];
+  required_failed_dimensions?: string[];
+  optional_failed_dimensions?: string[];
+  total_dimensions?: number;
+  applicable_total?: number;
+  skipped_dimensions?: string[];
   wall_clock_ms: number;
   will_fall_back: boolean;
 }
@@ -39,8 +44,27 @@ interface GleanFallbackPayload {
   reason: string;
 }
 
-/** Total number of Glean enrichment dimensions (health, relationships, etc.). */
+/** Legacy total used when older backend payloads do not include applicability. */
 const GLEAN_DIMENSIONS_TOTAL = 6;
+
+export function formatGleanDegradedMessage(payload: GleanDegradedPayload) {
+  const applicableTotal = Math.max(
+    1,
+    payload.applicable_total ?? payload.total_dimensions ?? GLEAN_DIMENSIONS_TOTAL,
+  );
+  const succeeded = Math.max(0, Math.min(payload.succeeded, applicableTotal));
+  const skippedCount = payload.skipped_dimensions?.length ?? 0;
+  const requiredFailures =
+    payload.required_failed_dimensions ?? payload.failed_dimensions ?? [];
+  const skippedText =
+    skippedCount > 0 ? `; ${skippedCount} not applicable` : "";
+  const failureText =
+    requiredFailures.length > 0
+      ? `; ${requiredFailures.length} need attention`
+      : "";
+
+  return `Glean refresh incomplete (${succeeded}/${applicableTotal} applicable areas updated${skippedText}${failureText}) - showing partial results`;
+}
 
 /**
  * Milestone operations worth toasting.
@@ -115,14 +139,7 @@ export function useNotifications() {
 
   const handleGleanDegraded = useCallback((payload: GleanDegradedPayload) => {
     if (!payload || payload.will_fall_back) return;
-    const succeeded = Math.max(
-      0,
-      Math.min(payload.succeeded, GLEAN_DIMENSIONS_TOTAL),
-    );
-    toast.warning(
-      `Glean enrichment degraded (${succeeded}/${GLEAN_DIMENSIONS_TOTAL} dimensions) — showing partial results`,
-      { duration: 10000 },
-    );
+    toast.warning(formatGleanDegradedMessage(payload), { duration: 10000 });
   }, []);
 
   const handleGleanFallback = useCallback((_payload: GleanFallbackPayload) => {
@@ -148,7 +165,7 @@ export function useNotifications() {
   // System status events — pipeline errors and auth issues from backend
   useTauriEvent("system-status", handleSystemStatus);
 
-  // Glean enrichment degraded — partial dimension failure. If the
+  // Glean refresh incomplete — partial dimension failure. If the
   // backend is also about to fall back to PTY (`will_fall_back`), let
   // the paired `enrichment-glean-fallback` toast own the messaging so
   // we don't double-toast the same account.


### PR DESCRIPTION
## Linear ticket

S0 Glean refresh quality / intelligence generation contract work.

## Summary

Refresh results now flow through one materialization contract before they reach claims, trust recompute, export side effects, or the notification surface. A Glean-backed refresh should no longer degrade because optional dimensions were inapplicable, should not duplicate exact existing claims/actions, and should remove stale Glean-sourced rows when refreshed evidence explicitly returns empty for that field.

## What changed

- Local and Glean outputs share the same schema/materialization path before claim projection and export side effects.
- Prompt parsing records which fields were actually refreshed, so explicit empty arrays can clear stale Glean-owned rows without wiping unrelated local intelligence.
- Generated projection claims carry source provenance and `source_asof`, reinforce matching active claims, and withdraw stale producer-scoped claims when refreshed output no longer retains them.
- Glean-produced projection claims cannot self-label as local evidence sources; unapproved item-level source labels are coerced to the Glean boundary and remain purgeable as Glean-owned.
- Post-commit PTY side-effect failures remain non-fatal, while visible Glean materialization failures no longer report a false completed state.
- Notification copy reports completion/degradation against applicable refresh areas instead of the legacy six-dimension denominator.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run src/hooks/useNotifications.test.ts` passes
- [x] Focused backend coverage for explicit empty Glean fields, dimension merge clearing, generated projection withdrawal/reissue, stakeholder person-subject lifecycle, parser refreshed-field tracking, queue final-status reporting, and Glean source-boundary coercion
- [ ] Manual verification: test merged app refresh path after PR lands

## Definition of Done

- [x] Acceptance criteria from the S0 plan are validated with real data-shaped fixtures, not stubs
- [x] End-to-end refresh flow works through materialization, claim projection, recompute enqueueing, and rendered notification states
- [x] No stubs, TODOs, or Phase 2 deferrals introduced
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: Not exempt. This PR touches `src-tauri/src/services/`, `src-tauri/src/intelligence/`, claim projection lifecycle, and source-boundary behavior.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- None.

## Notes for review

A bounded L2 security review found one source-boundary blocker: Glean-produced output could carry a non-Glean item source and make generated claims look local. Commit `57f03478` fixes this by allowing only approved Glean downstream labels for Glean-produced projection claims and coercing everything else back to `glean`. Security recheck: passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
