### PR TITLE
Implement v1.4.6 W2 recommendation surfacing

### DIFF
--- a/.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md
@@ -1,0 +1,429 @@
+# L0 packet — v1.4.6 W2 — DOS-331 / DOS-334
+
+## Status
+
+- Branch: `codex/v1.4.6-w2-surfacing-triggers`
+- Base: `public/dev` at `c2167424` (`Add salience scoring read path (#401)`)
+- Issues: DOS-331 surfacing policy, DOS-334 trigger policy
+- Scope: one coordinated W2 PR; two logical lanes sharing migration/devtools registration files and joined by the trigger -> surfacing handoff
+- L0 state: PASS after 2026-05-26 engineering-ladder + producer-era reconciliation; product/K-in/security/Codex challenge all passed after amendment cycles
+
+## 0. Ladder metadata and scope
+
+- Scope tier: **Standard with Amendment 3 add-on**. W2 is one bounded recommendation-domain PR, but it touches migrations, write paths, signal emission, provenance/privacy payloads, and surfacing policy.
+- Origination class: **Extension**. W2 extends the v1.4.6 W1 recommendation and salience substrate; it is not a debug-driven cure for a traced symptom and not greenfield substrate.
+- Trust topology: **local-to-local single-user**. W2 does not add MCP, SurfaceClient, remote, or multi-user exposure. Privacy-safe signal/audit payloads, source hygiene, prompt-injection discipline for external evidence inputs, and ADR-0108 log redaction still apply.
+- Current ladder source: `.docs/plans/engineering-ladder.md` / `.docs/plans/engineering-ladder.html`, adopted 2026-05-18 and revised 2026-05-23.
+- L0 panel for this amendment: `/codex challenge` + `ce-product-lens-reviewer` + `ce-security-lens-reviewer`, with `ce-learnings-researcher` K-in in parallel. Product lens reviews thresholds/budgets/cooldowns. Security lens reviews privacy-safe payloads, no direct bus semantics, and no surface/MCP authority.
+- L2 router expectation if L0 passes: `/codex review` through `l2-bounded-reviewer`, plus `ce-data-migrations-reviewer` and `pr-review-toolkit:silent-failure-hunter` unless the diff shape changes. Advisory reviewers file path-alpha findings to maintenance unless they are AC/ADR/touched-regression bound.
+
+## Goal
+
+W1 made recommendations claim-backed and salience-scored. W2 decides what happens next:
+
+- DOS-331 answers: render, defer, or suppress this recommendation now?
+- DOS-334 answers: why did this candidate refresh run, what did it consider, and which downstream policy owned the result?
+
+This is not notification automation and not a new queue. It is inspectable policy and audit state for existing claim/salience contracts.
+
+## Producer classification
+
+W2 is not a new durable recommendation producer. It coordinates derived policy/evaluation state over recommendation claims created by W1-A/upstream producers.
+
+| Artifact | Class | W2 rule |
+|---|---|---|
+| `RecommendationClaim` writes | Durable claim producer | Out of scope. W2 reads active `ClaimType::Recommendation` claims and never bypasses `services::claims::commit_claim`. |
+| `salience_evaluations` / factor rows | Derived read-model / evaluation evidence | W2-A may require stored salience evaluation ids before writing surfacing decisions. Salience does not mutate trust or claim lifecycle by itself. |
+| `surfacing_decisions` | Derived policy / audit state | W2-A writes render/defer/suppress decisions and safe reasons. The table is not a surface API and not a second claim authority. |
+| `triggers_log` | Operational audit state | W2-B logs run ids, trigger classes, safe source tokens, and returned salience/surfacing ids. No raw paths, claim text, prompt/output bodies, provider text, or source bodies. |
+| `why_this_now` | Deterministic render helper | Template over typed factor and trigger refs only. No LLM calls and no raw source interpolation. |
+| Future WP/MCP/Tauri consumers | Ability producer / projection | Out of scope for W2. Later lanes must expose an ability-backed recommendation projection before any surface consumes W2 state. |
+
+## Non-goals
+
+- No changes to `signals::bus` semantics.
+- No changes to `signals/policy_registry.rs`; W0 already predeclared `SalienceCandidateRefreshTriggered` and `SurfacingDecisionMade`.
+- No changes to `services/claims.rs`, `commit_claim`, trust recompute, or claim lifecycle helpers.
+- No MCP exposure, SurfaceClient exposure, or Tauri UI work.
+- No WP block or direct surface reader work. W2 emits/logs; W3+ owns ability-backed rendering.
+- No `external` surface class, external trigger disposition, or consumer-facing delivery semantics. External/MCP/surface consumer behavior requires a later L0 amendment.
+- No LLM/provider calls in recommendation policy modules.
+- No new recommendation feedback table. W4-A owns the feedback wrapper.
+
+## Current-code anchors
+
+- W2 wave plan: `.docs/plans/v1.4.6-waves.md:826`
+- Signal variants already present: `src-tauri/src/signals/policy_registry.rs`
+- Service signal facade: `src-tauri/src/services/signals.rs`
+- W1-A frozen contracts: `src-tauri/src/services/recommendations/contracts.rs`
+- W1-B salience read/write split: `src-tauri/src/services/recommendations/salience.rs`
+- Recommendation module skeleton: `src-tauri/src/services/recommendations/{surfacing,triggers,why_this_now}.rs`
+- Current migrations registered through v270: `src-tauri/src/migrations.rs`
+
+## K-in findings
+
+- ADR-0125 makes recommendations first-class claims. W2 reads `intelligence_claims` rows where `claim_type = 'recommendation'`; it does not create parallel recommendation state.
+- ADR-0126 warns against entity-wide attention budgets and hard-coded magic thresholds. W2 budgets are keyed by `actor_kind + local_day + claim_type + sensitivity + surface_class`, with the exact render surface stored for audit. The policy defaults are versioned rows for the `recommendation` claim type, not global entity constants.
+- ADR-0115 requires registry-backed signal policy. W2 emits predeclared typed invalidation signals by canonical string through `services::signals::emit_once_for_key_and_propagate`, passes the `PropagationEngine` through W2 service APIs, and never reaches into `signals::bus` directly.
+- ADR-0108 privacy rules apply to rendered/audit payloads: no raw claim text, raw paths, prompt/output bodies, or free-text rationale. W2 stores opaque IDs, enum reason codes, factor kinds, scores, and bounded typed trigger refs.
+- Existing `claim_feedback`, `claim_surface_dismissals`, and ADR-0123 feedback actions are enough for "recently dismissed/suppressed" reads. W2 may read current feedback/dismissal rows; W4-A later owns recommendation-specific feedback writes.
+
+## Product policy
+
+Policy version: `recommendation_surfacing_v1`.
+
+W2 treats these as the v1 claim-type surfacing policy for `ClaimType::Recommendation`. The migration materializes versioned policy defaults in `recommendation_surfacing_policy` because the existing `ClaimTypeMetadata` registry does not yet have budget fields. This is not a generic budget substrate and not a user setting; it is an auditable recommendation-policy table keyed the same way ADR-0126 requires budgets to be reasoned about.
+
+Budget key:
+
+`actor_kind + local_day + claim_type + sensitivity + surface_class`
+
+The exact `render_surface` is still recorded on every decision row, but primary recommendation volume is shared across primary app surfaces so the same user cannot receive three "top three" lists from briefing, entity detail, and work surfaces on the same local day.
+
+`surface_class` is a closed W2 enum: `primary | background | quiet | review`. `quiet` is first-class auditable policy state and must not be collapsed into `background`; `external` is explicitly out of scope for W2.
+
+Default surfacing thresholds, v1:
+
+| Condition | Decision |
+|---|---|
+| claim not active/currently surfaceable | `Suppress(BelowThreshold)` with audit code `claim_not_surfaceable` |
+| `claim_surface_dismissals` hides this claim on the requested surface | `Suppress(DismissedRecently)` |
+| recent claim feedback suppresses this recommendation family | `Suppress(DismissedRecently)` |
+| `salience.total >= 0.85` or urgency factor `>= 0.90` | `Render(Critical)` |
+| `salience.total >= 0.68` and budget remains | `Render(Notable)` |
+| `salience.total >= 0.68` and budget exhausted | `Defer(BudgetExhausted)` until next local day window |
+| `0.45 <= salience.total < 0.68` | `Render(Background)` for Activity Log / background slots only |
+| low-confidence but potentially important candidate | `Defer(AwaitingCorroboration)` |
+| active trigger is still pending | `Defer(PendingTrigger)` |
+| otherwise | `Suppress(BelowThreshold)` |
+
+Budget defaults, v1:
+
+- `Critical` does not consume the Notable budget, but all primary Critical renders are still bounded: max 1 Critical render per `actor_kind + local_day + claim_type + sensitivity + surface_class`. Additional Critical candidates always defer for the primary surface with `BudgetExhausted` until the next local day. If the overflow candidate has urgency `>= 0.95` and material new evidence, W2 may also record a review/background overflow outcome grouped by subject/action, but it must not create a second primary Critical render for the same budget key.
+- `Notable` consumes a shared primary daily budget of 3 for `recommendation/internal/primary` for the actor's local day.
+- `Background` and `Quiet` do not consume Notable budget, but `Background` has an Activity Log cap of 10 per actor/local day/surface_class and groups by subject/action when over cap.
+- Claim-level cooldown prevents the same claim from rendering in primary slots for 7 days.
+- Subject/action cooldown prevents the same `subject_kind + subject_id + action_signature` from rendering in primary slots for 3 days. `action_signature` is derived from W1-A `recommendation::action_key`; no semantic embedding or raw action text is used.
+- Recently suppressed feedback blocks resurfacing for 14 days. Critical/urgent candidates may override only when the trigger carries material new evidence after the dismissal timestamp: newer `source_asof`, changed `evidence_signature`, or changed subject/entity version. A new `source_signal_id` alone supports audit/dedupe, but it does not override dismissal or feedback suppression.
+
+Policy rationale:
+
+| Policy value | User-facing intent | Expected volume impact | False-positive risk | False-negative risk | DOS-338 validation |
+|---|---|---|---|---|---|
+| Critical threshold `0.85` or urgency `0.90` | Show the rare thing that should interrupt the normal shortlist. | At most 1 primary Critical per local day by storm guard. | Alarm fatigue if overflow review/background grouping fails. | A second urgent issue may be held outside primary until review/background or next day. | `high_signal_critical`, `critical_overflow_bounded`, `missed_important_urgent` |
+| Notable threshold `0.68`, budget `3` | Keep the main "what matters today" list to the morning top three. | Max 3 primary Notable recommendations per actor/local day/surface class. | Borderline items may crowd out truly useful later items. | Some good-but-not-top-three items wait until tomorrow or background. | `high_signal_notable`, `low_signal_stays_quiet`, `primary_budget_cap` |
+| Background threshold `0.45`, cap `10` | Preserve inspectability without creating primary-surface noise. | Activity Log can show lower-confidence candidates, grouped by subject/action. | Activity Log clutter if cap/grouping fails. | User may not see a weak early signal until it grows. | `background_grouping`, `low_signal_activity_log_only` |
+| Claim cooldown `7 days` | Avoid repeating the same recommendation after the user has seen it. | Same claim cannot occupy primary slots repeatedly within a week. | A still-relevant item may stay hidden too long. | Urgent same-claim changes could be delayed. | `stale_same_claim_cooldown`, `material_new_evidence_breaks_cooldown` |
+| Subject/action cooldown `3 days` | Avoid showing paraphrases of the same action. | Similar same-subject action family appears once per 3 days. | Generic action signatures may over-suppress related but distinct actions. | A second valid action of same kind may wait. | `subject_action_repeat_suppressed`, `distinct_action_allowed` |
+| Feedback suppression `14 days` | Respect explicit user judgment. | Dismissed/noisy recommendations stay suppressed unless the world changes. | User might dismiss too broadly. | Important recurrence could stay hidden without material evidence. | `suppressed_requires_new_evidence`, `noisy_fixture_stays_quiet` |
+
+## DOS-331 implementation shape
+
+Owned files:
+
+- `src-tauri/src/services/recommendations/surfacing.rs`
+- `src-tauri/src/services/recommendations/why_this_now.rs` for deterministic text helper only
+- Migration `src-tauri/src/migrations/271_recommendation_surfacing.sql`
+- `src-tauri/src/migrations.rs`
+- `src-tauri/src/devtools/mod.rs` seed/cleanup for new mock-data gate
+
+Service API:
+
+```rust
+pub fn decide_surfacing(candidate: SurfacingCandidate, policy: SurfacingPolicy, now: DateTime<Utc>) -> SurfacingDecision;
+
+pub fn evaluate_surfacing_for_claim(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &PropagationEngine,
+    input: SurfacingEvaluationInput,
+) -> Result<SurfacingEvaluation, SurfacingError>;
+```
+
+The pure function computes the decision. The service function is the write path:
+
+1. `ctx.check_mutation_allowed()?`
+2. Load the recommendation claim by id, including `claim_type`, `sensitivity`, lifecycle state, subject, metadata evidence, and W1-A action key.
+3. For mutation paths, W2-A is the sole owner of durable salience recompute: call W1-B `recompute_salience_for_claim` first and require `SaliencePersistence::Stored { evaluation_id }`. Pure/evaluate-only paths may use preview salience but must not write `surfacing_decisions` or emit signals.
+4. Read `recommendation_surfacing_policy` for `recommendation_surfacing_v1` and derive the ADR-0126 budget key.
+5. Read recent `surfacing_decisions` for budget/cooldown state.
+6. Read existing `claim_surface_dismissals` for the requested `ClaimDismissalSurface` and `claim_feedback` for broader suppression hints.
+7. Build sanitized `TriggerRef` values and deterministic `WhyThisNow`.
+8. Insert one `surfacing_decisions` row for every mutation-path evaluation.
+9. Emit `surfacing_decision_made` through `services::signals::emit_once_for_key_and_propagate` with source `recommendation_surfacing_policy` and a safe JSON value containing only IDs, policy version, decision kind, tier/reason code, and budget key.
+10. Return `SurfacingEvaluation` with the stored `salience_evaluation_id`, `surfacing_decision_id`, signal outcome, derived signal IDs, and decision. Trigger scans must copy these returned IDs into `triggers_log`; they must not recompute salience independently.
+
+`why_this_now.text` is deterministic template output:
+
+`Salience driven by {factor_label}: {typed_reason}. Triggers: {trigger_summary}.`
+
+No raw claim text is interpolated. Factor and trigger summaries come from closed enums and numeric fields.
+
+Policy table shape (`recommendation_surfacing_policy`):
+
+- `policy_version`
+- `claim_type`
+- `sensitivity`
+- `surface_class`: `primary | background | quiet | review`
+- `critical_threshold`
+- `urgent_threshold`
+- `notable_threshold`
+- `background_threshold`
+- `critical_daily_cap`
+- `notable_daily_budget`
+- `background_daily_cap`
+- `claim_cooldown_days`
+- `subject_action_cooldown_days`
+- `feedback_suppression_days`
+- `policy_source`: `claim_type:recommendation`
+- `created_at`
+
+Decision table shape (`surfacing_decisions`):
+
+- `id`
+- `evaluation_id`
+- `claim_id`
+- `subject_kind`, `subject_id`
+- `claim_type`
+- `sensitivity`
+- `decision_kind`: `render | defer | suppress`
+- `surfacing_tier`
+- `reason_kind`
+- `defer_until`
+- `why_this_now_json`
+- `trigger_refs_json`
+- `salience_total`
+- `primary_factor_kind`
+- `salience_evaluation_id`
+- `policy_version`
+- `policy_source`
+- `render_surface`
+- `surface_class`
+- `actor_kind`
+- `local_day`
+- `budget_key`
+- `budget_limit`
+- `budget_used_before`
+- `cooldown_until`
+- `action_signature`
+- `evidence_signature`
+- `material_evidence_after`
+- `created_at`
+
+Indexes:
+
+- `(claim_id, created_at DESC)`
+- `(subject_kind, subject_id, created_at DESC)`
+- `(budget_key, created_at DESC)`
+- `(subject_kind, subject_id, action_signature, created_at DESC)`
+- `(render_surface, created_at DESC)`
+- `(decision_kind, created_at DESC)`
+- unique idempotency index on `evaluation_id`
+
+## DOS-334 implementation shape
+
+Owned files:
+
+- `src-tauri/src/services/recommendations/triggers.rs`
+- Migration `src-tauri/src/migrations/272_recommendation_triggers_log.sql`
+- `src-tauri/src/migrations.rs`
+- `src-tauri/src/devtools/mod.rs` seed/cleanup for new mock-data gate
+
+Service API:
+
+```rust
+pub fn classify_trigger(input: TriggerPolicyInput, now: DateTime<Utc>) -> TriggerPolicy;
+
+pub fn run_trigger_scan(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &PropagationEngine,
+    input: TriggerScanInput,
+) -> Result<TriggerScanOutcome, TriggerError>;
+```
+
+The pure classifier makes trigger classes typed and inspectable. The service function is the write path:
+
+1. `ctx.check_mutation_allowed()?`
+2. Resolve the input into an internal `TriggerSourceClass`, frozen `TriggerKind`, subject/window, canonical signal/source type, and safe source token. `source_signal_type` is never caller-provided raw text; it is a registry-backed signal name or allowlisted policy token.
+3. Compute `dedupe_key`, `suppression_key`, `trust_floor`, `freshness_window_secs`, `trigger_disposition`, and `reason_code` from normalized tokens, opaque IDs, and keyed signatures only.
+4. Check existing `triggers_log` rows for the same `dedupe_key + policy_version`.
+   - `completed` inside the suppression window returns a coalesced outcome without a new scan.
+   - fresh `started` returns in-progress/coalesced.
+   - `failed_retryable` may insert a new attempt when `next_retry_at <= now`.
+5. Insert a `started` `triggers_log` row for the attempt. The unique idempotency key is `run_id`, not `dedupe_key`.
+6. Emit `salience_candidate_refresh_triggered` through `services::signals::emit_once_for_key_and_propagate` with source `recommendation_trigger_policy` and a safe JSON value containing only `run_id`, trigger class, subject/entity IDs, and reason code.
+7. Find recommendation claims for the subject/window.
+8. Hand each candidate into W2-A `evaluate_surfacing_for_claim(ctx, db, engine, ...)`. W2-B never calls `recompute_salience_for_claim` directly.
+9. Copy `candidate_claim_ids_json`, `salience_evaluation_ids_json`, and `surfacing_decision_ids_json` from the W2-A outcomes. These IDs must match the `surfacing_decisions.salience_evaluation_id` and decision IDs W2-A wrote.
+10. Update the `triggers_log` row to `completed` with candidate, salience, and surfacing decision IDs. On downstream failure, update to `failed_retryable` or `failed_terminal` with a closed error code and no raw error text.
+
+Trigger class defaults:
+
+| Trigger source class | Frozen `TriggerKind` | Trigger audit disposition | W2-A `surface_class` handoff | Trust floor | Freshness window | Dedupe key | Suppression key | Dedupe breaks when |
+|---|---|---|---|---|---|---|---|---|
+| `scheduled_freshness` | `ScheduledScan` | `silent_prepare` | `background` | `0.60` | `86400s` | `scheduled:{local_day}:{subject}:{surface_class}` | `subject_action:{subject}:{action_signature}` | local day changes or material evidence changes |
+| `event_invalidation` | `SignalArrival` | `primary_candidate` | `primary` | `0.70` | `21600s` | `signal:{source_signal_id}:{subject}` | `signal:{canonical_signal_type}:{subject}` | new signal id or subject version changes |
+| `manual_refresh` | `SignalArrival` | `review_candidate` | `review` | `0.50` | `0s` | `manual:{run_id}` | `manual:{actor_kind}:{subject}` | every explicit run id |
+| `entity_change` | `EntityChange` | `primary_candidate` | `primary` | `0.65` | `21600s` | `entity:{entity_type}:{entity_id}:{subject_version}` | `entity:{entity_type}:{entity_id}` | subject/entity version changes |
+| `claim_change` | `SignalArrival` | `primary_candidate` | `primary` | `0.70` | `21600s` | `claim:{claim_id}:{claim_version}` | `claim:{claim_id}` | claim version changes |
+| `source_change` | `SignalArrival` | `review_candidate` | `review` | `0.75` | `21600s` | `source:{source_signal_id}:{subject}` | `source:{source_fingerprint}:{subject}` | new source signal or newer `source_asof` |
+| `open_loop_change` | `SignalArrival` | `quiet_candidate` | `quiet` | `0.55` | `43200s` | `open_loop:{subject}:{open_loop_id}:{state}` | `subject_action:{subject}:{action_signature}` | open-loop state changes |
+| `meeting_window` | `EntityChange` | `primary_candidate` | `primary` | `0.65` | `7200s` | `meeting:{meeting_id}:{subject}:{window_start}` | `meeting:{meeting_id}:{subject}` | meeting window rolls or meeting evidence changes |
+| `decision_window` | `ScheduledScan` | `primary_candidate` | `primary` | `0.70` | `43200s` | `decision:{subject}:{decision_date}:{action_signature}` | `subject_action:{subject}:{action_signature}` | decision window/date or material evidence changes |
+| `feedback_echo` | `FeedbackEcho` | `quiet_candidate` | `quiet` | `0.50` | `604800s` | `feedback:{feedback_id}:{claim_id}` | `feedback:{claim_id}` | new feedback id |
+
+`trigger_disposition` is an internal audit/handoff hint only. It is not a delivery channel, notification target, surface API, or permission to render. W2-B passes the mapped W2-A `surface_class` into `evaluate_surfacing_for_claim`; W3+ ability projections decide whether anything is rendered.
+
+Table shape:
+
+- `id`
+- `run_id`
+- `policy_version`
+- `trigger_kind`
+- `trigger_class`
+- `source_signal_id`
+- `source_signal_type` (canonical registry/allowlisted token; never raw caller text)
+- `entity_type`, `entity_id`
+- `subject_ref_json`
+- `window_start`, `window_end`
+- `dedupe_key`
+- `suppression_key`
+- `trust_floor`
+- `freshness_window_secs`
+- `trigger_disposition`: `silent_prepare | primary_candidate | review_candidate | quiet_candidate`
+- `evidence_ref_ids_json`
+- `evidence_signature`
+- `candidate_claim_ids_json`
+- `salience_evaluation_ids_json`
+- `surfacing_decision_ids_json`
+- `status`: `started | completed | failed_retryable | failed_terminal` (`coalesced` is an outcome returned to callers, not a stored row status)
+- `result_kind`: `prepared_silently | render_decision_recorded | held_for_review | stayed_quiet | failed`
+- `downstream_policy`
+- `reason_code`
+- `attempt_count`
+- `next_retry_at`
+- `error_code`
+- `created_at`, `completed_at`
+
+Indexes:
+
+- unique idempotency index on `run_id`
+- `(dedupe_key, policy_version, status, next_retry_at)`
+- `(trigger_kind, created_at DESC)`
+- `(trigger_class, created_at DESC)`
+- `(entity_type, entity_id, created_at DESC)`
+- `(result_kind, created_at DESC)`
+
+Persisted `triggers_log` string/JSON privacy matrix:
+
+| Field | Privacy class | Construction rule |
+|---|---|---|
+| `id` | generated row ID | Generated by W2 storage code; never copied from caller text. |
+| `run_id` | generated/validated opaque run ID | Generated by W2 or validated as UUID/ULID-like opaque ID before storage/key use. |
+| `policy_version` | closed policy code | Constant allowlisted policy version such as `recommendation_trigger_policy_v1`. |
+| `trigger_kind` | closed enum code | Serialized from frozen `TriggerKind`. |
+| `trigger_class` | closed enum code | Serialized from internal `TriggerSourceClass`. |
+| `source_signal_id` | opaque signal ID | Existing signal row ID only; nullable when no source signal exists. |
+| `source_signal_type` | canonical registry/allowlisted token | Registry-backed signal name or W2 allowlisted source token; never caller raw text. |
+| `entity_type` | closed enum/allowlisted token | Internal entity kind token only. |
+| `entity_id` | opaque entity ID | Existing entity ID only; no display name/domain/path text. |
+| `subject_ref_json` | JSON subject ID object | Subject kind + opaque subject ID only; no names, claim text, or source strings. |
+| `dedupe_key` | normalized keyed policy key | Built only from closed prefixes, opaque IDs, canonical signal/source types, local-day/window tokens, and keyed signatures/hashes such as `action_signature` or `source_fingerprint`. |
+| `suppression_key` | normalized keyed policy key | Same constraints as `dedupe_key`; no raw source, action, path, or signal text. |
+| `trigger_disposition` | closed enum code | One of `silent_prepare | primary_candidate | review_candidate | quiet_candidate`; audit/handoff hint only, never delivery authority. |
+| `evidence_ref_ids_json` | JSON opaque ID array | Evidence IDs only; no `EvidenceRef.source` or source body. |
+| `evidence_signature` | keyed signature/hash | Stable keyed signature over evidence identity/materiality; no raw evidence content. |
+| `candidate_claim_ids_json` | JSON opaque ID array | Claim IDs only; no claim text or recommendation text. |
+| `salience_evaluation_ids_json` | JSON opaque ID array | W2-A returned salience evaluation IDs only. |
+| `surfacing_decision_ids_json` | JSON opaque ID array | W2-A returned surfacing decision IDs only. |
+| `status` | closed enum code | One of `started | completed | failed_retryable | failed_terminal`. |
+| `result_kind` | closed enum code | One of `prepared_silently | render_decision_recorded | held_for_review | stayed_quiet | failed`; `render_decision_recorded` means W2-A recorded a render decision, not that any user-facing surface rendered it. |
+| `downstream_policy` | closed allowlisted policy token | `recommendation_surfacing_policy` or another explicitly allowlisted W2 policy token only. |
+| `reason_code` | closed enum code | Trigger policy reason enum; no free text. |
+| `error_code` | closed enum/code | Nullable closed error code only; raw downstream errors are logged nowhere in W2 tables/signals. |
+
+The privacy regression must be schema-driven: it inventories every persisted `triggers_log` string/JSON column and fails if a current or future string/JSON column is missing from this matrix or the sentinel scan. Numeric/timestamp columns are type-constrained, but any serialized signal payload string leaves are scanned under the same sentinel rule.
+
+## Privacy and trust boundaries
+
+- Store IDs, enum codes, factor kinds, timestamps, numeric scores, and trigger disposition only.
+- Do not store raw recommendation/claim text in W2 tables.
+- Do not store raw source paths, prompt text, provider output, or user-authored free text.
+- Every string/JSON field in the `triggers_log` privacy matrix must be assembled from allowlisted IDs, canonical enum/signal names, opaque refs, JSON ID arrays, closed policy/error codes, or keyed hashes/signatures. They must never include caller-provided raw signal names, file paths, prompt/provider strings, claim text, user-authored free text, raw downstream error text, or raw evidence source strings.
+- `error_code` is a closed enum/code only. Raw downstream error messages are not persisted in `triggers_log` or emitted in signal payloads.
+- `why_this_now.rs` owns a closed template renderer. It must not use `Debug` formatting for rationale or trigger inputs, because that could serialize raw source strings.
+- `TriggerRef.source` is never caller-provided. W2 maps all inputs to allowlisted source tokens such as `scheduled_scan`, `signal_event`, `entity_change`, `manual_refresh`, and `feedback_echo`.
+- Signal emission uses constant sources (`recommendation_surfacing_policy`, `recommendation_trigger_policy`) and safe JSON values. No raw paths, claim text, prompt/provider output, or free-form error messages in `signal_events.value`.
+- Evidence references written by W2 are opaque IDs or stable hashes. W2 does not serialize W1-A `EvidenceRef.source` directly unless it has passed through the same source-token allowlist used for `TriggerRef.source`.
+- Existing `claim_feedback.payload_json` remains owned by `services::claims`; W2 reads only action, claim, timestamp, and allowlisted metadata keys needed for surface dismissal/suppression.
+- Mutating service functions reject Evaluate/Simulate mode before writing tables or signals.
+
+## Tests
+
+Migration tests:
+
+- v271 creates `recommendation_surfacing_policy` + `surfacing_decisions` with indexes and retry-safe idempotency.
+- v272 creates `triggers_log` with retry status fields and indexes, and does not put a unique index on `dedupe_key`.
+- current schema version reaches v272.
+
+Surfacing tests:
+
+- high-urgency candidate renders `Critical`.
+- second Critical on the same actor/local day/surface class defers for primary even with urgency `>= 0.95` and material new evidence; the overflow may be held/grouped for review/background but cannot create a second primary Critical render.
+- normal high-salience candidate renders `Notable` under budget.
+- over-budget candidate defers with `BudgetExhausted`.
+- recent surfacing cooldown defers with `CooldownActive`.
+- recent `claim_surface_dismissals` row suppresses with `DismissedRecently` on that surface.
+- recent feedback suppresses with `DismissedRecently` until material evidence arrives via newer `source_asof`, changed `evidence_signature`, or changed subject/entity version; a new `source_signal_id` alone does not override suppression.
+- subject/action repeat suppresses or defers by the 3-day cooldown while a distinct action signature is allowed.
+- low-confidence but important candidate defers with `AwaitingCorroboration`.
+- low salience suppresses with `BelowThreshold`.
+- `why_this_now` contains only deterministic enum/numeric summaries.
+- raw-looking trigger source/path input is sanitized out of `trigger_refs_json`, `why_this_now_json`, and emitted signal value.
+- Evaluate mode writes no `surfacing_decisions` row and emits no signal.
+- `surfacing_decision_made` uses the propagating deterministic signal facade, and duplicate idempotency keys do not re-propagate.
+
+Trigger tests:
+
+- scheduled refresh logs trigger and invokes W2-A evaluation, which owns salience recompute.
+- urgent signal refresh logs trigger and emits `salience_candidate_refresh_triggered`.
+- duplicate dedupe key coalesces without duplicate scan rows.
+- retryable partial failure can run again after `next_retry_at` and does not get blocked by the original dedupe key.
+- retryable partial failure retry copies the W2-A returned salience evaluation IDs, and trigger-log salience IDs exactly match the surfacing decision IDs they caused.
+- in-progress duplicate returns coalesced/in-progress instead of starting a competing scan.
+- every trigger class maps to the expected frozen `TriggerKind`, trigger audit disposition, W2-A `surface_class` handoff, trust floor, freshness window, dedupe key, and suppression key.
+- stale source stays quiet / held for review by explicit reason.
+- low-confidence candidate carries explicit trust floor and goes to review/defer.
+- user-suppressed candidate does not re-render.
+- urgent-but-low-trust candidate goes to review/defer instead of primary render.
+- noisy fixture stays quiet; high-signal fixture surfaces; primary daily volume stays within the budget key.
+- privacy regression feeds raw-path-looking, prompt-looking, provider-output-looking, raw evidence-source-looking, raw error-looking, and free-text-looking sentinels through trigger input/evidence/error paths, inventories every persisted `triggers_log` string/JSON column against the privacy matrix above, and asserts every matrix field plus emitted signal payload string leaf contains only allowlisted IDs, enum/signal codes, opaque refs, keyed signatures/hashes, and closed error/policy codes.
+- Evaluate mode writes no `triggers_log` row and emits no signal.
+- `salience_candidate_refresh_triggered` uses the propagating deterministic signal facade, and duplicate idempotency keys do not re-propagate.
+
+Validation commands:
+
+- `cargo test --manifest-path src-tauri/Cargo.toml -p dailyos recommendations::surfacing --lib`
+- `cargo test --manifest-path src-tauri/Cargo.toml -p dailyos recommendations::triggers --lib`
+- `cargo test --manifest-path src-tauri/Cargo.toml -p dailyos migration_27 --lib`
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
+- `pnpm tsc --noEmit`
+
+## Rollout and coordination
+
+- W2 is safe to implement now because W1-A and W1-B are merged into `dev`.
+- The two W2 modules are logical lanes coupled by trigger -> salience -> surfacing handoff and shared registration files (`migrations.rs`, `devtools/mod.rs`), so a single coordinated PR is lower-risk than two racing PRs.
+- If implementation discovers missing signal behavior, stop and coordinate before touching `signals::bus` or `signals/policy_registry.rs`.
+- If implementation needs new claim lifecycle behavior, stop and coordinate before touching `services/claims.rs` or `commit_claim`.
+
+## L0 reviewer prompts
+
+1. Does the packet's §0 scope tier / origination / trust-topology declaration match the actual touched paths?
+2. Does this policy improve the user's working understanding rather than increasing notification/UI volume?
+3. Are budgets/cooldowns scoped narrowly enough per ADR-0126?
+4. Does the trigger log explain enough without storing sensitive raw content?
+5. Does W2 correctly reuse W1-B salience, W1-A recommendation claims, and existing service signal APIs without inventing substrate?
+6. Does the producer classification hold: W2 writes derived audit/read-model state, not durable recommendation claims or surface authority?
+7. Are there acceptance criteria from DOS-331 or DOS-334 not covered by tests?
+8. Did K-in cite any `docs/solutions/` or `.docs/decisions/` entries that make any W2 substrate net-new claim invalid?

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle1.md
@@ -1,0 +1,16 @@
+# W2 L0 architecture / K-in review — cycle 1
+
+Verdict: BLOCK
+
+Findings:
+
+- Budget policy conflicted with ADR-0126 because it was a hard-coded budget per `surface_key`, and the decision row lacked `claim_type` and `sensitivity` for audit.
+- Mutation-path surfacing could log preview salience without a persisted `salience_evaluation_id`; W1-B only returns an evaluation id from `recompute_salience_for_claim`.
+
+Reuse checks:
+
+- Recommendation substrate reuse is correct: no parallel `recommendation_claims` table.
+- Signal boundary is acceptable: variants are already present and W2 uses `services::signals`.
+- Mock data and migration coverage are acknowledged.
+
+Cycle 2 packet changes: key budgets by `actor_kind + local_day + claim_type + sensitivity + surface_class`, add versioned recommendation surfacing policy rows, add `claim_type`/`sensitivity` to decision rows, and require W1-B durable recompute before mutation-path audit writes.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle2.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle2.md
@@ -1,0 +1,11 @@
+# W2 L0 architecture / K-in review — cycle 2
+
+Verdict: BLOCK
+
+Finding:
+
+- `SurfacingDecisionMade` and `SalienceCandidateRefreshTriggered` are registered as invalidation signals, but the cycle 2 packet emitted both with non-propagating `emit_once_for_key`. The service facade's `emit_once_for_key` only inserts the signal row; it does not run propagation. Current registry policy places both variants under `coalesced_invalidation_policy`, which is `SignalRole::Invalidation` / async propagation. That violates ADR-0115's "policies are declared, not chosen per call site" contract.
+
+Required fix:
+
+- Align the signal role and emission path before implementation. Cycle 3 keeps the predeclared invalidation role and switches W2 to `services::signals::emit_once_for_key_and_propagate`, with `PropagationEngine` passed through the W2 service APIs.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle3.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-architect-k-in-cycle3.md
@@ -1,0 +1,11 @@
+# W2 L0 architecture / K-in review — cycle 3
+
+Verdict: PASS
+
+No pre-code architecture/K-in blockers.
+
+- Both predeclared W2 signals are registered as invalidation signals and the packet now uses `services::signals::emit_once_for_key_and_propagate` with `PropagationEngine`.
+- Durable salience recompute ownership is singular: W2-A calls W1-B `recompute_salience_for_claim`; W2-B calls W2-A and copies returned evaluation/decision IDs.
+- No parallel claim/feedback/signal substrate: recommendations stay claim-backed, feedback/dismissal reads reuse `claim_feedback` and `claim_surface_dismissals`, and policy state is scoped to recommendation surfacing audit rather than a generic replacement substrate.
+
+Note: ADR files are named `0125-claim-anatomy-temporal-sensitivity-typeregistry.md` and `0126-memory-substrate-invariants.md` in this worktree.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle1.md
@@ -1,0 +1,15 @@
+# W2 L0 CEO/product review — cycle 1
+
+Verdict: BLOCK
+
+Findings:
+
+- Thresholds, budgets, and cooldowns were named as constants without product rationale or expected eval coverage.
+- Critical bypass could create unbounded primary-surface noise without a storm guard.
+- Notable budget keyed only by `surface_key` could multiply the same user's primary volume across surfaces.
+- Background items need an Activity Log cap/grouping rule.
+- Suppressed feedback should only be overridden by critical/urgent candidates when material new evidence or subject state changed.
+- Trigger classes and their defaults need to be explicit product policy, not implementation placeholders.
+- Tests need to prove noisy fixtures stay quiet, low-trust urgent items go to review/defer, suppressed items require new evidence, and primary daily volume stays in budget.
+
+Cycle 2 packet changes: add policy rationale table, shared primary budget, Critical storm guard, Activity Log cap, material-evidence override rule, trigger-class defaults, and calibration tests.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle2.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle2.md
@@ -1,0 +1,13 @@
+# W2 L0 CEO/product review — cycle 2
+
+Verdict: BLOCK
+
+Findings:
+
+- Critical bypass was still unbounded. The plan set max 1 Critical, then allowed additional `urgency >= 0.95` plus material-evidence candidates without a cap, grouping rule, or review fallback.
+- Suppression override was still too loose because a new `source_signal_id` alone counted as material evidence.
+
+Required fixes:
+
+- Make all primary Critical renders bounded per budget key, with explicit overflow behavior.
+- Require changed evidence, newer `source_asof`, or changed subject/entity version for dismissal/feedback suppression override. A new signal ID may support audit and dedupe, but not override.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle3.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-ceo-cycle3.md
@@ -1,0 +1,9 @@
+# W2 L0 CEO/product review — cycle 3
+
+Verdict: PASS
+
+No remaining product-policy blockers.
+
+- Primary Critical is bounded: max 1 primary Critical per budget key, overflow defers with `BudgetExhausted`; review/background overflow is grouped and cannot create a second primary render.
+- Feedback/dismissal override now requires material world change: newer `source_asof`, changed `evidence_signature`, or changed subject/entity version. New `source_signal_id` is audit/dedupe only.
+- Thresholds, budgets, cooldowns are coherent and testable with explicit values, rationale, expected volume impact, risks, and DOS-338 validation hooks.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle1.md
@@ -1,0 +1,21 @@
+# W2 L0 Codex challenge — amendment cycle 1
+
+Verdict: REQUEST_CHANGES
+
+Findings:
+
+- HIGH: Quiet/background semantics were inconsistent across the packet and current W2 code shape. The packet made `quiet` a policy state, while current schema/code collapsed quiet into background and introduced unplanned `external` scope.
+- HIGH: Trigger source privacy was under-specified. The packet required safe source tokens, but `source_signal_type`, dedupe keys, suppression keys, and current implementation shape could persist caller-provided source text.
+- MEDIUM: The packet described W2 as two file-disjoint lanes even though DOS-331 and DOS-334 share `migrations.rs`, `devtools/mod.rs`, and the W2-B -> W2-A handoff.
+
+Required fold:
+
+- Make `quiet` first-class auditable policy state and explicitly forbid W2 `external` surface/channel semantics.
+- Require `source_signal_type`, dedupe keys, suppression keys, evidence refs/signatures, reason codes, and error codes to be assembled from canonical/allowlisted tokens, opaque refs, or keyed signatures only.
+- Reword W2 as one coordinated PR with two logical lanes, shared registration files, and a trigger -> surfacing handoff.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`
+- `.docs/plans/v1.4.6-waves.html`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle2.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle2.md
@@ -1,0 +1,20 @@
+# W2 L0 Codex challenge — amendment cycle 2
+
+Verdict: REQUEST_CHANGES
+
+Blocking gap:
+
+- Privacy test coverage was still not exhaustive for `triggers_log`. The packet defined more persisted string/JSON fields than the test enumerated, including `run_id`, `policy_version`, `trigger_kind`, `trigger_class`, `source_signal_id`, `entity_type`, `entity_id`, `selected_channel`, `candidate_claim_ids_json`, `salience_evaluation_ids_json`, `surfacing_decision_ids_json`, `status`, `result_kind`, and `downstream_policy`.
+
+Required fold:
+
+- Make the W2 test requirement exhaustive against every current and future `triggers_log` string/JSON column through an explicit matrix or schema-driven assertion.
+- Include emitted signal payload string leaves in the same invariant.
+- Classify each field as allowlisted enum/code, opaque ID/ref, JSON ID array, or keyed signature/hash.
+- Exclude raw path, claim text, prompt/provider output, user-authored free text, raw evidence source string, and raw error text.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`
+- `.docs/plans/v1.4.6-waves.html`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle3.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle3.md
@@ -1,0 +1,17 @@
+# W2 L0 Codex challenge — amendment cycle 3
+
+Verdict: REQUEST_CHANGES
+
+Blocking gaps:
+
+- The broader wave doc still said the LLM was reserved for `why_this_now` text rendering, contradicting the W2 packet's deterministic-template-only and no-provider rules.
+- The broader wave doc still said W2-A activation included product surface inline rendering and a debug surface link, which reintroduced W2 surface authority.
+
+Required fold:
+
+- Replace the stale release-thesis language with deterministic typed template output only; no LLM/provider calls in `salience`, `surfacing`, `triggers`, or `why_this_now`.
+- Reword the invariant so W2-A writes safe `surfacing_decisions` / `why_this_now` audit state, while W3+ ability projection/block owns inline product rendering and debug/user-facing inspection paths.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-waves.md`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle4.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle4.md
@@ -1,0 +1,19 @@
+# W2 L0 Codex challenge — amendment cycle 4
+
+Verdict: REQUEST_CHANGES
+
+Blocking gaps:
+
+- `selected_channel` was still internally contradictory and could be read as delivery authority. The packet said no selected-channel semantics while also storing/testing `selected_channel` with an ambiguous `surface` value.
+- The broader wave doc still allowed debug/eval consumers to inspect `triggers_log` directly, while another row said W3+ owns debug/user-facing inspection paths.
+
+Required fold:
+
+- Rename/define the trigger field as a non-delivery internal audit/handoff disposition, with an explicit mapping into W2-A `surface_class`.
+- Remove ambiguous `surface` channel value.
+- Reword the `triggers_log` consumer rule so W2 writes safe audit state; product/debug inspection goes through W3+ ability projection/block. W5/test-only DB assertions remain separate proof evidence.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle5.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle5.md
@@ -1,0 +1,20 @@
+# W2 L0 Codex challenge — amendment cycle 5
+
+Verdict: REQUEST_CHANGES
+
+Blocking gaps:
+
+- Budget overflow semantics were contradictory: the W2 packet said primary over-budget high-salience candidates defer with `BudgetExhausted`, while the broader wave plan still said over-budget candidates land in quiet/background and tests expected `Defer/Quiet`.
+- `triggers_log.result_kind = rendered` could reintroduce delivery semantics despite W2 having no consumer-facing delivery authority.
+- Active W2 wave text referenced `{primary_factor.rationale}`, but the frozen contract stores `WhyThisNow.primary_factor` as `SalienceFactorKind`; W2 needs to derive the typed reason from the selected `SalienceFactor.rationale` and store safe deterministic text/JSON.
+
+Required fold:
+
+- Align the wave plan with the packet: primary budget exhaustion is `Defer(BudgetExhausted)`; background/quiet are explicit policy states, not generic overflow buckets.
+- Rename the trigger result code to a non-delivery code such as `render_decision_recorded`.
+- Fix the `why_this_now` template wording to use `factor_label`, typed reason, and trigger summary without `Debug` formatting or raw rationale/source strings.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle6.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-amendment-cycle6.md
@@ -1,0 +1,14 @@
+# W2 L0 Codex challenge — amendment cycle 6
+
+Verdict: PASS
+
+No blocking pre-code contradictions found in the W2 packet or supporting wave docs.
+
+Checked folds:
+
+- W2 remains derived policy/audit state, not claim producer, surface/MCP authority, or trust/lifecycle owner.
+- `surface_class` is closed to `primary | background | quiet | review`; `external` is out of scope.
+- `trigger_disposition` is a non-delivery audit/handoff hint with explicit W2-A `surface_class` mapping.
+- `triggers_log` has an exhaustive privacy matrix and schema-driven privacy regression requirement.
+- `why_this_now` is deterministic typed template output only.
+- Primary budget overflow is `Defer(BudgetExhausted)`; background/quiet are explicit policy states.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle1.md
@@ -1,0 +1,14 @@
+# W2 L0 codex challenge — cycle 1
+
+Verdict: BLOCK
+
+Findings:
+
+- Trigger idempotency needs explicit failure/retry semantics. A unique `dedupe_key` plus pre-downstream insert can permanently coalesce an incomplete run after partial failure.
+- Surface-specific suppression must reuse `claim_surface_dismissals`; reading only `claim_feedback` can re-render claims dismissed on a specific surface.
+- Privacy plan must account for free-string fields in `WhyThisNow.text`, `TriggerRef.source`, and `signal_events.value`.
+- Subject/action cooldown needs an auditable `action_signature` and tests, not an undefined semantic similarity rule.
+- Mutation-path surfacing must reference persisted salience, not preview-only scores without a durable evaluation id.
+- Migration slots should be contiguous from current `dev` v270 rather than skipping v271/v272/v274.
+
+Cycle 2 packet changes: add retry statuses, surface dismissal reads, source/text sanitization rules, `action_signature`, durable salience recompute, and v271/v272 migration slots.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle2.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle2.md
@@ -1,0 +1,11 @@
+# W2 L0 codex challenge — cycle 2
+
+Verdict: BLOCK
+
+Findings:
+
+- Trigger → salience → surfacing still had split ownership that could produce divergent durable salience references. W2-A required every mutation-path surfacing evaluation to call `recompute_salience_for_claim`, while W2-B also recomputed salience before handing candidates to W2-A. Each recompute creates a new stored `evaluation_id`, so `triggers_log.salience_evaluation_ids_json` could fail to match `surfacing_decisions.salience_evaluation_id`.
+
+Required fix:
+
+- Make one component own recompute. Cycle 3 assigns durable recompute ownership to W2-A. W2-B calls W2-A for candidates and copies W2-A's returned salience evaluation IDs and surfacing decision IDs into `triggers_log`. Add retry coverage proving trigger-log salience IDs exactly match the surfacing decisions they caused.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle3.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle3.md
@@ -1,0 +1,11 @@
+# W2 L0 codex challenge — cycle 3
+
+Verdict: BLOCK
+
+Finding:
+
+- Cycle-2 salience ownership closure was consistent in the W2 packet but stale in the wave-plan anchor. The amended packet made W2-A the sole durable recompute owner and required W2-B to copy W2-A returned IDs, but `.docs/plans/v1.4.6-waves.md` still said W2-B's signal is "consumed by W1-B salience re-compute path" and that the scan "invokes salience re-compute." That could reintroduce split ownership and divergent `salience_evaluation_id`s.
+
+Required fix:
+
+- Amend the W2 wave section to say W2-B calls W2-A `evaluate_surfacing_for_claim`; only W2-A calls `recompute_salience_for_claim`; W2-B copies returned salience and surfacing decision IDs into `triggers_log`.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle4.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-codex-challenge-cycle4.md
@@ -1,0 +1,3 @@
+PASS.
+
+Cycle-3 blocker is closed: `v1.4.6-waves.md` now says W2-B never calls `recompute_salience_for_claim`, hands candidates to W2-A `evaluate_surfacing_for_claim`, and copies W2-A returned salience/decision IDs into `triggers_log`. The W2 packet is consistent with that ownership chain. No new pre-code blocker found.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-k-in-amendment-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-k-in-amendment-cycle1.md
@@ -1,0 +1,24 @@
+# W2 L0 K-in review — amendment cycle 1
+
+Verdict: PASS
+
+K-in searched `docs/solutions/` and `.docs/decisions/` for prior substrate and architectural decisions. No reinvented substrate blocker found.
+
+Relevant prior art:
+
+- `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md`
+- `docs/solutions/architecture-patterns/emit-or-log-wrapper-silent-error-swallow-class-2026-05-18.md`
+- `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md`
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`
+- `.docs/decisions/0125-claim-anatomy-temporal-sensitivity-typeregistry.md`
+- `.docs/decisions/0126-memory-substrate-invariants.md`
+- `.docs/decisions/0115-signal-granularity-audit.md`
+- `.docs/decisions/0108-provenance-rendering-and-privacy.md`
+- `.docs/decisions/0123-typed-claim-feedback-semantics.md`
+- `.docs/decisions/0102-abilities-as-runtime-contract.md`
+- `.docs/decisions/0111-surface-independent-ability-invocation.md`
+- `.docs/decisions/0128-headless-dailyos-mcp-as-product-surface.md`
+- `.docs/decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md`
+- `.docs/decisions/0130-surface-independent-composition-contract.md`
+
+Watchpoint: no existing general attention-budget substrate was found. The W2 recommendation-local, versioned policy table is acceptable only because it is scoped to recommendation surfacing audit state.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-product-lens-amendment-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-product-lens-amendment-cycle1.md
@@ -1,0 +1,12 @@
+# W2 L0 product lens review — amendment cycle 1
+
+Verdict: PASS
+
+No product blockers.
+
+- W2 remains scoped to render/defer/suppress policy and trigger audit state, not notification automation or a new user queue.
+- The producer classification is correct: W2 reads existing recommendation claims and salience, then writes derived policy/audit rows only.
+- Budgets, cooldowns, and thresholds are concrete enough for L1 and are covered by DOS-338 validation scenarios for false positives, false negatives, noisy fixtures, and missed-important cases.
+- `selected_channel = surface` remains policy metadata until W3+ ability consumers exist.
+
+Residual product risks stay with DOS-338 validation, not L0 blocking.

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle1.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle1.md
@@ -1,0 +1,18 @@
+# W2 L0 security lens review — amendment cycle 1
+
+Verdict: REQUEST_CHANGES
+
+Blocking gap:
+
+- Trigger/audit privacy tests did not cover every W2 storage surface. The packet forbids raw paths, claim text, prompt/provider output, user-authored free text, and raw evidence sources in W2 tables/signals, but the test list only explicitly covered `trigger_refs_json`, `why_this_now_json`, and emitted surfacing signal values.
+
+Required fold:
+
+- Add a W2-B privacy regression that feeds raw-path-looking, prompt-looking, provider-output-looking, raw evidence-source-looking, and free-text-looking values through trigger input/evidence/error paths.
+- Assert every persisted `triggers_log` JSON/string field plus emitted signal payload contains only allowlisted IDs, enum/signal codes, opaque refs, keyed signatures, and closed error codes.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`
+- `.docs/plans/v1.4.6-waves.html`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle2.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle2.md
@@ -1,0 +1,20 @@
+# W2 L0 security lens review — amendment cycle 2
+
+Verdict: REQUEST_CHANGES
+
+Blocking gap:
+
+- The W2-B privacy regression still did not cover every persisted `triggers_log` JSON/string field it claimed to cover. The table included fields such as `candidate_claim_ids_json`, `salience_evaluation_ids_json`, `surfacing_decision_ids_json`, `downstream_policy`, `source_signal_id`, and closed enum/string fields, but the test fold only enumerated a subset.
+
+Required fold:
+
+- Add an explicit persisted-field privacy matrix for `triggers_log`.
+- Classify every string/JSON field as generated ID, closed enum/code, allowlisted token, opaque ref, keyed signature/hash, or JSON ID array.
+- Update the regression test requirement to assert raw-path/prompt/provider/raw-evidence/free-text/error sentinels are absent from every matrix field plus emitted signal payloads.
+- Explicitly classify and test `downstream_policy` as closed/allowlisted.
+
+Folded into:
+
+- `.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md`
+- `.docs/plans/v1.4.6-waves.md`
+- `.docs/plans/v1.4.6-waves.html`

--- a/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle3.md
+++ b/.docs/plans/v1.4.6-salience-recommendations/reviews/w2-security-lens-amendment-cycle3.md
@@ -1,0 +1,9 @@
+# W2 L0 security lens review — amendment cycle 3
+
+Verdict: PASS
+
+Read-only L0 security review found no blocking pre-code issues.
+
+- `triggers_log` now has a field-by-field privacy matrix, including `downstream_policy` and all ID arrays.
+- Tests require schema-driven coverage over every persisted string/JSON field plus emitted signal payload string leaves.
+- W2 keeps signal emission behind service APIs and does not add surface/MCP authority.

--- a/.docs/plans/v1.4.6-waves.html
+++ b/.docs/plans/v1.4.6-waves.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>v1.4.6 Salience and Recommendations - DailyOS Planning</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+</head>
+<body data-tint="turmeric">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS - Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="v1.4.6-waves.html" data-active="true">v1.4.6 Waves</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS - v1.4.6 - Wave Plan</p>
+  <h1 class="plans-title">Make DailyOS selective without making new authority.</h1>
+  <p class="plans-kicker">Salience, surfacing, triggers, and recommendation blocks stay claim-backed, ability-backed, and quiet by default.</p>
+  <p class="plans-lede">
+    v1.4.6 turns trustworthy intelligence into selective recommendations: what matters, why it matters now, and what the user should consider doing next.
+    This revision reconciles the original plan with the current Engineering Ladder and the ability producer model that landed after the first draft.
+    W2 may continue as service-local surfacing and trigger plumbing, but future surfaces must consume a recommendation ability projection rather than W2 tables.
+  </p>
+  <div class="plans-meta">
+    <span>Target: v1.4.6</span>
+    <span>Revision: 2026-05-26 reconciliation</span>
+    <span>Waves: W0-W5</span>
+    <span>Parallel agents: 3 peak</span>
+    <span>Source: Linear + v1.4.6-waves.md</span>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="source-and-scope">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Source and scope</p>
+    <h2 id="source-and-scope" class="plans-section-title">A recommendation is a claim, not a parallel product state.</h2>
+    <p class="plans-section-lede">
+      v1.4.6 consumes the claim substrate, trust bands, signal policy registry, ability runtime, WordPress block producer pattern, and producer-remediation lessons from v1.4.4 through v1.4.7.
+    </p>
+  </header>
+  <ul class="plans-related">
+    <li><strong>Canonical markdown:</strong> <code>.docs/plans/v1.4.6-waves.md</code></li>
+    <li><strong>Current W2 packet:</strong> <code>.docs/plans/v1.4.6-salience-recommendations/L0-packet-W2-DOS-331-DOS-334.md</code></li>
+    <li><strong>Scope tier:</strong> project wave plan is Wave; W2 is Standard with Amendment 3 add-on.</li>
+    <li><strong>Origination:</strong> Extension. This extends existing claim, salience, signal, trust, ability, and WP surface substrate.</li>
+    <li><strong>Trust topology:</strong> local-to-local single-user. No new MCP, SurfaceClient, remote, or multi-user exposure ships in W2.</li>
+    <li><strong>Non-goal:</strong> no direct table-backed recommendation surface, no proactive notification policy, no LLM ranking, no new trust primitive, and no Tauri React surface work.</li>
+    <li><strong>K-in basis:</strong> v1.4.4 WordPress surface migration, v1.4.4a ability-backed Tauri cutover, v1.4.5 workspace memory, v1.4.7 MCP abilities-first plan, and the abilities-runtime producer remediation plan.</li>
+  </ul>
+</section>
+
+<section class="plans-section" aria-labelledby="reconciliation">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reconciliation</p>
+    <h2 id="reconciliation" class="plans-section-title">Two old assumptions are now superseded.</h2>
+    <p class="plans-section-lede">
+      The original plan used an older review panel and was written before ability producers became the surface authority pattern.
+      This revision makes both constraints explicit.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Area</th>
+        <th>Old assumption</th>
+        <th>Current rule</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Review process</td>
+        <td>Codex challenge + domain reviewer + Codex consult; code-reviewer/domain-reviewer at L2; separate L5 drift.</td>
+        <td>Use the 2026-05-23 Engineering Ladder: scoped L0, mandatory K-in, bounded L2 router, advisory path-alpha, L4 before L2 for surfaces, and L5 folded into L3 for v1.x.y.</td>
+      </tr>
+      <tr>
+        <td>Surface authority</td>
+        <td>W3 could render recommendation state through a React component or direct surface contract.</td>
+        <td>W3 is WordPress / SurfaceClient block work over an ability-backed recommendation projection. Blocks never read W2 tables as authority.</td>
+      </tr>
+      <tr>
+        <td>Producer boundary</td>
+        <td>Recommendation, salience, surfacing, and trigger outputs were discussed as one system state.</td>
+        <td>Recommendation claims are durable producers through <code>commit_claim</code>; salience, surfacing, and trigger rows are derived evidence or audit state unless promoted through an ability producer.</td>
+      </tr>
+      <tr>
+        <td>v1.4.7 coupling</td>
+        <td>v1.4.6 release blocked on a specific v1.4.7 portfolio-attention consumer.</td>
+        <td>v1.4.6 publishes stable schema-versioned read contracts; v1.4.7 can consume them or remain on an approved fallback path without blocking v1.4.6.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="wave-overview">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave shape</p>
+    <h2 id="wave-overview" class="plans-section-title">W0-W5, hard ordering across waves.</h2>
+    <p class="plans-section-lede">
+      The wave sequence stays intact. The change is authority: W2 emits and logs policy decisions, while W3+ must expose user-visible recommendation state through ability producers.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Wave</th>
+        <th>Issues</th>
+        <th>Primary output</th>
+        <th>Gate</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>W0 - Project freeze</td>
+        <td>coordination + ADRs</td>
+        <td>Claim type, signal registry, migration block, dependency confirmation</td>
+        <td>L0-ready substrate</td>
+      </tr>
+      <tr>
+        <td>W1 - Contract and salience</td>
+        <td>DOS-329, DOS-330</td>
+        <td><code>RecommendationClaim</code> helper and explicit salience factors / read ability</td>
+        <td>L3 with producer contract verified</td>
+      </tr>
+      <tr>
+        <td>W2 - Surfacing policy</td>
+        <td>DOS-331, DOS-334</td>
+        <td>Surfacing decisions, trigger logs, propagating signals, safe audit payloads</td>
+        <td>Targeted L0 amendment, bounded L2, L3</td>
+      </tr>
+      <tr>
+        <td>W3 - Recommendation surfaces</td>
+        <td>DOS-298, DOS-333</td>
+        <td><code>dailyos/suggested-next-steps</code> block over ability projection</td>
+        <td>L0, L4 before L2, then L3</td>
+      </tr>
+      <tr>
+        <td>W4 - Feedback and adjacent signals</td>
+        <td>DOS-332, DOS-316, DOS-317</td>
+        <td>Recommendation feedback, deviation input, engagement signal bounded to ranking</td>
+        <td>L3 with Suite S/E/P as fired</td>
+      </tr>
+      <tr>
+        <td>W5 - Evaluation and release</td>
+        <td>DOS-338</td>
+        <td><code>tests/v146_eval</code> fixture suite and folded drift close</td>
+        <td>L3 release gate</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="producer-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Producer matrix</p>
+    <h2 id="producer-matrix" class="plans-section-title">Durable assertions and audit rows have different jobs.</h2>
+    <p class="plans-section-lede">
+      W2 remains valid only because it is framed as derived policy and audit state. The first user-visible consumer must be an ability projection.
+    </p>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Artifact</th>
+        <th>Authority class</th>
+        <th>Owner</th>
+        <th>Consumer rule</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>RecommendationClaim</code></td>
+        <td>Durable claim producer</td>
+        <td>W1-A / upstream helpers through <code>commit_claim</code></td>
+        <td>All writes carry claim provenance, source dates, sensitivity, lifecycle, and trust semantics.</td>
+      </tr>
+      <tr>
+        <td><code>salience_evaluations</code></td>
+        <td>Derived read-model evidence</td>
+        <td>W1-B</td>
+        <td>Inspectable factor rows are not trust mutations or lifecycle authority.</td>
+      </tr>
+      <tr>
+        <td><code>surfacing_decisions</code></td>
+        <td>Policy audit state</td>
+        <td>W2-A</td>
+        <td>Records render/defer/suppress decisions. Not a surface API and not a second claim authority.</td>
+      </tr>
+      <tr>
+        <td><code>triggers_log</code></td>
+        <td>Operational audit state</td>
+        <td>W2-B</td>
+        <td>Stores run ids, trigger classes, safe source tokens, returned result ids, and closed error codes only.</td>
+      </tr>
+      <tr>
+        <td><code>why_this_now</code></td>
+        <td>Deterministic render helper</td>
+        <td>W2-A</td>
+        <td>Template over typed factors and trigger refs. No LLM, raw claim text, or source body interpolation.</td>
+      </tr>
+      <tr>
+        <td>WP / MCP / Tauri consumers</td>
+        <td>Ability producer / projection</td>
+        <td>W3+ / future v1.4.7+</td>
+        <td>Must consume actor-filtered ability output with rendered provenance and caveats.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="reviewer-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Reviewer routing</p>
+    <h2 id="reviewer-matrix" class="plans-section-title">Use the current ladder, not the old panel names.</h2>
+  </header>
+
+  <table class="reviewer-matrix">
+    <thead>
+      <tr>
+        <th>Rung</th>
+        <th>v1.4.6 rule</th>
+        <th>Notable routing</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>L0</td>
+        <td><code>/codex challenge</code> plus routed planning reviewers; K-in is mandatory.</td>
+        <td>W2 uses product + security lens. W3 uses design lens and security lens if actor/provenance output changes.</td>
+      </tr>
+      <tr>
+        <td>L2</td>
+        <td><code>/codex review</code> through <code>l2-bounded-reviewer</code>; 0-2 specialists by diff.</td>
+        <td>W2 expects data migrations + silent-failure hunter. Surface work gets L4 evidence before L2 dispatch.</td>
+      </tr>
+      <tr>
+        <td>L3</td>
+        <td>Integrated wave challenge + architecture strategist; Suite E always, S/P by touched paths.</td>
+        <td>L5 drift is folded into W5's L3 release gate.</td>
+      </tr>
+      <tr>
+        <td>L4</td>
+        <td>User-facing WordPress blocks need hands-on surface proof before L2.</td>
+        <td>W3 Suggested Next Steps and W4 What's Unusual must capture WP Studio/browser evidence.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="plans-section" aria-labelledby="wave-details">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Wave details</p>
+    <h2 id="wave-details" class="plans-section-title">Execution boundaries that matter.</h2>
+  </header>
+
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">W2 boundary</h3>
+      <p class="callout-prose">Proceed with <code>services/recommendations/{surfacing,triggers,why_this_now}.rs</code>, v271-v272 migrations, and service signal facade calls. <code>quiet</code> is a first-class auditable surface class; <code>external</code> is out of W2 scope. Do not touch <code>services/claims.rs</code>, <code>commit_claim</code>, trust recompute, or surface/MCP readers.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">W2 L0 amendment</h3>
+      <p class="callout-prose">The current W2 packet now declares Standard + Amendment 3 scope, Extension origination, local-to-local topology, producer classification, a field-by-field trigger-log privacy matrix, and the current L2 router expectation.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">W3 producer gate</h3>
+      <p class="callout-prose">Before a block renders recommendations, the lane identifies the ability projection that returns recommendations, surfacing state, trust, provenance, caveats, and receipt refs. If missing, W3 blocks.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">W4 telemetry</h3>
+      <p class="callout-prose">Engagement is a ranking input only. It never feeds trust scoring, and W4-C carries security review, retention, opt-out, and delete-on-opt-out tests.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">W5 evaluation</h3>
+      <p class="callout-prose">The eval harness lives under <code>tests/v146_eval</code> and validates high-signal, low-signal, stale, noisy, missed-important, and user-corrected cases.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Compatibility</h3>
+      <p class="callout-prose">v1.4.6 publishes stable schemas for future consumers. v1.4.7 portfolio attention may consume them or stay on its approved fallback; that status is recorded, not used as a release blocker.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section" aria-labelledby="suites">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Suites</p>
+    <h2 id="suites" class="plans-section-title">S/P/E fire by need at L3.</h2>
+  </header>
+
+  <div class="suite-grid">
+    <article class="suite-card" data-suite="s">
+      <span class="suite-letter">S</span>
+      <h3 class="suite-name">Security</h3>
+      <p class="suite-prose">Privacy-safe signal payloads, actor-filtered provenance, no direct surface authority, telemetry opt-out, and no raw source/prompt/output text in audit rows.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>ce-security-reviewer</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> zero blocker privacy or authority bypass findings</p>
+    </article>
+    <article class="suite-card" data-suite="p">
+      <span class="suite-letter">P</span>
+      <h3 class="suite-name">Performance</h3>
+      <p class="suite-prose">Migration safety, indexed surfacing/trigger queries, and bounded projection fan-out for block consumers.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>ce-performance-oracle</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> no unbounded hot-path or migration regression</p>
+    </article>
+    <article class="suite-card" data-suite="e">
+      <span class="suite-letter">E</span>
+      <h3 class="suite-name">Edge cases</h3>
+      <p class="suite-prose">Budget overflow, cooldowns, noisy feedback, material-new-evidence overrides, typed empty/degraded producer states, and missed-important fixtures.</p>
+      <p class="suite-owner"><span class="suite-owner-label">Owner</span> <code>ce-testing-reviewer</code></p>
+      <p class="suite-pass-rule"><span class="suite-pass-label">Pass</span> all required fixture axes green</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section plans-section-callouts">
+  <div class="callout-grid">
+    <article class="callout">
+      <h3 class="callout-title">Pacing</h3>
+      <p class="callout-prose">No wave starts until the prior wave clears L3. W3 and later user-facing work must complete L4 evidence before L2 review.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Bounding</h3>
+      <p class="callout-prose">Path-alpha findings file to the maintenance project unless they violate acceptance criteria, ADR contracts, or PR-touched behavior.</p>
+    </article>
+    <article class="callout">
+      <h3 class="callout-title">Migration slots</h3>
+      <p class="callout-prose">v1.4.6 owns v269-v288. W1 used v269-v270; W2 uses v271-v272; later waves claim contiguous remaining slots after rebase.</p>
+    </article>
+  </div>
+</section>
+
+<section class="plans-section plans-section-footer">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Related</p>
+    <h2 class="plans-section-title">Cross-references.</h2>
+  </header>
+  <ul class="plans-related">
+    <li><strong><code>v1.4.6-waves.md</code></strong> Canonical editable wave plan.</li>
+    <li><strong><code>engineering-ladder.html</code></strong> Current L0-L6 and K-channel protocol.</li>
+    <li><strong><code>v1.4.4a-tauri-briefing-entity-intelligence-waves.html</code></strong> Ability-backed consumer cutover and no-bypass rules.</li>
+    <li><strong><code>abilities-runtime-producer-remediation-waves.html</code></strong> Producer classification and runtime authority rules.</li>
+    <li><strong><code>v1.4.5-waves.md</code></strong> Workspace Memory producer/ability lessons.</li>
+    <li><strong><code>v1.4.7-waves.md</code></strong> MCP abilities-first consumer contract and fallback state.</li>
+  </ul>
+</section>
+
+<div class="finis">
+  <div class="finis-mark">W0 - W1 - W2 - W3 - W4 - W5</div>
+  <div class="finis-date">v1.4.6 Salience and Recommendations - 2026-05-26</div>
+  <div class="finis-caption">Selective intelligence only works when surfacing is explainable and surfaces stay ability-backed.</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/.docs/plans/v1.4.6-waves.md
+++ b/.docs/plans/v1.4.6-waves.md
@@ -10,6 +10,28 @@ The original v1.4.6 L0 plan reserved **v260-v279**. Current `dev` now registers 
 
 This amendment moves the active v1.4.6 block to **v269-v288**. Historical cycle notes below may still mention the original v260-v279 block as cycle history; all active assignments are in §"Migration slot assignments".
 
+## Engineering Ladder + Producer Reconciliation Amendment (2026-05-26)
+
+This plan now uses the current Engineering Ladder adopted 2026-05-18 and revised 2026-05-23. The old "Review ladder" language from earlier v1.4.x packets is superseded wherever it conflicts with `.docs/plans/engineering-ladder.md` / `.docs/plans/engineering-ladder.html`.
+
+Active process changes:
+
+- L0 packets declare scope tier, origination class, and trust topology before reviewer prompts.
+- L0 review is `/codex challenge` plus routed planning reviewers and mandatory K-in from `ce-learnings-researcher`, not the older "Codex consult" panel.
+- L2 review is `/codex review` through the `l2-bounded-reviewer` with 0-2 routed specialists; advisory maintainability/simplicity/testing findings file to the maintenance project unless they violate acceptance criteria, ADR contracts, or PR-touched behavior.
+- For this v1.x.y version, L5 drift folds into L3. There is no separate W5 L5 gate; W5 closes through L3 integrated drift review.
+- User-facing WordPress block work runs L4 before L2.
+
+Active producer-era changes:
+
+- `RecommendationClaim` writes are durable claim producers and must flow through the existing claim substrate (`services::claims::commit_claim`) via the recommendation service helper. W2 does not create recommendation claims.
+- `salience_evaluations` / salience factors are derived read-model evaluation evidence. They are inspectable and provenance-linked, but they do not mutate trust or claim lifecycle by themselves.
+- `surfacing_decisions` are read-model / audit policy state. They decide whether an already-existing recommendation claim renders, defers, or suppresses; they are not a second claim authority and are not a surface API.
+- `triggers_log` is operational audit state for candidate scans. It stores opaque IDs, policy versions, trigger classes, and result IDs; it must not carry raw paths, claim text, prompt text, provider output, or source bodies.
+- Future WP, Tauri, and MCP consumers must call an ability producer / projection contract. They may not read W2 tables directly as authority.
+
+This amendment also supersedes stale surface wording in the older plan body. W3 is WordPress / SurfaceClient block work over an ability-backed recommendation projection, not new Tauri React UI. Any future MCP exposure is v1.4.7+ scope and uses the same ability projection rather than a parallel table reader.
+
 ## WordPress Foundation Reorientation (2026-05-15)
 
 This wave plan was authored assuming a Tauri React surface for W3 (Suggested Next Steps surface contract + cross-surface rendering) and W4-B ("What's unusual" briefing section). Per [ADR-0129](../decisions/0129-composable-surfaces-wordpress-studio-as-primary-surface.md) and the v1.4.2 WordPress foundation work, those surface targets shift to DailyOS Gutenberg blocks on the v1.4.2 magazine theme.
@@ -25,7 +47,7 @@ This wave plan was authored assuming a Tauri React surface for W3 (Suggested Nex
 
 **Tauri UI freeze** applies. No new Tauri React W3/W4-B UI work in this version.
 
-**No new full L0 panel** is required for this reorientation — substrate L0 is unchanged; surface re-shape is L0-blessed by ADR-0129/0130 + v1.4.2 L0 panel. Targeted `/cso` re-review applies at block design lock-in (covers trust-band-in-block + edit-as-feedback-claim wire + DOS-510 inheritance for block context). See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md) for full rationale.
+**2026-05-26 update:** the substrate L0 remains unchanged, but W3/W4-B surface lanes now use the current Engineering Ladder. Before code starts, W3 must pass a lane L0 with design review, producer-boundary review, K-in, and explicit ability-projection ownership. L4 surface QA runs before L2. Targeted security review applies at block design lock-in when trust-band rendering, edit-as-feedback-claim wiring, actor exposure, or DOS-510 inheritance changes. See [`.docs/plans/wp-foundation-roadmap-reorientation.md`](./wp-foundation-roadmap-reorientation.md) for the original reorientation rationale.
 
 **Audit issues superseded:** [DOS-625](https://linear.app/a8c/issue/DOS-625), [DOS-626](https://linear.app/a8c/issue/DOS-626), [DOS-627](https://linear.app/a8c/issue/DOS-627) — surface-specific concerns become moot post-reorientation; close on this PR landing. v1.4.3 substrate citations stay relevant as cross-version dependencies but materialize on the WP-block path, not the Tauri path.
 
@@ -182,7 +204,7 @@ Cycle 2 codex verdicts: Challenge **BLOCK** (4 OPEN + 1 NEW BLOCK + 4 CLOSED); E
 
 **Class F — SurfacingTier::Background destination pinned (DX OPEN #5):**
 - `v1.4.6-waves.md:455` — change comment from `"shown in low-noise tier (Activity Log? Lint?)"` to:
-  > `Background, // rendered to the Activity Log surface only (not briefing/entity primary slots); not pulled into floating callouts. Activity Log surface owned by v1.4.0 substrate (existing).`
+  > `Background, // eligible only for later background/Activity Log projection paths, never briefing/entity primary slots or floating callouts; W2 records policy state only.`
 
 **Class G — FeedbackState vs recommendation decision naming collision (DX OPEN #4; renamed 2026-05-26):**
 - Cycle 2 contract uses `FeedbackState` for the persisted state machine (Pending → Accepted/Dismissed/NotUseful/TooNoisy/Converted). W4-A says it records "outcomes" using the same names. Split:
@@ -247,10 +269,10 @@ Cycle 2 changes (folded in below):
    // Compatibility: schema_version increments only for breaking changes; additions ride at v1; consumers (v1.4.7 W2-C) MUST verify and fail-closed on unknown version
    ```
 
-**Class E — WhyThisNow deterministic OR pinned-LLM (Challenge #5 + DX #3):**
-8. `WhyThisNow.text` generation path frozen: **deterministic template over `primary_factor` + `triggers`**. NO LLM call in surfacing.rs or why_this_now.rs. (LLM rendering deferred to a post-decision text renderer at a later release.) Template format:
+**Class E — WhyThisNow deterministic template (Challenge #5 + DX #3):**
+8. `WhyThisNow.text` generation path frozen: **deterministic template over `primary_factor` + `triggers`**. NO LLM call in surfacing.rs or why_this_now.rs. Any future natural-language renderer is later-release scope and cannot feed W2 ranking or audit semantics. Template format:
    ```
-   "Salience driven by {primary_factor.label}: {primary_factor.rationale}. Triggers: {triggers.summary}."
+   "Salience driven by {factor_label}: {typed_reason}. Triggers: {trigger_summary}."
    ```
    Both `primary_factor` and `triggers` are W1-A `contracts.rs` types with deterministic computation. CI invariant added: no provider/LLM call in `services/recommendations/{salience,surfacing,triggers,why_this_now}.rs`.
 
@@ -328,7 +350,7 @@ Like v1.4.7 (and unlike v1.4.4 / v1.4.5 which had prior project-level L0 verdict
 - v1.4.3 — Briefing Experience: Daily Briefing + Meeting Detail surfaces (consume W3 cross-surface rendering for "Suggested Next Steps" slots per DOS-298).
 - v1.4.4 — Claim Experience & Trust UI: Shared Receipt DTO (recommendations render through it); `services::claim_review_queue` + DOS-336 extension hook for `Candidate` target_kind; semantic feedback action surface from DOS-8.
 - ADRs: 0074 (vector search), 0078 (embed model), 0080 (signals), 0098 (source-aware lifecycle), 0102 (abilities runtime), 0105 (trust scoring), 0108 (provenance + privacy), 0125 (claim anatomy — likely amended by v1.4.6 W0 for `RecommendationClaim` variant), 0129 (composable surfaces), 0130 (composition).
-- v1.4.7 forward-coupling: v1.4.7's W2-C portfolio attention tool says it "consumes existing v1.4.6 salience ability when v1.4.6 ships." v1.4.6's salience scoring + surfacing decision API must be stable enough for v1.4.7 to consume without an amendment.
+- v1.4.7 forward-coupling: v1.4.7's portfolio attention lane may consume v1.4.6 salience / recommendation reads when available, or use its approved fallback if it ships first. v1.4.6 owns a stable, schema-versioned read contract; it does not block on a v1.4.7 consumer.
 **Success metric:** Wave 5 release gate green: recommendations are typed (RecommendationClaim variant lives in CLAIM_TYPE_REGISTRY); salience scoring uses explicit inspectable factor table (no ad-hoc prompt phrasing); surfacing budget enforced (high-signal candidates render; low-signal stay quiet — measured via DOS-338 eval); user feedback (accepted / dismissed / not useful / too noisy) changes future ranking on the same fixture entity within 1 surfacing cycle; `why this now` text attached to every surfaced item; engagement telemetry feeds ranking (not trust); evaluation matrix green for high-signal, low-signal, stale, noisy, missed-important, and user-corrected cases.
 **Migration slots reserved:** v269–v288 (20 slots; live-dev amendment from stale v260-v279 after `dev` reached v268). v1.4.4 W1 substrate used v240-v245; v1.4.5 Workspace Memory used v250-v254, v262, and v268; v1.4.7 MCP substrate used v255-v258; v1.4.4a runtime evidence/reader work used v260-v267. The active v1.4.6 block starts at the next executable slot, v269.
 
@@ -338,7 +360,7 @@ Like v1.4.7 (and unlike v1.4.4 / v1.4.5 which had prior project-level L0 verdict
 
 DailyOS already has trustworthy intelligence. v1.4.6 makes it **selective**. The shape of the win is: a CSM opens DailyOS in the morning and the briefing surfaces three things — "Acme renewal — escalation since last touch, source: customer email yesterday" / "Hooli — quiet for 14 days, last health flag was a week-3 onboarding miss" / "Suggested next step: 30-min check-in with Globex sponsor before Q2 board sync." Each of these has a `why this now` ("escalation signal" / "interaction gap × renewal date proximity" / "champion-mentioned objective + recurring meeting cadence drop"), shows trust band + provenance, and supports `accept` / `dismiss` / `too noisy` / `not useful` actions that change next morning's ranking.
 
-The constraint v1.4.6 must respect is **explicit factors over ad-hoc prompt phrasing**. The L0 review will likely surface: don't build "ranking via LLM judgment of importance"; build a typed factor table (importance / novelty / urgency / timing / user-fit / freshness / trust / corroboration / contradiction / open-loop relevance) where each factor has a deterministic computation path consuming existing v1.4.0–v1.4.4 substrate, and the LLM is reserved for `why this now` text rendering — not the ranking decision itself.
+The constraint v1.4.6 must respect is **explicit factors over ad-hoc prompt phrasing**. The L0 review will likely surface: don't build "ranking via LLM judgment of importance"; build a typed factor table (importance / novelty / urgency / timing / user-fit / freshness / trust / corroboration / contradiction / open-loop relevance) where each factor has a deterministic computation path consuming existing v1.4.0–v1.4.4 substrate. `why_this_now` is deterministic typed template output over closed factor and trigger refs; LLM/provider text rendering is out of W2 and cannot feed ranking or audit semantics.
 
 The other constraint is **stay quiet by default**. Surfacing budget caps daily/per-tier/per-entity volume. Cooldowns prevent same-claim resurfacing. Quiet/background tiers exist for items that scored salient but didn't clear the surfacing threshold. The eval harness explicitly tests "missed-important" cases (false negatives) alongside "noisy" (false positives) so the budget doesn't optimize for engagement.
 
@@ -366,7 +388,7 @@ This section lists the EXACT frozen contracts v1.4.6 consumes.
 - DOS-447 per-claim_type render rules — recommendations may need their own render rule when promoted.
 
 **From v1.4.7 (forward-coupling — only the API surface contract matters here, not implementation):**
-- `dailyos.<verb>.<noun>` scope naming convention. v1.4.6 abilities exposed to MCP (post-v1.4.6; not v1.4.6 scope) will use `dailyos.read.recommendations`, `dailyos.submit.recommendation_feedback`. v1.4.7 W2-C `dailyos.read.portfolio_attention` consumes v1.4.6's salience ability — v1.4.6 W2 must produce the ability with a stable schema v1.4.7 can build against.
+- `dailyos.<verb>.<noun>` scope naming convention. v1.4.6 abilities exposed to MCP later (post-v1.4.6; not v1.4.6 scope) will use `dailyos.read.recommendations`, `dailyos.submit.recommendation_feedback`. v1.4.6 W2/W3 must produce stable schema-versioned read contracts that future MCP consumers can wrap.
 
 **v1.4.6 does NOT ship:**
 - Generic action generation disconnected from the working model (explicit non-goal).
@@ -381,35 +403,49 @@ This section lists the EXACT frozen contracts v1.4.6 consumes.
 ## Reading order
 
 1. This doc — wave assignments, merge gates, frozen contracts.
-2. v1.4.6 Linear project description — full scope + Definition of Done.
-3. v1.4.4 Surface Migration W1 substrate (Linear project [v1.4.4 — WordPress Surface Migration](https://linear.app/a8c/project/v144-wordpress-surface-migration-877aaa780177); L0-converged contracts archived at `.docs/plans/_archive/v1.4.4-waves-claim-experience-DISSOLVED-2026-05-17.md`) — Shared Receipt DTO + DOS-336 extension hook are frozen contracts v1.4.6 consumes. The OLD v1.4.4 "Claim Experience" project was dissolved 2026-05-17 and the substrate absorbed into NEW v1.4.4 Surface Migration W1; see `.docs/plans/wp-foundation-roadmap-reorientation.md` §"v1.4.4 — WordPress Surface Migration" for the rehoming.
-4. ADR-0105 (trust scoring), ADR-0125 (claim anatomy — likely amended by v1.4.6 W0), ADR-0102 (abilities runtime), ADR-0080 (signals), ADR-0074 (vector search), ADR-0078 (embed model).
-5. Per-issue Linear ticket — the frozen implementation contract.
-6. Shared Primitive and Service Ownership doc (Linear doc `9585a9ed-128f-47d2-8732-30effb5800a6`) — applies to every issue.
-7. Prior wave proof bundles when working after Wave 0.
+2. `.docs/plans/v1.4.6-waves.html` — visual share/read surface for the reconciled wave plan.
+3. v1.4.6 Linear project description — full scope + Definition of Done.
+4. v1.4.4 Surface Migration W1 substrate (Linear project [v1.4.4 — WordPress Surface Migration](https://linear.app/a8c/project/v144-wordpress-surface-migration-877aaa780177); L0-converged contracts archived at `.docs/plans/_archive/v1.4.4-waves-claim-experience-DISSOLVED-2026-05-17.md`) — Shared Receipt DTO + DOS-336 extension hook are frozen contracts v1.4.6 consumes. The OLD v1.4.4 "Claim Experience" project was dissolved 2026-05-17 and the substrate absorbed into NEW v1.4.4 Surface Migration W1; see `.docs/plans/wp-foundation-roadmap-reorientation.md` §"v1.4.4 — WordPress Surface Migration" for the rehoming.
+5. ADR-0105 (trust scoring), ADR-0125 (claim anatomy), ADR-0102 (abilities runtime), ADR-0080 (signals), ADR-0074 (vector search), ADR-0078 (embed model).
+6. Per-issue Linear ticket — the frozen implementation contract.
+7. Shared Primitive and Service Ownership doc (Linear doc `9585a9ed-128f-47d2-8732-30effb5800a6`) — applies to every issue.
+8. Prior wave proof bundles when working after Wave 0.
 
 ---
 
 ## Review ladder for v1.4.6
 
-The L0–L6 ladder from v1.4.0-waves.md applies. v1.4.6-specific amendments:
+Current source: `.docs/plans/engineering-ladder.md` and `.docs/plans/engineering-ladder.html`. This section supersedes the older v1.4.0-era "Review Ladder" panel language in the amendment history above.
+
+### Scope, origination, and topology
+
+| Unit | Scope tier | Origination | Trust topology | Notes |
+|---|---|---|---|---|
+| Project wave plan | Wave | Extension | local-to-local single-user | Extends existing claim, salience, trust, signals, ability-runtime, and WP block substrate. |
+| W1-A / W1-B | Standard with Amendment 3 add-on | Extension | local-to-local single-user | Durable claim-producer contract and salience read ability touch claim/provenance/schema paths. |
+| W2-A / W2-B | Standard with Amendment 3 add-on | Extension | local-to-local single-user | Migrations, signal emission, privacy-safe audit payloads, and product surfacing policy. |
+| W3 | Wave | Extension | local-to-local single-user | User-facing WP block plus ability producer/projection boundary. L4 before L2. |
+| W4 | Wave | Extension | local-to-local single-user | Feedback, possible deviation substrate, privacy-sensitive engagement telemetry. |
+| W5 | Standard | Extension | local-to-local single-user | Eval harness and integrated release proof. L5 folds into L3. |
+
+### Current reviewer routing
 
 | Level | Applies | Notes |
 |---|---|---|
-| **L0 Prep (Plan Hardening)** | Every issue + project-scope (cycle 1 folds both) | `/plan-eng-review` default. `/plan-ceo-review` mandatory for **W2** lanes (surfacing policy IS the product strategy artifact — what gets surfaced, what stays quiet, what the daily budget is). `/plan-design-review` mandatory for **W3** lanes (cross-surface rendering on briefing/entity/work). `/plan-devex-review` mandatory for **W1-A** (RecommendationClaim contract is the consumer-facing API every other v1.4.6 lane + v1.4.7 consumes) and **W5** (eval harness DX). `/cso` mandatory for **W4-C** (engagement telemetry — privacy-sensitive). |
-| **L0 (Plan)** | Every issue + project-scope | Codex challenge + domain reviewer + Codex consult. |
+| **L0 Prep (Plan Hardening)** | Every issue + project-scope | `/plan-eng-review` default. Add `/plan-ceo-review` for **W2** surfacing/trigger policy, `/plan-design-review` for **W3** block/workflow scope, `/plan-devex-review` for **W1-A** recommendation contract and **W5** eval harness, and `/cso` for **W4-C** telemetry or any lane broadening actor exposure. |
+| **L0 (Plan)** | Every issue + project-scope | `/codex challenge` plus the routed planning reviewer(s) required by scope. Mandatory K-in: `ce-learnings-researcher` cites `docs/solutions/` and `.docs/decisions/` hits. Add a second planning reviewer for Wave tier or Amendment 3 paths. |
 | **L1 (Self)** | Every issue | Standard. |
-| **L2 (Diff)** | Every issue | Codex review + code-reviewer + domain reviewer. `/cso` re-review on W4-C. `/plan-design-review` re-review on W3 lanes. |
-| **L3 (Wave)** | W1, W2, W4 (heaviest contract / policy / privacy surfaces) | Codex challenge + architect-reviewer + Suite S/P/E. |
-| **L4 (Surface)** | W3 (cross-surface UI rendering) | `/qa-only` first; `/qa` if remediation needed. |
-| **L5 (Drift)** | W5 release close | `/plan-eng-review` + architect-reviewer against v1.4.6 DoD. |
+| **L2 (Diff)** | Every issue | `/codex review` through `l2-bounded-reviewer`. Router-selected specialists apply by touched path. For W2, expected specialists are `ce-data-migrations-reviewer` and `pr-review-toolkit:silent-failure-hunter`; type-design concerns are routed only if the diff changes shared contracts. Advisory findings file path-alpha maintenance issues unless AC/ADR/touched-regression bound. |
+| **L3 (Wave)** | W1, W2, W3, W4, W5 | `/codex challenge` + `ce-architecture-strategist`; Suite E always; Suite S when privacy / signal / actor exposure / prompt boundary is touched; Suite P when migrations, hot paths, or projections are touched. L5 drift is folded into this rung for v1.x.y. |
+| **L4 (Surface)** | W3 and any user-facing block/render work | `/qa-only` first; `/qa` if remediation needed; L4 evidence is collected before L2 dispatch. |
+| **L5 (Drift)** | Folded into L3 | No separate v1.4.6 L5 rung. W5 release close uses L3 integrated drift review. |
 | **L6 (Human)** | If escalated | Same triggers as v1.4.x. |
 
-CEO-review lane (`/plan-ceo-review` at L0): **DOS-331** (surfacing policy thresholds + budgets + cooldowns + why-this-now), **DOS-334** (trigger policy). These are product-strategy artifacts, not just engineering specs.
+W2 L0 reviewer composition: `/codex challenge` + `ce-product-lens-reviewer` + `ce-security-lens-reviewer`, with `ce-learnings-researcher` K-in in parallel. Product lens reviews the surfacing budget/threshold premise; security lens reviews privacy-safe payloads, signal emission boundaries, and no-direct-table authority.
 
-DX-mandatory lanes (`/plan-devex-review` at L0): **DOS-329** (RecommendationClaim contract — consumer-facing API for v1.4.7 + future consumers), **DOS-338** (eval harness shape — DX for v1.4.5+ test maintainers).
+DX-mandatory lanes (`/plan-devex-review` at L0): **DOS-329** (RecommendationClaim contract - consumer-facing API for future consumers), **DOS-338** (eval harness shape - DX for v1.4.6+ test maintainers).
 
-Design-mandatory lanes (`/plan-design-review` at L0): **DOS-333** (cross-surface rendering on briefing/entity/work), **DOS-298** (Suggested Next Steps surface contract — UI section that must integrate calmly).
+Design-mandatory lanes (`/plan-design-review` at L0): **DOS-333** (cross-surface WP block composition), **DOS-298** (Suggested Next Steps block contract - UI section that must integrate calmly).
 
 Security-annotated lanes (`/cso` at L0 + L2): **DOS-317** (engagement telemetry — what user behaviors are captured + how they aggregate; privacy boundary).
 
@@ -419,24 +455,24 @@ Security-annotated lanes (`/cso` at L0 + L2): **DOS-317** (engagement telemetry 
 
 Reserved block: **v269–v288** (20 slots; live-dev amendment from stale v260-v279).
 
-**Cross-version coordination (amended 2026-05-26):** active `dev` now has registered migrations through v268. v1.4.6 therefore claims v269-v288. Any later branch that also needs v269+ must rebase and take the next available contiguous slot inside this amended block before writing a migration filename.
+**Cross-version coordination (amended 2026-05-26):** active `dev` now has registered migrations through v270 after W1 landed. v1.4.6 still owns v269-v288, but each later branch must rebase and take the next available contiguous slot inside this block before writing a migration filename. W1 actually used v269-v270, so W2 takes v271-v272.
 
 | Wave | Issues | Likely slots |
 |---|---|---|
-| W1 — Contract & substrate | DOS-329, DOS-330 | v269-v272 — recommendation metadata indexes; `salience_factors` table for inspectable per-factor scoring |
-| W2 — Surfacing policy | DOS-331, DOS-334 | v273-v276 — `surfacing_decisions` (rendered / deferred / suppressed log with rationale); `triggers_log` (which event triggered which scan) |
+| W1 — Contract & substrate | DOS-329, DOS-330 | v269-v270 — recommendation metadata indexes; `salience_factors` table for inspectable per-factor scoring |
+| W2 — Surfacing policy | DOS-331, DOS-334 | v271-v272 — `recommendation_surfacing_policy`, `surfacing_decisions`, and `triggers_log` |
 | W3 — Cross-surface rendering | DOS-333, DOS-298 | (none expected — UI consuming W1+W2 contracts) |
-| W4 — Feedback + adjacent intelligence | DOS-332, DOS-316, DOS-317 | v277-v283 — no `recommendation_feedback` table by default; DOS-332 bridges through `claim_feedback`; `deviation_baselines` (rolling per-entity baseline for "what's unusual"); `engagement_telemetry` (per-claim per-surface render/click/dismiss with PII-bounded rollups) |
+| W4 — Feedback + adjacent intelligence | DOS-332, DOS-316, DOS-317 | next contiguous slots after W2 — no `recommendation_feedback` table by default; DOS-332 bridges through `claim_feedback`; `deviation_baselines` (rolling per-entity baseline for "what's unusual"); `engagement_telemetry` (per-claim per-surface render/click/dismiss with PII-bounded rollups) |
 | W5 — Eval | DOS-338 | (none expected — eval fixtures live in tests) |
 
-Slots v284-v288 held as buffer.
+Remaining slots in v273-v288 are held for later v1.4.6 waves and must be claimed contiguously at that wave's L0.
 
 ---
 
 ## Scope cleanup before kickoff (W0)
 
 1. **Cross-version dependency confirmation — v1.4.4.** Confirm v1.4.4 has merged with `services::claim_receipt::contracts::ClaimReceipt` shipped, `services::claim_review_queue` shipped (with DOS-336 extension hook for `target_kind = candidate`), and DOS-8 semantic feedback action enum extended-or-extendable.
-2. **Cross-version dependency confirmation — v1.4.7 forward-coupling.** Confirm the v1.4.7 wave plan still names `dailyos.read.portfolio_attention` as consuming v1.4.6's salience ability (v1.4.7 W2-C). v1.4.6 W2's salience-ability schema must satisfy that consumer.
+2. **Cross-version dependency confirmation — v1.4.7 forward-coupling.** Record the current v1.4.7 plan state for `dailyos.read.portfolio_attention`. v1.4.6 must publish a stable salience / recommendation read contract for future consumers, but it no longer blocks on a pre-approved v1.4.7 consumer; if v1.4.7 ships or shipped a recency-only fallback, this plan records compatibility instead of failing the release gate.
 3. **ADR amendments needed:**
    - **ADR-0125 (claim anatomy)** — for `RecommendationClaim` variant. Defines: subject, recommended action, evidence, provenance (inherited from claim base), trust (inherited), salience factors (new), user-feedback state (`Accepted` / `Dismissed` / `NotUseful` / `TooNoisy` / `Converted`), conversion state, supersession + dismissal lifecycle.
    - **ADR-0102 (abilities runtime) — possibly.** If v1.4.6 needs new ability surface conventions (e.g., `recommend_for_entity` ability variant with `mcp_exposure: MetadataOnly` for now since MCP exposure is v1.4.7 scope), record. If existing tri-state covers it, no amendment needed.
@@ -487,7 +523,7 @@ Total: 10 implementation issues across 5 waves + W0 coordination wave. Estimated
 
 **Named exceptions:**
 - W1 internal staging: **DOS-329 (RecommendationClaim contract) merges first as 1a**; DOS-330 (salience scoring) consumes the contract so runs as **1b after DOS-329 merges**.
-- W2 internal staging: **DOS-331 (surfacing policy) and DOS-334 (trigger policy) run in parallel as 2a** — different file ownership (policy table vs trigger handler). Both consume W1's RecommendationClaim + SalienceScore.
+- W2 internal staging: **DOS-331 (surfacing policy) and DOS-334 (trigger policy) run as one coordinated 2a PR** — two logical lanes with separate service modules, shared migration/devtools registration files, and a required trigger -> surfacing handoff. Both consume W1's RecommendationClaim + SalienceScore.
 - W3 internal staging: **DOS-298 (Suggested Next Steps surface contract) merges first as 3a**; DOS-333 (cross-surface rendering) consumes the contract so runs as **3b after DOS-298 merges**.
 - W4 internal staging: **DOS-332 (recommendation feedback loop) merges first as 4a** (extends v1.4.4 semantic feedback substrate); **DOS-316 (deviation detection) and DOS-317 (engagement telemetry) run in parallel as 4b** (different domain — one ranking input, one privacy-bounded telemetry).
 - W5: single agent (DOS-338) — consumes everything from W1–W4.
@@ -500,13 +536,28 @@ All v1.4.0–v1.4.4 invariants remain active. v1.4.6 adds:
 
 | Invariant | Mechanism | Activated by |
 |---|---|---|
-| Salience score is computed from explicit inspectable factors, NOT ad-hoc LLM ranking judgment | `salience_factors` table writes per claim with one row per factor; UI render shows factor breakdown on demand; CI test asserts no LLM ranking call sites in `services/recommendations/salience.rs` | W1-B merge |
-| Surfacing decisions are explainable — every surfaced item has `why_this_now`; every NOT-surfaced item has a `surfacing_decisions` log row with rationale (under-budget / threshold / cooldown / quiet-tier) | `surfacing_decisions` table writes per evaluation; product surface renders `why this now` text inline; debug surface (Activity Log link from v1.4.4 W3-C) links to decision rationale | W2-A merge |
+| Salience score is computed from explicit inspectable factors, NOT ad-hoc LLM ranking judgment | `salience_factors` table writes per claim with one row per factor; later ability/UI rendering may show factor breakdown on demand; CI test asserts no LLM ranking call sites in `services/recommendations/salience.rs` | W1-B merge |
+| Surfacing decisions are explainable — every surfaced item has stored `why_this_now`; every NOT-surfaced item has a `surfacing_decisions` log row with rationale (under-budget / threshold / cooldown / quiet-tier) | `surfacing_decisions` table writes per evaluation with safe typed `why_this_now` data; W3+ ability projection/block owns inline product rendering and any debug/user-facing inspection path | W2-A writes, W3 renders |
 | Recommendation feedback (`Accepted` / `Dismissed` / `NotUseful` / `TooNoisy`) updates ranking + suppression behavior on the next surfacing cycle for the same claim/entity | Eval test (W5) seeds feedback then re-runs surfacing; ranking delta verified | W4-A merge |
 | Engagement telemetry feeds RANKING signal, NOT trust signal — `services::trust` (and `abilities-runtime/src/abilities/trust/` module tree) MUST NOT import `services::recommendations::engagement` OR query `engagement_telemetry` table. Salience IS allowed to consume trust as a factor input — that's correct (cycle 2 #9 direction fix per Challenge + CSO findings). | grep CI: `services::recommendations::engagement` import OR `engagement_telemetry` SQL across `src-tauri/src/services/trust*.rs` AND `src-tauri/abilities-runtime/src/abilities/trust/**.rs` must be empty | W4-C merge |
 | Recommendation rendering uses v1.4.4 Shared Receipt DTO (extended target enum), NOT a parallel recommendation receipt | grep CI on `RecommendationReceipt` / `RecRow` / similar struct definitions outside `services/claim_receipt/contracts.rs` | W3 merge |
-| Daily surfacing budget enforced; over-budget candidates land in quiet/background tier with logged rationale, NEVER hard-block briefing/work surfaces | Suite S test on overflow behavior; UI matrix in W3 covers full / empty / over-budget states | W2 merge |
+| Daily surfacing budget enforced; primary over-budget candidates defer with `BudgetExhausted` and logged rationale, NEVER hard-block briefing/work surfaces. Background/quiet are explicit policy states, not the generic overflow bucket; only Critical overflow with material new evidence may optionally record grouped review/background overflow per the W2 packet. | Suite S test on overflow behavior; UI matrix in W3 covers full / empty / over-budget states | W2 merge |
 | No new substrate primitives for vector / embed / trust / signals — v1.4.6 consumes existing per ADR-0074/0078/0105/0080 | L0 plan substrate-consultation reuse audit (W0); architect-reviewer L3 check | W0 close, re-checked W1+W4 merges |
+
+## Producer authority model
+
+This section reconciles v1.4.6 with v1.4.4a and the abilities-runtime producer remediation plan. Recommendation work is no longer allowed to blur durable claim production, derived read models, and surface rendering.
+
+| Artifact | Authority class | Owner | Trust / lifecycle rule | Consumer rule |
+|---|---|---|---|---|
+| `RecommendationClaim` metadata envelope | Durable claim producer | W1-A helper in `services/recommendations/recommendation.rs` calling `services::claims::commit_claim` | Carries subject, provenance, source dates, sensitivity, lifecycle, and trust through the claim substrate. Trust recompute remains claim-substrate owned. | W2 reads existing recommendation claims; it does not create or mutate recommendation claims. |
+| `salience_evaluations` and factor rows | Derived read-model / evaluation evidence | W1-B salience service and hidden `score_salience` ability | No independent trust or lifecycle mutation. Factors are typed, numeric, privacy-safe, and linked back to claim ids / evaluation ids. | Surfaces may consume only through an ability producer/projection, not raw factor table reads. |
+| `surfacing_decisions` | Derived policy / audit state | W2-A surfacing policy | Records render/defer/suppress decisions and safe `why_this_now` inputs. It is not a claim, not a lifecycle table, and not a trust input by itself. | WP/Tauri/MCP surfaces may not treat this table as authority; W3 must expose an ability-backed recommendation projection. |
+| `triggers_log` | Operational audit state | W2-B trigger scanner | Stores run ids, trigger class, policy version, safe subject/entity ids, and downstream evaluation/decision ids only. | W2 only writes safe audit state. Product/debug inspection goes through the W3+ ability projection/block path; W5/tests may assert DB rows directly as test evidence only. |
+| `why_this_now` | Deterministic render helper | W2-A / `why_this_now.rs` | Template over typed factor and trigger refs. No LLM, raw claim text, source body, prompt, or output text. | Rendered inline only after actor/surface filtering through the producer/renderer boundary. |
+| `dailyos/suggested-next-steps` / "What's unusual" blocks | Surface renderer over ability output | W3 / W4-B | Blocks render already-filtered, actor-safe ability responses and claim receipts. | Blocks do not query recommendation tables directly and do not store claim data in block attributes. |
+
+Producer gate: before W3 or later user-facing work starts, the lane L0 must identify the exact ability producer / projection that returns recommendation lists, surfacing state, trust, provenance, caveats, and receipt refs. If that ability is not present, W3 blocks rather than reading `surfacing_decisions` directly.
 
 ---
 
@@ -695,7 +746,7 @@ Two agents.
     pub enum SurfacingTier {
         Critical,         // budget bypass; user must see
         Notable,          // counts against daily budget
-        Background,       // cycle 3 Class F: rendered to Activity Log surface only (v1.4.0 substrate); never floating callouts
+        Background,       // cycle 3 Class F: eligible only for later background/Activity Log projection paths; W2 records policy state only
         Quiet,            // NOT shown; logged for inspection
     }
 
@@ -741,16 +792,16 @@ Two agents.
 	  - `src-tauri/src/services/recommendations/recommendation.rs` (W1-A only owner) — metadata-envelope construction, `RecommendedAction` action-key derivation, and `RecommendationDraft -> ClaimProposal` conversion. It sets `field_path = Some(format!("recommendation.{action_key}"))`, `topic_key = Some(action_key)`, leaves fresh-write `id = None`, and never bypasses `services::claims::commit_claim`.
 	  - Existing placeholder files for `salience.rs`, `surfacing.rs`, `triggers.rs`, `feedback.rs`, `deviation.rs`, `engagement.rs`, `render.rs`, `eval.rs`, `why_this_now.rs` remain owned by later lanes and are not rewritten by W1-A.
   - TypeScript mirror at `src/services/recommendations/contracts.ts` (W1-A only owner).
-  - ADR-0125 amendment file in `.docs/decisions/0125-*-amendment-v145.md` (W0 deliverable; W1-A inherits the merged version).
+  - ADR-0125 amendment in `.docs/decisions/0125-claim-anatomy-temporal-sensitivity-typeregistry.md` (W0 deliverable; W1-A inherits the merged version).
 - **Don't touch:** Existing `services::claims::commit_claim`; v1.4.4 `services::claim_receipt` `<materializes-on:v1.4.4>` (consumer-only — cycle 3 Class C: path resolves only when v1.4.4 W1-A skeleton merges on dev; W0 close gate confirms commit SHA); subsequent W1+ lanes' submodule contents.
 - **Depends on:** v1.4.4 fully merged (cycle 3 Class C: W0 close gate records v1.4.4 W1-A skeleton commit SHA on dev; missing → BLOCK W1-A start); W0 ADR-0125 amendment merged.
-- **DX gate:** `/plan-devex-review` mandatory at L0 plan. RecommendationClaim contract IS the consumer-facing API every v1.4.6 lane + v1.4.7 W2-C (`dailyos.read.portfolio_attention`) consumes. Field shape, naming, serde behavior, TypeScript mirror codegen path all need reviewer-quality DX before subsequent lanes start.
+- **DX gate:** `/plan-devex-review` mandatory at L0 plan. RecommendationClaim contract IS the consumer-facing API every v1.4.6 lane and future external consumer wraps. Field shape, naming, serde behavior, TypeScript mirror codegen path all need reviewer-quality DX before subsequent lanes start.
 - **Substrate-consultation reuse audit (per W0 close gate; cycle 2 corrected; cycle 4 added RenderSurface):** consumes existing `SubjectRef`, `Provenance`, `TrustBand`, `ClaimState` / `SurfacingState` / `ClaimVerificationState`, `DateTime<Utc>`, **`RenderSurface` (`abilities-runtime/src/sensitivity.rs:8` — cycle 4 fix D)**, and ADR-0123 `services::claims::record_claim_feedback` for the later W4-A bridge. Introduces NEW recommendation-local types: `ClaimId` newtype, `EvidenceRef` newtype, `RecommendationDraft`, `RecommendationClaim`, `RecommendedAction`, `FeedbackState`, `RecommendationFeedbackDecision`, `DismissReason`, `BoundedNote`, `RecommendationFeedbackContext`, `ConversionTarget`, `ConversionState`, `SalienceScore`, `SalienceFactor`, `SalienceFactorKind`, `FactorRationale`, `WhyThisNow`, `SurfacingDecision`, `SurfacingTier`, `DeferReason`, `SuppressReason`, `TriggerRef`, `TriggerKind`, `EngagementSignal`, `RecommendationMetadataEnvelope`, `RecommendationMetadataPayload`. All new types are scoped to recommendation domain; no parallel claim infrastructure. All new contract types receive `#[derive(Serialize, Deserialize)]` + `#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]` on struct-variant enums + `#[serde(rename_all = "camelCase")]` on field structs and externally tagged tuple enums (cycle 8). `BoundedNote` derives only `Serialize`; `Deserialize` is custom-impl per cycle 4 fix E. Golden Rust JSON + TypeScript parity fixtures required at W1-A done-when for every type listed above, including externally tagged tuple variants.
 - **Intelligence Loop gate:**
   1. *Claim model:* `RecommendationClaim` is a new variant in `CLAIM_TYPE_REGISTRY` per ADR-0125 amendment. Writes go through existing `services::claims::commit_claim`.
   2. *Provenance + trust:* Inherits from claim base. Salience is separate from trust (per release thesis).
   3. *Signals + invalidation:* W2 emits `SalienceCandidateRefreshTriggered` and `SurfacingDecisionMade` SignalType variants — **W0 pre-declares the variants in `signals/policy_registry.rs` (cycle 4 fix C)**; W1-A and W2 do not touch the registry file.
-  4. *Runtime + surfaces:* Consumed by W2 (surfacing), W3 (rendering), W4 (feedback), W5 (eval), v1.4.7 W2-C (portfolio attention).
+  4. *Runtime + surfaces:* Consumed by W2 (surfacing), W3 (rendering), W4 (feedback), W5 (eval), and future MCP consumers through ability projections.
   5. *Feedback loop:* `FeedbackState` enum + `RecommendationFeedbackDecision` metadata state bridge to ADR-0123 `record_claim_feedback`; W4-A may add a recommendation service wrapper but must not bypass the claim feedback substrate.
 - **Tests required:** Property test on `RecommendationClaim` shape; ADR-0125 amendment compile-test (variant present in `CLAIM_TYPE_REGISTRY`); migration round-trip; TypeScript mirror parity (Rust ↔ TS); `cargo test` + `cargo clippy -D warnings` + `pnpm tsc --noEmit` clean.
 - **Done when:** `RecommendationClaim` contract compiles against the existing `CLAIM_TYPE_REGISTRY` variant; `recommendation.rs` helper conversion compiles and routes through `ClaimProposal`; submodule skeleton + `pub mod` declarations remain in place; subsequent lanes can fill placeholders without touching `mod.rs`; TypeScript mirror exists + parity-tested; `/plan-devex-review` L0 plan approval recorded.
@@ -762,7 +813,7 @@ Two agents.
 - **Files owned (exclusive):**
   - `src-tauri/src/services/recommendations/salience.rs` (placeholder from W1-A; W1-B fills) — `compute_salience(claim) -> SalienceScore`, `compute_factor(kind, claim) -> SalienceFactor`, factor weight table.
   - `src-tauri/abilities-runtime/src/abilities/recommendations/salience.rs` (cycle 3 Class B: W1-B owns the ScoreSalience ability surface alongside the engine; matches cycle 2 #7 contract).
-  - Migration v270-v272 — `salience_factors` table for inspectable per-factor scoring history (one row per claim per factor per evaluation).
+  - Migration v270 — `salience_factors` table for inspectable per-factor scoring history (one row per claim per factor per evaluation).
 - **Aggregation formula (cycle 3 Class B):**
   ```
   total = clamp(
@@ -772,7 +823,7 @@ Two agents.
   )
   ```
   Omitted factors (`value: None`) are skipped from BOTH numerator and denominator (true average over present factors), NOT zeroed (which would dilute). Empty-factor edge case → `total = 0.0`. Cycle 2 #7 inline comment ("None treated as 0.0") was wrong; cycle 3 supersedes.
-- **Schema-version reject behavior (cycle 3 Class B):** `ScoreSalienceResponse.schema_version = 1`; future versions break by mismatch — callers (v1.4.7 W2-C) MUST verify and fail-closed on unknown version.
+- **Schema-version reject behavior (cycle 3 Class B):** `ScoreSalienceResponse.schema_version = 1`; future versions break by mismatch — callers MUST verify and fail-closed on unknown version.
 - **Default weight table (cycle 4 fix G — sums to 1.0):**
   | SalienceFactorKind | Default weight |
   |---|---|
@@ -787,7 +838,7 @@ Two agents.
   | Contradiction | 0.05 |
   | OpenLoopRelevance | 0.05 |
 
-  Stored as seed rows in `salience_factors_weights` (migration v270-v272) OR as `const` table in `services/recommendations/salience.rs` (W1-B L0 plan picks based on whether per-user tuning ships in v1.4.6; W4-A feedback-loop weight tuning currently expected post-v1.4.6).
+  Stored as seed rows in `salience_factors_weights` (migration v270) OR as `const` table in `services/recommendations/salience.rs` (W1-B L0 plan picks based on whether per-user tuning ships in v1.4.6; W4-A feedback-loop weight tuning currently expected post-v1.4.6).
 - **Tie-break rule (cycle 4 fix G):** when two `salience.total` values are equal, sort by: (1) higher `Importance` factor value, (2) higher `Urgency` factor value, (3) older (smaller) `ClaimId` lexical order. Deterministic across runs. W1-B test case: identical-total fixture pair sorts identically every run.
 - **Don't touch:** `services::claims` core; v1.4.4 trust scoring (consumed read-only); other recommendations submodules.
 - **Depends on:** W1-A merged (RecommendationClaim + SalienceScore types).
@@ -815,9 +866,9 @@ Two agents.
 ### W1 merge gate
 
 L0 → L2 → L3 cleared per the Review Ladder. Required artifacts:
-- L0 plan approvals: architect-reviewer + `/plan-devex-review` for W1-A; architect-reviewer for W1-B.
-- L2 diff approvals on 2 PRs.
-- L3 wave adversarial: codex-challenge + architect-reviewer + Suite S (no LLM ranking calls; no new substrate primitives; salience-NOT-trust separation enforced).
+- L0 plan approvals under current ladder: `/codex challenge` plus `ce-feasibility-reviewer` / `ce-devex`-equivalent routed reviewer for W1-A, mandatory K-in, and any Amendment 3 second reviewer selected by scope.
+- L2 diff approvals through `l2-bounded-reviewer` plus routed specialists for schema/type/API changes.
+- L3 wave adversarial: `/codex challenge` + `ce-architecture-strategist` + fired suites (no LLM ranking calls; no new substrate primitives; salience-NOT-trust separation enforced).
 - CI invariants now active: salience explicit-factors invariant; substrate-consultation reuse-audit confirmation.
 - **Mandatory retro** (first wave; substrate decisions encoded for the rest of v1.4.6).
 
@@ -825,55 +876,55 @@ L0 → L2 → L3 cleared per the Review Ladder. Required artifacts:
 
 ## Wave 2 — Surfacing policy
 
-Two agents in parallel (file-disjoint).
+Two logical lanes in one coordinated W2 PR. They share migration/devtools registration files and are coupled by the trigger -> salience -> surfacing handoff.
 
 ### Agent W2-A — DOS-331: Surfacing policy thresholds, budgets, cooldowns, why-this-now
 
 - **Spec:** [DOS-331](https://linear.app/a8c/issue/DOS-331).
 - **Goal:** Define what gets surfaced, what stays quiet, what the daily budget is, how cooldowns prevent same-claim resurfacing, and how `why this now` text is generated per surfaced item. Per release thesis discipline: surfacing decisions are EXPLAINABLE — every NOT-surfaced item has a logged rationale.
-- **Files owned (exclusive):**
-  - `src-tauri/src/services/recommendations/surfacing.rs` (placeholder from W1-A; W2-A fills) — `make_surfacing_decision(claim) -> SurfacingDecision`, threshold tier evaluation, budget tracking. **`why_this_now.text` generation is deterministic-template-only (cycle 2 #8 amendment per Challenge + DX findings)** — NO LLM call; template format `"Salience driven by {primary_factor.label}: {primary_factor.rationale}. Triggers: {triggers.summary}."` over `WhyThisNow.primary_factor` + `triggers`.
-  - Migration v273-v274 — `surfacing_decisions` table (rendered / deferred / suppressed log with rationale + factor breakdown reference).
+- **Files owned:**
+  - `src-tauri/src/services/recommendations/surfacing.rs` (placeholder from W1-A; W2-A fills) — `make_surfacing_decision(claim) -> SurfacingDecision`, threshold tier evaluation, budget tracking. **`why_this_now.text` generation is deterministic-template-only (cycle 2 #8 amendment per Challenge + DX findings)** — NO LLM call; W2 derives the typed reason from the selected `SalienceFactor.rationale`, then stores only `primary_factor_kind` plus safe deterministic text/JSON using template format `"Salience driven by {factor_label}: {typed_reason}. Triggers: {trigger_summary}."` No `Debug` formatting or raw rationale/source strings.
+  - Migration v271 — `recommendation_surfacing_policy` + `surfacing_decisions` tables (rendered / deferred / suppressed log with rationale + factor breakdown reference). `surface_class` is closed to `primary | background | quiet | review`; `quiet` is first-class auditable state and must not be collapsed into `background`; `external` is out of W2 scope.
 - **Don't touch:** Salience scoring (W1-B); trigger policy (W2-B); rendering (W3); `signals/policy_registry.rs` (**W0 pre-declares both v1.4.6 SignalType variants per cycle 4 fix C**; supersedes cycle 2 #10 W1-A ownership).
 - **Depends on:** W1 fully merged.
-- **CEO-review gate:** `/plan-ceo-review` mandatory at L0 plan. Surfacing thresholds + daily budget IS the product strategy artifact.
-- **Frozen surfacing decision contract:** Imported from W1-A `services/recommendations/contracts.rs` per cycle 3 Class D (W1-A is SSoT). W2-A uses `SurfacingDecision`, `SurfacingTier` (with `Background` rendered to Activity Log only per cycle 3 Class F), `DeferReason`, `SuppressReason`, `WhyThisNow`, `TriggerRef`, `TriggerKind` as imports — does NOT redeclare. See W1-A contracts.rs frozen block above for exact shape.
+- **Product-policy L0 gate:** current W2 L0 uses `ce-product-lens-reviewer` to review surfacing thresholds and daily budget. `/plan-ceo-review` remains useful L0 Prep context when thresholds need product-strategy hardening, but it is not the current approval slot.
+- **Frozen surfacing decision contract:** Imported from W1-A `services/recommendations/contracts.rs` per cycle 3 Class D (W1-A is SSoT). W2-A uses `SurfacingDecision`, `SurfacingTier` (with `Background` eligible only for later background/Activity Log projection paths per cycle 3 Class F), `DeferReason`, `SuppressReason`, `WhyThisNow`, `TriggerRef`, `TriggerKind` as imports — does NOT redeclare. See W1-A contracts.rs frozen block above for exact shape.
 - **Intelligence Loop gate:**
   1. *Claim model:* Read-only over claims + recommendations.
   2. *Provenance + trust:* Decision rationale captured; surfacing transparency = `why this now` IS provenance for the surfacing itself.
   3. *Signals + invalidation:* `SurfacingDecisionMade` SignalType — **W0 pre-declares in `signals/policy_registry.rs` (cycle 4 fix C — supersedes cycle 2 #10 W1-A ownership)**; W2-A only emits the signal, never touches the registry file.
   4. *Runtime + surfaces:* Consumed by W3 rendering.
   5. *Feedback loop:* W4-A feedback updates per-user thresholds + cooldowns.
-- **Tests required:** Each decision variant produced under representative inputs; budget overflow → Defer/Quiet (NOT hard-block); cooldown + suppress + suppress-by-feedback behaviors; `why this now` text well-formed; `cargo test` + `cargo clippy -D warnings` clean.
-- **Done when:** Surfacing policy live with all decision branches; `surfacing_decisions` table populated on every evaluation; `/plan-ceo-review` L0 plan approval recorded.
+- **Tests required:** Each decision variant produced under representative inputs; primary budget overflow -> `Defer(BudgetExhausted)`; background/quiet exercised as explicit policy states, not generic overflow buckets; cooldown + suppress + suppress-by-feedback behaviors; `why this now` text well-formed; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** Surfacing policy live with all decision branches; `surfacing_decisions` table populated on every evaluation; current W2 L0 approval recorded.
 
 ### Agent W2-B — DOS-334: Trigger policy for salience candidate refresh + scanner orchestration
 
 - **Spec:** [DOS-334](https://linear.app/a8c/issue/DOS-334).
 - **Goal:** Inspectable candidate intake contract — DailyOS knows which events are allowed to create or refresh salience candidates, why the scan ran, what evidence it considered. Limited to candidate intake + refresh, NOT notification automation (explicit non-goal).
-- **Files owned (exclusive):**
+- **Files owned:**
   - `src-tauri/src/services/recommendations/triggers.rs` (placeholder from W1-A; W2-B fills) — trigger handler subscriptions + scanner orchestration.
-  - Migration v275-v276 — `triggers_log` table (which event triggered which scan + scan inputs/outputs reference).
+  - Migration v272 — `triggers_log` table (which event triggered which scan + scan inputs/outputs reference).
   - **Cycle 4 fix C amendment (supersedes cycle 2 #10 / Challenge #4):** `signals/policy_registry.rs` is NOT touched by W2-B. Both `SalienceCandidateRefreshTriggered` and `SurfacingDecisionMade` SignalType variants are pre-declared by **W0 (coordination — file is shared infrastructure outside the recommendations module tree)** and merged before W1 kickoff. W2-B references the W0-pre-declared variants. Same pattern v1.4.7 W3-B used.
-- **Don't touch:** Surfacing decision (W2-A); salience computation (W1-B — consumed read-only); other recommendations submodules.
+- **Don't touch:** Surfacing decision policy internals (W2-A); salience computation internals (W1-B). W2-B never calls `recompute_salience_for_claim` directly; it hands candidates to W2-A `evaluate_surfacing_for_claim` and copies W2-A's returned `salience_evaluation_id` + `surfacing_decision_id` values into `triggers_log`.
 - **Depends on:** W1 fully merged.
-- **CEO-review gate:** `/plan-ceo-review` at L0 plan (trigger policy is product strategy alongside surfacing policy).
+- **Product-policy L0 gate:** current W2 L0 uses `ce-product-lens-reviewer` because trigger policy is product strategy alongside surfacing policy.
 - **Substrate-consultation reuse audit:** consumes existing Signal Policy Registry; trigger handler subscriptions wire to existing v1.4.1 signal infrastructure. NO new signal infrastructure.
 - **Intelligence Loop gate:**
-  1. *Claim model:* Read-only; trigger fires salience re-compute via W1-B.
+  1. *Claim model:* Read-only candidate intake; trigger scan hands candidate claims to W2-A. W2-A owns durable W1-B salience recompute.
   2. *Provenance + trust:* Trigger log records why scan ran (which signal, which entity).
-  3. *Signals + invalidation:* `SalienceCandidateRefreshTriggered` emitted; consumed by W1-B salience re-compute path.
+  3. *Signals + invalidation:* `SalienceCandidateRefreshTriggered` emitted through the propagating deterministic signal facade; W2-B logs the trigger and W2-A owns the downstream surfacing/salience evaluation.
   4. *Runtime + surfaces:* Background substrate; not user-facing directly.
   5. *Feedback loop:* User dismissals feed back into trigger throttling.
-- **Tests required:** Each trigger source fires correctly; trigger log captures inputs; scan invokes salience re-compute; `cargo test` + `cargo clippy -D warnings` clean.
-- **Done when:** Trigger policy live; SignalType variant registered; trigger log populated; `/plan-ceo-review` L0 plan approval recorded.
+- **Tests required:** Each trigger source fires correctly; trigger log captures sanitized inputs; scan invokes W2-A evaluation; trigger-log `salience_evaluation_ids_json` and `surfacing_decision_ids_json` exactly match W2-A returned IDs, including retryable-failure retry; schema-driven privacy regression inventories every persisted `triggers_log` string/JSON column against the W2 packet's privacy matrix and proves raw paths, prompt/provider-looking strings, raw evidence sources, user-authored free text, and raw error messages cannot persist in any trigger-log string/JSON field or emitted signal payload string leaf; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** Trigger policy live; W0-predeclared SignalType variant emitted through the service signal facade; trigger log populated with W2-A returned salience/decision IDs; current W2 L0 approval recorded.
 
 ### W2 merge gate
 
 L0 → L2 → L3 cleared. Required artifacts:
-- L0 plan approvals: architect-reviewer + `/plan-ceo-review` for both lanes.
-- L2 diff approvals on 2 PRs.
-- L3 wave adversarial: codex-challenge + architect-reviewer + Suite S (surfacing-decision rationale logged for every NOT-surfaced item; budget overflow doesn't hard-block).
+- L0 plan approvals under the current ladder: `/codex challenge` + `ce-product-lens-reviewer` + `ce-security-lens-reviewer`, with `ce-learnings-researcher` K-in in parallel.
+- L2 diff approval through `l2-bounded-reviewer`, with `ce-data-migrations-reviewer` and `pr-review-toolkit:silent-failure-hunter` expected unless the diff shape changes.
+- L3 wave adversarial: `/codex challenge` + `ce-architecture-strategist` + Suite S/E/P as fired by touched paths (surfacing-decision rationale logged for every NOT-surfaced item; budget overflow does not hard-block; signal payloads remain privacy-safe).
 - **Mandatory retro.**
 
 ---
@@ -885,43 +936,46 @@ Two agents.
 ### Agent W3-A — DOS-298: Suggested Next Steps surface contract
 
 - **Spec:** [DOS-298](https://linear.app/a8c/issue/DOS-298).
-- **Goal:** Reserve + validate `Suggested Next Steps` / `Suggested Topics` surface contracts that consume typed recommendations with evidence, provenance, trust/salience explanation, and feedback affordances. **Surface contract** = the React component + hook layer that briefing/entity/work surfaces drop in.
-- **Files owned (exclusive):** `src/components/suggested-next-steps/` (new directory — `SuggestedNextSteps.tsx`, `SuggestedNextStepRow.tsx`, hooks); CSS modules co-located.
-- **Don't touch:** v1.4.4 Shared Receipt DTO (consumer-only); recommendations service (W1-W2 own).
+- **Goal:** Ship the ability-backed `dailyos/suggested-next-steps` Gutenberg block contract. The block consumes typed recommendations with evidence, provenance, trust/salience explanation, caveats, receipt refs, and feedback affordances through a recommendation ability producer/projection. It does not read W2 tables directly.
+- **Files owned (exclusive):**
+  - `src-tauri/abilities-runtime/src/abilities/recommendations/*` only for the list/projection contract needed by surfaces. W3-A may extend the existing recommendations ability module or add a sibling producer file after L0 confirms the exact shape. It must preserve the hidden per-claim `score_salience` read ability contract unless a W3 L0 amendment explicitly changes it.
+  - `wp/dailyos/blocks/suggested-next-steps/` (new block directory: `block.json`, `render.php`, `render-functions.php`, editor/view files only if the block needs interactive controls).
+  - Shared WP block helpers only by additive, reusable helper calls; no direct SQL/table access from PHP.
+- **Don't touch:** v1.4.4 Shared Receipt DTO core (consumer-only); W2 surfacing/trigger write paths except through a stable read API; Tauri React surfaces.
 - **Depends on:** W1 + W2 merged.
-- **Design gate:** `/plan-design-review` mandatory at L0 + L2.
+- **Design gate:** `/plan-design-review` mandatory at L0. L4 surface QA runs before L2; L2 uses current routed diff reviewers.
 - **Intelligence Loop gate:**
-  1. *Claim model:* Renders RecommendationClaim through Shared Receipt DTO with extended target enum.
-  2. *Provenance + trust:* Receipt drawer surfaces full provenance + trust + salience factors + `why this now`.
-  3. *Signals + invalidation:* Re-renders on recommendation lifecycle signals.
-  4. *Runtime + surfaces:* Embedded in briefing / entity / work pages by W3-B.
+  1. *Claim model:* Renders `RecommendationClaim` refs through Shared Receipt DTO / `claim_receipt` where row detail is needed.
+  2. *Provenance + trust:* User-visible provenance comes from actor-rendered ability output and receipt refs, not DTO-local raw provenance.
+  3. *Signals + invalidation:* Re-renders on recommendation lifecycle and W2 surfacing signals through the ability/runtime invalidation contract.
+  4. *Runtime + surfaces:* `dailyos/suggested-next-steps` invokes the recommendation projection as `Actor::SurfaceClient`; no MCP exposure unless a later v1.4.7+ L0 approves it.
   5. *Feedback loop:* Each row exposes `Accepted` / `Dismissed` / `NotUseful` / `TooNoisy` actions wired to W4-A feedback API.
-- **Tests required:** Component renders for each FeedbackState; `why this now` displays inline; receipt drawer expand; feedback action invocation roundtrip; `pnpm tsc --noEmit` + `pnpm test` clean.
-- **Done when:** Suggested Next Steps component ships; receipt drawer + feedback actions functional; `/plan-design-review` L0 + L2 approval recorded.
+- **Tests required:** Ability descriptor allows the intended SurfaceClient actor and keeps MCP exposure `None`; block render covers full/empty/degraded/caveated states; `why this now` displays inline from typed factors/triggers; receipt refs resolve without raw claim text leakage; feedback action invocation roundtrip is wired to W4-A once available or renders disabled/degraded state before W4-A; PHP/WP tests + `pnpm tsc --noEmit` + `pnpm test` clean where applicable.
+- **Done when:** `dailyos/suggested-next-steps` block renders from the ability projection, never raw W2 tables; receipt/provenance/trust/caveats visible; `/plan-design-review` L0 + L4 surface QA evidence recorded before L2.
 
 ### Agent W3-B — DOS-333: Cross-surface recommendation rendering for briefing/entity/work
 
 - **Spec:** [DOS-333](https://linear.app/a8c/issue/DOS-333).
-- **Goal:** Embed W3-A's Suggested Next Steps component into Daily Briefing, Meeting Briefing, Entity Detail, and Work/Open-Loop surfaces. Each slot supports evidence, provenance, trust/salience explanation, feedback actions.
-- **Files owned (exclusive):** Embedding-site changes in existing briefing/entity/work page files (W3-B confirms paths via fresh grep at L0 plan).
-- **Don't touch:** Suggested Next Steps component (W3-A); recommendations service (W1-W2).
+- **Goal:** Embed W3-A's `dailyos/suggested-next-steps` block into the WordPress-composed Daily Briefing, Meeting Detail, Entity Detail, and Work/Open-Loop surfaces. Each slot supports evidence, provenance, trust/salience explanation, caveats, and feedback actions through the block's ability-backed projection.
+- **Files owned (exclusive):** WP block composition/templates and page block registration paths confirmed by fresh grep at W3-B L0. Expected consumers include existing `wp/dailyos/blocks/{daily-briefing,meeting-detail,account-detail,project-detail,person-detail}/` compositions or their inner-block template arrays.
+- **Don't touch:** Suggested Next Steps block/projection contract (W3-A); recommendations service write paths (W1-W2).
 - **Depends on:** W3-A merged.
-- **Design gate:** `/plan-design-review` mandatory at L0 + L2.
+- **Design gate:** `/plan-design-review` mandatory at L0. L4 surface QA runs before L2; L2 uses current routed diff reviewers.
 - **Intelligence Loop gate:**
-  1. *Claim model:* Surfaces consume W3-A component.
+  1. *Claim model:* Surfaces consume W3-A block/projection.
   2. *Provenance + trust:* Inherited from W3-A.
   3. *Signals + invalidation:* Re-renders on recommendation lifecycle signals.
-  4. *Runtime + surfaces:* Daily Briefing, Meeting Briefing, Entity Detail, Work surfaces all show recommendations consistently.
+  4. *Runtime + surfaces:* Daily Briefing, Meeting Detail, Entity Detail, and Work/Open-Loop pages show recommendations consistently through WP block composition.
   5. *Feedback loop:* Inherited from W3-A.
-- **Tests required:** Each surface renders the component correctly; integration with v1.4.3 briefing surfaces verified; `pnpm tsc --noEmit` + `pnpm test` clean.
-- **Done when:** All four surfaces embed Suggested Next Steps consistently; `/plan-design-review` L0 + L2 approval recorded.
+- **Tests required:** Each WP surface renders the block correctly with seeded ability fixtures; empty/degraded states do not collapse layout; no Tauri React route work; L4 WP Studio/browser proof captured before L2.
+- **Done when:** All target WP surfaces embed Suggested Next Steps consistently; `/plan-design-review` L0 + L4 evidence + L2 approval recorded.
 
 ### W3 merge gate
 
-L0 → L2 → L4 cleared. Required artifacts:
-- L0 plan approvals: architect-reviewer + `/plan-design-review` for both.
-- L2 diff approvals on 2 PRs. `/plan-design-review` re-review.
-- L4 surface QA: matrix across briefing / entity / work surfaces in `wave-W3-v145/proof-bundle.md`.
+L0 → L4 → L2 cleared. Required artifacts:
+- L0 plan approvals under current ladder: `/codex challenge` + `ce-design-lens-reviewer` + `ce-security-lens-reviewer` when actor/sensitivity/provenance output changes, with `ce-learnings-researcher` K-in in parallel.
+- L4 surface QA before L2: matrix across briefing / entity / work WP surfaces in `wave-W3-v146/proof-bundle.md`.
+- L2 diff approvals through `l2-bounded-reviewer` plus routed frontend/API/security specialists as applicable.
 
 ---
 
@@ -951,21 +1005,23 @@ Three agents — **cycle 2 amendment serializes per Challenge + Eng findings**: 
 ### Agent W4-B — DOS-316: Deviation detection + "What's unusual" briefing section
 
 - **Spec:** [DOS-316](https://linear.app/a8c/issue/DOS-316).
-- **Goal:** Detect when today's signals are unusual versus the rolling baseline for that entity / pattern. Surfaces as a "What's unusual" briefing section. **Per the L0 reframe (2026-04-24):** does NOT introduce a parallel `ClaimSchema` type system; uses ADR-0125 claim type registry per existing substrate.
+- **Goal:** Detect when today's signals are unusual versus the rolling baseline for that entity / pattern. Surfaces through a WordPress `dailyos/whats-unusual` block or existing entity/briefing block inner section backed by an ability projection. **Per the L0 reframe (2026-04-24):** does NOT introduce a parallel `ClaimSchema` type system; uses ADR-0125 claim type registry per existing substrate.
 - **Files owned (exclusive):**
   - `src-tauri/src/services/recommendations/deviation.rs` (placeholder from W1-A; W4-B fills) — rolling baseline computation + deviation detection.
-  - Migration v279-v280 — `deviation_baselines` table for per-entity rolling statistics.
-- **Don't touch:** Salience scoring (W1-B — deviation is a Novelty factor INPUT, not a parallel scoring path); other submodules.
+  - Ability projection file under `src-tauri/abilities-runtime/src/abilities/recommendations/` or `get_entity_intelligence` section wiring only if W4-B L0 proves the projection owner. Claim-backed sections still flow through ability producers, not direct table reads.
+  - `wp/dailyos/blocks/whats-unusual/` or additive composition in existing briefing/entity blocks after W4-B L0 confirms the target block pattern.
+  - Migration slot TBD at W4-B L0 — take the next contiguous v1.4.6 slot after W2/W4-A; expected `deviation_baselines` table for per-entity rolling statistics if the L0 reuse audit justifies net-new storage.
+- **Don't touch:** Salience scoring (W1-B — deviation is a Novelty factor INPUT, not a parallel scoring path); W2 surfacing/trigger write paths; Tauri React surfaces.
 - **Depends on:** W1 + W2 + **W4-A merged** (cycle 2 amendment per Challenge + Eng findings — feedback substrate must exist for deviation factor inputs to integrate cleanly). Stage 4b: parallel with W4-C only.
 - **Substrate-consultation reuse audit (cycle 2 #19 amendment per Challenge #8):** v1.4.1 already ships `entity_engagement_curve` (`src-tauri/src/migrations.rs:762-770`) + `TrajectoryBundle` (`abilities-runtime/src/abilities/temporal/mod.rs:39`). W4-B's L0 plan **MUST** either consume those existing temporal primitives for deviation factor inputs, OR justify a NEW `deviation_baselines` table with explicit non-overlap proof. Default expectation: consume; net-new substrate requires proof bundle.
 - **Intelligence Loop gate:**
   1. *Claim model:* Computes baselines over claim time-series; feeds into salience Novelty factor.
   2. *Provenance + trust:* Deviation rationale captured (which baseline, what threshold, observed value).
   3. *Signals + invalidation:* New signal `EntityDeviationDetected` (or feeds existing); confirm at L0.
-  4. *Runtime + surfaces:* Briefing surfaces "What's unusual" via W3.
+  4. *Runtime + surfaces:* WP briefing/entity surfaces render "What's unusual" only through the ability-backed projection.
   5. *Feedback loop:* User dismissing "what's unusual" tunes baseline confidence.
-- **Tests required:** Baseline computation correct; deviation threshold detection; rolling-window decay; `cargo test` + `cargo clippy -D warnings` clean.
-- **Done when:** Deviation detection live; baselines table populated; "What's unusual" surfacing wired through salience.
+- **Tests required:** Baseline computation correct; deviation threshold detection; rolling-window decay; projection emits typed empty/stale/caveated state when unavailable; block render does not read deviation tables directly; `cargo test` + `cargo clippy -D warnings` clean.
+- **Done when:** Deviation detection live; baselines table populated only if L0 proves net-new storage; "What's unusual" surfacing wired through the ability projection and salience.
 
 ### Agent W4-C — DOS-317: Engagement telemetry → ranking signal (not trust)
 
@@ -973,7 +1029,7 @@ Three agents — **cycle 2 amendment serializes per Challenge + Eng findings**: 
 - **Goal:** Capture which sections users read, which chips they clicked, which they ignored. Feeds into salience UserFit factor (ranking) — NEVER feeds trust scoring. Per release thesis: engagement-maximizing ranking is an explicit non-goal; engagement is one factor among ten, not the optimization target.
 - **Files owned (exclusive):**
   - `src-tauri/src/services/recommendations/engagement.rs` (placeholder from W1-A; W4-C fills) — engagement event capture + per-user rollup.
-  - Migration v281-v282 — `engagement_telemetry` table with PII-bounded rollups (per-claim / per-surface / per-user with bounded retention).
+  - Migration slot TBD at W4-C L0 — take the next contiguous v1.4.6 slot after W2/W4-A/W4-B; expected `engagement_telemetry` table with PII-bounded rollups (per-claim / per-surface / per-user with bounded retention) if the L0 privacy/reuse audit approves net-new storage.
 - **Don't touch:** Trust scoring (`services::trust` — engagement_telemetry table forbidden as input per CI invariant); other submodules.
 - **Depends on:** W1 + W2 + W3 + **W4-A merged** (cycle 2 amendment per Challenge + Eng findings). Stage 4b: parallel with W4-B only.
 - **Security gate:** `/cso` mandatory at L0 + L2. Telemetry IS privacy-sensitive.
@@ -995,9 +1051,9 @@ Three agents — **cycle 2 amendment serializes per Challenge + Eng findings**: 
 ### W4 merge gate
 
 L0 → L2 → L3 cleared. Required artifacts:
-- L0 plan approvals: architect-reviewer for W4-A/B; architect-reviewer + `/cso` for W4-C.
-- L2 diff approvals on 3 PRs. `/cso` re-review on W4-C.
-- L3 wave adversarial: codex-challenge + `/cso` + architect-reviewer + Suite S (engagement-NOT-trust enforced; privacy bounded; feedback updates ranking on next cycle).
+- L0 plan approvals under current ladder: `/codex challenge` plus routed planning reviewers. W4-C always adds `ce-security-lens-reviewer`; W4-B adds `ce-feasibility-reviewer` when it proposes new baseline storage.
+- L2 diff approvals through `l2-bounded-reviewer` plus routed specialists. W4-C adds `ce-security-reviewer`; migrations add `ce-data-migrations-reviewer`.
+- L3 wave adversarial: `/codex challenge` + `ce-architecture-strategist` + Suite S/E/P as fired (engagement-NOT-trust enforced; privacy bounded; feedback updates ranking on next cycle).
 - **Mandatory retro.**
 
 ---
@@ -1016,20 +1072,19 @@ Single agent.
   - **Noisy:** items dismissed as `TooNoisy` should suppress similar future items for that user
   - **Missed-important:** false-negative test cases (engagement is NOT the optimization target — must catch important items even when prior user behavior would suggest filtering)
   - **User-corrected:** feedback updates ranking on next cycle
-- **Files owned (exclusive):** `tests/v145_eval/` (new test suite directory); fixture corpus at `tests/v145_eval/fixtures/`.
+- **Files owned (exclusive):** `tests/v146_eval/` (new test suite directory); fixture corpus at `tests/v146_eval/fixtures/`.
 - **Depends on:** W1 + W2 + W3 + W4 fully merged.
-- **DX gate:** `/plan-devex-review` mandatory at L0 plan. Eval harness shape IS the maintenance DX for v1.4.5+ test maintainers.
+- **DX gate:** `/plan-devex-review` mandatory at L0 plan. Eval harness shape IS the maintenance DX for v1.4.6+ test maintainers.
 - **Intelligence Loop gate:** This wave IS the Intelligence Loop validation — all five questions are the validation axes.
 - **Tests required:** Each eval axis green on fixture corpus; ranking delta verifiable post-feedback; missed-important coverage explicit; `cargo test` + `cargo clippy -D warnings` clean.
 - **Done when:** Eval harness runs all six axes; missed-important baseline + threshold defined; CI integration; `/plan-devex-review` L0 plan approval recorded.
 
 ### W5 merge gate = release gate
 
-L0 → L2 → L3 → L5 cleared. Required artifacts:
-- L0 plan approvals: architect-reviewer + qa-expert + `/plan-devex-review` for W5-A.
-- L2 diff approvals on 1 PR.
-- L3 wave adversarial: codex-challenge + architect-reviewer + **Suite S** (engagement-NOT-trust; surfacing-decision rationale logged) + **Suite E** (all six eval axes green; v1.4.0–v1.4.4 substrate fixtures still green).
-- L5 drift check: integrated state matches v1.4.6 project DoD verbatim AND v1.4.7 W2-C `dailyos.read.portfolio_attention` consumer contract verified.
+L0 → L2 → L3 cleared. Required artifacts:
+- L0 plan approvals under current ladder: `/codex challenge` + `ce-feasibility-reviewer` or `ce-devex`-equivalent planning reviewer selected by the router, plus `/plan-devex-review` for harness usability and mandatory K-in.
+- L2 diff approval through `l2-bounded-reviewer`; add test/harness specialist if the router selects it.
+- L3 wave adversarial and folded drift check: `/codex challenge` + `ce-architecture-strategist` + **Suite S** (engagement-NOT-trust; surfacing-decision rationale logged) + **Suite E** (all six eval axes green; v1.4.0–v1.4.5 substrate fixtures still green). L3 verifies integrated state matches the v1.4.6 DoD and records v1.4.7 compatibility state.
 - **Mandatory retro.**
 
 ---
@@ -1063,8 +1118,8 @@ L0 → L2 → L3 → L5 cleared. Required artifacts:
 - [ ] User-corrected ranking delta verified
 
 ### v1.4.7 forward-compatibility
-- [ ] dailyos.read.portfolio_attention contract verified against v1.4.6 salience ability
-- [ ] v1.4.6 salience ability schema has not changed since v1.4.7 wave plan was approved (or if changed, v1.4.7 W2-C lane informed)
+- [ ] v1.4.6 salience / recommendation read contract is schema-versioned and documented for future MCP consumers
+- [ ] v1.4.7 `dailyos.read.portfolio_attention` status recorded: consumes v1.4.6 if available, or remains on its approved fallback path without blocking v1.4.6
 
 ### Privacy
 - [ ] DOS-317 engagement telemetry: capture taxonomy explicit; PII bounded; retention auto-purge tested
@@ -1074,8 +1129,8 @@ L0 → L2 → L3 → L5 cleared. Required artifacts:
 - [ ] /cso L2 approval recorded for DOS-317
 
 ### UI proof matrix
-- [ ] Suggested Next Steps component: rendered on briefing / entity / work surfaces
-- [ ] "What's unusual" briefing section: deviation surfaces correctly
+- [ ] `dailyos/suggested-next-steps` block rendered on briefing / entity / work WP surfaces through ability projection
+- [ ] `dailyos/whats-unusual` block or approved inner section renders deviation state correctly through ability projection
 
 ### Linear hygiene
 - [ ] All 10 v1.4.6 issues closed Done
@@ -1099,7 +1154,7 @@ L0 → L2 → L3 → L5 cleared. Required artifacts:
 | 2 | Does ADR-0102 need amendment for `recommend_for_entity` ability variant + `mcp_exposure: MetadataOnly`? | W0 | **RESOLVED (2026-05-26)** — no W1-A ADR-0102 amendment required; existing metadata-only exposure is sufficient until v1.4.7 MCP wrapping. |
 | 3 | Is `RecommendationClaim` a discriminated payload column on `intelligence_claims`, or a separate table joined by claim_id? | W1-A (DOS-329) | **RESOLVED (2026-05-26)** — no separate table; store the typed envelope under `intelligence_claims.metadata_json.recommendation` and add v269 JSON-path indexes. |
 | 4 | Does v1.4.4 `services::claim_review_queue` DOS-336 candidate extension hook accept v1.4.6 RecommendationClaim as `target_kind = "candidate"` cleanly, or does v1.4.6 need a separate W3-E-style extension? | W3 | **Deferred-to-W3-L0** — cross-version coordination; cycle 3 Class C: `<materializes-on:v1.4.4>` annotation; W0 close gate confirms v1.4.4 W1-A skeleton merged on dev (commit SHA recorded) before W1-A start |
-| 5 | Confirm v1.4.7 W2-C `dailyos.read.portfolio_attention` is still the named consumer of v1.4.6 salience ability. If v1.4.7 has shipped W2 since the wave plan was written, the schema must match what shipped. | W0 close | **RESOLVED (cycle 2 #7)** — v1.4.6 commits to producing the salience ability (`abilities-runtime/src/abilities/recommendations/salience.rs`) with stable schema_version=1 by W2-A merge; v1.4.7 W2-C consumes without amendment; schema-version mismatch fails-closed (cycle 3 Class B) |
+| 5 | What is the v1.4.7 compatibility state for `dailyos.read.portfolio_attention`? | W0 close / W5 release | **UPDATED (2026-05-26)** — v1.4.6 commits to stable schema-versioned salience / recommendation read contracts. v1.4.7 may consume them when available or remain on its approved fallback path if it ships first; v1.4.6 release records the status but does not block on the external consumer. |
 | 6 | Does `services::recommendations::feedback::record_recommendation_feedback` exist as a sibling to v1.4.4's `services::claims::record_claim_feedback`, or does v1.4.4's API extend with new variants? | W4-A (DOS-332) | **RESOLVED for W1-A (2026-05-26)** — W4-A owns a recommendation wrapper that calls existing `services::claims::record_claim_feedback`; no ADR-0123 enum extension or parallel feedback table unless W4-A explicitly amends ADR-0123 at L0. |
 | 7 | Does `deviation_baselines` (W4-B) overlap with existing v1.4.1 temporal/trend primitives, or is it genuinely new substrate? | W4-B (DOS-316) | **Open** — defer to W4-B L0 plan with substrate-consultation audit |
 | 8 | Does `engagement_telemetry` (W4-C) overlap with existing audit/event infrastructure, or is it genuinely new substrate? | W4-C (DOS-317) | **Open** — defer to W4-C L0 plan with substrate-consultation audit |

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -828,6 +828,10 @@ pub fn purge_mock_data(_state: &AppState) -> Result<String, String> {
 
     let n = delete_mock("salience_factors", "claim_id");
     summary.push(format!("salience_factors: {}", n));
+    let n = delete_mock("surfacing_decisions", "claim_id");
+    summary.push(format!("surfacing_decisions: {}", n));
+    let n = delete_mock("triggers_log", "entity_id");
+    summary.push(format!("triggers_log: {}", n));
 
     let n = delete_mock("intelligence_feedback", "entity_id");
     summary.push(format!("intelligence_feedback: {}", n));

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use rusqlite::{Connection, Error as SqliteError, ErrorCode};
+use sha2::{Digest, Sha256};
 
 mod v144_audit_action_token;
 mod v166_semantic_merge_safety;
@@ -1083,6 +1084,22 @@ const MIGRATIONS: &[Migration] = &[
     Migration::Sql {
         version: 270,
         sql: include_str!("migrations/270_salience_factors.sql"),
+    },
+    // v1.4.6 W2-A — recommendation surfacing policy and decision audit.
+    Migration::Fn {
+        version: 271,
+        apply: migrate_v271_recommendation_surfacing,
+    },
+    // v1.4.6 W2-B — salience candidate trigger run log.
+    Migration::Sql {
+        version: 272,
+        sql: include_str!("migrations/272_recommendation_triggers_log.sql"),
+    },
+    // v1.4.6 W2 repair — normalize local databases that ran draft W2
+    // surfacing/trigger migrations before L0 terminology hardening.
+    Migration::Fn {
+        version: 273,
+        apply: migrate_v273_recommendation_w2_shape_repair,
     },
 ];
 
@@ -2903,6 +2920,485 @@ fn migrate_v269_recommendation_claim_metadata_indexes(
         include_str!("migrations/269_recommendation_claim_metadata_indexes.sql"),
         "v1.4.6 W1-A recommendation claim metadata indexes",
     )
+}
+
+fn migrate_v271_recommendation_surfacing(conn: &Connection) -> Result<(), MigrationError> {
+    apply_idempotent_sql_migration(
+        conn,
+        include_str!("migrations/271_recommendation_surfacing.sql"),
+        "v1.4.6 W2-A recommendation surfacing policy and decision audit",
+    )
+}
+
+fn migrate_v273_recommendation_w2_shape_repair(conn: &Connection) -> Result<(), MigrationError> {
+    repair_v273_surfacing_decisions(conn)?;
+    repair_v273_triggers_log(conn)
+}
+
+fn repair_v273_surfacing_decisions(conn: &Connection) -> Result<(), MigrationError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return apply_idempotent_sql_migration(
+            conn,
+            include_str!("migrations/271_recommendation_surfacing.sql"),
+            "v1.4.6 W2 repair surfacing decisions create",
+        );
+    }
+
+    let columns = table_columns(conn, "surfacing_decisions")?;
+    let table_sql = sqlite_table_sql(conn, "surfacing_decisions")?;
+    let has_final_surface_class =
+        table_sql.contains("surface_class IN ('primary', 'background', 'quiet', 'review')");
+    if columns.contains("defer_until") && has_final_surface_class {
+        return sanitize_v273_surfacing_decisions(conn);
+    }
+
+    let defer_until_expr = if columns.contains("defer_until") {
+        "defer_until"
+    } else {
+        "NULL"
+    };
+
+    run_immediate_migration_transaction(
+        conn,
+        "v1.4.6 W2 repair surfacing decisions rebuild",
+        |conn| {
+            conn.execute_batch(
+                "DROP TABLE IF EXISTS surfacing_decisions_v273_old;
+                 ALTER TABLE surfacing_decisions RENAME TO surfacing_decisions_v273_old;
+                 DROP INDEX IF EXISTS idx_surfacing_decisions_claim_created;
+                 DROP INDEX IF EXISTS idx_surfacing_decisions_budget;
+                 DROP INDEX IF EXISTS idx_surfacing_decisions_subject_action;
+                 DROP INDEX IF EXISTS idx_surfacing_decisions_salience;",
+            )
+            .map_err(|e| format!("v273 surfacing decisions rename: {e}"))?;
+
+            apply_idempotent_sql_statements(
+                conn,
+                include_str!("migrations/271_recommendation_surfacing.sql"),
+                "v1.4.6 W2 repair surfacing decisions create final table",
+            )?;
+
+            conn.execute_batch(&format!(
+                "INSERT INTO surfacing_decisions (
+                    id,
+                    idempotency_key,
+                    policy_version,
+                    claim_id,
+                    decision_kind,
+                    surfacing_tier,
+                    defer_reason,
+                    defer_until,
+                    suppress_reason,
+                    budget_key,
+                    actor_kind,
+                    local_day,
+                    claim_type,
+                    sensitivity,
+                    surface_class,
+                    render_surface,
+                    subject_kind,
+                    subject_id,
+                    action_signature,
+                    salience_total,
+                    salience_evaluation_id,
+                    why_this_now_json,
+                    trigger_refs_json,
+                    evidence_signature,
+                    source_asof,
+                    source_signal_id,
+                    created_at
+                )
+                SELECT
+                    id,
+                    idempotency_key,
+                    policy_version,
+                    claim_id,
+                    decision_kind,
+                    surfacing_tier,
+                    defer_reason,
+                    {defer_until_expr} AS defer_until,
+                    suppress_reason,
+                    budget_key,
+                    actor_kind,
+                    local_day,
+                    claim_type,
+                    sensitivity,
+                    CASE surface_class
+                        WHEN 'external' THEN 'quiet'
+                        ELSE surface_class
+                    END AS surface_class,
+                    render_surface,
+                    subject_kind,
+                    subject_id,
+                    action_signature,
+                    salience_total,
+                    salience_evaluation_id,
+                    why_this_now_json,
+                    trigger_refs_json,
+                    evidence_signature,
+                    source_asof,
+                    source_signal_id,
+                    created_at
+                FROM surfacing_decisions_v273_old;
+                DROP TABLE surfacing_decisions_v273_old;"
+            ))
+            .map_err(|e| format!("v273 surfacing decisions copy: {e}"))?;
+
+            sanitize_v273_surfacing_decisions(conn)?;
+
+            Ok(())
+        },
+    )
+}
+
+fn repair_v273_triggers_log(conn: &Connection) -> Result<(), MigrationError> {
+    if !table_exists(conn, "triggers_log")? {
+        return apply_idempotent_sql_migration(
+            conn,
+            include_str!("migrations/272_recommendation_triggers_log.sql"),
+            "v1.4.6 W2 repair triggers log create",
+        );
+    }
+
+    let columns = table_columns(conn, "triggers_log")?;
+    let needs_rebuild = columns.contains("selected_channel")
+        || !columns.contains("trigger_disposition")
+        || !columns.contains("result_kind")
+        || !columns.contains("downstream_policy");
+    if !needs_rebuild {
+        return sanitize_v273_triggers_log(conn);
+    }
+
+    let selected_channel_expr = if columns.contains("selected_channel") {
+        "COALESCE(selected_channel, '')"
+    } else {
+        "''"
+    };
+    let trigger_disposition_expr = if columns.contains("trigger_disposition") {
+        "trigger_disposition".to_string()
+    } else {
+        format!(
+            "CASE {selected_channel_expr}
+                WHEN 'surface' THEN 'primary_candidate'
+                WHEN 'review' THEN 'review_candidate'
+                WHEN 'quiet' THEN 'quiet_candidate'
+                WHEN 'background' THEN 'silent_prepare'
+                ELSE 'silent_prepare'
+            END"
+        )
+    };
+    let result_kind_expr = if columns.contains("result_kind") {
+        "result_kind".to_string()
+    } else {
+        format!(
+            "CASE
+                WHEN status IN ('failed_retryable', 'failed_terminal') THEN 'failed'
+                WHEN {selected_channel_expr} = 'surface'
+                     AND COALESCE(surfacing_decision_ids_json, '[]') <> '[]'
+                    THEN 'render_decision_recorded'
+                WHEN {selected_channel_expr} = 'review'
+                     AND COALESCE(surfacing_decision_ids_json, '[]') <> '[]'
+                    THEN 'held_for_review'
+                WHEN {selected_channel_expr} = 'quiet'
+                     AND COALESCE(surfacing_decision_ids_json, '[]') <> '[]'
+                    THEN 'stayed_quiet'
+                ELSE 'prepared_silently'
+            END"
+        )
+    };
+    let downstream_policy_expr = if columns.contains("downstream_policy") {
+        "downstream_policy"
+    } else {
+        "'recommendation_surfacing_policy'"
+    };
+
+    run_immediate_migration_transaction(conn, "v1.4.6 W2 repair triggers log rebuild", |conn| {
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS triggers_log_v273_old;
+                 ALTER TABLE triggers_log RENAME TO triggers_log_v273_old;
+                 DROP INDEX IF EXISTS idx_triggers_log_dedupe_policy;
+                 DROP INDEX IF EXISTS idx_triggers_log_subject;
+                 DROP INDEX IF EXISTS idx_triggers_log_retry;
+                 DROP INDEX IF EXISTS idx_triggers_log_signal;",
+        )
+        .map_err(|e| format!("v273 triggers log rename: {e}"))?;
+
+        apply_idempotent_sql_statements(
+            conn,
+            include_str!("migrations/272_recommendation_triggers_log.sql"),
+            "v1.4.6 W2 repair triggers log create final table",
+        )?;
+
+        conn.execute_batch(&format!(
+            "INSERT INTO triggers_log (
+                    run_id,
+                    policy_version,
+                    trigger_class,
+                    trigger_kind,
+                    status,
+                    trigger_disposition,
+                    result_kind,
+                    downstream_policy,
+                    subject_kind,
+                    subject_id,
+                    entity_type,
+                    entity_id,
+                    reason_code,
+                    dedupe_key,
+                    suppression_key,
+                    trust_floor,
+                    freshness_window_secs,
+                    source_signal_id,
+                    source_signal_type,
+                    source_asof,
+                    evidence_signature,
+                    subject_version,
+                    signal_id,
+                    signal_coalesced,
+                    derived_signal_ids_json,
+                    candidate_claim_ids_json,
+                    salience_evaluation_ids_json,
+                    surfacing_decision_ids_json,
+                    error_code,
+                    retry_count,
+                    next_retry_at,
+                    started_at,
+                    completed_at,
+                    updated_at
+                )
+                SELECT
+                    run_id,
+                    policy_version,
+                    trigger_class,
+                    trigger_kind,
+                    status,
+                    {trigger_disposition_expr} AS trigger_disposition,
+                    {result_kind_expr} AS result_kind,
+                    {downstream_policy_expr} AS downstream_policy,
+                    subject_kind,
+                    subject_id,
+                    entity_type,
+                    entity_id,
+                    reason_code,
+                    dedupe_key,
+                    suppression_key,
+                    trust_floor,
+                    freshness_window_secs,
+                    source_signal_id,
+                    source_signal_type,
+                    source_asof,
+                    evidence_signature,
+                    subject_version,
+                    signal_id,
+                    signal_coalesced,
+                    derived_signal_ids_json,
+                    candidate_claim_ids_json,
+                    salience_evaluation_ids_json,
+                    surfacing_decision_ids_json,
+                    error_code,
+                    retry_count,
+                    next_retry_at,
+                    started_at,
+                    completed_at,
+                    updated_at
+                FROM triggers_log_v273_old;
+                DROP TABLE triggers_log_v273_old;"
+        ))
+        .map_err(|e| format!("v273 triggers log copy: {e}"))?;
+
+        sanitize_v273_triggers_log(conn)?;
+
+        Ok(())
+    })
+}
+
+struct V273SurfacingAuditRow {
+    id: String,
+    evidence_signature: Option<String>,
+    source_signal_id: Option<String>,
+}
+
+fn sanitize_v273_surfacing_decisions(conn: &Connection) -> Result<(), MigrationError> {
+    let rows = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, evidence_signature, source_signal_id
+                   FROM surfacing_decisions",
+            )
+            .map_err(|e| format!("v273 surfacing sanitize prepare: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(V273SurfacingAuditRow {
+                    id: row.get(0)?,
+                    evidence_signature: row.get(1)?,
+                    source_signal_id: row.get(2)?,
+                })
+            })
+            .map_err(|e| format!("v273 surfacing sanitize read: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("v273 surfacing sanitize collect: {e}"))?
+    };
+
+    for row in rows {
+        conn.execute(
+            "UPDATE surfacing_decisions
+                SET evidence_signature = ?2,
+                    source_signal_id = ?3
+              WHERE id = ?1",
+            rusqlite::params![
+                row.id,
+                v273_safe_optional_ref("evidence", row.evidence_signature.as_deref()),
+                v273_safe_optional_ref("signal_ref", row.source_signal_id.as_deref()),
+            ],
+        )
+        .map_err(|e| format!("v273 surfacing sanitize update: {e}"))?;
+    }
+
+    Ok(())
+}
+
+struct V273TriggerAuditRow {
+    run_id: String,
+    source_signal_id: Option<String>,
+    source_signal_type: Option<String>,
+    evidence_signature: Option<String>,
+    dedupe_key: String,
+    suppression_key: String,
+}
+
+fn sanitize_v273_triggers_log(conn: &Connection) -> Result<(), MigrationError> {
+    let rows = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT run_id, source_signal_id, source_signal_type, evidence_signature,
+                        dedupe_key, suppression_key
+                   FROM triggers_log",
+            )
+            .map_err(|e| format!("v273 triggers sanitize prepare: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(V273TriggerAuditRow {
+                    run_id: row.get(0)?,
+                    source_signal_id: row.get(1)?,
+                    source_signal_type: row.get(2)?,
+                    evidence_signature: row.get(3)?,
+                    dedupe_key: row.get(4)?,
+                    suppression_key: row.get(5)?,
+                })
+            })
+            .map_err(|e| format!("v273 triggers sanitize read: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("v273 triggers sanitize collect: {e}"))?
+    };
+
+    for row in rows {
+        conn.execute(
+            "UPDATE triggers_log
+                SET source_signal_id = ?2,
+                    source_signal_type = ?3,
+                    evidence_signature = ?4,
+                    dedupe_key = ?5,
+                    suppression_key = ?6
+              WHERE run_id = ?1",
+            rusqlite::params![
+                row.run_id,
+                v273_safe_optional_ref("signal_ref", row.source_signal_id.as_deref()),
+                v273_safe_optional_token("signal_type", row.source_signal_type.as_deref()),
+                v273_safe_optional_ref("evidence", row.evidence_signature.as_deref()),
+                v273_safe_storage_ref("dedupe", &row.dedupe_key),
+                v273_safe_storage_ref("suppression", &row.suppression_key),
+            ],
+        )
+        .map_err(|e| format!("v273 triggers sanitize update: {e}"))?;
+    }
+
+    Ok(())
+}
+
+fn v273_safe_optional_token(prefix: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| v273_safe_storage_token(prefix, value))
+}
+
+fn v273_safe_optional_ref(prefix: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| v273_safe_storage_ref(prefix, value))
+}
+
+fn v273_safe_storage_token(prefix: &str, value: &str) -> String {
+    let value = value.trim();
+    if v273_is_safe_storage_token(value) {
+        value.to_string()
+    } else {
+        v273_hashed_storage_ref(prefix, value)
+    }
+}
+
+fn v273_safe_storage_ref(prefix: &str, value: &str) -> String {
+    let value = value.trim();
+    if v273_is_safe_storage_ref(value) {
+        value.to_string()
+    } else {
+        v273_hashed_storage_ref(prefix, value)
+    }
+}
+
+fn v273_is_safe_storage_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b':' | b'.'))
+}
+
+fn v273_is_safe_storage_ref(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b':' | b'.'))
+}
+
+fn v273_hashed_storage_ref(prefix: &str, value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(b":");
+    hasher.update(value.as_bytes());
+    format!("{prefix}_{}", hex::encode(&hasher.finalize()[..16]))
+}
+
+fn sqlite_table_sql(conn: &Connection, table_name: &str) -> Result<String, MigrationError> {
+    conn.query_row(
+        "SELECT sql
+           FROM sqlite_master
+          WHERE type = 'table'
+            AND name = ?1",
+        [table_name],
+        |row| row.get(0),
+    )
+    .map_err(|e| format!("Failed to read table SQL for '{}': {e}", table_name))
+}
+
+fn run_immediate_migration_transaction(
+    conn: &Connection,
+    label: &str,
+    apply: impl FnOnce(&Connection) -> Result<(), MigrationError>,
+) -> Result<(), MigrationError> {
+    conn.execute_batch("BEGIN IMMEDIATE;")
+        .map_err(|e| format!("{label}: begin transaction: {e}"))?;
+
+    let result = apply(conn);
+    match result {
+        Ok(()) => conn
+            .execute_batch("COMMIT;")
+            .map_err(|e| format!("{label}: commit transaction: {e}")),
+        Err(error) => {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort cleanup after migration failure"
+            )]
+            let _ = conn.execute_batch("ROLLBACK;");
+            Err(error)
+        }
+    }
 }
 
 fn apply_idempotent_sql_migration(
@@ -6888,8 +7384,8 @@ mod tests {
             [],
         )
         .expect("simulate partial weight mutation");
-        conn.execute("DELETE FROM schema_version WHERE version = 270", [])
-            .expect("simulate v270 version record gap");
+        conn.execute("DELETE FROM schema_version WHERE version >= 270", [])
+            .expect("simulate v270 version record gap before newer migrations run");
 
         run_migrations(&conn).expect("rerun v270 after version record gap");
 
@@ -6906,6 +7402,671 @@ mod tests {
         assert_eq!(weight_count, 10);
         assert!((weight_sum - 1.0).abs() < 0.0001);
         assert!((importance_weight - 0.20).abs() < 0.0001);
-        assert_eq!(current_version(&conn).expect("current version"), 270);
+        assert!(
+            current_version(&conn).expect("current version") >= 270,
+            "current version remains at or beyond v270"
+        );
+    }
+
+    #[test]
+    fn migration_271_creates_recommendation_surfacing_policy_and_decisions() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+
+        for table_name in ["recommendation_surfacing_policy", "surfacing_decisions"] {
+            let table_count: i64 = conn
+                .query_row(
+                    "SELECT count(*)
+                       FROM sqlite_master
+                      WHERE type = 'table'
+                        AND name = ?1",
+                    [table_name],
+                    |row| row.get(0),
+                )
+                .expect("query surfacing table");
+            assert_eq!(table_count, 1, "{table_name} exists");
+        }
+
+        let policy: (f64, i64, i64, String) = conn
+            .query_row(
+                "SELECT critical_threshold, critical_primary_daily_budget,
+                        notable_primary_daily_budget, policy_source
+                   FROM recommendation_surfacing_policy
+                  WHERE policy_version = 'recommendation_surfacing_v1'
+                    AND claim_type = 'recommendation'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("read surfacing policy defaults");
+        assert!((policy.0 - 0.85).abs() < 0.0001);
+        assert_eq!(policy.1, 1);
+        assert_eq!(policy.2, 3);
+        assert_eq!(policy.3, "claim_type:recommendation");
+        let defer_until_columns: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                   FROM pragma_table_info('surfacing_decisions')
+                  WHERE name = 'defer_until'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read surfacing decision columns");
+        assert_eq!(defer_until_columns, 1);
+        assert!(
+            current_version(&conn).expect("current version") >= 271,
+            "schema version is at least v271"
+        );
+    }
+
+    #[test]
+    fn migration_272_creates_trigger_log_with_retry_and_id_tables() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+
+        let table_count: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                   FROM sqlite_master
+                  WHERE type = 'table'
+                    AND name = 'triggers_log'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query trigger log table");
+        assert_eq!(table_count, 1);
+
+        for column_name in [
+            "status",
+            "trigger_disposition",
+            "result_kind",
+            "downstream_policy",
+            "dedupe_key",
+            "next_retry_at",
+            "candidate_claim_ids_json",
+            "salience_evaluation_ids_json",
+            "surfacing_decision_ids_json",
+        ] {
+            let column_count: i64 = conn
+                .query_row(
+                    "SELECT count(*)
+                       FROM pragma_table_info('triggers_log')
+                      WHERE name = ?1",
+                    [column_name],
+                    |row| row.get(0),
+                )
+                .expect("query trigger log column");
+            assert_eq!(column_count, 1, "{column_name} exists");
+        }
+        let legacy_channel_columns: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                   FROM pragma_table_info('triggers_log')
+                  WHERE name = 'selected_channel'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("query legacy trigger channel column");
+        assert_eq!(legacy_channel_columns, 0);
+        assert!(
+            current_version(&conn).expect("current version") >= 272,
+            "schema version is at least v272"
+        );
+    }
+
+    #[test]
+    fn migration_273_repairs_draft_w2_table_shapes() {
+        let conn = mem_db();
+        conn.execute_batch(
+            "CREATE TABLE intelligence_claims (id TEXT PRIMARY KEY);
+            INSERT INTO intelligence_claims (id) VALUES ('claim-old');
+
+            CREATE TABLE surfacing_decisions (
+                id TEXT PRIMARY KEY,
+                idempotency_key TEXT NOT NULL UNIQUE,
+                policy_version TEXT NOT NULL,
+                claim_id TEXT NOT NULL REFERENCES intelligence_claims(id) ON DELETE CASCADE,
+                decision_kind TEXT NOT NULL CHECK (decision_kind IN ('render', 'defer', 'suppress')),
+                surfacing_tier TEXT CHECK (
+                    surfacing_tier IS NULL
+                    OR surfacing_tier IN ('critical', 'notable', 'background', 'quiet')
+                ),
+                defer_reason TEXT CHECK (
+                    defer_reason IS NULL
+                    OR defer_reason IN (
+                        'cooldown_active',
+                        'budget_exhausted',
+                        'awaiting_corroboration',
+                        'pending_trigger'
+                    )
+                ),
+                suppress_reason TEXT CHECK (
+                    suppress_reason IS NULL
+                    OR suppress_reason IN (
+                        'below_threshold',
+                        'user_muted_subject',
+                        'dismissed_recently',
+                        'contradicted_with_stronger_evidence'
+                    )
+                ),
+                budget_key TEXT NOT NULL,
+                actor_kind TEXT NOT NULL,
+                local_day TEXT NOT NULL,
+                claim_type TEXT NOT NULL,
+                sensitivity TEXT NOT NULL,
+                surface_class TEXT NOT NULL CHECK (surface_class IN ('primary', 'background', 'review', 'external')),
+                render_surface TEXT NOT NULL,
+                subject_kind TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                action_signature TEXT NOT NULL,
+                salience_total REAL NOT NULL CHECK (salience_total >= 0.0 AND salience_total <= 1.0),
+                salience_evaluation_id TEXT NOT NULL,
+                why_this_now_json TEXT CHECK (why_this_now_json IS NULL OR json_valid(why_this_now_json) = 1),
+                trigger_refs_json TEXT NOT NULL CHECK (json_valid(trigger_refs_json) = 1),
+                evidence_signature TEXT,
+                source_asof TEXT,
+                source_signal_id TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE INDEX idx_surfacing_decisions_claim_created
+                ON surfacing_decisions(claim_id, created_at DESC);
+            CREATE INDEX idx_surfacing_decisions_budget
+                ON surfacing_decisions(policy_version, budget_key, decision_kind, surfacing_tier);
+            CREATE INDEX idx_surfacing_decisions_subject_action
+                ON surfacing_decisions(
+                    policy_version,
+                    subject_kind,
+                    subject_id,
+                    action_signature,
+                    surface_class,
+                    created_at DESC
+                );
+            CREATE INDEX idx_surfacing_decisions_salience
+                ON surfacing_decisions(salience_evaluation_id);
+            INSERT INTO surfacing_decisions (
+                id,
+                idempotency_key,
+                policy_version,
+                claim_id,
+                decision_kind,
+                surfacing_tier,
+                defer_reason,
+                suppress_reason,
+                budget_key,
+                actor_kind,
+                local_day,
+                claim_type,
+                sensitivity,
+                surface_class,
+                render_surface,
+                subject_kind,
+                subject_id,
+                action_signature,
+                salience_total,
+                salience_evaluation_id,
+                why_this_now_json,
+                trigger_refs_json,
+                evidence_signature,
+                source_asof,
+                source_signal_id,
+                created_at
+            ) VALUES (
+                'decision-old',
+                'idem-old',
+                'recommendation_surfacing_v1',
+                'claim-old',
+                'render',
+                'notable',
+                NULL,
+                NULL,
+                'actor:2026-05-26:recommendation:low:external',
+                'system',
+                '2026-05-26',
+                'recommendation',
+                'low',
+                'external',
+                'activity_log',
+                'account',
+                'acct-1',
+                'follow-up',
+                0.72,
+                'eval-1',
+                NULL,
+                '[]',
+                'provider raw evidence /Users/example/workspace-note.md',
+                '2026-05-26T00:00:00Z',
+                '/Users/example/raw-workspace-note.md',
+                '2026-05-26T01:00:00Z'
+            );
+
+            CREATE TABLE triggers_log (
+                run_id TEXT PRIMARY KEY,
+                policy_version TEXT NOT NULL,
+                trigger_class TEXT NOT NULL CHECK (
+                    trigger_class IN (
+                        'scheduled_freshness',
+                        'event_invalidation',
+                        'manual_refresh',
+                        'entity_change',
+                        'claim_change',
+                        'source_change',
+                        'open_loop_change',
+                        'meeting_window',
+                        'decision_window',
+                        'feedback_echo'
+                    )
+                ),
+                trigger_kind TEXT NOT NULL CHECK (
+                    trigger_kind IN ('signal_arrival', 'entity_change', 'scheduled_scan', 'feedback_echo')
+                ),
+                status TEXT NOT NULL CHECK (
+                    status IN ('started', 'completed', 'failed_retryable', 'failed_terminal')
+                ),
+                selected_channel TEXT NOT NULL CHECK (selected_channel IN ('surface', 'review', 'background', 'quiet')),
+                subject_kind TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                reason_code TEXT NOT NULL,
+                dedupe_key TEXT NOT NULL,
+                suppression_key TEXT NOT NULL,
+                trust_floor REAL NOT NULL CHECK (trust_floor >= 0.0 AND trust_floor <= 1.0),
+                freshness_window_secs INTEGER NOT NULL CHECK (freshness_window_secs >= 0),
+                source_signal_id TEXT,
+                source_signal_type TEXT,
+                source_asof TEXT,
+                evidence_signature TEXT,
+                subject_version INTEGER,
+                signal_id TEXT,
+                signal_coalesced INTEGER NOT NULL DEFAULT 0 CHECK (signal_coalesced IN (0, 1)),
+                derived_signal_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(derived_signal_ids_json) = 1),
+                candidate_claim_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(candidate_claim_ids_json) = 1),
+                salience_evaluation_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(salience_evaluation_ids_json) = 1),
+                surfacing_decision_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(surfacing_decision_ids_json) = 1),
+                error_code TEXT,
+                retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+                next_retry_at TEXT,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX idx_triggers_log_dedupe_policy
+                ON triggers_log(policy_version, dedupe_key, updated_at DESC);
+            CREATE INDEX idx_triggers_log_subject
+                ON triggers_log(subject_kind, subject_id, started_at DESC);
+            CREATE INDEX idx_triggers_log_retry
+                ON triggers_log(status, next_retry_at)
+                WHERE status = 'failed_retryable';
+            CREATE INDEX idx_triggers_log_signal
+                ON triggers_log(source_signal_id)
+                WHERE source_signal_id IS NOT NULL;
+            INSERT INTO triggers_log (
+                run_id,
+                policy_version,
+                trigger_class,
+                trigger_kind,
+                status,
+                selected_channel,
+                subject_kind,
+                subject_id,
+                entity_type,
+                entity_id,
+                reason_code,
+                dedupe_key,
+                suppression_key,
+                trust_floor,
+                freshness_window_secs,
+                source_signal_id,
+                source_signal_type,
+                source_asof,
+                evidence_signature,
+                subject_version,
+                signal_id,
+                signal_coalesced,
+                derived_signal_ids_json,
+                candidate_claim_ids_json,
+                salience_evaluation_ids_json,
+                surfacing_decision_ids_json,
+                error_code,
+                retry_count,
+                next_retry_at,
+                started_at,
+                completed_at,
+                updated_at
+            ) VALUES (
+                'run-old',
+                'recommendation_trigger_v1',
+                'manual_refresh',
+                'signal_arrival',
+                'completed',
+                'review',
+                'account',
+                'acct-1',
+                'account',
+                'acct-1',
+                'manual_refresh',
+                'dedupe:/Users/example/raw-workspace-note.md',
+                'suppress:/Users/example/raw-workspace-note.md',
+                0.8,
+                3600,
+                '/Users/example/raw-workspace-note.md',
+                'provider output /Users/example/raw-workspace-note.md',
+                '2026-05-26T00:00:00Z',
+                'provider raw evidence /Users/example/workspace-note.md',
+                7,
+                'sig-1',
+                0,
+                '[]',
+                '[\"claim-old\"]',
+                '[\"eval-1\"]',
+                '[\"decision-old\"]',
+                NULL,
+                0,
+                NULL,
+                '2026-05-26T01:00:00Z',
+                '2026-05-26T01:00:01Z',
+                '2026-05-26T01:00:01Z'
+            );",
+        )
+        .expect("create draft W2 tables");
+
+        migrate_v273_recommendation_w2_shape_repair(&conn).expect("repair draft W2 tables");
+
+        let defer_until_columns: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                   FROM pragma_table_info('surfacing_decisions')
+                  WHERE name = 'defer_until'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired surfacing columns");
+        assert_eq!(defer_until_columns, 1);
+
+        let (surface_class, defer_until): (String, Option<String>) = conn
+            .query_row(
+                "SELECT surface_class, defer_until
+                   FROM surfacing_decisions
+                  WHERE id = 'decision-old'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read repaired surfacing row");
+        assert_eq!(surface_class, "quiet");
+        assert_eq!(defer_until, None);
+        let (surfacing_evidence, surfacing_signal): (String, String) = conn
+            .query_row(
+                "SELECT evidence_signature, source_signal_id
+                   FROM surfacing_decisions
+                  WHERE id = 'decision-old'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read repaired surfacing privacy fields");
+        assert!(surfacing_evidence.starts_with("evidence_"));
+        assert!(surfacing_signal.starts_with("signal_ref_"));
+        assert!(
+            index_exists(&conn, "idx_surfacing_decisions_claim_created")
+                .expect("query surfacing index"),
+            "surfacing indexes are recreated on the final table"
+        );
+
+        let legacy_channel_columns: i64 = conn
+            .query_row(
+                "SELECT count(*)
+                   FROM pragma_table_info('triggers_log')
+                  WHERE name = 'selected_channel'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired trigger columns");
+        assert_eq!(legacy_channel_columns, 0);
+
+        let (trigger_disposition, result_kind, downstream_policy): (String, String, String) = conn
+            .query_row(
+                "SELECT trigger_disposition, result_kind, downstream_policy
+                   FROM triggers_log
+                  WHERE run_id = 'run-old'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read repaired trigger row");
+        assert_eq!(trigger_disposition, "review_candidate");
+        assert_eq!(result_kind, "held_for_review");
+        assert_eq!(downstream_policy, "recommendation_surfacing_policy");
+        let (
+            source_signal_id,
+            source_signal_type,
+            evidence_signature,
+            dedupe_key,
+            suppression_key,
+        ): (String, String, String, String, String) = conn
+            .query_row(
+                "SELECT source_signal_id, source_signal_type, evidence_signature,
+                        dedupe_key, suppression_key
+                   FROM triggers_log
+                  WHERE run_id = 'run-old'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("read repaired trigger privacy fields");
+        assert!(source_signal_id.starts_with("signal_ref_"));
+        assert!(source_signal_type.starts_with("signal_type_"));
+        assert!(evidence_signature.starts_with("evidence_"));
+        assert!(dedupe_key.starts_with("dedupe_"));
+        assert!(suppression_key.starts_with("suppression_"));
+        let repaired_privacy_fields = format!(
+            "{surfacing_evidence} {surfacing_signal} {source_signal_id} \
+             {source_signal_type} {evidence_signature} {dedupe_key} {suppression_key}"
+        );
+        assert!(!repaired_privacy_fields.contains("/Users/"));
+        assert!(
+            index_exists(&conn, "idx_triggers_log_dedupe_policy").expect("query trigger index"),
+            "trigger indexes are recreated on the final table"
+        );
+    }
+
+    #[test]
+    fn migration_273_sanitizes_final_w2_tables_without_rebuild() {
+        let conn = mem_db();
+        conn.execute_batch(
+            "CREATE TABLE intelligence_claims (id TEXT PRIMARY KEY);
+             INSERT INTO intelligence_claims (id) VALUES ('claim-final');",
+        )
+        .expect("create parent claim table");
+        migrate_v271_recommendation_surfacing(&conn).expect("create final surfacing schema");
+        conn.execute_batch(include_str!(
+            "migrations/272_recommendation_triggers_log.sql"
+        ))
+        .expect("create final trigger schema");
+
+        conn.execute_batch(
+            "INSERT INTO surfacing_decisions (
+                id,
+                idempotency_key,
+                policy_version,
+                claim_id,
+                decision_kind,
+                surfacing_tier,
+                defer_reason,
+                defer_until,
+                suppress_reason,
+                budget_key,
+                actor_kind,
+                local_day,
+                claim_type,
+                sensitivity,
+                surface_class,
+                render_surface,
+                subject_kind,
+                subject_id,
+                action_signature,
+                salience_total,
+                salience_evaluation_id,
+                why_this_now_json,
+                trigger_refs_json,
+                evidence_signature,
+                source_asof,
+                source_signal_id,
+                created_at
+            ) VALUES (
+                'decision-final',
+                'idem-final',
+                'recommendation_surfacing_v1',
+                'claim-final',
+                'render',
+                'notable',
+                NULL,
+                NULL,
+                NULL,
+                'system:2026-05-26:recommendation:low:primary',
+                'system',
+                '2026-05-26',
+                'recommendation',
+                'low',
+                'primary',
+                'activity_log',
+                'account',
+                'acct-1',
+                'follow-up',
+                0.72,
+                'eval-final',
+                NULL,
+                '[]',
+                'provider raw evidence /Users/example/final-workspace-note.md',
+                '2026-05-26T00:00:00Z',
+                '/Users/example/final-workspace-note.md',
+                '2026-05-26T01:00:00Z'
+            );
+
+            INSERT INTO triggers_log (
+                run_id,
+                policy_version,
+                trigger_class,
+                trigger_kind,
+                status,
+                trigger_disposition,
+                result_kind,
+                downstream_policy,
+                subject_kind,
+                subject_id,
+                entity_type,
+                entity_id,
+                reason_code,
+                dedupe_key,
+                suppression_key,
+                trust_floor,
+                freshness_window_secs,
+                source_signal_id,
+                source_signal_type,
+                source_asof,
+                evidence_signature,
+                subject_version,
+                signal_id,
+                signal_coalesced,
+                derived_signal_ids_json,
+                candidate_claim_ids_json,
+                salience_evaluation_ids_json,
+                surfacing_decision_ids_json,
+                error_code,
+                retry_count,
+                next_retry_at,
+                started_at,
+                completed_at,
+                updated_at
+            ) VALUES (
+                'run-final',
+                'recommendation_trigger_v1',
+                'event_invalidation',
+                'signal_arrival',
+                'completed',
+                'primary_candidate',
+                'render_decision_recorded',
+                'recommendation_surfacing_policy',
+                'account',
+                'acct-1',
+                'account',
+                'acct-1',
+                'source_changed',
+                'dedupe:/Users/example/final-workspace-note.md',
+                'suppress:/Users/example/final-workspace-note.md',
+                0.8,
+                3600,
+                '/Users/example/final-workspace-note.md',
+                'provider output /Users/example/final-workspace-note.md',
+                '2026-05-26T00:00:00Z',
+                'provider raw evidence /Users/example/final-workspace-note.md',
+                7,
+                'sig-final',
+                0,
+                '[]',
+                '[\"claim-final\"]',
+                '[\"eval-final\"]',
+                '[\"decision-final\"]',
+                NULL,
+                0,
+                NULL,
+                '2026-05-26T01:00:00Z',
+                '2026-05-26T01:00:01Z',
+                '2026-05-26T01:00:01Z'
+            );",
+        )
+        .expect("seed final W2 tables with raw audit fields");
+
+        migrate_v273_recommendation_w2_shape_repair(&conn).expect("sanitize final-shape W2 tables");
+
+        let (surfacing_evidence, surfacing_signal): (String, String) = conn
+            .query_row(
+                "SELECT evidence_signature, source_signal_id
+                   FROM surfacing_decisions
+                  WHERE id = 'decision-final'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read sanitized final surfacing fields");
+        assert!(surfacing_evidence.starts_with("evidence_"));
+        assert!(surfacing_signal.starts_with("signal_ref_"));
+
+        let (
+            source_signal_id,
+            source_signal_type,
+            evidence_signature,
+            dedupe_key,
+            suppression_key,
+        ): (String, String, String, String, String) = conn
+            .query_row(
+                "SELECT source_signal_id, source_signal_type, evidence_signature,
+                        dedupe_key, suppression_key
+                   FROM triggers_log
+                  WHERE run_id = 'run-final'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .expect("read sanitized final trigger fields");
+        assert!(source_signal_id.starts_with("signal_ref_"));
+        assert!(source_signal_type.starts_with("signal_type_"));
+        assert!(evidence_signature.starts_with("evidence_"));
+        assert!(dedupe_key.starts_with("dedupe_"));
+        assert!(suppression_key.starts_with("suppression_"));
+        let repaired_privacy_fields = format!(
+            "{surfacing_evidence} {surfacing_signal} {source_signal_id} \
+             {source_signal_type} {evidence_signature} {dedupe_key} {suppression_key}"
+        );
+        assert!(!repaired_privacy_fields.contains("/Users/"));
     }
 }

--- a/src-tauri/src/migrations/271_recommendation_surfacing.sql
+++ b/src-tauri/src/migrations/271_recommendation_surfacing.sql
@@ -1,0 +1,129 @@
+CREATE TABLE IF NOT EXISTS recommendation_surfacing_policy (
+    policy_version TEXT NOT NULL,
+    claim_type TEXT NOT NULL CHECK (claim_type = 'recommendation'),
+    critical_threshold REAL NOT NULL CHECK (critical_threshold >= 0.0 AND critical_threshold <= 1.0),
+    urgent_factor_threshold REAL NOT NULL CHECK (urgent_factor_threshold >= 0.0 AND urgent_factor_threshold <= 1.0),
+    critical_primary_daily_budget INTEGER NOT NULL CHECK (critical_primary_daily_budget >= 0),
+    notable_threshold REAL NOT NULL CHECK (notable_threshold >= 0.0 AND notable_threshold <= 1.0),
+    notable_primary_daily_budget INTEGER NOT NULL CHECK (notable_primary_daily_budget >= 0),
+    background_threshold REAL NOT NULL CHECK (background_threshold >= 0.0 AND background_threshold <= 1.0),
+    background_daily_budget INTEGER NOT NULL CHECK (background_daily_budget >= 0),
+    claim_cooldown_days INTEGER NOT NULL CHECK (claim_cooldown_days >= 0),
+    subject_action_cooldown_days INTEGER NOT NULL CHECK (subject_action_cooldown_days >= 0),
+    feedback_suppression_days INTEGER NOT NULL CHECK (feedback_suppression_days >= 0),
+    policy_source TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (policy_version, claim_type)
+);
+
+INSERT INTO recommendation_surfacing_policy (
+    policy_version,
+    claim_type,
+    critical_threshold,
+    urgent_factor_threshold,
+    critical_primary_daily_budget,
+    notable_threshold,
+    notable_primary_daily_budget,
+    background_threshold,
+    background_daily_budget,
+    claim_cooldown_days,
+    subject_action_cooldown_days,
+    feedback_suppression_days,
+    policy_source
+) VALUES (
+    'recommendation_surfacing_v1',
+    'recommendation',
+    0.85,
+    0.90,
+    1,
+    0.68,
+    3,
+    0.45,
+    10,
+    7,
+    3,
+    14,
+    'claim_type:recommendation'
+)
+ON CONFLICT(policy_version, claim_type) DO UPDATE SET
+    critical_threshold = excluded.critical_threshold,
+    urgent_factor_threshold = excluded.urgent_factor_threshold,
+    critical_primary_daily_budget = excluded.critical_primary_daily_budget,
+    notable_threshold = excluded.notable_threshold,
+    notable_primary_daily_budget = excluded.notable_primary_daily_budget,
+    background_threshold = excluded.background_threshold,
+    background_daily_budget = excluded.background_daily_budget,
+    claim_cooldown_days = excluded.claim_cooldown_days,
+    subject_action_cooldown_days = excluded.subject_action_cooldown_days,
+    feedback_suppression_days = excluded.feedback_suppression_days,
+    policy_source = excluded.policy_source,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now');
+
+CREATE TABLE IF NOT EXISTS surfacing_decisions (
+    id TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    policy_version TEXT NOT NULL,
+    claim_id TEXT NOT NULL REFERENCES intelligence_claims(id) ON DELETE CASCADE,
+    decision_kind TEXT NOT NULL CHECK (decision_kind IN ('render', 'defer', 'suppress')),
+    surfacing_tier TEXT CHECK (
+        surfacing_tier IS NULL
+        OR surfacing_tier IN ('critical', 'notable', 'background', 'quiet')
+    ),
+    defer_reason TEXT CHECK (
+        defer_reason IS NULL
+        OR defer_reason IN (
+            'cooldown_active',
+            'budget_exhausted',
+            'awaiting_corroboration',
+            'pending_trigger'
+        )
+    ),
+    defer_until TEXT,
+    suppress_reason TEXT CHECK (
+        suppress_reason IS NULL
+        OR suppress_reason IN (
+            'below_threshold',
+            'user_muted_subject',
+            'dismissed_recently',
+            'contradicted_with_stronger_evidence'
+        )
+    ),
+    budget_key TEXT NOT NULL,
+    actor_kind TEXT NOT NULL,
+    local_day TEXT NOT NULL,
+    claim_type TEXT NOT NULL,
+    sensitivity TEXT NOT NULL,
+    surface_class TEXT NOT NULL CHECK (surface_class IN ('primary', 'background', 'quiet', 'review')),
+    render_surface TEXT NOT NULL,
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    action_signature TEXT NOT NULL,
+    salience_total REAL NOT NULL CHECK (salience_total >= 0.0 AND salience_total <= 1.0),
+    salience_evaluation_id TEXT NOT NULL,
+    why_this_now_json TEXT CHECK (why_this_now_json IS NULL OR json_valid(why_this_now_json) = 1),
+    trigger_refs_json TEXT NOT NULL CHECK (json_valid(trigger_refs_json) = 1),
+    evidence_signature TEXT,
+    source_asof TEXT,
+    source_signal_id TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_surfacing_decisions_claim_created
+    ON surfacing_decisions(claim_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_surfacing_decisions_budget
+    ON surfacing_decisions(policy_version, budget_key, decision_kind, surfacing_tier);
+
+CREATE INDEX IF NOT EXISTS idx_surfacing_decisions_subject_action
+    ON surfacing_decisions(
+        policy_version,
+        subject_kind,
+        subject_id,
+        action_signature,
+        surface_class,
+        created_at DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_surfacing_decisions_salience
+    ON surfacing_decisions(salience_evaluation_id);

--- a/src-tauri/src/migrations/272_recommendation_triggers_log.sql
+++ b/src-tauri/src/migrations/272_recommendation_triggers_log.sql
@@ -1,0 +1,84 @@
+CREATE TABLE IF NOT EXISTS triggers_log (
+    run_id TEXT PRIMARY KEY,
+    policy_version TEXT NOT NULL,
+    trigger_class TEXT NOT NULL CHECK (
+        trigger_class IN (
+            'scheduled_freshness',
+            'event_invalidation',
+            'manual_refresh',
+            'entity_change',
+            'claim_change',
+            'source_change',
+            'open_loop_change',
+            'meeting_window',
+            'decision_window',
+            'feedback_echo'
+        )
+    ),
+    trigger_kind TEXT NOT NULL CHECK (
+        trigger_kind IN ('signal_arrival', 'entity_change', 'scheduled_scan', 'feedback_echo')
+    ),
+    status TEXT NOT NULL CHECK (
+        status IN ('started', 'completed', 'failed_retryable', 'failed_terminal')
+    ),
+    trigger_disposition TEXT NOT NULL CHECK (
+        trigger_disposition IN (
+            'silent_prepare',
+            'primary_candidate',
+            'review_candidate',
+            'quiet_candidate'
+        )
+    ),
+    result_kind TEXT NOT NULL DEFAULT 'prepared_silently' CHECK (
+        result_kind IN (
+            'prepared_silently',
+            'render_decision_recorded',
+            'held_for_review',
+            'stayed_quiet',
+            'failed'
+        )
+    ),
+    downstream_policy TEXT NOT NULL DEFAULT 'recommendation_surfacing_policy' CHECK (
+        downstream_policy = 'recommendation_surfacing_policy'
+    ),
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    dedupe_key TEXT NOT NULL,
+    suppression_key TEXT NOT NULL,
+    trust_floor REAL NOT NULL CHECK (trust_floor >= 0.0 AND trust_floor <= 1.0),
+    freshness_window_secs INTEGER NOT NULL CHECK (freshness_window_secs >= 0),
+    source_signal_id TEXT,
+    source_signal_type TEXT,
+    source_asof TEXT,
+    evidence_signature TEXT,
+    subject_version INTEGER,
+    signal_id TEXT,
+    signal_coalesced INTEGER NOT NULL DEFAULT 0 CHECK (signal_coalesced IN (0, 1)),
+    derived_signal_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(derived_signal_ids_json) = 1),
+    candidate_claim_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(candidate_claim_ids_json) = 1),
+    salience_evaluation_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(salience_evaluation_ids_json) = 1),
+    surfacing_decision_ids_json TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(surfacing_decision_ids_json) = 1),
+    error_code TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    next_retry_at TEXT,
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_triggers_log_dedupe_policy
+    ON triggers_log(policy_version, dedupe_key, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_triggers_log_subject
+    ON triggers_log(subject_kind, subject_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_triggers_log_retry
+    ON triggers_log(status, next_retry_at)
+    WHERE status = 'failed_retryable';
+
+CREATE INDEX IF NOT EXISTS idx_triggers_log_signal
+    ON triggers_log(source_signal_id)
+    WHERE source_signal_id IS NOT NULL;

--- a/src-tauri/src/services/recommendations/surfacing.rs
+++ b/src-tauri/src/services/recommendations/surfacing.rs
@@ -5,3 +5,1973 @@
 //! `SurfacingDecisionMade` audit signal for each decision. Enforces
 //! the daily surfacing budget. No provider / LLM call from this
 //! module.
+
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use abilities_runtime::sensitivity::ClaimDismissalSurface;
+
+use super::contracts::{
+    ClaimId, DeferReason, RecommendationMetadataEnvelope, RecommendedAction, SalienceFactorKind,
+    SalienceScore, SuppressReason, SurfacingDecision, SurfacingTier, TriggerRef,
+};
+use super::recommendation::action_key;
+use super::salience::{
+    recompute_salience_for_claim, score_salience, SalienceError, SaliencePersistence,
+    ScoreSalienceRequest, SCORE_SALIENCE_SCHEMA_VERSION,
+};
+use super::why_this_now::why_this_now_for_score;
+use crate::db::ActionDb;
+use crate::services::context::{ExecutionMode, ServiceContext, ServiceError};
+use crate::signals::propagation::PropagationEngine;
+
+pub const SURFACING_POLICY_VERSION: &str = "recommendation_surfacing_v1";
+pub const SURFACING_EVALUATION_SCHEMA_VERSION: u32 = 1;
+pub const SURFACING_DECISION_SIGNAL: &str = "surfacing_decision_made";
+const SURFACING_SIGNAL_SOURCE: &str = "recommendation_surfacing_policy";
+const CLAIM_TYPE_RECOMMENDATION: &str = "recommendation";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceClass {
+    Primary,
+    Background,
+    Quiet,
+    Review,
+}
+
+impl SurfaceClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Background => "background",
+            Self::Quiet => "quiet",
+            Self::Review => "review",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfacingEvaluationInput {
+    pub schema_version: u32,
+    pub claim_id: ClaimId,
+    pub render_surface: ClaimDismissalSurface,
+    pub surface_class: SurfaceClass,
+    pub trigger_refs: Vec<TriggerRef>,
+    pub source_signal_id: Option<String>,
+    pub trigger_source_asof: Option<DateTime<Utc>>,
+    pub evidence_signature_changed: bool,
+    pub subject_version_changed: bool,
+}
+
+impl SurfacingEvaluationInput {
+    pub fn primary(claim_id: ClaimId, render_surface: ClaimDismissalSurface) -> Self {
+        Self {
+            schema_version: SURFACING_EVALUATION_SCHEMA_VERSION,
+            claim_id,
+            render_surface,
+            surface_class: SurfaceClass::Primary,
+            trigger_refs: Vec::new(),
+            source_signal_id: None,
+            trigger_source_asof: None,
+            evidence_signature_changed: false,
+            subject_version_changed: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfacingSignalOutcome {
+    pub signal_id: String,
+    pub signal_coalesced: bool,
+    pub derived_signal_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfacingEvaluation {
+    pub schema_version: u32,
+    pub policy_version: String,
+    pub claim_id: ClaimId,
+    pub salience_evaluation_id: Option<String>,
+    pub surfacing_decision_id: Option<String>,
+    pub budget_key: String,
+    pub decision: SurfacingDecision,
+    pub signal: Option<SurfacingSignalOutcome>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SurfacingPolicy {
+    pub policy_version: String,
+    pub critical_threshold: f64,
+    pub urgent_factor_threshold: f64,
+    pub critical_primary_daily_budget: u32,
+    pub notable_threshold: f64,
+    pub notable_primary_daily_budget: u32,
+    pub background_threshold: f64,
+    pub background_daily_budget: u32,
+    pub claim_cooldown_days: i64,
+    pub subject_action_cooldown_days: i64,
+    pub feedback_suppression_days: i64,
+}
+
+impl Default for SurfacingPolicy {
+    fn default() -> Self {
+        Self {
+            policy_version: SURFACING_POLICY_VERSION.to_string(),
+            critical_threshold: 0.85,
+            urgent_factor_threshold: 0.90,
+            critical_primary_daily_budget: 1,
+            notable_threshold: 0.68,
+            notable_primary_daily_budget: 3,
+            background_threshold: 0.45,
+            background_daily_budget: 10,
+            claim_cooldown_days: 7,
+            subject_action_cooldown_days: 3,
+            feedback_suppression_days: 14,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SurfacingCandidate {
+    pub claim_id: ClaimId,
+    pub claim_type: String,
+    pub sensitivity: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub action_signature: String,
+    pub source_asof: Option<DateTime<Utc>>,
+    pub evidence_signature: Option<String>,
+    pub salience: SalienceScore,
+    pub trigger_refs: Vec<TriggerRef>,
+    pub surface_class: SurfaceClass,
+    pub material_new_evidence: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SurfacingPolicyState {
+    pub claim_dismissed_recently: bool,
+    pub feedback_suppressed_recently: bool,
+    pub claim_cooldown_active: bool,
+    pub claim_cooldown_until: Option<DateTime<Utc>>,
+    pub subject_action_cooldown_active: bool,
+    pub subject_action_cooldown_until: Option<DateTime<Utc>>,
+    pub critical_primary_used: u32,
+    pub notable_primary_used: u32,
+    pub background_used: u32,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SurfacingError {
+    #[error("unsupported schema_version `{0}` for evaluate_surfacing_for_claim")]
+    UnsupportedSchemaVersion(u32),
+    #[error("claim `{0}` not found")]
+    ClaimNotFound(String),
+    #[error("claim `{0}` is not a recommendation claim")]
+    NotRecommendationClaim(String),
+    #[error("claim `{0}` is not visible to surfacing policy")]
+    ClaimNotVisible(String),
+    #[error("salience recompute did not persist an evaluation for claim `{0}`")]
+    MissingStoredSalience(String),
+    #[error("surfacing database error: {0}")]
+    Database(String),
+    #[error(transparent)]
+    Service(#[from] ServiceError),
+    #[error(transparent)]
+    Salience(#[from] SalienceError),
+    #[error("surfacing signal emit failed: {0}")]
+    Signal(String),
+    #[error("surfacing serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl From<rusqlite::Error> for SurfacingError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Database(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClaimRow {
+    id: ClaimId,
+    subject_ref: String,
+    claim_type: String,
+    source_asof: Option<String>,
+    metadata_json: Option<String>,
+    claim_state: String,
+    surfacing_state: String,
+    sensitivity: String,
+}
+
+#[derive(Debug, Clone)]
+struct LoadedClaim {
+    row: ClaimRow,
+    subject_kind: String,
+    subject_id: String,
+    action_signature: String,
+    evidence_signature: Option<String>,
+}
+
+pub fn decide_surfacing(
+    candidate: SurfacingCandidate,
+    policy: &SurfacingPolicy,
+    state: SurfacingPolicyState,
+    now: DateTime<Utc>,
+) -> SurfacingDecision {
+    if (state.claim_dismissed_recently || state.feedback_suppressed_recently)
+        && !candidate.material_new_evidence
+    {
+        return SurfacingDecision::Suppress {
+            reason: SuppressReason::DismissedRecently,
+        };
+    }
+
+    if (state.claim_cooldown_active || state.subject_action_cooldown_active)
+        && !candidate.material_new_evidence
+    {
+        let until = max_datetime(
+            state.claim_cooldown_until,
+            state.subject_action_cooldown_until,
+        )
+        .unwrap_or_else(|| now + Duration::days(policy.claim_cooldown_days));
+        return SurfacingDecision::Defer {
+            until,
+            reason: DeferReason::CooldownActive,
+        };
+    }
+
+    let urgency = factor_value(&candidate.salience, SalienceFactorKind::Urgency);
+    let tier = if candidate.salience.total >= policy.critical_threshold
+        || urgency >= policy.urgent_factor_threshold
+    {
+        Some(SurfacingTier::Critical)
+    } else if candidate.salience.total >= policy.notable_threshold {
+        Some(SurfacingTier::Notable)
+    } else if candidate.salience.total >= policy.background_threshold {
+        Some(SurfacingTier::Background)
+    } else {
+        None
+    };
+
+    let Some(tier) = tier else {
+        return SurfacingDecision::Suppress {
+            reason: SuppressReason::BelowThreshold,
+        };
+    };
+
+    if candidate.surface_class == SurfaceClass::Background
+        && state.background_used >= policy.background_daily_budget
+    {
+        return SurfacingDecision::Defer {
+            until: next_local_day(now),
+            reason: DeferReason::BudgetExhausted,
+        };
+    }
+
+    match tier {
+        SurfacingTier::Critical if candidate.surface_class == SurfaceClass::Primary => {
+            if state.critical_primary_used >= policy.critical_primary_daily_budget {
+                return SurfacingDecision::Defer {
+                    until: next_local_day(now),
+                    reason: DeferReason::BudgetExhausted,
+                };
+            }
+        }
+        SurfacingTier::Notable if candidate.surface_class == SurfaceClass::Primary => {
+            if state.notable_primary_used >= policy.notable_primary_daily_budget {
+                return SurfacingDecision::Defer {
+                    until: next_local_day(now),
+                    reason: DeferReason::BudgetExhausted,
+                };
+            }
+        }
+        SurfacingTier::Background => {
+            if candidate.surface_class == SurfaceClass::Primary {
+                return SurfacingDecision::Defer {
+                    until: now + Duration::hours(6),
+                    reason: DeferReason::PendingTrigger,
+                };
+            }
+        }
+        SurfacingTier::Quiet | SurfacingTier::Critical | SurfacingTier::Notable => {}
+    }
+
+    SurfacingDecision::Render {
+        tier,
+        why_this_now: why_this_now_for_score(&candidate.salience, &candidate.trigger_refs, now),
+    }
+}
+
+pub fn evaluate_surfacing_for_claim(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &PropagationEngine,
+    input: SurfacingEvaluationInput,
+) -> Result<SurfacingEvaluation, SurfacingError> {
+    validate_schema_version(input.schema_version)?;
+    let input = sanitize_surfacing_input(input);
+
+    if !matches!(ctx.mode, ExecutionMode::Live) {
+        let claim = load_recommendation_claim(db.conn_ref(), &input.claim_id)?;
+        let policy = load_policy(db.conn_ref())?;
+        let salience = score_salience(
+            ctx,
+            db,
+            ScoreSalienceRequest {
+                schema_version: SCORE_SALIENCE_SCHEMA_VERSION,
+                claim_id: input.claim_id.clone(),
+            },
+        )?;
+        let budget_key = budget_key(
+            ctx,
+            &claim.row.claim_type,
+            &claim.row.sensitivity,
+            input.surface_class,
+            ctx.clock.now().date_naive(),
+        );
+        let candidate = candidate_from_parts(
+            &claim,
+            salience.salience,
+            input.surface_class,
+            input.trigger_refs,
+            false,
+        );
+        return Ok(SurfacingEvaluation {
+            schema_version: SURFACING_EVALUATION_SCHEMA_VERSION,
+            policy_version: policy.policy_version.clone(),
+            claim_id: input.claim_id,
+            salience_evaluation_id: None,
+            surfacing_decision_id: None,
+            budget_key,
+            decision: decide_surfacing(
+                candidate,
+                &policy,
+                SurfacingPolicyState::default(),
+                ctx.clock.now(),
+            ),
+            signal: None,
+        });
+    }
+
+    ctx.check_mutation_allowed()?;
+    let now = ctx.clock.now();
+    let claim = load_recommendation_claim(db.conn_ref(), &input.claim_id)?;
+    let policy = load_policy(db.conn_ref())?;
+    let salience = recompute_salience_for_claim(
+        ctx,
+        db,
+        ScoreSalienceRequest {
+            schema_version: SCORE_SALIENCE_SCHEMA_VERSION,
+            claim_id: input.claim_id.clone(),
+        },
+    )?;
+    let SaliencePersistence::Stored {
+        evaluation_id: salience_evaluation_id,
+    } = salience.persistence.clone()
+    else {
+        return Err(SurfacingError::MissingStoredSalience(input.claim_id.0));
+    };
+
+    let local_day = now.date_naive();
+    let budget_key = budget_key(
+        ctx,
+        &claim.row.claim_type,
+        &claim.row.sensitivity,
+        input.surface_class,
+        local_day,
+    );
+    let decision_id = format!("surfacing-decision-{}", uuid::Uuid::new_v4());
+    let idempotency_key = format!(
+        "surfacing:{policy_version}:{claim_id}:{salience_evaluation_id}:{surface}",
+        policy_version = policy.policy_version,
+        claim_id = claim.row.id.0,
+        surface = input.render_surface.as_str(),
+    );
+    let actor_kind = actor_kind(ctx);
+
+    let (decision, signal_outcome, derived_signal_ids) = db
+        .with_transaction(|tx| {
+            let latest_suppression_at =
+                latest_suppression_at(tx.conn_ref(), &claim, &input, now, &policy)
+                    .map_err(|error| error.to_string())?;
+            let latest_render_at = max_datetime(
+                latest_render_at(tx.conn_ref(), &claim.row.id)
+                    .map_err(|error| error.to_string())?,
+                latest_subject_action_render_at(
+                    tx.conn_ref(),
+                    &claim.subject_kind,
+                    &claim.subject_id,
+                    &claim.action_signature,
+                )
+                .map_err(|error| error.to_string())?,
+            );
+            let material_change_key_fresh =
+                material_change_key_fresh(tx.conn_ref(), &claim, input.source_signal_id.as_deref())
+                    .map_err(|error| error.to_string())?;
+            let material_source_asof = max_datetime(
+                claim.row.source_asof.as_deref().and_then(parse_datetime),
+                input.trigger_source_asof.as_ref().cloned(),
+            );
+            let material_new_evidence = has_material_new_evidence(
+                latest_suppression_at,
+                latest_render_at,
+                material_source_asof,
+                input.evidence_signature_changed,
+                input.subject_version_changed,
+                material_change_key_fresh,
+            );
+            let candidate = candidate_from_parts(
+                &claim,
+                salience.salience.clone(),
+                input.surface_class,
+                input.trigger_refs.clone(),
+                material_new_evidence,
+            );
+            let policy_state = load_policy_state(
+                tx.conn_ref(),
+                &policy,
+                &claim,
+                &candidate,
+                &budget_key,
+                input.render_surface,
+                now,
+            )
+            .map_err(|error| error.to_string())?;
+            let decision = decide_surfacing(candidate.clone(), &policy, policy_state, now);
+            let trigger_refs_json = serde_json::to_string(&sanitized_trigger_refs_for_storage(
+                &decision, &candidate, now,
+            ))
+            .map_err(|error| error.to_string())?;
+            let why_this_now_json = match &decision {
+                SurfacingDecision::Render { why_this_now, .. } => {
+                    Some(serde_json::to_string(why_this_now).map_err(|error| error.to_string())?)
+                }
+                SurfacingDecision::Defer { .. } | SurfacingDecision::Suppress { .. } => None,
+            };
+            let decision_payload = decision_storage(&decision);
+            let signal_value = surfacing_signal_value(
+                &decision_id,
+                &candidate,
+                &budget_key,
+                &policy.policy_version,
+                &salience_evaluation_id,
+                &decision_payload,
+            )
+            .map_err(|error| error.to_string())?;
+
+            insert_surfacing_decision(
+                tx,
+                InsertSurfacingDecision {
+                    decision_id: &decision_id,
+                    idempotency_key: &idempotency_key,
+                    candidate: &candidate,
+                    policy: &policy,
+                    input: &input,
+                    local_day,
+                    budget_key: &budget_key,
+                    actor_kind: &actor_kind,
+                    salience_evaluation_id: &salience_evaluation_id,
+                    decision_payload: &decision_payload,
+                    salience_total: salience.salience.total,
+                    why_this_now_json: why_this_now_json.as_deref(),
+                    trigger_refs_json: &trigger_refs_json,
+                    created_at: now,
+                },
+            )
+            .map_err(|error| error.to_string())?;
+
+            crate::services::signals::emit_once_for_key_and_propagate(
+                ctx,
+                tx,
+                engine,
+                &idempotency_key,
+                "claim",
+                &candidate.claim_id.0,
+                SURFACING_DECISION_SIGNAL,
+                SURFACING_SIGNAL_SOURCE,
+                Some(&signal_value),
+                1.0,
+            )
+            .map_err(SurfacingError::Signal)
+            .map_err(|error| error.to_string())
+            .map(|(signal_outcome, derived_signal_ids)| {
+                (decision, signal_outcome, derived_signal_ids)
+            })
+        })
+        .map_err(SurfacingError::Database)?;
+
+    Ok(SurfacingEvaluation {
+        schema_version: SURFACING_EVALUATION_SCHEMA_VERSION,
+        policy_version: policy.policy_version,
+        claim_id: input.claim_id,
+        salience_evaluation_id: Some(salience_evaluation_id),
+        surfacing_decision_id: Some(decision_id),
+        budget_key,
+        decision,
+        signal: Some(SurfacingSignalOutcome {
+            signal_id: signal_outcome.id,
+            signal_coalesced: signal_outcome.coalesced,
+            derived_signal_ids,
+        }),
+    })
+}
+
+fn validate_schema_version(schema_version: u32) -> Result<(), SurfacingError> {
+    if schema_version == SURFACING_EVALUATION_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(SurfacingError::UnsupportedSchemaVersion(schema_version))
+    }
+}
+
+fn candidate_from_parts(
+    claim: &LoadedClaim,
+    salience: SalienceScore,
+    surface_class: SurfaceClass,
+    trigger_refs: Vec<TriggerRef>,
+    material_new_evidence: bool,
+) -> SurfacingCandidate {
+    SurfacingCandidate {
+        claim_id: claim.row.id.clone(),
+        claim_type: claim.row.claim_type.clone(),
+        sensitivity: claim.row.sensitivity.clone(),
+        subject_kind: claim.subject_kind.clone(),
+        subject_id: claim.subject_id.clone(),
+        action_signature: claim.action_signature.clone(),
+        source_asof: claim.row.source_asof.as_deref().and_then(parse_datetime),
+        evidence_signature: claim.evidence_signature.clone(),
+        salience,
+        trigger_refs,
+        surface_class,
+        material_new_evidence,
+    }
+}
+
+fn load_recommendation_claim(
+    conn: &rusqlite::Connection,
+    claim_id: &ClaimId,
+) -> Result<LoadedClaim, SurfacingError> {
+    let row = conn
+        .query_row(
+            "SELECT id, subject_ref, claim_type, source_asof, metadata_json,
+                    claim_state, surfacing_state, sensitivity
+               FROM intelligence_claims
+              WHERE id = ?1",
+            [&claim_id.0],
+            |row| {
+                Ok(ClaimRow {
+                    id: ClaimId(row.get(0)?),
+                    subject_ref: row.get(1)?,
+                    claim_type: row.get(2)?,
+                    source_asof: row.get(3)?,
+                    metadata_json: row.get(4)?,
+                    claim_state: row.get(5)?,
+                    surfacing_state: row.get(6)?,
+                    sensitivity: row.get(7)?,
+                })
+            },
+        )
+        .optional()?
+        .ok_or_else(|| SurfacingError::ClaimNotFound(claim_id.0.clone()))?;
+
+    if row.claim_type != CLAIM_TYPE_RECOMMENDATION {
+        return Err(SurfacingError::NotRecommendationClaim(claim_id.0.clone()));
+    }
+    if row.claim_state != "active" || row.surfacing_state != "active" {
+        return Err(SurfacingError::ClaimNotVisible(claim_id.0.clone()));
+    }
+
+    let (subject_kind, subject_id) = subject_scope(&row.subject_ref).ok_or_else(|| {
+        SurfacingError::Database("claim subject_ref is not typed JSON".to_string())
+    })?;
+    let action_signature = action_signature(&row.metadata_json);
+    let evidence_signature = evidence_signature(&row.metadata_json);
+
+    Ok(LoadedClaim {
+        row,
+        subject_kind,
+        subject_id,
+        action_signature,
+        evidence_signature,
+    })
+}
+
+fn load_policy(conn: &rusqlite::Connection) -> Result<SurfacingPolicy, SurfacingError> {
+    if !table_exists(conn, "recommendation_surfacing_policy")? {
+        return Ok(SurfacingPolicy::default());
+    }
+
+    conn.query_row(
+        "SELECT policy_version, critical_threshold, urgent_factor_threshold,
+                critical_primary_daily_budget, notable_threshold,
+                notable_primary_daily_budget, background_threshold,
+                background_daily_budget, claim_cooldown_days,
+                subject_action_cooldown_days, feedback_suppression_days
+           FROM recommendation_surfacing_policy
+          WHERE policy_version = ?1 AND claim_type = 'recommendation'",
+        [SURFACING_POLICY_VERSION],
+        |row| {
+            Ok(SurfacingPolicy {
+                policy_version: row.get(0)?,
+                critical_threshold: row.get(1)?,
+                urgent_factor_threshold: row.get(2)?,
+                critical_primary_daily_budget: row.get::<_, i64>(3)?.max(0) as u32,
+                notable_threshold: row.get(4)?,
+                notable_primary_daily_budget: row.get::<_, i64>(5)?.max(0) as u32,
+                background_threshold: row.get(6)?,
+                background_daily_budget: row.get::<_, i64>(7)?.max(0) as u32,
+                claim_cooldown_days: row.get(8)?,
+                subject_action_cooldown_days: row.get(9)?,
+                feedback_suppression_days: row.get(10)?,
+            })
+        },
+    )
+    .optional()?
+    .map(Ok)
+    .unwrap_or_else(|| Ok(SurfacingPolicy::default()))
+}
+
+fn latest_suppression_at(
+    conn: &rusqlite::Connection,
+    claim: &LoadedClaim,
+    input: &SurfacingEvaluationInput,
+    now: DateTime<Utc>,
+    policy: &SurfacingPolicy,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    let dismissal = latest_surface_dismissal(conn, &claim.row.id, input.render_surface)?;
+    let feedback = latest_feedback_suppression(conn, &claim.row.id, now, policy)?;
+    Ok(match (dismissal, feedback) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    })
+}
+
+fn load_policy_state(
+    conn: &rusqlite::Connection,
+    policy: &SurfacingPolicy,
+    claim: &LoadedClaim,
+    candidate: &SurfacingCandidate,
+    budget_key: &str,
+    render_surface: ClaimDismissalSurface,
+    now: DateTime<Utc>,
+) -> Result<SurfacingPolicyState, SurfacingError> {
+    let claim_dismissed_recently =
+        latest_surface_dismissal(conn, &claim.row.id, render_surface)?.is_some();
+    let feedback_suppressed_recently =
+        latest_feedback_suppression(conn, &claim.row.id, now, policy)?.is_some();
+    let claim_cooldown_until =
+        claim_render_cooldown_until(conn, &claim.row.id, now, policy.claim_cooldown_days)?;
+    let subject_action_cooldown_until = subject_action_render_cooldown_until(
+        conn,
+        &candidate.subject_kind,
+        &candidate.subject_id,
+        &candidate.action_signature,
+        now,
+        policy.subject_action_cooldown_days,
+    )?;
+
+    Ok(SurfacingPolicyState {
+        claim_dismissed_recently,
+        feedback_suppressed_recently,
+        claim_cooldown_active: claim_cooldown_until.is_some(),
+        claim_cooldown_until,
+        subject_action_cooldown_active: subject_action_cooldown_until.is_some(),
+        subject_action_cooldown_until,
+        critical_primary_used: rendered_budget_count(
+            conn,
+            budget_key,
+            Some(SurfacingTier::Critical),
+        )?,
+        notable_primary_used: rendered_budget_count(
+            conn,
+            budget_key,
+            Some(SurfacingTier::Notable),
+        )?,
+        background_used: rendered_background_count(conn, budget_key)?,
+    })
+}
+
+fn latest_surface_dismissal(
+    conn: &rusqlite::Connection,
+    claim_id: &ClaimId,
+    render_surface: ClaimDismissalSurface,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "claim_surface_dismissals")? {
+        return Ok(None);
+    }
+
+    let raw = conn
+        .query_row(
+            "SELECT dismissed_at
+               FROM claim_surface_dismissals
+              WHERE claim_id = ?1 AND surface = ?2
+              ORDER BY dismissed_at DESC
+              LIMIT 1",
+            params![&claim_id.0, render_surface.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.as_deref().and_then(parse_datetime))
+}
+
+fn latest_feedback_suppression(
+    conn: &rusqlite::Connection,
+    claim_id: &ClaimId,
+    now: DateTime<Utc>,
+    policy: &SurfacingPolicy,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "claim_feedback")? {
+        return Ok(None);
+    }
+
+    let threshold = (now - Duration::days(policy.feedback_suppression_days)).to_rfc3339();
+    let raw = conn
+        .query_row(
+            "SELECT submitted_at
+               FROM claim_feedback
+              WHERE claim_id = ?1
+                AND feedback_type IN (
+                    'surface_inappropriate',
+                    'not_relevant_here',
+                    'mark_false',
+                    'wrong_subject'
+                )
+                AND submitted_at >= ?2
+              ORDER BY submitted_at DESC
+              LIMIT 1",
+            params![&claim_id.0, threshold],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(raw.as_deref().and_then(parse_datetime))
+}
+
+fn latest_render_at(
+    conn: &rusqlite::Connection,
+    claim_id: &ClaimId,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(None);
+    }
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT created_at
+               FROM surfacing_decisions
+              WHERE claim_id = ?1
+                AND policy_version = ?2
+                AND decision_kind = 'render'
+              ORDER BY created_at DESC
+              LIMIT 1",
+            params![&claim_id.0, SURFACING_POLICY_VERSION],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(raw.as_deref().and_then(parse_datetime))
+}
+
+fn latest_subject_action_render_at(
+    conn: &rusqlite::Connection,
+    subject_kind: &str,
+    subject_id: &str,
+    action_signature: &str,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(None);
+    }
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT created_at
+               FROM surfacing_decisions
+              WHERE policy_version = ?1
+                AND decision_kind = 'render'
+                AND surfacing_tier IN ('critical', 'notable')
+                AND surface_class = 'primary'
+                AND subject_kind = ?2
+                AND subject_id = ?3
+                AND action_signature = ?4
+              ORDER BY created_at DESC
+              LIMIT 1",
+            params![
+                SURFACING_POLICY_VERSION,
+                subject_kind,
+                subject_id,
+                action_signature
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(raw.as_deref().and_then(parse_datetime))
+}
+
+fn material_change_key_fresh(
+    conn: &rusqlite::Connection,
+    claim: &LoadedClaim,
+    source_signal_id: Option<&str>,
+) -> Result<bool, SurfacingError> {
+    let Some(source_signal_id) = source_signal_id else {
+        return Ok(false);
+    };
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(true);
+    }
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+           FROM surfacing_decisions
+          WHERE policy_version = ?1
+            AND decision_kind = 'render'
+            AND source_signal_id = ?2
+            AND (
+                claim_id = ?3
+                OR (
+                    subject_kind = ?4
+                    AND subject_id = ?5
+                    AND action_signature = ?6
+                )
+            )",
+        params![
+            SURFACING_POLICY_VERSION,
+            source_signal_id,
+            &claim.row.id.0,
+            &claim.subject_kind,
+            &claim.subject_id,
+            &claim.action_signature,
+        ],
+        |row| row.get(0),
+    )?;
+    Ok(count == 0)
+}
+
+fn claim_render_cooldown_until(
+    conn: &rusqlite::Connection,
+    claim_id: &ClaimId,
+    now: DateTime<Utc>,
+    cooldown_days: i64,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(None);
+    }
+    let threshold = (now - Duration::days(cooldown_days)).to_rfc3339();
+    let rendered_at: Option<String> = conn
+        .query_row(
+            "SELECT created_at
+           FROM surfacing_decisions
+          WHERE claim_id = ?1
+            AND policy_version = ?2
+            AND decision_kind = 'render'
+            AND surfacing_tier IN ('critical', 'notable')
+            AND surface_class = 'primary'
+            AND created_at >= ?3
+          ORDER BY created_at DESC
+          LIMIT 1",
+            params![&claim_id.0, SURFACING_POLICY_VERSION, threshold],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(rendered_at
+        .as_deref()
+        .and_then(parse_datetime)
+        .map(|rendered_at| rendered_at + Duration::days(cooldown_days)))
+}
+
+fn subject_action_render_cooldown_until(
+    conn: &rusqlite::Connection,
+    subject_kind: &str,
+    subject_id: &str,
+    action_signature: &str,
+    now: DateTime<Utc>,
+    cooldown_days: i64,
+) -> Result<Option<DateTime<Utc>>, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(None);
+    }
+    let threshold = (now - Duration::days(cooldown_days)).to_rfc3339();
+    let rendered_at: Option<String> = conn
+        .query_row(
+            "SELECT created_at
+           FROM surfacing_decisions
+          WHERE policy_version = ?1
+            AND decision_kind = 'render'
+            AND surfacing_tier IN ('critical', 'notable')
+            AND surface_class = 'primary'
+            AND subject_kind = ?2
+            AND subject_id = ?3
+            AND action_signature = ?4
+            AND created_at >= ?5
+          ORDER BY created_at DESC
+          LIMIT 1",
+            params![
+                SURFACING_POLICY_VERSION,
+                subject_kind,
+                subject_id,
+                action_signature,
+                threshold
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(rendered_at
+        .as_deref()
+        .and_then(parse_datetime)
+        .map(|rendered_at| rendered_at + Duration::days(cooldown_days)))
+}
+
+fn rendered_budget_count(
+    conn: &rusqlite::Connection,
+    budget_key: &str,
+    tier: Option<SurfacingTier>,
+) -> Result<u32, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(0);
+    }
+
+    let count: i64 = if let Some(tier) = tier {
+        conn.query_row(
+            "SELECT COUNT(*)
+               FROM surfacing_decisions
+              WHERE budget_key = ?1
+                AND decision_kind = 'render'
+                AND surface_class = 'primary'
+                AND surfacing_tier = ?2",
+            params![budget_key, tier_storage(tier)],
+            |row| row.get(0),
+        )?
+    } else {
+        conn.query_row(
+            "SELECT COUNT(*)
+               FROM surfacing_decisions
+              WHERE budget_key = ?1
+                AND decision_kind = 'render'
+                AND surface_class = 'primary'
+                AND surfacing_tier IN ('critical', 'notable')",
+            params![budget_key],
+            |row| row.get(0),
+        )?
+    };
+    Ok(count.clamp(0, i64::from(u32::MAX)) as u32)
+}
+
+fn rendered_background_count(
+    conn: &rusqlite::Connection,
+    budget_key: &str,
+) -> Result<u32, SurfacingError> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(0);
+    }
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*)
+           FROM surfacing_decisions
+          WHERE budget_key = ?1
+            AND decision_kind = 'render'
+            AND surface_class = 'background'",
+        params![budget_key],
+        |row| row.get(0),
+    )?;
+    Ok(count.clamp(0, i64::from(u32::MAX)) as u32)
+}
+
+struct InsertSurfacingDecision<'a> {
+    decision_id: &'a str,
+    idempotency_key: &'a str,
+    candidate: &'a SurfacingCandidate,
+    policy: &'a SurfacingPolicy,
+    input: &'a SurfacingEvaluationInput,
+    local_day: NaiveDate,
+    budget_key: &'a str,
+    actor_kind: &'a str,
+    salience_evaluation_id: &'a str,
+    decision_payload: &'a DecisionStorage,
+    salience_total: f64,
+    why_this_now_json: Option<&'a str>,
+    trigger_refs_json: &'a str,
+    created_at: DateTime<Utc>,
+}
+
+fn insert_surfacing_decision(
+    db: &ActionDb,
+    input: InsertSurfacingDecision<'_>,
+) -> Result<(), rusqlite::Error> {
+    db.conn_ref().execute(
+        "INSERT INTO surfacing_decisions (
+             id, idempotency_key, policy_version, claim_id, decision_kind,
+             surfacing_tier, defer_reason, defer_until, suppress_reason, budget_key,
+             actor_kind, local_day, claim_type, sensitivity, surface_class,
+             render_surface, subject_kind, subject_id, action_signature,
+             salience_total, salience_evaluation_id, why_this_now_json,
+             trigger_refs_json, evidence_signature, source_asof,
+             source_signal_id, created_at
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5,
+             ?6, ?7, ?8, ?9, ?10,
+             ?11, ?12, ?13, ?14, ?15,
+             ?16, ?17, ?18, ?19,
+             ?20, ?21, ?22,
+             ?23, ?24, ?25,
+             ?26, ?27
+         )",
+        params![
+            input.decision_id,
+            input.idempotency_key,
+            &input.policy.policy_version,
+            &input.candidate.claim_id.0,
+            input.decision_payload.kind,
+            input.decision_payload.tier,
+            input.decision_payload.defer_reason,
+            input.decision_payload.defer_until.as_deref(),
+            input.decision_payload.suppress_reason,
+            input.budget_key,
+            input.actor_kind,
+            input.local_day.to_string(),
+            &input.candidate.claim_type,
+            &input.candidate.sensitivity,
+            input.candidate.surface_class.as_str(),
+            input.input.render_surface.as_str(),
+            &input.candidate.subject_kind,
+            &input.candidate.subject_id,
+            &input.candidate.action_signature,
+            input.salience_total,
+            input.salience_evaluation_id,
+            input.why_this_now_json,
+            input.trigger_refs_json,
+            input.candidate.evidence_signature.as_deref(),
+            input
+                .candidate
+                .source_asof
+                .as_ref()
+                .map(|dt| dt.to_rfc3339()),
+            input.input.source_signal_id.as_deref(),
+            input.created_at.to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn surfacing_signal_value(
+    decision_id: &str,
+    candidate: &SurfacingCandidate,
+    budget_key: &str,
+    policy_version: &str,
+    salience_evaluation_id: &str,
+    decision: &DecisionStorage,
+) -> Result<String, SurfacingError> {
+    serde_json::to_string(&json!({
+        "surfacingDecisionId": decision_id,
+        "claimId": candidate.claim_id.0,
+        "policyVersion": policy_version,
+        "decisionKind": decision.kind,
+        "tier": decision.tier,
+        "deferReason": decision.defer_reason,
+        "deferUntil": decision.defer_until.as_deref(),
+        "suppressReason": decision.suppress_reason,
+        "budgetKey": budget_key,
+        "salienceEvaluationId": salience_evaluation_id,
+        "subject": {
+            "kind": candidate.subject_kind,
+            "id": candidate.subject_id,
+        }
+    }))
+    .map_err(SurfacingError::from)
+}
+
+#[derive(Debug, Clone)]
+struct DecisionStorage {
+    kind: &'static str,
+    tier: Option<&'static str>,
+    defer_reason: Option<&'static str>,
+    defer_until: Option<String>,
+    suppress_reason: Option<&'static str>,
+}
+
+fn decision_storage(decision: &SurfacingDecision) -> DecisionStorage {
+    match decision {
+        SurfacingDecision::Render { tier, .. } => DecisionStorage {
+            kind: "render",
+            tier: Some(tier_storage(*tier)),
+            defer_reason: None,
+            defer_until: None,
+            suppress_reason: None,
+        },
+        SurfacingDecision::Defer { reason, until } => DecisionStorage {
+            kind: "defer",
+            tier: None,
+            defer_reason: Some(defer_reason_storage(*reason)),
+            defer_until: Some(until.to_rfc3339()),
+            suppress_reason: None,
+        },
+        SurfacingDecision::Suppress { reason } => DecisionStorage {
+            kind: "suppress",
+            tier: None,
+            defer_reason: None,
+            defer_until: None,
+            suppress_reason: Some(suppress_reason_storage(*reason)),
+        },
+    }
+}
+
+fn sanitized_trigger_refs_for_storage(
+    decision: &SurfacingDecision,
+    candidate: &SurfacingCandidate,
+    now: DateTime<Utc>,
+) -> Vec<TriggerRef> {
+    match decision {
+        SurfacingDecision::Render { why_this_now, .. } => why_this_now.triggers.clone(),
+        SurfacingDecision::Defer { .. } | SurfacingDecision::Suppress { .. } => {
+            why_this_now_for_score(&candidate.salience, &candidate.trigger_refs, now).triggers
+        }
+    }
+}
+
+fn has_material_new_evidence(
+    suppression_at: Option<DateTime<Utc>>,
+    latest_render_at: Option<DateTime<Utc>>,
+    source_asof: Option<DateTime<Utc>>,
+    evidence_signature_changed: bool,
+    subject_version_changed: bool,
+    material_change_key_fresh: bool,
+) -> bool {
+    let has_changed_marker = evidence_signature_changed || subject_version_changed;
+    if has_changed_marker && material_change_key_fresh {
+        return true;
+    }
+    if let Some(rendered_at) = latest_render_at.filter(|rendered_at| {
+        suppression_at.is_none_or(|suppression_at| *rendered_at > suppression_at)
+    }) {
+        return source_asof.is_some_and(|source_asof| source_asof > rendered_at);
+    }
+    let Some(suppression_at) = suppression_at else {
+        return source_asof.is_some() || has_changed_marker;
+    };
+    source_asof.is_some_and(|source_asof| source_asof > suppression_at) || has_changed_marker
+}
+
+fn max_datetime(
+    left: Option<DateTime<Utc>>,
+    right: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn subject_scope(subject_ref: &str) -> Option<(String, String)> {
+    let value = serde_json::from_str::<serde_json::Value>(subject_ref).ok()?;
+    let kind = value.get("kind")?.as_str()?.to_string();
+    let id = value.get("id")?.as_str()?.to_string();
+    Some((kind, id))
+}
+
+fn action_signature(metadata_json: &Option<String>) -> String {
+    let Some(action) = metadata_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<RecommendationMetadataEnvelope>(raw).ok())
+        .map(|envelope| envelope.recommendation.recommended_action)
+    else {
+        return "unknown".to_string();
+    };
+
+    action_key(&action).unwrap_or_else(|_| fallback_action_signature(&action))
+}
+
+fn fallback_action_signature(action: &RecommendedAction) -> String {
+    match action {
+        RecommendedAction::ScheduleMeeting { .. } => "scheduleMeeting".to_string(),
+        RecommendedAction::SendMessage { .. } => "sendMessage".to_string(),
+        RecommendedAction::ReviewClaim { .. } => "reviewClaim".to_string(),
+        RecommendedAction::UpdateRecord { .. } => "updateRecord".to_string(),
+        RecommendedAction::InvestigateChange { .. } => "investigateChange".to_string(),
+        RecommendedAction::Custom { .. } => "custom.invalid".to_string(),
+    }
+}
+
+pub(super) fn evidence_signature(metadata_json: &Option<String>) -> Option<String> {
+    let evidence = metadata_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.pointer("/recommendation/evidence").cloned())?;
+    let mut hasher = Sha256::new();
+    hasher.update(evidence.to_string().as_bytes());
+    Some(format!("evsig_{}", hex::encode(&hasher.finalize()[..16])))
+}
+
+fn budget_key(
+    ctx: &ServiceContext<'_>,
+    claim_type: &str,
+    sensitivity: &str,
+    surface_class: SurfaceClass,
+    local_day: NaiveDate,
+) -> String {
+    format!(
+        "{}:{}:{}:{}:{}",
+        actor_kind(ctx),
+        local_day,
+        claim_type,
+        sensitivity,
+        surface_class.as_str()
+    )
+}
+
+fn actor_kind(ctx: &ServiceContext<'_>) -> String {
+    ctx.actor.split(':').next().unwrap_or("system").to_string()
+}
+
+fn factor_value(score: &SalienceScore, kind: SalienceFactorKind) -> f64 {
+    score
+        .factors
+        .iter()
+        .find(|factor| factor.kind == kind)
+        .and_then(|factor| factor.value)
+        .unwrap_or(0.0)
+}
+
+fn next_local_day(now: DateTime<Utc>) -> DateTime<Utc> {
+    now.date_naive()
+        .succ_opt()
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .map(|naive| naive.and_utc())
+        .unwrap_or(now + Duration::days(1))
+}
+
+fn table_exists(conn: &rusqlite::Connection, table: &str) -> Result<bool, SurfacingError> {
+    conn.query_row(
+        "SELECT COUNT(*)
+           FROM sqlite_master
+          WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get::<_, i64>(0).map(|count| count > 0),
+    )
+    .map_err(SurfacingError::from)
+}
+
+fn sanitize_surfacing_input(mut input: SurfacingEvaluationInput) -> SurfacingEvaluationInput {
+    input.source_signal_id =
+        safe_optional_storage_ref("signal_ref", input.source_signal_id.as_deref());
+    input
+}
+
+fn safe_optional_storage_ref(prefix: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| safe_storage_ref(prefix, value))
+}
+
+fn safe_storage_ref(prefix: &str, value: &str) -> String {
+    let value = value.trim();
+    if is_safe_storage_ref(value) {
+        value.to_string()
+    } else {
+        hashed_storage_ref(prefix, value)
+    }
+}
+
+fn is_safe_storage_ref(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b':' | b'.'))
+}
+
+fn hashed_storage_ref(prefix: &str, value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(b":");
+    hasher.update(value.as_bytes());
+    format!("{prefix}_{}", hex::encode(&hasher.finalize()[..16]))
+}
+
+fn parse_datetime(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S")
+                .map(|value| value.and_utc())
+        })
+        .ok()
+}
+
+fn tier_storage(tier: SurfacingTier) -> &'static str {
+    match tier {
+        SurfacingTier::Critical => "critical",
+        SurfacingTier::Notable => "notable",
+        SurfacingTier::Background => "background",
+        SurfacingTier::Quiet => "quiet",
+    }
+}
+
+fn defer_reason_storage(reason: DeferReason) -> &'static str {
+    match reason {
+        DeferReason::CooldownActive => "cooldown_active",
+        DeferReason::BudgetExhausted => "budget_exhausted",
+        DeferReason::AwaitingCorroboration => "awaiting_corroboration",
+        DeferReason::PendingTrigger => "pending_trigger",
+    }
+}
+
+fn suppress_reason_storage(reason: SuppressReason) -> &'static str {
+    match reason {
+        SuppressReason::BelowThreshold => "below_threshold",
+        SuppressReason::UserMutedSubject => "user_muted_subject",
+        SuppressReason::DismissedRecently => "dismissed_recently",
+        SuppressReason::ContradictedWithStrongerEvidence => "contradicted_with_stronger_evidence",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::TimeZone;
+
+    use abilities_runtime::abilities::trust::types::TrustBand;
+    use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
+
+    use crate::abilities::claims::ClaimType;
+    use crate::services::claims::{
+        commit_claim, update_claim_trust, ClaimProposal, DeterministicInsertProposal, TrustScore,
+    };
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
+    use crate::services::recommendations::contracts::{
+        EvidenceRef, FactorRationale, RecommendationDraft, SalienceFactor, TriggerKind,
+    };
+    use crate::services::recommendations::recommendation::metadata_envelope;
+
+    fn test_db() -> ActionDb {
+        ActionDb::from_connection_for_tests(crate::migrations::migrated_in_memory_for_tests())
+    }
+
+    fn test_ctx() -> (FixedClock, SeedableRng, ExternalClients) {
+        (
+            FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap()),
+            SeedableRng::new(17),
+            ExternalClients::default(),
+        )
+    }
+
+    fn live_ctx<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external).with_actor("system:test")
+    }
+
+    fn insert_recommendation_claim(db: &ActionDb, id: &str, trust_score: f64, source_asof: &str) {
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let metadata = metadata_envelope(&super_recommendation_draft(id, source_asof));
+        let proposal = ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: r#"{"kind":"account","id":"acct-example"}"#.to_string(),
+            claim_type: ClaimType::Recommendation.as_str().to_string(),
+            field_path: Some(format!("recommendation.{id}")),
+            topic_key: Some(id.to_string()),
+            text: "Review the account before the next customer conversation.".to_string(),
+            actor: "agent".to_string(),
+            data_source: "recommendation".to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(source_asof.to_string()),
+            observed_at: "2026-05-26T10:00:00Z".to_string(),
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            metadata_json: Some(serde_json::to_string(&metadata).unwrap()),
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        };
+        commit_claim(
+            &ctx,
+            db,
+            DeterministicInsertProposal::new(id.to_string(), proposal),
+        )
+        .expect("insert recommendation claim");
+        update_claim_trust(db, id, TrustScore(trust_score), 1, &ctx).expect("seed trust score");
+    }
+
+    fn super_recommendation_draft(id: &str, source_asof: &str) -> RecommendationDraft {
+        RecommendationDraft {
+            subject: abilities_runtime::abilities::provenance::subject::SubjectRef::Account(
+                "acct-example".to_string(),
+            ),
+            recommended_action: RecommendedAction::Custom {
+                action_kind: format!("action_{id}").replace([':', '-'], "_"),
+                payload: serde_json::json!({ "opaque": true }),
+            },
+            evidence: vec![EvidenceRef {
+                source: "claim:source-1".to_string(),
+                chunk: None,
+            }],
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(source_asof.parse::<DateTime<Utc>>().unwrap()),
+            observed_at: "2026-05-26T10:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+            text: "Review the account before the next customer conversation.".to_string(),
+            salience: SalienceScore {
+                total: 0.75,
+                factors: vec![SalienceFactor {
+                    kind: SalienceFactorKind::Trust,
+                    value: Some(0.9),
+                    weight: 0.1,
+                    rationale: FactorRationale::Trust {
+                        trust_band: TrustBand::LikelyCurrent,
+                    },
+                }],
+            },
+        }
+    }
+
+    fn input(claim_id: &str) -> SurfacingEvaluationInput {
+        SurfacingEvaluationInput {
+            schema_version: SURFACING_EVALUATION_SCHEMA_VERSION,
+            claim_id: ClaimId(claim_id.to_string()),
+            render_surface: ClaimDismissalSurface::Briefing,
+            surface_class: SurfaceClass::Primary,
+            trigger_refs: vec![TriggerRef {
+                trigger_kind: TriggerKind::SignalArrival,
+                at: "2026-05-26T12:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                source: "/Users/example/raw.md".to_string(),
+            }],
+            source_signal_id: Some("signal-1".to_string()),
+            trigger_source_asof: None,
+            evidence_signature_changed: false,
+            subject_version_changed: false,
+        }
+    }
+
+    #[test]
+    fn high_salience_candidate_renders_notable_and_persists_signal() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-surface-1", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let result = evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-surface-1"))
+            .expect("surface evaluation succeeds");
+
+        assert!(matches!(
+            result.decision,
+            SurfacingDecision::Render {
+                tier: SurfacingTier::Notable,
+                ..
+            }
+        ));
+        assert!(result.salience_evaluation_id.is_some());
+        assert!(result.surfacing_decision_id.is_some());
+        assert!(result.signal.is_some());
+        let row_count: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM surfacing_decisions", [], |row| {
+                row.get(0)
+            })
+            .expect("count surfacing decisions");
+        assert_eq!(row_count, 1);
+        let stored: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT trigger_refs_json FROM surfacing_decisions",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read trigger refs");
+        assert!(!stored.contains("/Users/"));
+        assert!(stored.contains("signal_event"));
+    }
+
+    #[test]
+    fn direct_surfacing_hashes_untrusted_source_signal_id() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-surface-privacy", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut request = input("claim-surface-privacy");
+        request.source_signal_id = Some("/Users/example/raw-workspace-note.md".to_string());
+
+        let result = evaluate_surfacing_for_claim(&ctx, &db, &engine, request)
+            .expect("surface evaluation succeeds");
+
+        let stored: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT source_signal_id
+                   FROM surfacing_decisions
+                  WHERE id = ?1",
+                [result.surfacing_decision_id.as_deref().unwrap()],
+                |row| row.get(0),
+            )
+            .expect("read stored source signal id");
+        assert!(stored.starts_with("signal_ref_"));
+        assert!(!stored.contains("/Users/"));
+    }
+
+    #[test]
+    fn primary_budget_overflow_defers_fourth_notable() {
+        let db = test_db();
+        for id in [
+            "claim-budget-1",
+            "claim-budget-2",
+            "claim-budget-3",
+            "claim-budget-4",
+        ] {
+            insert_recommendation_claim(&db, id, 0.95, "2026-05-26T10:00:00Z");
+        }
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        for id in ["claim-budget-1", "claim-budget-2", "claim-budget-3"] {
+            let result =
+                evaluate_surfacing_for_claim(&ctx, &db, &engine, input(id)).expect("render");
+            assert!(matches!(result.decision, SurfacingDecision::Render { .. }));
+        }
+        let result = evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-budget-4"))
+            .expect("overflow decision");
+
+        assert!(matches!(
+            result.decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::BudgetExhausted,
+                ..
+            }
+        ));
+        let stored: (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT defer_reason, defer_until
+                   FROM surfacing_decisions
+                  WHERE id = ?1",
+                [result.surfacing_decision_id.as_deref().unwrap()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read persisted deferral");
+        assert_eq!(stored.0, "budget_exhausted");
+        assert_eq!(
+            parse_datetime(&stored.1),
+            Some(Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap())
+        );
+    }
+
+    #[test]
+    fn background_budget_caps_high_salience_background_candidates() {
+        let db = test_db();
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        for index in 0..11 {
+            let id = format!("claim-background-budget-{index}");
+            insert_recommendation_claim(&db, &id, 0.95, "2026-05-26T10:00:00Z");
+            let mut request = input(&id);
+            request.surface_class = SurfaceClass::Background;
+            let result =
+                evaluate_surfacing_for_claim(&ctx, &db, &engine, request).expect("evaluate");
+
+            if index < 10 {
+                assert!(matches!(result.decision, SurfacingDecision::Render { .. }));
+            } else {
+                assert!(matches!(
+                    result.decision,
+                    SurfacingDecision::Defer {
+                        reason: DeferReason::BudgetExhausted,
+                        ..
+                    }
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn critical_primary_render_does_not_spend_notable_budget() {
+        let db = test_db();
+        for id in [
+            "claim-budget-critical",
+            "claim-budget-notable-1",
+            "claim-budget-notable-2",
+            "claim-budget-notable-3",
+        ] {
+            insert_recommendation_claim(&db, id, 0.95, "2026-05-26T10:00:00Z");
+        }
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let critical =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-budget-critical"))
+                .expect("render critical seed");
+        db.conn_ref()
+            .execute(
+                "UPDATE surfacing_decisions
+                    SET surfacing_tier = 'critical'
+                  WHERE id = ?1",
+                [critical.surfacing_decision_id.as_deref().unwrap()],
+            )
+            .expect("mark seed as critical");
+
+        for id in [
+            "claim-budget-notable-1",
+            "claim-budget-notable-2",
+            "claim-budget-notable-3",
+        ] {
+            let result =
+                evaluate_surfacing_for_claim(&ctx, &db, &engine, input(id)).expect("render");
+            assert!(matches!(
+                result.decision,
+                SurfacingDecision::Render {
+                    tier: SurfacingTier::Notable,
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn cooldown_defer_until_uses_original_render_expiry() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-cooldown-expiry", 0.95, "2026-05-20T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let initial =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-cooldown-expiry"))
+                .expect("initial render");
+        db.conn_ref()
+            .execute(
+                "UPDATE surfacing_decisions
+                    SET created_at = '2026-05-20T12:00:00+00:00'
+                  WHERE id = ?1",
+                [initial.surfacing_decision_id.as_deref().unwrap()],
+            )
+            .expect("age render");
+
+        let result =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-cooldown-expiry"))
+                .expect("cooldown decision");
+
+        assert!(matches!(
+            result.decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::CooldownActive,
+                until,
+            } if until == Utc.with_ymd_and_hms(2026, 5, 27, 12, 0, 0).unwrap()
+        ));
+    }
+
+    #[test]
+    fn recent_surface_dismissal_suppresses_until_material_evidence_changes() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-dismissed", 0.95, "2026-05-26T10:00:00Z");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO claim_surface_dismissals (
+                     claim_id, surface, actor, dismissed_at
+                 ) VALUES ('claim-dismissed', 'briefing', 'user', '2026-05-26T11:00:00Z')",
+                [],
+            )
+            .expect("insert dismissal");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let suppressed = evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-dismissed"))
+            .expect("suppression decision");
+        assert!(matches!(
+            suppressed.decision,
+            SurfacingDecision::Suppress {
+                reason: SuppressReason::DismissedRecently
+            }
+        ));
+
+        let mut changed = input("claim-dismissed");
+        changed.evidence_signature_changed = true;
+        let resurfaced = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed)
+            .expect("material evidence can resurface");
+        assert!(matches!(
+            resurfaced.decision,
+            SurfacingDecision::Render { .. }
+        ));
+
+        let mut same_change = input("claim-dismissed");
+        same_change.evidence_signature_changed = true;
+        let repeated = evaluate_surfacing_for_claim(&ctx, &db, &engine, same_change)
+            .expect("same material evidence is consumed");
+        assert!(matches!(
+            repeated.decision,
+            SurfacingDecision::Suppress {
+                reason: SuppressReason::DismissedRecently,
+            }
+        ));
+    }
+
+    #[test]
+    fn old_surface_dismissal_remains_suppressed_until_material_evidence_changes() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-old-dismissed", 0.95, "2026-04-30T10:00:00Z");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO claim_surface_dismissals (
+                     claim_id, surface, actor, dismissed_at
+                 ) VALUES ('claim-old-dismissed', 'briefing', 'user', '2026-05-01T11:00:00Z')",
+                [],
+            )
+            .expect("insert old dismissal");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let suppressed =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-old-dismissed"))
+                .expect("old dismissal still suppresses");
+        assert!(matches!(
+            suppressed.decision,
+            SurfacingDecision::Suppress {
+                reason: SuppressReason::DismissedRecently
+            }
+        ));
+
+        let mut changed = input("claim-old-dismissed");
+        changed.evidence_signature_changed = true;
+        let resurfaced = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed)
+            .expect("material evidence can override durable dismissal");
+        assert!(matches!(
+            resurfaced.decision,
+            SurfacingDecision::Render { .. }
+        ));
+    }
+
+    #[test]
+    fn material_source_after_recent_render_bypasses_cooldown_once() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-material-cooldown", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let initial =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-material-cooldown"))
+                .expect("initial render");
+        db.conn_ref()
+            .execute(
+                "UPDATE surfacing_decisions
+                    SET created_at = '2026-05-26T11:00:00+00:00'
+                  WHERE id = ?1",
+                [initial.surfacing_decision_id.as_deref().unwrap()],
+            )
+            .expect("age render");
+
+        let mut changed = input("claim-material-cooldown");
+        changed.trigger_source_asof = Some(Utc.with_ymd_and_hms(2026, 5, 26, 11, 30, 0).unwrap());
+        changed.evidence_signature_changed = true;
+        let resurfaced = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed.clone())
+            .expect("material evidence bypasses cooldown");
+        assert!(matches!(
+            resurfaced.decision,
+            SurfacingDecision::Render { .. }
+        ));
+
+        let repeated = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed)
+            .expect("same material evidence is consumed");
+        assert!(matches!(
+            repeated.decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::CooldownActive,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn material_baseline_uses_subject_action_render_for_duplicate_claims() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-subject-action-1", 0.95, "2026-05-26T10:00:00Z");
+        insert_recommendation_claim(&db, "claim-subject-action-2", 0.95, "2026-05-26T10:00:00Z");
+        let shared_metadata_json: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT metadata_json FROM intelligence_claims WHERE id = 'claim-subject-action-1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read shared metadata");
+        db.conn_ref()
+            .execute(
+                "UPDATE intelligence_claims
+                    SET metadata_json = ?1
+                  WHERE id = 'claim-subject-action-2'",
+                [shared_metadata_json],
+            )
+            .expect("share action signature");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let first =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-subject-action-1"))
+                .expect("first render");
+        assert!(matches!(first.decision, SurfacingDecision::Render { .. }));
+        let second =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-subject-action-2"))
+                .expect("second same action");
+
+        assert!(matches!(
+            second.decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::CooldownActive,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn evidence_change_signal_after_render_bypasses_cooldown_once() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-evidence-signal", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let initial =
+            evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-evidence-signal"))
+                .expect("initial render");
+        assert!(matches!(initial.decision, SurfacingDecision::Render { .. }));
+
+        let mut changed = input("claim-evidence-signal");
+        changed.evidence_signature_changed = true;
+        changed.source_signal_id = Some("signal-evidence-change-1".to_string());
+        let resurfaced = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed.clone())
+            .expect("evidence signal bypasses cooldown");
+        assert!(matches!(
+            resurfaced.decision,
+            SurfacingDecision::Render { .. }
+        ));
+
+        let repeated = evaluate_surfacing_for_claim(&ctx, &db, &engine, changed)
+            .expect("same evidence signal is consumed");
+        assert!(matches!(
+            repeated.decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::CooldownActive,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn source_signal_id_alone_does_not_override_recent_feedback() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-feedback", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO claim_feedback (
+                     id, claim_id, feedback_type, actor, actor_id, submitted_at
+                 ) VALUES (
+                     'feedback-suppress-1', 'claim-feedback', 'not_relevant_here',
+                     'user', 'user-1', '2026-05-26T11:00:00Z'
+                 )",
+                [],
+            )
+            .expect("insert feedback");
+        let engine = PropagationEngine::new();
+        let mut request = input("claim-feedback");
+        request.source_signal_id = Some("new-source-signal-id".to_string());
+
+        let result = evaluate_surfacing_for_claim(&ctx, &db, &engine, request)
+            .expect("feedback suppression");
+
+        assert!(matches!(
+            result.decision,
+            SurfacingDecision::Suppress {
+                reason: SuppressReason::DismissedRecently
+            }
+        ));
+    }
+
+    #[test]
+    fn evaluate_mode_does_not_write_or_emit() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-evaluate", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, _external) = test_ctx();
+        let ctx = ServiceContext::new_evaluate_default(&clock, &rng).with_actor("system:test");
+        let engine = PropagationEngine::new();
+
+        let result = evaluate_surfacing_for_claim(&ctx, &db, &engine, input("claim-evaluate"))
+            .expect("evaluate mode returns preview decision");
+
+        assert!(result.surfacing_decision_id.is_none());
+        assert!(result.signal.is_none());
+        let decision_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM surfacing_decisions", [], |row| {
+                row.get(0)
+            })
+            .expect("count decisions");
+        let signal_rows: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*) FROM signal_events WHERE signal_type = 'surfacing_decision_made'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count signals");
+        assert_eq!(decision_rows, 0);
+        assert_eq!(signal_rows, 0);
+    }
+
+    #[test]
+    fn pure_decision_bounds_critical_primary_to_one_per_day() {
+        let now = "2026-05-26T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let candidate = SurfacingCandidate {
+            claim_id: ClaimId("claim-critical".to_string()),
+            claim_type: "recommendation".to_string(),
+            sensitivity: "internal".to_string(),
+            subject_kind: "account".to_string(),
+            subject_id: "acct-example".to_string(),
+            action_signature: "reviewClaim".to_string(),
+            source_asof: Some(now),
+            evidence_signature: Some("evsig_test".to_string()),
+            salience: SalienceScore {
+                total: 0.97,
+                factors: vec![SalienceFactor {
+                    kind: SalienceFactorKind::Urgency,
+                    value: Some(0.97),
+                    weight: 0.15,
+                    rationale: FactorRationale::Urgency {
+                        deadline: None,
+                        decay_factor: 0.97,
+                    },
+                }],
+            },
+            trigger_refs: Vec::new(),
+            surface_class: SurfaceClass::Primary,
+            material_new_evidence: true,
+        };
+
+        let decision = decide_surfacing(
+            candidate,
+            &SurfacingPolicy::default(),
+            SurfacingPolicyState {
+                critical_primary_used: 1,
+                ..SurfacingPolicyState::default()
+            },
+            now,
+        );
+
+        assert!(matches!(
+            decision,
+            SurfacingDecision::Defer {
+                reason: DeferReason::BudgetExhausted,
+                ..
+            }
+        ));
+    }
+}

--- a/src-tauri/src/services/recommendations/triggers.rs
+++ b/src-tauri/src/services/recommendations/triggers.rs
@@ -4,3 +4,1715 @@
 //! emits `SalienceCandidateRefreshTriggered` when a candidate's
 //! salience must be re-scored. Deterministic — no provider / LLM
 //! call from this module.
+
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use abilities_runtime::sensitivity::ClaimDismissalSurface;
+
+use super::contracts::{ClaimId, TriggerKind, TriggerRef};
+use super::surfacing::{
+    evaluate_surfacing_for_claim, evidence_signature as claim_evidence_signature, SurfaceClass,
+    SurfacingError, SurfacingEvaluationInput, SURFACING_EVALUATION_SCHEMA_VERSION,
+};
+use crate::db::ActionDb;
+use crate::services::context::{ExecutionMode, ServiceContext, ServiceError};
+use crate::signals::propagation::PropagationEngine;
+
+pub const TRIGGER_POLICY_VERSION: &str = "recommendation_trigger_policy_v1";
+pub const TRIGGER_SCAN_SCHEMA_VERSION: u32 = 1;
+pub const SALIENCE_CANDIDATE_REFRESH_SIGNAL: &str = "salience_candidate_refresh_triggered";
+const TRIGGER_SIGNAL_SOURCE: &str = "recommendation_trigger_policy";
+const DOWNSTREAM_POLICY: &str = "recommendation_surfacing_policy";
+const STARTED_COALESCE_SECS: i64 = 900;
+const DEFAULT_MAX_CANDIDATES: usize = 25;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerClass {
+    ScheduledFreshness,
+    EventInvalidation,
+    ManualRefresh,
+    EntityChange,
+    ClaimChange,
+    SourceChange,
+    OpenLoopChange,
+    MeetingWindow,
+    DecisionWindow,
+    FeedbackEcho,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerDisposition {
+    SilentPrepare,
+    PrimaryCandidate,
+    ReviewCandidate,
+    QuietCandidate,
+}
+
+impl TriggerDisposition {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::SilentPrepare => "silent_prepare",
+            Self::PrimaryCandidate => "primary_candidate",
+            Self::ReviewCandidate => "review_candidate",
+            Self::QuietCandidate => "quiet_candidate",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerScanInput {
+    pub schema_version: u32,
+    pub trigger_class: TriggerClass,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub render_surface: ClaimDismissalSurface,
+    pub surface_class: SurfaceClass,
+    pub run_id: Option<String>,
+    pub source_signal_id: Option<String>,
+    pub source_signal_type: Option<String>,
+    pub source_asof: Option<DateTime<Utc>>,
+    pub evidence_signature: Option<String>,
+    pub subject_version: Option<i64>,
+    pub max_candidates: Option<usize>,
+}
+
+impl TriggerScanInput {
+    pub fn scheduled(subject_kind: impl Into<String>, subject_id: impl Into<String>) -> Self {
+        Self {
+            schema_version: TRIGGER_SCAN_SCHEMA_VERSION,
+            trigger_class: TriggerClass::ScheduledFreshness,
+            subject_kind: subject_kind.into(),
+            subject_id: subject_id.into(),
+            render_surface: ClaimDismissalSurface::Briefing,
+            surface_class: SurfaceClass::Background,
+            run_id: None,
+            source_signal_id: None,
+            source_signal_type: None,
+            source_asof: None,
+            evidence_signature: None,
+            subject_version: None,
+            max_candidates: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerScanStatus {
+    Completed,
+    CoalescedCompleted,
+    CoalescedInProgress,
+    CoalescedRetryNotDue,
+    EvaluateOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerScanOutcome {
+    pub schema_version: u32,
+    pub policy_version: String,
+    pub run_id: String,
+    pub status: TriggerScanStatus,
+    pub signal_id: Option<String>,
+    pub signal_coalesced: bool,
+    pub derived_signal_ids: Vec<String>,
+    pub candidate_claim_ids: Vec<String>,
+    pub salience_evaluation_ids: Vec<String>,
+    pub surfacing_decision_ids: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TriggerError {
+    #[error("unsupported schema_version `{0}` for run_trigger_scan")]
+    UnsupportedSchemaVersion(u32),
+    #[error("trigger subject kind/id must be non-empty")]
+    EmptySubject,
+    #[error("trigger {0} must be privacy-safe")]
+    UnsafeInput(&'static str),
+    #[error("trigger database error: {0}")]
+    Database(String),
+    #[error(transparent)]
+    Service(#[from] ServiceError),
+    #[error("trigger signal emit failed: {0}")]
+    Signal(String),
+    #[error(transparent)]
+    Surfacing(#[from] SurfacingError),
+    #[error("trigger serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl From<rusqlite::Error> for TriggerError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Database(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TriggerPolicy {
+    trigger_kind: TriggerKind,
+    trigger_disposition: TriggerDisposition,
+    trust_floor: f64,
+    freshness_window_secs: i64,
+    suppression_window_secs: i64,
+    reason_code: &'static str,
+}
+
+#[derive(Debug)]
+struct ExistingTrigger {
+    run_id: String,
+    status: String,
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    next_retry_at: Option<DateTime<Utc>>,
+    retry_count: i64,
+    signal_id: Option<String>,
+    signal_coalesced: bool,
+    derived_signal_ids: Vec<String>,
+    candidate_claim_ids: Vec<String>,
+    salience_evaluation_ids: Vec<String>,
+    surfacing_decision_ids: Vec<String>,
+}
+
+#[derive(Debug)]
+struct CandidateClaim {
+    claim_id: String,
+    freshness_at: Option<DateTime<Utc>>,
+    evidence_signature: Option<String>,
+}
+
+pub fn run_trigger_scan(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &PropagationEngine,
+    input: TriggerScanInput,
+) -> Result<TriggerScanOutcome, TriggerError> {
+    validate_schema_version(input.schema_version)?;
+    validate_subject(&input)?;
+    let policy = policy_for_trigger(input.trigger_class);
+    let now = ctx.clock.now();
+    let run_id = input
+        .run_id
+        .as_deref()
+        .map(|value| safe_storage_ref("run_ref", value))
+        .unwrap_or_else(|| {
+            if matches!(ctx.mode, ExecutionMode::Live) {
+                format!("trigger-run-{}", uuid::Uuid::new_v4())
+            } else {
+                "evaluate-only".to_string()
+            }
+        });
+    let source_signal_id = safe_optional_ref("signal_ref", input.source_signal_id.as_deref());
+    let dedupe_key = dedupe_key(&input, policy, now, &run_id);
+    let suppression_key = suppression_key(&input, policy);
+
+    if !matches!(ctx.mode, ExecutionMode::Live) {
+        return Ok(TriggerScanOutcome {
+            schema_version: TRIGGER_SCAN_SCHEMA_VERSION,
+            policy_version: TRIGGER_POLICY_VERSION.to_string(),
+            run_id,
+            status: TriggerScanStatus::EvaluateOnly,
+            signal_id: None,
+            signal_coalesced: false,
+            derived_signal_ids: Vec::new(),
+            candidate_claim_ids: Vec::new(),
+            salience_evaluation_ids: Vec::new(),
+            surfacing_decision_ids: Vec::new(),
+        });
+    }
+
+    ctx.check_mutation_allowed()?;
+    if let Some(existing) = coalesced_existing_trigger(db.conn_ref(), &dedupe_key, policy, now)? {
+        return Ok(existing_outcome(existing));
+    }
+
+    let subject_version_changed = subject_version_changed_since_latest_trigger(
+        db.conn_ref(),
+        &suppression_key,
+        input.subject_version,
+    )?;
+    let retry_count = latest_retry_count(db.conn_ref(), &dedupe_key)? + 1;
+    insert_started_trigger(db, &run_id, &input, policy, &dedupe_key, retry_count, now)?;
+
+    let signal_value = trigger_signal_value(&run_id, &input, policy)?;
+    let signal_key = format!("{TRIGGER_POLICY_VERSION}:{run_id}");
+    let (signal_outcome, derived_signal_ids) =
+        match crate::services::signals::emit_once_for_key_and_propagate(
+            ctx,
+            db,
+            engine,
+            &signal_key,
+            &input.subject_kind,
+            &input.subject_id,
+            SALIENCE_CANDIDATE_REFRESH_SIGNAL,
+            TRIGGER_SIGNAL_SOURCE,
+            Some(&signal_value),
+            1.0,
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                mark_trigger_failed(db, &run_id, "signal_emit_failed", true, now)?;
+                return Err(TriggerError::Signal(error));
+            }
+        };
+
+    let candidates = find_candidate_claims(db.conn_ref(), &input, policy, now)?;
+    let mut claim_ids = Vec::with_capacity(candidates.len());
+    let mut salience_ids = Vec::with_capacity(candidates.len());
+    let mut decision_ids = Vec::with_capacity(candidates.len());
+
+    for candidate in candidates {
+        claim_ids.push(candidate.claim_id.clone());
+        let evidence_signature_changed = evidence_signature_changed(&input, &candidate);
+        let evaluation_input = SurfacingEvaluationInput {
+            schema_version: SURFACING_EVALUATION_SCHEMA_VERSION,
+            claim_id: ClaimId(candidate.claim_id),
+            render_surface: input.render_surface,
+            surface_class: surface_class_for_disposition(policy.trigger_disposition),
+            trigger_refs: vec![trigger_ref_for_input(&input, policy, now)],
+            source_signal_id: source_signal_id.clone(),
+            trigger_source_asof: input
+                .source_asof
+                .as_ref()
+                .cloned()
+                .or(candidate.freshness_at),
+            evidence_signature_changed,
+            subject_version_changed,
+        };
+        match evaluate_surfacing_for_claim(ctx, db, engine, evaluation_input) {
+            Ok(evaluation) => {
+                if let Some(id) = evaluation.salience_evaluation_id {
+                    salience_ids.push(id);
+                }
+                if let Some(id) = evaluation.surfacing_decision_id {
+                    decision_ids.push(id);
+                }
+            }
+            Err(error) => {
+                mark_trigger_failed(db, &run_id, closed_error_code(&error), true, now)?;
+                return Err(error.into());
+            }
+        }
+    }
+
+    mark_trigger_completed(
+        db,
+        &run_id,
+        CompletedTrigger {
+            signal_id: &signal_outcome.id,
+            signal_coalesced: signal_outcome.coalesced,
+            derived_signal_ids: &derived_signal_ids,
+            candidate_claim_ids: &claim_ids,
+            salience_evaluation_ids: &salience_ids,
+            surfacing_decision_ids: &decision_ids,
+            result_kind: result_kind_for_completion(policy.trigger_disposition, &decision_ids),
+            completed_at: now,
+        },
+    )?;
+
+    Ok(TriggerScanOutcome {
+        schema_version: TRIGGER_SCAN_SCHEMA_VERSION,
+        policy_version: TRIGGER_POLICY_VERSION.to_string(),
+        run_id,
+        status: TriggerScanStatus::Completed,
+        signal_id: Some(signal_outcome.id),
+        signal_coalesced: signal_outcome.coalesced,
+        derived_signal_ids,
+        candidate_claim_ids: claim_ids,
+        salience_evaluation_ids: salience_ids,
+        surfacing_decision_ids: decision_ids,
+    })
+}
+
+fn validate_schema_version(schema_version: u32) -> Result<(), TriggerError> {
+    if schema_version == TRIGGER_SCAN_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(TriggerError::UnsupportedSchemaVersion(schema_version))
+    }
+}
+
+fn validate_subject(input: &TriggerScanInput) -> Result<(), TriggerError> {
+    if input.subject_kind.trim().is_empty() || input.subject_id.trim().is_empty() {
+        return Err(TriggerError::EmptySubject);
+    }
+    if !is_safe_storage_token(&input.subject_kind) {
+        return Err(TriggerError::UnsafeInput("subject_kind"));
+    }
+    if !is_safe_storage_ref(&input.subject_id) {
+        return Err(TriggerError::UnsafeInput("subject_id"));
+    }
+    if input
+        .run_id
+        .as_deref()
+        .is_some_and(|run_id| run_id.trim().is_empty())
+    {
+        return Err(TriggerError::UnsafeInput("run_id"));
+    }
+    Ok(())
+}
+
+fn policy_for_trigger(trigger_class: TriggerClass) -> TriggerPolicy {
+    match trigger_class {
+        TriggerClass::ScheduledFreshness => TriggerPolicy {
+            trigger_kind: TriggerKind::ScheduledScan,
+            trigger_disposition: TriggerDisposition::SilentPrepare,
+            trust_floor: 0.60,
+            freshness_window_secs: 86_400,
+            suppression_window_secs: 86_400,
+            reason_code: "scheduled_freshness",
+        },
+        TriggerClass::EventInvalidation => TriggerPolicy {
+            trigger_kind: TriggerKind::SignalArrival,
+            trigger_disposition: TriggerDisposition::PrimaryCandidate,
+            trust_floor: 0.70,
+            freshness_window_secs: 21_600,
+            suppression_window_secs: 21_600,
+            reason_code: "event_invalidation",
+        },
+        TriggerClass::ManualRefresh => TriggerPolicy {
+            trigger_kind: TriggerKind::SignalArrival,
+            trigger_disposition: TriggerDisposition::ReviewCandidate,
+            trust_floor: 0.50,
+            freshness_window_secs: 0,
+            suppression_window_secs: 60,
+            reason_code: "manual_refresh",
+        },
+        TriggerClass::EntityChange => TriggerPolicy {
+            trigger_kind: TriggerKind::EntityChange,
+            trigger_disposition: TriggerDisposition::PrimaryCandidate,
+            trust_floor: 0.65,
+            freshness_window_secs: 21_600,
+            suppression_window_secs: 21_600,
+            reason_code: "entity_change",
+        },
+        TriggerClass::ClaimChange => TriggerPolicy {
+            trigger_kind: TriggerKind::SignalArrival,
+            trigger_disposition: TriggerDisposition::PrimaryCandidate,
+            trust_floor: 0.70,
+            freshness_window_secs: 21_600,
+            suppression_window_secs: 3_600,
+            reason_code: "claim_change",
+        },
+        TriggerClass::SourceChange => TriggerPolicy {
+            trigger_kind: TriggerKind::SignalArrival,
+            trigger_disposition: TriggerDisposition::ReviewCandidate,
+            trust_floor: 0.75,
+            freshness_window_secs: 21_600,
+            suppression_window_secs: 21_600,
+            reason_code: "source_change",
+        },
+        TriggerClass::OpenLoopChange => TriggerPolicy {
+            trigger_kind: TriggerKind::SignalArrival,
+            trigger_disposition: TriggerDisposition::QuietCandidate,
+            trust_floor: 0.55,
+            freshness_window_secs: 43_200,
+            suppression_window_secs: 10_800,
+            reason_code: "open_loop_change",
+        },
+        TriggerClass::MeetingWindow => TriggerPolicy {
+            trigger_kind: TriggerKind::EntityChange,
+            trigger_disposition: TriggerDisposition::PrimaryCandidate,
+            trust_floor: 0.65,
+            freshness_window_secs: 7_200,
+            suppression_window_secs: 10_800,
+            reason_code: "meeting_window",
+        },
+        TriggerClass::DecisionWindow => TriggerPolicy {
+            trigger_kind: TriggerKind::ScheduledScan,
+            trigger_disposition: TriggerDisposition::PrimaryCandidate,
+            trust_floor: 0.70,
+            freshness_window_secs: 43_200,
+            suppression_window_secs: 21_600,
+            reason_code: "decision_window",
+        },
+        TriggerClass::FeedbackEcho => TriggerPolicy {
+            trigger_kind: TriggerKind::FeedbackEcho,
+            trigger_disposition: TriggerDisposition::QuietCandidate,
+            trust_floor: 0.50,
+            freshness_window_secs: 604_800,
+            suppression_window_secs: 300,
+            reason_code: "feedback_echo",
+        },
+    }
+}
+
+fn coalesced_existing_trigger(
+    conn: &rusqlite::Connection,
+    dedupe_key: &str,
+    policy: TriggerPolicy,
+    now: DateTime<Utc>,
+) -> Result<Option<ExistingTrigger>, TriggerError> {
+    if !table_exists(conn, "triggers_log")? {
+        return Ok(None);
+    }
+    let Some(existing) = load_latest_trigger(conn, dedupe_key)? else {
+        return Ok(None);
+    };
+
+    let coalesces = match existing.status.as_str() {
+        "completed" => existing.completed_at.is_some_and(|at| {
+            now.signed_duration_since(at).num_seconds() <= policy.suppression_window_secs
+        }),
+        "started" => existing
+            .started_at
+            .is_some_and(|at| now.signed_duration_since(at).num_seconds() <= STARTED_COALESCE_SECS),
+        "failed_retryable" => existing.next_retry_at.is_some_and(|at| at > now),
+        "failed_terminal" => false,
+        _ => false,
+    };
+
+    Ok(coalesces.then_some(existing))
+}
+
+fn load_latest_trigger(
+    conn: &rusqlite::Connection,
+    dedupe_key: &str,
+) -> Result<Option<ExistingTrigger>, TriggerError> {
+    conn.query_row(
+        "SELECT run_id, status, started_at, completed_at, next_retry_at, retry_count,
+                signal_id, signal_coalesced, derived_signal_ids_json,
+                candidate_claim_ids_json, salience_evaluation_ids_json,
+                surfacing_decision_ids_json
+           FROM triggers_log
+          WHERE policy_version = ?1 AND dedupe_key = ?2
+          ORDER BY updated_at DESC
+          LIMIT 1",
+        params![TRIGGER_POLICY_VERSION, dedupe_key],
+        |row| {
+            Ok(ExistingTrigger {
+                run_id: row.get(0)?,
+                status: row.get(1)?,
+                started_at: row
+                    .get::<_, Option<String>>(2)?
+                    .as_deref()
+                    .and_then(parse_datetime),
+                completed_at: row
+                    .get::<_, Option<String>>(3)?
+                    .as_deref()
+                    .and_then(parse_datetime),
+                next_retry_at: row
+                    .get::<_, Option<String>>(4)?
+                    .as_deref()
+                    .and_then(parse_datetime),
+                retry_count: row.get(5)?,
+                signal_id: row.get(6)?,
+                signal_coalesced: row.get::<_, i64>(7)? == 1,
+                derived_signal_ids: decode_string_vec(row.get::<_, String>(8)?),
+                candidate_claim_ids: decode_string_vec(row.get::<_, String>(9)?),
+                salience_evaluation_ids: decode_string_vec(row.get::<_, String>(10)?),
+                surfacing_decision_ids: decode_string_vec(row.get::<_, String>(11)?),
+            })
+        },
+    )
+    .optional()
+    .map_err(TriggerError::from)
+}
+
+fn existing_outcome(existing: ExistingTrigger) -> TriggerScanOutcome {
+    let status = match existing.status.as_str() {
+        "completed" => TriggerScanStatus::CoalescedCompleted,
+        "started" => TriggerScanStatus::CoalescedInProgress,
+        "failed_retryable" => TriggerScanStatus::CoalescedRetryNotDue,
+        _ => TriggerScanStatus::CoalescedCompleted,
+    };
+
+    TriggerScanOutcome {
+        schema_version: TRIGGER_SCAN_SCHEMA_VERSION,
+        policy_version: TRIGGER_POLICY_VERSION.to_string(),
+        run_id: existing.run_id,
+        status,
+        signal_id: existing.signal_id,
+        signal_coalesced: existing.signal_coalesced,
+        derived_signal_ids: existing.derived_signal_ids,
+        candidate_claim_ids: existing.candidate_claim_ids,
+        salience_evaluation_ids: existing.salience_evaluation_ids,
+        surfacing_decision_ids: existing.surfacing_decision_ids,
+    }
+}
+
+fn latest_retry_count(conn: &rusqlite::Connection, dedupe_key: &str) -> Result<i64, TriggerError> {
+    if !table_exists(conn, "triggers_log")? {
+        return Ok(0);
+    }
+    let retry_count = conn
+        .query_row(
+            "SELECT retry_count
+               FROM triggers_log
+              WHERE policy_version = ?1 AND dedupe_key = ?2
+              ORDER BY updated_at DESC
+              LIMIT 1",
+            params![TRIGGER_POLICY_VERSION, dedupe_key],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .unwrap_or(0);
+    Ok(retry_count)
+}
+
+fn insert_started_trigger(
+    db: &ActionDb,
+    run_id: &str,
+    input: &TriggerScanInput,
+    policy: TriggerPolicy,
+    dedupe_key: &str,
+    retry_count: i64,
+    now: DateTime<Utc>,
+) -> Result<(), TriggerError> {
+    let suppression_key = suppression_key(input, policy);
+    let source_signal_id = safe_optional_ref("signal_ref", input.source_signal_id.as_deref());
+    let source_signal_type =
+        safe_optional_token("signal_type", input.source_signal_type.as_deref());
+    let evidence_signature = safe_optional_ref("evidence", input.evidence_signature.as_deref());
+    db.conn_ref().execute(
+        "INSERT INTO triggers_log (
+             run_id, policy_version, trigger_class, trigger_kind, status,
+             trigger_disposition, result_kind, downstream_policy,
+             subject_kind, subject_id, entity_type, entity_id,
+             reason_code, dedupe_key, suppression_key, trust_floor,
+             freshness_window_secs, source_signal_id, source_signal_type,
+             source_asof, evidence_signature, subject_version, retry_count,
+             started_at, updated_at
+         ) VALUES (
+             ?1, ?2, ?3, ?4, 'started',
+             ?5, 'prepared_silently', ?6,
+             ?7, ?8, ?9, ?10,
+             ?11, ?12, ?13, ?14,
+             ?15, ?16, ?17,
+             ?18, ?19, ?20, ?21,
+             ?22, ?23
+         )",
+        params![
+            run_id,
+            TRIGGER_POLICY_VERSION,
+            trigger_class_storage(input.trigger_class),
+            trigger_kind_storage(policy.trigger_kind),
+            policy.trigger_disposition.as_str(),
+            DOWNSTREAM_POLICY,
+            &input.subject_kind,
+            &input.subject_id,
+            &input.subject_kind,
+            &input.subject_id,
+            policy.reason_code,
+            dedupe_key,
+            suppression_key,
+            policy.trust_floor,
+            policy.freshness_window_secs,
+            source_signal_id.as_deref(),
+            source_signal_type.as_deref(),
+            input.source_asof.as_ref().map(|dt| dt.to_rfc3339()),
+            evidence_signature.as_deref(),
+            input.subject_version,
+            retry_count,
+            now.to_rfc3339(),
+            now.to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+struct CompletedTrigger<'a> {
+    signal_id: &'a str,
+    signal_coalesced: bool,
+    derived_signal_ids: &'a [String],
+    candidate_claim_ids: &'a [String],
+    salience_evaluation_ids: &'a [String],
+    surfacing_decision_ids: &'a [String],
+    result_kind: &'static str,
+    completed_at: DateTime<Utc>,
+}
+
+fn mark_trigger_completed(
+    db: &ActionDb,
+    run_id: &str,
+    completed: CompletedTrigger<'_>,
+) -> Result<(), TriggerError> {
+    db.conn_ref().execute(
+        "UPDATE triggers_log
+            SET status = 'completed',
+                signal_id = ?2,
+                signal_coalesced = ?3,
+                derived_signal_ids_json = ?4,
+                candidate_claim_ids_json = ?5,
+                salience_evaluation_ids_json = ?6,
+                surfacing_decision_ids_json = ?7,
+                result_kind = ?8,
+                completed_at = ?9,
+                updated_at = ?9
+          WHERE run_id = ?1",
+        params![
+            run_id,
+            completed.signal_id,
+            if completed.signal_coalesced { 1 } else { 0 },
+            serde_json::to_string(completed.derived_signal_ids)?,
+            serde_json::to_string(completed.candidate_claim_ids)?,
+            serde_json::to_string(completed.salience_evaluation_ids)?,
+            serde_json::to_string(completed.surfacing_decision_ids)?,
+            completed.result_kind,
+            completed.completed_at.to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn mark_trigger_failed(
+    db: &ActionDb,
+    run_id: &str,
+    error_code: &'static str,
+    retryable: bool,
+    now: DateTime<Utc>,
+) -> Result<(), TriggerError> {
+    let status = if retryable {
+        "failed_retryable"
+    } else {
+        "failed_terminal"
+    };
+    let next_retry_at = retryable.then(|| (now + Duration::minutes(10)).to_rfc3339());
+    db.conn_ref().execute(
+        "UPDATE triggers_log
+            SET status = ?2,
+                error_code = ?3,
+                next_retry_at = ?4,
+                result_kind = 'failed',
+                updated_at = ?5
+          WHERE run_id = ?1",
+        params![
+            run_id,
+            status,
+            error_code,
+            next_retry_at.as_deref(),
+            now.to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn find_candidate_claims(
+    conn: &rusqlite::Connection,
+    input: &TriggerScanInput,
+    policy: TriggerPolicy,
+    now: DateTime<Utc>,
+) -> Result<Vec<CandidateClaim>, TriggerError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, COALESCE(source_asof, observed_at, created_at) AS freshness_at,
+                metadata_json
+           FROM intelligence_claims
+          WHERE claim_type = 'recommendation'
+            AND claim_state = 'active'
+            AND surfacing_state = 'active'
+            AND json_valid(subject_ref) = 1
+            AND lower(json_extract(subject_ref, '$.kind')) = lower(?1)
+            AND json_extract(subject_ref, '$.id') = ?2
+            AND COALESCE(trust_score, 0.0) >= ?3
+          ORDER BY COALESCE(trust_score, 0.0) DESC, observed_at DESC, id ASC",
+    )?;
+    let rows = stmt.query_map(
+        params![&input.subject_kind, &input.subject_id, policy.trust_floor],
+        |row| {
+            let metadata_json: Option<String> = row.get(2)?;
+            Ok(CandidateClaim {
+                claim_id: row.get(0)?,
+                freshness_at: row
+                    .get::<_, Option<String>>(1)?
+                    .as_deref()
+                    .and_then(parse_datetime),
+                evidence_signature: claim_evidence_signature(&metadata_json),
+            })
+        },
+    )?;
+
+    let cutoff = (policy.freshness_window_secs > 0)
+        .then(|| now - Duration::seconds(policy.freshness_window_secs));
+    let mut candidates = Vec::new();
+    for row in rows {
+        let candidate = row?;
+        let effective_freshness_at = effective_candidate_freshness_at(input, &candidate);
+        if cutoff
+            .zip(effective_freshness_at)
+            .is_some_and(|(cutoff, freshness_at)| freshness_at < cutoff)
+        {
+            continue;
+        }
+        candidates.push(candidate);
+        if candidates.len() >= input.max_candidates.unwrap_or(DEFAULT_MAX_CANDIDATES) {
+            break;
+        }
+    }
+    Ok(candidates)
+}
+
+fn trigger_ref_for_input(
+    input: &TriggerScanInput,
+    policy: TriggerPolicy,
+    now: DateTime<Utc>,
+) -> TriggerRef {
+    TriggerRef {
+        trigger_kind: policy.trigger_kind,
+        at: input.source_asof.as_ref().cloned().unwrap_or(now),
+        source: trigger_source_token(input.trigger_class).to_string(),
+    }
+}
+
+fn trigger_signal_value(
+    run_id: &str,
+    input: &TriggerScanInput,
+    policy: TriggerPolicy,
+) -> Result<String, TriggerError> {
+    Ok(serde_json::to_string(&json!({
+        "runId": run_id,
+        "policyVersion": TRIGGER_POLICY_VERSION,
+        "triggerClass": trigger_class_storage(input.trigger_class),
+        "triggerKind": trigger_kind_storage(policy.trigger_kind),
+        "subject": {
+            "kind": input.subject_kind,
+            "id": input.subject_id,
+        },
+        "reasonCode": policy.reason_code,
+        "triggerDisposition": policy.trigger_disposition.as_str(),
+        "surfaceClass": surface_class_for_disposition(policy.trigger_disposition).as_str(),
+    }))?)
+}
+
+fn surface_class_for_disposition(disposition: TriggerDisposition) -> SurfaceClass {
+    match disposition {
+        TriggerDisposition::SilentPrepare => SurfaceClass::Background,
+        TriggerDisposition::PrimaryCandidate => SurfaceClass::Primary,
+        TriggerDisposition::ReviewCandidate => SurfaceClass::Review,
+        TriggerDisposition::QuietCandidate => SurfaceClass::Quiet,
+    }
+}
+
+fn evidence_signature_changed(input: &TriggerScanInput, candidate: &CandidateClaim) -> bool {
+    input
+        .evidence_signature
+        .as_deref()
+        .is_some_and(|signature| candidate.evidence_signature.as_deref() != Some(signature))
+}
+
+fn subject_version_changed_since_latest_trigger(
+    conn: &rusqlite::Connection,
+    suppression_key: &str,
+    current_subject_version: Option<i64>,
+) -> Result<bool, TriggerError> {
+    let Some(current_subject_version) = current_subject_version else {
+        return Ok(false);
+    };
+    let previous_subject_version = conn
+        .query_row(
+            "SELECT subject_version
+               FROM triggers_log
+              WHERE policy_version = ?1
+                AND suppression_key = ?2
+                AND status = 'completed'
+                AND subject_version IS NOT NULL
+              ORDER BY COALESCE(completed_at, updated_at, started_at) DESC
+              LIMIT 1",
+            params![TRIGGER_POLICY_VERSION, suppression_key],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+
+    Ok(previous_subject_version.is_some_and(|previous| previous != current_subject_version))
+}
+
+fn dedupe_key(
+    input: &TriggerScanInput,
+    policy: TriggerPolicy,
+    now: DateTime<Utc>,
+    run_id: &str,
+) -> String {
+    let metadata_suffix = metadata_dedupe_suffix(input);
+    match input.trigger_class {
+        TriggerClass::ScheduledFreshness => format!(
+            "{}:{}:{}:{}:{}:{}:{}",
+            trigger_class_storage(input.trigger_class),
+            policy.reason_code,
+            input.subject_kind,
+            input.subject_id,
+            input.render_surface.as_str(),
+            input.surface_class.as_str(),
+            scheduled_day_dedupe_suffix(now, &metadata_suffix)
+        ),
+        TriggerClass::ManualRefresh => {
+            format!("{}:{}", trigger_class_storage(input.trigger_class), run_id)
+        }
+        TriggerClass::EventInvalidation | TriggerClass::SourceChange => format!(
+            "{}:{}:{}:{}:{}",
+            trigger_class_storage(input.trigger_class),
+            safe_optional_ref("signal_ref", input.source_signal_id.as_deref())
+                .unwrap_or_else(|| "signal_ref_none".to_string()),
+            input.subject_kind,
+            input.subject_id,
+            metadata_suffix
+        ),
+        _ => format!(
+            "{}:{}:{}:{}:{}",
+            trigger_class_storage(input.trigger_class),
+            policy.reason_code,
+            input.subject_kind,
+            input.subject_id,
+            metadata_suffix
+        ),
+    }
+}
+
+fn effective_candidate_freshness_at(
+    input: &TriggerScanInput,
+    candidate: &CandidateClaim,
+) -> Option<DateTime<Utc>> {
+    match input.trigger_class {
+        TriggerClass::EventInvalidation | TriggerClass::SourceChange => {
+            max_datetime(candidate.freshness_at, input.source_asof)
+        }
+        TriggerClass::ScheduledFreshness
+        | TriggerClass::ManualRefresh
+        | TriggerClass::EntityChange
+        | TriggerClass::ClaimChange
+        | TriggerClass::OpenLoopChange
+        | TriggerClass::MeetingWindow
+        | TriggerClass::DecisionWindow
+        | TriggerClass::FeedbackEcho => candidate.freshness_at,
+    }
+}
+
+fn scheduled_day_dedupe_suffix(now: DateTime<Utc>, metadata_suffix: &str) -> String {
+    format!("day:{}:{}", now.date_naive(), metadata_suffix)
+}
+
+fn max_datetime(
+    left: Option<DateTime<Utc>>,
+    right: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn metadata_dedupe_suffix(input: &TriggerScanInput) -> String {
+    if input.source_asof.is_none()
+        && input.evidence_signature.is_none()
+        && input.subject_version.is_none()
+    {
+        return "meta_none".to_string();
+    }
+
+    let mut hasher = Sha256::new();
+    if let Some(source_asof) = input.source_asof.as_ref() {
+        hasher.update(b"source_asof");
+        hasher.update(source_asof.to_rfc3339().as_bytes());
+    }
+    if let Some(evidence_signature) = input.evidence_signature.as_deref() {
+        hasher.update(b"evidence_signature");
+        hasher.update(evidence_signature.as_bytes());
+    }
+    if let Some(subject_version) = input.subject_version {
+        hasher.update(b"subject_version");
+        hasher.update(subject_version.to_string().as_bytes());
+    }
+
+    format!("meta_{}", hex::encode(&hasher.finalize()[..16]))
+}
+
+fn suppression_key(input: &TriggerScanInput, policy: TriggerPolicy) -> String {
+    match input.trigger_class {
+        TriggerClass::EventInvalidation => format!(
+            "signal:{}:{}:{}",
+            safe_optional_token("signal_type", input.source_signal_type.as_deref())
+                .unwrap_or_else(|| "signal_type_unknown".to_string()),
+            input.subject_kind,
+            input.subject_id
+        ),
+        TriggerClass::SourceChange => format!(
+            "source:{}:{}:{}",
+            safe_optional_ref("evidence", input.evidence_signature.as_deref())
+                .unwrap_or_else(|| "evidence_unknown".to_string()),
+            input.subject_kind,
+            input.subject_id
+        ),
+        _ => format!(
+            "{}:{}:{}",
+            policy.reason_code, input.subject_kind, input.subject_id
+        ),
+    }
+}
+
+fn result_kind_for_completion(
+    disposition: TriggerDisposition,
+    surfacing_decision_ids: &[String],
+) -> &'static str {
+    if surfacing_decision_ids.is_empty() {
+        return "prepared_silently";
+    }
+    match disposition {
+        TriggerDisposition::SilentPrepare => "prepared_silently",
+        TriggerDisposition::PrimaryCandidate => "render_decision_recorded",
+        TriggerDisposition::ReviewCandidate => "held_for_review",
+        TriggerDisposition::QuietCandidate => "stayed_quiet",
+    }
+}
+
+fn safe_optional_token(prefix: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| safe_storage_token(prefix, value))
+}
+
+fn safe_optional_ref(prefix: &str, value: Option<&str>) -> Option<String> {
+    value.map(|value| safe_storage_ref(prefix, value))
+}
+
+fn safe_storage_token(prefix: &str, value: &str) -> String {
+    let value = value.trim();
+    if is_safe_storage_token(value) {
+        value.to_string()
+    } else {
+        hashed_storage_ref(prefix, value)
+    }
+}
+
+fn safe_storage_ref(prefix: &str, value: &str) -> String {
+    let value = value.trim();
+    if is_safe_storage_ref(value) {
+        value.to_string()
+    } else {
+        hashed_storage_ref(prefix, value)
+    }
+}
+
+fn is_safe_storage_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b':' | b'.'))
+}
+
+fn is_safe_storage_ref(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 160
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b':' | b'.'))
+}
+
+fn hashed_storage_ref(prefix: &str, value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(b":");
+    hasher.update(value.as_bytes());
+    format!("{prefix}_{}", hex::encode(&hasher.finalize()[..16]))
+}
+
+fn table_exists(conn: &rusqlite::Connection, table: &str) -> Result<bool, TriggerError> {
+    conn.query_row(
+        "SELECT COUNT(*)
+           FROM sqlite_master
+          WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get::<_, i64>(0).map(|count| count > 0),
+    )
+    .map_err(TriggerError::from)
+}
+
+fn decode_string_vec(raw: String) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(&raw).unwrap_or_default()
+}
+
+fn parse_datetime(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S")
+                .map(|value| value.and_utc())
+        })
+        .ok()
+}
+
+fn closed_error_code(error: &SurfacingError) -> &'static str {
+    match error {
+        SurfacingError::UnsupportedSchemaVersion(_) => "unsupported_schema_version",
+        SurfacingError::ClaimNotFound(_) => "claim_not_found",
+        SurfacingError::NotRecommendationClaim(_) => "not_recommendation_claim",
+        SurfacingError::ClaimNotVisible(_) => "claim_not_visible",
+        SurfacingError::MissingStoredSalience(_) => "missing_stored_salience",
+        SurfacingError::Database(_) => "database_error",
+        SurfacingError::Service(_) => "service_error",
+        SurfacingError::Salience(_) => "salience_error",
+        SurfacingError::Signal(_) => "signal_error",
+        SurfacingError::Serialization(_) => "serialization_error",
+    }
+}
+
+fn trigger_class_storage(trigger_class: TriggerClass) -> &'static str {
+    match trigger_class {
+        TriggerClass::ScheduledFreshness => "scheduled_freshness",
+        TriggerClass::EventInvalidation => "event_invalidation",
+        TriggerClass::ManualRefresh => "manual_refresh",
+        TriggerClass::EntityChange => "entity_change",
+        TriggerClass::ClaimChange => "claim_change",
+        TriggerClass::SourceChange => "source_change",
+        TriggerClass::OpenLoopChange => "open_loop_change",
+        TriggerClass::MeetingWindow => "meeting_window",
+        TriggerClass::DecisionWindow => "decision_window",
+        TriggerClass::FeedbackEcho => "feedback_echo",
+    }
+}
+
+fn trigger_kind_storage(trigger_kind: TriggerKind) -> &'static str {
+    match trigger_kind {
+        TriggerKind::SignalArrival => "signal_arrival",
+        TriggerKind::EntityChange => "entity_change",
+        TriggerKind::ScheduledScan => "scheduled_scan",
+        TriggerKind::FeedbackEcho => "feedback_echo",
+    }
+}
+
+fn trigger_source_token(trigger_class: TriggerClass) -> &'static str {
+    match trigger_class {
+        TriggerClass::ScheduledFreshness => "scheduled_scan",
+        TriggerClass::EventInvalidation => "signal_event",
+        TriggerClass::ManualRefresh => "manual_refresh",
+        TriggerClass::EntityChange => "entity_change",
+        TriggerClass::ClaimChange => "claim_change",
+        TriggerClass::SourceChange => "source_change",
+        TriggerClass::OpenLoopChange => "open_loop_change",
+        TriggerClass::MeetingWindow => "meeting_window",
+        TriggerClass::DecisionWindow => "decision_window",
+        TriggerClass::FeedbackEcho => "feedback_echo",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use chrono::TimeZone;
+
+    use abilities_runtime::abilities::provenance::subject::SubjectRef;
+    use abilities_runtime::abilities::trust::types::TrustBand;
+    use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
+
+    use crate::abilities::claims::ClaimType;
+    use crate::services::claims::{
+        commit_claim, update_claim_trust, ClaimProposal, DeterministicInsertProposal, TrustScore,
+    };
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
+    use crate::services::recommendations::contracts::{
+        EvidenceRef, FactorRationale, RecommendationDraft, RecommendedAction, SalienceFactor,
+        SalienceFactorKind, SalienceScore,
+    };
+    use crate::services::recommendations::recommendation::metadata_envelope;
+
+    fn test_db() -> ActionDb {
+        ActionDb::from_connection_for_tests(crate::migrations::migrated_in_memory_for_tests())
+    }
+
+    fn test_ctx() -> (FixedClock, SeedableRng, ExternalClients) {
+        (
+            FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap()),
+            SeedableRng::new(23),
+            ExternalClients::default(),
+        )
+    }
+
+    fn live_ctx<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external).with_actor("system:test")
+    }
+
+    fn insert_recommendation_claim(db: &ActionDb, id: &str, trust_score: f64, source_asof: &str) {
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let draft = RecommendationDraft {
+            subject: SubjectRef::Account("acct-example".to_string()),
+            recommended_action: RecommendedAction::ReviewClaim {
+                claim_id: ClaimId("claim-source".to_string()),
+                reason: "verify".to_string(),
+            },
+            evidence: vec![EvidenceRef {
+                source: "claim:source-1".to_string(),
+                chunk: None,
+            }],
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(source_asof.parse::<DateTime<Utc>>().unwrap()),
+            observed_at: "2026-05-26T10:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+            text: "Review the account before the next customer conversation.".to_string(),
+            salience: SalienceScore {
+                total: 0.75,
+                factors: vec![SalienceFactor {
+                    kind: SalienceFactorKind::Trust,
+                    value: Some(0.9),
+                    weight: 0.1,
+                    rationale: FactorRationale::Trust {
+                        trust_band: TrustBand::LikelyCurrent,
+                    },
+                }],
+            },
+        };
+        let proposal = ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: r#"{"kind":"account","id":"acct-example"}"#.to_string(),
+            claim_type: ClaimType::Recommendation.as_str().to_string(),
+            field_path: Some("recommendation.reviewClaim".to_string()),
+            topic_key: Some("reviewClaim".to_string()),
+            text: draft.text.clone(),
+            actor: "agent".to_string(),
+            data_source: "recommendation".to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(source_asof.to_string()),
+            observed_at: "2026-05-26T10:00:00Z".to_string(),
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            metadata_json: Some(serde_json::to_string(&metadata_envelope(&draft)).unwrap()),
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        };
+        commit_claim(
+            &ctx,
+            db,
+            DeterministicInsertProposal::new(id.to_string(), proposal),
+        )
+        .expect("insert recommendation claim");
+        update_claim_trust(db, id, TrustScore(trust_score), 1, &ctx).expect("seed trust score");
+    }
+
+    fn stored_evidence_signature(db: &ActionDb, claim_id: &str) -> String {
+        let metadata_json: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT metadata_json FROM intelligence_claims WHERE id = ?1",
+                [claim_id],
+                |row| row.get(0),
+            )
+            .expect("read recommendation metadata");
+        claim_evidence_signature(&metadata_json).expect("metadata has evidence signature")
+    }
+
+    #[test]
+    fn trigger_policy_defaults_match_l0_contract() {
+        let cases = [
+            (
+                TriggerClass::ScheduledFreshness,
+                TriggerKind::ScheduledScan,
+                TriggerDisposition::SilentPrepare,
+                0.60,
+                86_400,
+            ),
+            (
+                TriggerClass::EventInvalidation,
+                TriggerKind::SignalArrival,
+                TriggerDisposition::PrimaryCandidate,
+                0.70,
+                21_600,
+            ),
+            (
+                TriggerClass::ManualRefresh,
+                TriggerKind::SignalArrival,
+                TriggerDisposition::ReviewCandidate,
+                0.50,
+                0,
+            ),
+            (
+                TriggerClass::EntityChange,
+                TriggerKind::EntityChange,
+                TriggerDisposition::PrimaryCandidate,
+                0.65,
+                21_600,
+            ),
+            (
+                TriggerClass::ClaimChange,
+                TriggerKind::SignalArrival,
+                TriggerDisposition::PrimaryCandidate,
+                0.70,
+                21_600,
+            ),
+            (
+                TriggerClass::SourceChange,
+                TriggerKind::SignalArrival,
+                TriggerDisposition::ReviewCandidate,
+                0.75,
+                21_600,
+            ),
+            (
+                TriggerClass::OpenLoopChange,
+                TriggerKind::SignalArrival,
+                TriggerDisposition::QuietCandidate,
+                0.55,
+                43_200,
+            ),
+            (
+                TriggerClass::MeetingWindow,
+                TriggerKind::EntityChange,
+                TriggerDisposition::PrimaryCandidate,
+                0.65,
+                7_200,
+            ),
+            (
+                TriggerClass::DecisionWindow,
+                TriggerKind::ScheduledScan,
+                TriggerDisposition::PrimaryCandidate,
+                0.70,
+                43_200,
+            ),
+            (
+                TriggerClass::FeedbackEcho,
+                TriggerKind::FeedbackEcho,
+                TriggerDisposition::QuietCandidate,
+                0.50,
+                604_800,
+            ),
+        ];
+
+        for (trigger_class, trigger_kind, trigger_disposition, trust_floor, freshness_window) in
+            cases
+        {
+            let policy = policy_for_trigger(trigger_class);
+            assert_eq!(policy.trigger_kind, trigger_kind);
+            assert_eq!(policy.trigger_disposition, trigger_disposition);
+            assert!((policy.trust_floor - trust_floor).abs() < f64::EPSILON);
+            assert_eq!(policy.freshness_window_secs, freshness_window);
+        }
+    }
+
+    #[test]
+    fn scheduled_refresh_logs_trigger_and_invokes_w2a_evaluation() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-1", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let outcome = run_trigger_scan(
+            &ctx,
+            &db,
+            &engine,
+            TriggerScanInput::scheduled("account", "acct-example"),
+        )
+        .expect("trigger scan succeeds");
+
+        assert_eq!(outcome.status, TriggerScanStatus::Completed);
+        assert_eq!(outcome.candidate_claim_ids, vec!["claim-trigger-1"]);
+        assert_eq!(outcome.salience_evaluation_ids.len(), 1);
+        assert_eq!(outcome.surfacing_decision_ids.len(), 1);
+        let stored_salience_ids: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT salience_evaluation_ids_json FROM triggers_log WHERE run_id = ?1",
+                [&outcome.run_id],
+                |row| row.get(0),
+            )
+            .expect("read trigger log salience ids");
+        assert!(stored_salience_ids.contains(&outcome.salience_evaluation_ids[0]));
+        let decision_salience_id: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT salience_evaluation_id FROM surfacing_decisions WHERE id = ?1",
+                [&outcome.surfacing_decision_ids[0]],
+                |row| row.get(0),
+            )
+            .expect("read surfacing decision");
+        assert_eq!(decision_salience_id, outcome.salience_evaluation_ids[0]);
+        let decision_surface_class: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT surface_class FROM surfacing_decisions WHERE id = ?1",
+                [&outcome.surfacing_decision_ids[0]],
+                |row| row.get(0),
+            )
+            .expect("read surfacing class");
+        assert_eq!(decision_surface_class, "background");
+        let (trigger_disposition, result_kind, downstream_policy): (String, String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT trigger_disposition, result_kind, downstream_policy
+                   FROM triggers_log
+                  WHERE run_id = ?1",
+                [&outcome.run_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read trigger disposition");
+        assert_eq!(trigger_disposition, "silent_prepare");
+        assert_eq!(result_kind, "prepared_silently");
+        assert_eq!(downstream_policy, DOWNSTREAM_POLICY);
+    }
+
+    #[test]
+    fn duplicate_completed_scan_coalesces_without_new_log_row() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-dup", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let input = TriggerScanInput::scheduled("account", "acct-example");
+
+        let first = run_trigger_scan(&ctx, &db, &engine, input.clone()).expect("first scan");
+        let second = run_trigger_scan(&ctx, &db, &engine, input).expect("second scan");
+
+        assert_eq!(second.status, TriggerScanStatus::CoalescedCompleted);
+        assert_eq!(second.run_id, first.run_id);
+        let log_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM triggers_log", [], |row| row.get(0))
+            .expect("count trigger logs");
+        assert_eq!(log_rows, 1);
+    }
+
+    #[test]
+    fn scheduled_refresh_dedupe_is_per_day() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-daily", 0.95, "2026-05-26T10:00:00Z");
+        let rng = SeedableRng::new(17);
+        let external = ExternalClients::default();
+        let first_clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 26, 23, 59, 0).unwrap());
+        let second_clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 27, 0, 1, 0).unwrap());
+        let first_ctx = live_ctx(&first_clock, &rng, &external);
+        let second_ctx = live_ctx(&second_clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let input = TriggerScanInput::scheduled("account", "acct-example");
+
+        let first = run_trigger_scan(&first_ctx, &db, &engine, input.clone()).expect("first scan");
+        let second = run_trigger_scan(&second_ctx, &db, &engine, input).expect("second scan");
+
+        assert_eq!(first.status, TriggerScanStatus::Completed);
+        assert_eq!(second.status, TriggerScanStatus::Completed);
+        assert_ne!(first.run_id, second.run_id);
+        let log_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM triggers_log", [], |row| row.get(0))
+            .expect("count trigger logs");
+        assert_eq!(log_rows, 2);
+    }
+
+    #[test]
+    fn manual_refresh_dedupe_uses_explicit_run_id() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-manual", 0.95, "2026-05-20T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut first = TriggerScanInput::scheduled("account", "acct-example");
+        first.trigger_class = TriggerClass::ManualRefresh;
+        first.run_id = Some("manual-run-1".to_string());
+        let mut second = first.clone();
+        second.run_id = Some("manual-run-2".to_string());
+
+        let first_outcome = run_trigger_scan(&ctx, &db, &engine, first).expect("first manual run");
+        let second_outcome =
+            run_trigger_scan(&ctx, &db, &engine, second).expect("second manual run");
+
+        assert_eq!(first_outcome.status, TriggerScanStatus::Completed);
+        assert_eq!(second_outcome.status, TriggerScanStatus::Completed);
+        assert_ne!(first_outcome.run_id, second_outcome.run_id);
+        let log_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM triggers_log", [], |row| row.get(0))
+            .expect("count trigger logs");
+        assert_eq!(log_rows, 2);
+    }
+
+    #[test]
+    fn unchanged_evidence_signature_does_not_override_recent_feedback() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-feedback", 0.95, "2026-05-26T10:00:00Z");
+        let signature = stored_evidence_signature(&db, "claim-trigger-feedback");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO claim_feedback (
+                     id, claim_id, feedback_type, actor, actor_id, submitted_at
+                 ) VALUES (
+                     'feedback-trigger-suppress-1', 'claim-trigger-feedback',
+                     'not_relevant_here', 'user', 'user-1', '2026-05-26T11:00:00Z'
+                 )",
+                [],
+            )
+            .expect("insert feedback");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut input = TriggerScanInput::scheduled("account", "acct-example");
+        input.trigger_class = TriggerClass::SourceChange;
+        input.run_id = Some("trigger-source-same-evidence".to_string());
+        input.evidence_signature = Some(signature);
+
+        let outcome = run_trigger_scan(&ctx, &db, &engine, input).expect("source trigger");
+
+        assert_eq!(outcome.status, TriggerScanStatus::Completed);
+        let (decision_kind, suppress_reason): (String, Option<String>) = db
+            .conn_ref()
+            .query_row(
+                "SELECT decision_kind, suppress_reason
+                   FROM surfacing_decisions
+                  WHERE id = ?1",
+                [&outcome.surfacing_decision_ids[0]],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read surfacing decision");
+        assert_eq!(decision_kind, "suppress");
+        assert_eq!(suppress_reason.as_deref(), Some("dismissed_recently"));
+    }
+
+    #[test]
+    fn entity_change_subject_version_breaks_trigger_dedupe() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-versioned", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut first = TriggerScanInput::scheduled("account", "acct-example");
+        first.trigger_class = TriggerClass::EntityChange;
+        first.run_id = Some("trigger-entity-version-1".to_string());
+        first.subject_version = Some(1);
+        let mut second = first.clone();
+        second.run_id = Some("trigger-entity-version-2".to_string());
+        second.subject_version = Some(2);
+
+        let first_outcome = run_trigger_scan(&ctx, &db, &engine, first).expect("first trigger");
+        let second_outcome = run_trigger_scan(&ctx, &db, &engine, second).expect("second trigger");
+
+        assert_eq!(first_outcome.status, TriggerScanStatus::Completed);
+        assert_eq!(second_outcome.status, TriggerScanStatus::Completed);
+        assert_ne!(first_outcome.run_id, second_outcome.run_id);
+        let log_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM triggers_log", [], |row| row.get(0))
+            .expect("count trigger logs");
+        assert_eq!(log_rows, 2);
+    }
+
+    #[test]
+    fn stale_source_is_not_selected_for_routine_refresh() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-stale", 0.95, "2026-05-20T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+
+        let outcome = run_trigger_scan(
+            &ctx,
+            &db,
+            &engine,
+            TriggerScanInput::scheduled("account", "acct-example"),
+        )
+        .expect("scan succeeds");
+
+        assert!(outcome.candidate_claim_ids.is_empty());
+        assert!(outcome.salience_evaluation_ids.is_empty());
+    }
+
+    #[test]
+    fn source_change_uses_trigger_freshness_for_stale_candidate() {
+        let db = test_db();
+        insert_recommendation_claim(
+            &db,
+            "claim-stale-source-change",
+            0.95,
+            "2026-05-20T10:00:00Z",
+        );
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut input = TriggerScanInput::scheduled("account", "acct-example");
+        input.trigger_class = TriggerClass::SourceChange;
+        input.run_id = Some("trigger-source-fresh-stale-claim".to_string());
+        input.source_signal_id = Some("signal-source-fresh".to_string());
+        input.source_asof = Some(Utc.with_ymd_and_hms(2026, 5, 26, 11, 30, 0).unwrap());
+
+        let outcome = run_trigger_scan(&ctx, &db, &engine, input).expect("source trigger");
+
+        assert_eq!(outcome.status, TriggerScanStatus::Completed);
+        assert_eq!(
+            outcome.candidate_claim_ids,
+            vec!["claim-stale-source-change"]
+        );
+        assert_eq!(outcome.salience_evaluation_ids.len(), 1);
+        let decision_surface_class: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT surface_class FROM surfacing_decisions WHERE id = ?1",
+                [&outcome.surfacing_decision_ids[0]],
+                |row| row.get(0),
+            )
+            .expect("read source-change surfacing class");
+        assert_eq!(decision_surface_class, "review");
+    }
+
+    #[test]
+    fn signal_emit_failure_marks_started_trigger_retryable() {
+        let db = test_db();
+        insert_recommendation_claim(
+            &db,
+            "claim-trigger-signal-error",
+            0.95,
+            "2026-05-26T10:00:00Z",
+        );
+        db.conn_ref()
+            .execute("DROP TABLE signal_events", [])
+            .expect("remove signal table");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut input = TriggerScanInput::scheduled("account", "acct-example");
+        input.run_id = Some("trigger-signal-error-run".to_string());
+
+        let error = run_trigger_scan(&ctx, &db, &engine, input).expect_err("signal emit fails");
+
+        assert!(matches!(error, TriggerError::Signal(_)));
+        let (status, error_code): (String, Option<String>) = db
+            .conn_ref()
+            .query_row(
+                "SELECT status, error_code
+                   FROM triggers_log
+                  WHERE run_id = 'trigger-signal-error-run'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read failed trigger");
+        assert_eq!(status, "failed_retryable");
+        assert_eq!(error_code.as_deref(), Some("signal_emit_failed"));
+    }
+
+    #[test]
+    fn trigger_log_hashes_untrusted_source_fields() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-privacy", 0.95, "2026-05-20T10:00:00Z");
+        let (clock, rng, external) = test_ctx();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let engine = PropagationEngine::new();
+        let mut input = TriggerScanInput::scheduled("account", "acct-example");
+        input.trigger_class = TriggerClass::SourceChange;
+        input.run_id = Some("trigger-privacy-run".to_string());
+        input.source_signal_id = Some("/Users/example/raw-workspace-note.md".to_string());
+        input.source_signal_type = Some("prompt body from provider output".to_string());
+        input.evidence_signature = Some("provider output /Users/example/raw body".to_string());
+        input.source_asof = Some(Utc.with_ymd_and_hms(2026, 5, 26, 11, 30, 0).unwrap());
+
+        let outcome = run_trigger_scan(&ctx, &db, &engine, input).expect("privacy trigger");
+
+        assert_eq!(outcome.status, TriggerScanStatus::Completed);
+        let (
+            source_signal_id,
+            source_signal_type,
+            evidence_signature,
+            dedupe_key,
+            suppression_key,
+            result_kind,
+        ): (String, String, String, String, String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT source_signal_id, source_signal_type, evidence_signature,
+                        dedupe_key, suppression_key, result_kind
+                   FROM triggers_log
+                  WHERE run_id = ?1",
+                [&outcome.run_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .expect("read trigger privacy fields");
+        let decision_source_signal_id: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT source_signal_id
+                   FROM surfacing_decisions
+                  WHERE id = ?1",
+                [&outcome.surfacing_decision_ids[0]],
+                |row| row.get(0),
+            )
+            .expect("read surfacing source signal");
+        let signal_values: Vec<String> = {
+            let mut stmt = db
+                .conn_ref()
+                .prepare(
+                    "SELECT COALESCE(value, '')
+                       FROM signal_events
+                      WHERE data_source IN (
+                          'recommendation_trigger_policy',
+                          'recommendation_surfacing_policy'
+                      )
+                      ORDER BY created_at, id",
+                )
+                .expect("prepare signal value query");
+            stmt.query_map([], |row| row.get::<_, String>(0))
+                .expect("query signal values")
+                .collect::<Result<Vec<_>, _>>()
+                .expect("collect signal values")
+        };
+
+        assert!(source_signal_id.starts_with("signal_ref_"));
+        assert!(decision_source_signal_id.starts_with("signal_ref_"));
+        assert!(source_signal_type.starts_with("signal_type_"));
+        assert!(evidence_signature.starts_with("evidence_"));
+        assert_eq!(result_kind, "held_for_review");
+
+        let persisted = format!(
+            "{source_signal_id} {decision_source_signal_id} {source_signal_type} \
+             {evidence_signature} {dedupe_key} {suppression_key} {}",
+            signal_values.join(" ")
+        );
+        for forbidden in [
+            "/Users/example",
+            "raw-workspace-note",
+            "prompt body",
+            "provider output",
+            "raw body",
+        ] {
+            assert!(
+                !persisted.contains(forbidden),
+                "persisted trigger artifacts leaked `{forbidden}`: {persisted}"
+            );
+        }
+    }
+
+    #[test]
+    fn evaluate_mode_does_not_write_or_emit() {
+        let db = test_db();
+        insert_recommendation_claim(&db, "claim-trigger-eval", 0.95, "2026-05-26T10:00:00Z");
+        let (clock, rng, _external) = test_ctx();
+        let ctx = ServiceContext::new_evaluate_default(&clock, &rng).with_actor("system:test");
+        let engine = PropagationEngine::new();
+
+        let outcome = run_trigger_scan(
+            &ctx,
+            &db,
+            &engine,
+            TriggerScanInput::scheduled("account", "acct-example"),
+        )
+        .expect("evaluate mode returns no-op outcome");
+
+        assert_eq!(outcome.status, TriggerScanStatus::EvaluateOnly);
+        let trigger_rows: i64 = db
+            .conn_ref()
+            .query_row("SELECT COUNT(*) FROM triggers_log", [], |row| row.get(0))
+            .expect("count trigger logs");
+        let signal_rows: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*) FROM signal_events WHERE signal_type = 'salience_candidate_refresh_triggered'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count signals");
+        assert_eq!(trigger_rows, 0);
+        assert_eq!(signal_rows, 0);
+    }
+}

--- a/src-tauri/src/services/recommendations/why_this_now.rs
+++ b/src-tauri/src/services/recommendations/why_this_now.rs
@@ -1,6 +1,214 @@
 //! Deterministic `why this now` rationale construction.
 //!
 //! Given a scored candidate, returns a typed `WhyThisNow` payload
-//! built from the primary factor and a closed set of triggers. The
-//! render layer formats this for display; no string templating
-//! happens here. No provider / LLM call from this module.
+//! built from the primary factor and a closed set of triggers. No
+//! provider / LLM call from this module.
+
+use chrono::{DateTime, Utc};
+
+use super::contracts::{
+    FactorRationale, SalienceFactor, SalienceFactorKind, SalienceScore, TriggerKind, TriggerRef,
+    WhyThisNow,
+};
+
+const MAX_TRIGGER_SUMMARY_ITEMS: usize = 3;
+
+pub fn why_this_now_for_score(
+    score: &SalienceScore,
+    triggers: &[TriggerRef],
+    now: DateTime<Utc>,
+) -> WhyThisNow {
+    let primary = primary_factor(score);
+    let sanitized_triggers = sanitize_trigger_refs(triggers, now);
+    let text = format!(
+        "Salience driven by {}: {}. Triggers: {}.",
+        factor_label(primary.kind),
+        rationale_summary(&primary.rationale),
+        trigger_summary(&sanitized_triggers)
+    );
+
+    WhyThisNow {
+        primary_factor: primary.kind,
+        text,
+        triggers: sanitized_triggers,
+    }
+}
+
+pub fn sanitized_trigger_ref(
+    trigger_kind: TriggerKind,
+    source: &str,
+    at: DateTime<Utc>,
+) -> TriggerRef {
+    TriggerRef {
+        trigger_kind,
+        at,
+        source: sanitize_trigger_source(trigger_kind, source).to_string(),
+    }
+}
+
+fn primary_factor(score: &SalienceScore) -> SalienceFactor {
+    score
+        .factors
+        .iter()
+        .filter(|factor| factor.value.is_some())
+        .max_by(|left, right| weighted_value(left).total_cmp(&weighted_value(right)))
+        .cloned()
+        .or_else(|| score.factors.first().cloned())
+        .unwrap_or(SalienceFactor {
+            kind: SalienceFactorKind::Freshness,
+            value: Some(0.0),
+            weight: 1.0,
+            rationale: FactorRationale::Freshness { decay_factor: 0.0 },
+        })
+}
+
+fn weighted_value(factor: &SalienceFactor) -> f64 {
+    factor.value.unwrap_or(0.0) * factor.weight
+}
+
+fn sanitize_trigger_refs(triggers: &[TriggerRef], now: DateTime<Utc>) -> Vec<TriggerRef> {
+    if triggers.is_empty() {
+        return vec![sanitized_trigger_ref(
+            TriggerKind::ScheduledScan,
+            "scheduled_scan",
+            now,
+        )];
+    }
+
+    triggers
+        .iter()
+        .map(|trigger| {
+            sanitized_trigger_ref(trigger.trigger_kind, trigger.source.as_str(), trigger.at)
+        })
+        .collect()
+}
+
+fn sanitize_trigger_source(kind: TriggerKind, source: &str) -> &str {
+    match source {
+        "scheduled_scan" | "signal_event" | "entity_change" | "manual_refresh"
+        | "feedback_echo" | "claim_change" | "source_change" | "open_loop_change"
+        | "meeting_window" | "decision_window" => source,
+        _ => match kind {
+            TriggerKind::SignalArrival => "signal_event",
+            TriggerKind::EntityChange => "entity_change",
+            TriggerKind::ScheduledScan => "scheduled_scan",
+            TriggerKind::FeedbackEcho => "feedback_echo",
+        },
+    }
+}
+
+fn trigger_summary(triggers: &[TriggerRef]) -> String {
+    let mut sources = triggers
+        .iter()
+        .map(|trigger| trigger.source.as_str())
+        .collect::<Vec<_>>();
+    sources.sort_unstable();
+    sources.dedup();
+
+    if sources.is_empty() {
+        return "scheduled_scan".to_string();
+    }
+
+    let mut summary = sources
+        .iter()
+        .take(MAX_TRIGGER_SUMMARY_ITEMS)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+    if sources.len() > MAX_TRIGGER_SUMMARY_ITEMS {
+        summary.push_str(", additional_trigger");
+    }
+    summary
+}
+
+fn factor_label(kind: SalienceFactorKind) -> &'static str {
+    match kind {
+        SalienceFactorKind::Importance => "importance",
+        SalienceFactorKind::Novelty => "novelty",
+        SalienceFactorKind::Urgency => "urgency",
+        SalienceFactorKind::Timing => "timing",
+        SalienceFactorKind::UserFit => "user fit",
+        SalienceFactorKind::Freshness => "freshness",
+        SalienceFactorKind::Trust => "trust",
+        SalienceFactorKind::Corroboration => "corroboration",
+        SalienceFactorKind::Contradiction => "contradiction",
+        SalienceFactorKind::OpenLoopRelevance => "open loop relevance",
+    }
+}
+
+fn rationale_summary(rationale: &FactorRationale) -> &'static str {
+    match rationale {
+        FactorRationale::Importance { .. } => "trusted source strength",
+        FactorRationale::Novelty { .. } => "new compared with nearby memory",
+        FactorRationale::Urgency { .. } => "deadline or time pressure",
+        FactorRationale::Timing { .. } => "recent signal timing",
+        FactorRationale::UserFit { .. } => "prior feedback fit",
+        FactorRationale::Freshness { .. } => "current source timing",
+        FactorRationale::Trust { .. } => "trust band",
+        FactorRationale::Corroboration { .. } => "supporting evidence count",
+        FactorRationale::Contradiction { .. } => "contradiction state",
+        FactorRationale::OpenLoopRelevance { .. } => "open loop relevance",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use abilities_runtime::abilities::trust::types::TrustBand;
+
+    #[test]
+    fn rationale_uses_closed_tokens_and_sanitized_trigger_sources() {
+        let now = "2026-05-26T12:00:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("fixture time parses");
+        let score = SalienceScore {
+            total: 0.9,
+            factors: vec![SalienceFactor {
+                kind: SalienceFactorKind::Urgency,
+                value: Some(0.95),
+                weight: 0.15,
+                rationale: FactorRationale::Urgency {
+                    deadline: Some(now),
+                    decay_factor: 0.95,
+                },
+            }],
+        };
+        let trigger = TriggerRef {
+            trigger_kind: TriggerKind::SignalArrival,
+            at: now,
+            source: "/Users/example/raw/file.md".to_string(),
+        };
+
+        let why = why_this_now_for_score(&score, &[trigger], now);
+
+        assert_eq!(why.primary_factor, SalienceFactorKind::Urgency);
+        assert_eq!(why.triggers[0].source, "signal_event");
+        assert!(why.text.contains("urgency"));
+        assert!(!why.text.contains("/Users/"));
+        assert!(!serde_json::to_string(&why).unwrap().contains("/Users/"));
+    }
+
+    #[test]
+    fn empty_triggers_default_to_scheduled_scan() {
+        let now = "2026-05-26T12:00:00Z"
+            .parse::<DateTime<Utc>>()
+            .expect("fixture time parses");
+        let score = SalienceScore {
+            total: 0.4,
+            factors: vec![SalienceFactor {
+                kind: SalienceFactorKind::Trust,
+                value: Some(0.6),
+                weight: 0.1,
+                rationale: FactorRationale::Trust {
+                    trust_band: TrustBand::UseWithCaution,
+                },
+            }],
+        };
+
+        let why = why_this_now_for_score(&score, &[], now);
+
+        assert_eq!(why.triggers[0].source, "scheduled_scan");
+        assert!(why.text.contains("scheduled_scan"));
+    }
+}


### PR DESCRIPTION
## Linear ticket

DOS-331, DOS-334

## Summary

Implements v1.4.6 W2 recommendation surfacing and trigger policy so salience candidates can render, defer, stay quiet, or be held for review with inspectable audit records.

## What changed

- Added surfacing decisions schema, trigger log schema, and v273 W2 shape repair/sanitization.
- Implemented recommendation surfacing policy with budgets, cooldowns, dismissal suppression, material-evidence bypass, and privacy-safe source signal storage.
- Implemented trigger orchestration with typed trigger classes, dispositions, dedupe/suppression keys, retry state, and downstream surfacing handoff.
- Wired devtools visibility and why-this-now trigger context.
- Added W2 L0 packet/review artifacts and updated the v1.4.6 wave docs/HTML.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes via commit hook
- [ ] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (if frontend changes)
- [x] Manual verification: local L2 cycle 4 PASS; PR #404 is mergeable and CI started.

Additional focused validation:

- [x] `cargo test migration_273 -- --nocapture`
- [x] `cargo test recommendations::surfacing --lib -- --nocapture`
- [x] `cargo test recommendations::triggers --lib -- --nocapture`
- [x] touched-file `rustfmt --check`
- [x] `git diff --check`

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [ ] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: Not exempt. This PR touches service code, migration registration, and SQL migrations, and it persists privacy-sensitive audit metadata. W2 L0 included security-lens review and local L2 focused on privacy-safe persisted trigger/surfacing audit data.

- [x] Touches service, ability, bridge, command, or intelligence paths.
- [x] Modifies SQL migrations and migration registration.
- [ ] Touches a claim-substrate table.
- [ ] Changes a prompt template.
- [x] Modifies rendering policy or redaction-adjacent logic.
- [ ] Modifies MCP configs, tool registry, or skill definitions.
- [ ] Adds a new trust boundary.
- [ ] Defines a privileged action.
- [ ] Adds or modifies GitHub workflows with elevated authority.
- [ ] Adds a new dependency.

## Follow-ups

- None from this W2 slice.

## Notes for review

- L2 cycle 3 repeated a stale final-shaped v273 sanitization concern; the current diff already had the sanitize calls and the added regression test. Cycle 4 reran against a fresh diff and passed.
- Full `cargo fmt --check` is known to fail on unrelated abilities-runtime formatting in this worktree; touched W2 Rust files pass `rustfmt --check`.
