### PR TITLE
v1.4.6 W3-A: Suggested Next Steps block + ability (DOS-298)

### DIFF
--- a/.docs/design/reference/surfaces/account.html
+++ b/.docs/design/reference/surfaces/account.html
@@ -76,7 +76,7 @@
   data-folio-date="MONDAY, MAY 4, 2026"
   data-folio-actions="refresh,reports,tools"
   data-folio-refresh-title="Refresh account"
-  data-chapters="headline:alignleft:The Headline|outlook:compass:Outlook|state-of-play:activity:State of Play|the-room:users:The Room|watch-list:eye:Watch List|value-commitments:star:Value & Commitments|strategic-landscape:compass:Competitive & Strategic|the-record:activity:The Record|the-work:checksquare:The Work|reports:filetext:Reports">
+  data-chapters="headline:alignleft:The Headline|outlook:compass:Outlook|state-of-play:activity:State of Play|the-room:users:The Room|whats-next:arrowright:What's Next|watch-list:eye:Watch List|value-commitments:star:Value & Commitments|strategic-landscape:compass:Competitive & Strategic|the-record:activity:The Record|the-work:checksquare:The Work|reports:filetext:Reports">
 
 <!-- MagazinePageLayout shell — mirrors src/components/layout/MagazinePageLayout.tsx.
      Folio bar, atmosphere, and floating nav are injected by chrome.js. -->
@@ -511,6 +511,113 @@
               Add
             </button>
           </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div id="whats-next" class="editorial-reveal entity-detail_marginLabelSection">
+    <div class="entity-detail_marginLabel">What's<br/>Next</div>
+    <div class="entity-detail_marginContent">
+      <section class="SuggestedNextSteps_section" data-surface="account">
+        <div class="ChapterHeading_heading">
+          <hr class="ChapterHeading_rule" />
+          <div class="ChapterHeading_titleRow">
+            <h2 class="ChapterHeading_title">What's next with Acme Corp</h2>
+          </div>
+          <p class="ChapterHeading_epigraph">Five recommendations to consider this week.</p>
+        </div>
+
+        <div class="suggested-next-steps_list">
+          <article class="suggested-next-steps_row" data-claim-id="rec-claim-1" data-feedback-state="pending">
+            <header class="suggested-next-steps_rowHeader">
+              <h3 class="suggested-next-steps_headline">Schedule kickoff with their new VP of Engineering<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+            </header>
+            <p class="suggested-next-steps_whyThisNow">Urgency this week — first 30 days for the new role, and you don't have a thread open yet.</p>
+            <p class="suggested-next-steps_action">Schedule meeting &middot; next two weeks</p>
+            <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-1-more" aria-label="More feedback options">More feedback&hellip;</button>
+            </div>
+            <div id="rec-claim-1-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+            </div>
+          </article>
+
+          <article class="suggested-next-steps_row" data-claim-id="rec-claim-2" data-feedback-state="pending">
+            <header class="suggested-next-steps_rowHeader">
+              <h3 class="suggested-next-steps_headline">Send the H1 expansion follow-up Jen asked for<span class="TrustBandIndicator TrustBandIndicator_useWithCaution" title="Use with caution">&#9679;</span></h3>
+            </header>
+            <p class="suggested-next-steps_whyThisNow">Open loop since the May 12 review — the proposal owner and due date were promised in the meeting recap.</p>
+            <p class="suggested-next-steps_action">Send message &middot; email &middot; Jen Park</p>
+            <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-2-more" aria-label="More feedback options">More feedback&hellip;</button>
+            </div>
+            <div id="rec-claim-2-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+            </div>
+          </article>
+
+          <article class="suggested-next-steps_row suggested-next-steps_row--needsVerification" data-claim-id="rec-claim-3" data-feedback-state="pending">
+            <header class="suggested-next-steps_rowHeader">
+              <h3 class="suggested-next-steps_headline">Verify the procurement timeline shift Dan mentioned<span class="TrustBandIndicator TrustBandIndicator_needsVerification" title="Needs verification">&#9679;</span></h3>
+            </header>
+            <p class="suggested-next-steps_whyThisNow">A trust change worth checking — only one source mentions the shift and finance hasn't echoed it.</p>
+            <p class="suggested-next-steps_action">Investigate change &middot; renewal timeline</p>
+            <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-3-more" aria-label="More feedback options">More feedback&hellip;</button>
+            </div>
+            <div id="rec-claim-3-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+            </div>
+          </article>
+
+          <article class="suggested-next-steps_row" data-claim-id="rec-claim-4" data-feedback-state="pending">
+            <header class="suggested-next-steps_rowHeader">
+              <h3 class="suggested-next-steps_headline">Confirm Sara's support-workflow rollout dates<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+            </header>
+            <p class="suggested-next-steps_whyThisNow">Open loop on the support workflow rehearsal — dates not yet committed in the renewal package.</p>
+            <p class="suggested-next-steps_action">Send message &middot; Slack &middot; Sara Wu</p>
+            <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-4-more" aria-label="More feedback options">More feedback&hellip;</button>
+            </div>
+            <div id="rec-claim-4-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+            </div>
+          </article>
+
+          <article class="suggested-next-steps_row" data-claim-id="rec-claim-5" data-feedback-state="pending">
+            <header class="suggested-next-steps_rowHeader">
+              <h3 class="suggested-next-steps_headline">Update the renewal record with the new VP context<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+            </header>
+            <p class="suggested-next-steps_whyThisNow">New information on the account — the field history hasn't caught up to last week's signal.</p>
+            <p class="suggested-next-steps_action">Update record &middot; account notes</p>
+            <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+              <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-5-more" aria-label="More feedback options">More feedback&hellip;</button>
+            </div>
+            <div id="rec-claim-5-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+              <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+            </div>
+          </article>
         </div>
       </section>
     </div>

--- a/.docs/design/reference/surfaces/meeting.html
+++ b/.docs/design/reference/surfaces/meeting.html
@@ -42,7 +42,7 @@
   data-nav-base="."
   data-folio-actions="refresh"
   data-folio-refresh-title="Check for updates"
-  data-chapters="headline:alignleft:The Brief|risks:alerttriangle:Risks|the-room:users:The Room|your-plan:target:Your Plan">
+  data-chapters="headline:alignleft:The Brief|risks:alerttriangle:Risks|the-room:users:The Room|what-to-cover:arrowright:What to Cover|your-plan:target:Your Plan">
 
 <!-- MagazinePageLayout shell — mirrors src/components/layout/MagazinePageLayout.tsx.
      Folio bar, atmosphere, and floating nav are injected by chrome.js. -->
@@ -657,6 +657,90 @@
             <span class="IntelligenceFeedback_wrapper"><span class="IntelligenceFeedback_container"><button type="button" class="IntelligenceFeedback_button" aria-label="This was helpful" aria-pressed="false" title="Helpful"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z"/></svg></button><button type="button" class="IntelligenceFeedback_button" aria-label="This was not helpful" aria-pressed="false" title="Not helpful"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 14V2"/><path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22h0a3.13 3.13 0 0 1-3-3.88Z"/></svg></button></span></span>
           </span>
         </div>
+      </div>
+    </section>
+
+    <section id="what-to-cover" class="editorial-reveal meeting-intel_chapterSection SuggestedNextSteps_section" data-surface="meeting">
+      <div class="ChapterHeading_heading">
+        <hr class="ChapterHeading_rule">
+        <div class="ChapterHeading_titleRow">
+          <h2 class="ChapterHeading_title">What to cover</h2>
+        </div>
+        <p class="ChapterHeading_epigraph">Four prep topics worth landing.</p>
+      </div>
+
+      <div class="suggested-next-steps_list">
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-1" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Confirm the MSA redline owner and timing<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Urgency &mdash; the renewal is one week out and legal hasn't named who'll review the redlines yet.</p>
+          <p class="suggested-next-steps_action">Cover in meeting &middot; ask for owner + ETA</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-1-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-1-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-2" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Walk through the support-workflow proof point with Sara<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Open loop &mdash; she ran the rehearsal but the team hasn't validated the workflow for the renewal package.</p>
+          <p class="suggested-next-steps_action">Cover in meeting &middot; demo the rehearsal output</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-2-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-2-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row suggested-next-steps_row--needsVerification" data-claim-id="rec-claim-3" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Probe the procurement-timeline rumor Dan mentioned<span class="TrustBandIndicator TrustBandIndicator_needsVerification" title="Needs verification">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Trust change worth checking &mdash; one source, no echo from finance; ask carefully without assuming.</p>
+          <p class="suggested-next-steps_action">Cover in meeting &middot; open-ended question</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-3-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-3-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-4" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Acknowledge the new VP context Jen flagged<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">New information &mdash; raised informally last week; worth surfacing so it doesn't sit untreated.</p>
+          <p class="suggested-next-steps_action">Cover in meeting &middot; acknowledge + next-step</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-4-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-4-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
       </div>
     </section>
 

--- a/.docs/design/reference/surfaces/person.html
+++ b/.docs/design/reference/surfaces/person.html
@@ -48,7 +48,7 @@
   data-active-page="people"
   data-folio-crumbs="Reference > Surfaces > Person"
   data-nav-base="."
-  data-chapters="headline:alignleft:The Profile|the-dynamic:activity:The Dynamic|their-orbit:network:Their Orbit|their-network:users:Their Network|the-landscape:eye:The Landscape|the-record:activity:The Record|the-work:checksquare:The Work">
+  data-chapters="headline:alignleft:The Profile|the-dynamic:activity:The Dynamic|their-orbit:network:Their Orbit|their-network:users:Their Network|the-landscape:eye:The Landscape|open-threads:arrowright:Open Threads|the-record:activity:The Record|the-work:checksquare:The Work">
 
 <!-- MagazinePageLayout shell — mirrors src/components/layout/MagazinePageLayout.tsx.
      Folio bar, atmosphere, and floating nav are injected by chrome.js. -->
@@ -404,6 +404,93 @@
             </button>
           </div>
         </div>
+      </div>
+    </section>
+  </div>
+
+  <!-- Chapter 5.5: Open Threads. -->
+  <div id="open-threads" class="editorial-reveal entity-detail_chapterSectionWithPadding">
+    <section class="SuggestedNextSteps_section" data-surface="person">
+      <div class="ChapterHeading_heading">
+        <hr class="ChapterHeading_rule" />
+        <div class="ChapterHeading_titleRow">
+          <h2 class="ChapterHeading_title">Open threads with Jen Park</h2>
+        </div>
+        <p class="ChapterHeading_epigraph">Four threads to carry into the next 1:1.</p>
+      </div>
+
+      <div class="suggested-next-steps_list">
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-1" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Follow up on the H1 expansion proposal owner she asked for<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Open loop since May 12 &mdash; the owner and due date were promised in your last meeting recap.</p>
+          <p class="suggested-next-steps_action">Send message &middot; email &middot; Jen Park</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-1-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-1-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-2" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Cover the new VP of Engineering she flagged informally<span class="TrustBandIndicator TrustBandIndicator_useWithCaution" title="Use with caution">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">New information &mdash; she mentioned it in passing on May 18; not yet reflected in the relationship record.</p>
+          <p class="suggested-next-steps_action">Schedule meeting &middot; next 1:1 &middot; agenda item</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-2-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-2-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row suggested-next-steps_row--needsVerification" data-claim-id="rec-claim-3" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Confirm the timing shift she hinted at last week<span class="TrustBandIndicator TrustBandIndicator_needsVerification" title="Needs verification">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Trust change worth checking &mdash; one mention in a side-channel; nothing else has corroborated yet.</p>
+          <p class="suggested-next-steps_action">Investigate change &middot; timeline signal</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-3-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-3-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-4" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Update her engagement note with the new sponsor signal<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">New information &mdash; she stepped in on the renewal call without prompting, which is a sponsor pattern.</p>
+          <p class="suggested-next-steps_action">Update record &middot; relationship notes</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-4-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-4-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
       </div>
     </section>
   </div>

--- a/.docs/design/reference/surfaces/project.html
+++ b/.docs/design/reference/surfaces/project.html
@@ -48,7 +48,7 @@
   data-folio-crumbs="Reference > Surfaces > Project"
   data-nav-base="."
   data-entity-mode="project"
-  data-chapters="headline:alignleft:The Mission|portfolio:briefcase:Portfolio|trajectory:trendingup:Trajectory|the-horizon:compass:The Horizon|the-landscape:eye:The Landscape|the-room:users:The Team|the-record:activity:The Record|the-work:checksquare:The Work">
+  data-chapters="headline:alignleft:The Mission|portfolio:briefcase:Portfolio|trajectory:trendingup:Trajectory|the-horizon:compass:The Horizon|the-landscape:eye:The Landscape|the-room:users:The Team|whats-next:arrowright:What's Next|the-record:activity:The Record|the-work:checksquare:The Work">
 
 <!-- MagazinePageLayout shell — mirrors src/components/layout/MagazinePageLayout.tsx.
      Folio bar, atmosphere, and floating nav are injected by chrome.js. -->
@@ -282,6 +282,93 @@
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
           Add Stakeholder
         </button>
+      </div>
+    </section>
+  </div>
+
+  <!-- Chapter 6.5: What's Next -->
+  <div id="whats-next" class="editorial-reveal entity-detail_chapterSection">
+    <section class="SuggestedNextSteps_section" data-surface="project">
+      <div class="ChapterHeading_heading">
+        <hr class="ChapterHeading_rule" />
+        <div class="ChapterHeading_titleRow">
+          <h2 class="ChapterHeading_title">What's next on the platform unification</h2>
+        </div>
+        <p class="ChapterHeading_epigraph">Four moves to keep the project on its arc.</p>
+      </div>
+
+      <div class="suggested-next-steps_list">
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-1" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Lock the design system handoff date with Maya<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Urgency this week — the workstream that depends on it is starting the integration sprint next Monday.</p>
+          <p class="suggested-next-steps_action">Schedule meeting &middot; Maya Iyer &middot; this week</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-1-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-1-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-2" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Send the integration risk summary to the steering group<span class="TrustBandIndicator TrustBandIndicator_useWithCaution" title="Use with caution">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Open loop from the last review — two stakeholders asked for it before the next cycle starts.</p>
+          <p class="suggested-next-steps_action">Send message &middot; email &middot; steering group</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-2-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-2-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row suggested-next-steps_row--needsVerification" data-claim-id="rec-claim-3" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Verify the latest scope shift the eng lead mentioned<span class="TrustBandIndicator TrustBandIndicator_needsVerification" title="Needs verification">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">Trust change worth checking &mdash; only one source flagged this and the project plan hasn't moved yet.</p>
+          <p class="suggested-next-steps_action">Investigate change &middot; project scope</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-3-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-3-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
+
+        <article class="suggested-next-steps_row" data-claim-id="rec-claim-4" data-feedback-state="pending">
+          <header class="suggested-next-steps_rowHeader">
+            <h3 class="suggested-next-steps_headline">Update the milestone plan with the revised QA window<span class="TrustBandIndicator TrustBandIndicator_likelyCurrent" title="Likely current">&#9679;</span></h3>
+          </header>
+          <p class="suggested-next-steps_whyThisNow">New information &mdash; QA confirmed the extra week yesterday and the record hasn't caught up.</p>
+          <p class="suggested-next-steps_action">Update record &middot; milestone plan</p>
+          <div class="suggested-next-steps_affordances" role="group" aria-label="Feedback on this recommendation">
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="convert" aria-label="Convert this recommendation to an action">Convert to action</button>
+            <button type="button" class="suggested-next-steps_button" data-feedback-kind="dismiss" aria-label="Dismiss this recommendation">Dismiss</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_buttonExpand" aria-expanded="false" aria-controls="rec-claim-4-more" aria-label="More feedback options">More feedback&hellip;</button>
+          </div>
+          <div id="rec-claim-4-more" class="suggested-next-steps_subAffordances" aria-hidden="true">
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="notUseful">Mark as not useful</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="tooNoisy">Mark as too noisy</button>
+            <button type="button" class="suggested-next-steps_button suggested-next-steps_subButton" data-feedback-kind="dismissWithReason">Dismiss with reason&hellip;</button>
+          </div>
+        </article>
       </div>
     </section>
   </div>

--- a/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
@@ -4,20 +4,307 @@ title: "v1.4.6 W3-A — Suggested Next Steps block contract"
 parent_plan: ../v1.4.6-waves.md
 fork_sha: e73ac8949b0df46c33b441fc14737cee2a9c3a73
 branch: codex/v1.4.6-w3a-suggested-next-steps
-status: L0 — plan hardening, cycle 0 draft
+status: L0 — plan hardening, cycle 1 (5-reviewer panel resolutions folded)
 authors: James Giroux, Claude
 related:
-  - ADR-0129 (Composable Surfaces — WordPress Studio as Primary Surface)
-  - ADR-0130 (Surface-Independent Composition Contract)
+  - ADR-0102 (Abilities as Runtime Contract)
+  - ADR-0103 (Maintenance Ability Safety Constraints — hidden-actor pattern)
   - ADR-0105 (Provenance as First-Class Output)
   - ADR-0108 (Provenance Rendering and Privacy)
   - ADR-0111 (Surface-Independent Ability Invocation)
+  - ADR-0123 (Typed Claim Feedback Semantics — 10 variants)
+  - ADR-0125 (Claim Anatomy / Sensitivity / TypeRegistry)
+  - ADR-0126 (Memory Substrate Invariants)
+  - ADR-0129 (Composable Surfaces — WordPress Studio as Primary Surface)
+  - ADR-0130 (Surface-Independent Composition Contract)
+  - ADR-0132 (Pill Primitive Dual-Existence — trust-band pill)
   - DOS-329 (RecommendationClaim contract — landed)
   - DOS-333 (cross-surface embedding — W3-B, blocks on W3-A)
   - DOS-332 (recommendation feedback semantics — W4-A consumer)
 ---
 
 # v1.4.6 W3-A — Suggested Next Steps block contract (DOS-298)
+
+## Cycle 1 amendments (2026-05-26) — 5-reviewer panel resolutions
+
+Cycle 0 panel returned: **1 BLOCKED + 13 NEEDS_REVISION + 3 ACCEPT-with-tightening + NO_REINVENTION (conditional)** across adversarial / feasibility / scope-guardian / K-in / design-lens. This section consolidates resolutions. Where an amendment supersedes an original section it cites the section; where it adds new constraints it states "additive."
+
+**Codebase verifications performed before drafting amendments:**
+
+- `src-tauri/src/migrations/` contains `270_salience_factors.sql`, `271_recommendation_surfacing.sql`, `272_recommendation_triggers_log.sql` and no v273. **The fork-time handoff claim of a v273 W2 repair is wrong; v273 is the next-free slot, not a landed migration.**
+- `wp/dailyos/blocks/the-work/` and `wp/dailyos/blocks/open-loops-feed/` exist; `dailyos/work-surface` does NOT. W3-A original §4.3 string-match assumption is wrong.
+- `src-tauri/src/services/recommendations/render.rs` is a 6-line placeholder docblock that explicitly names the Shared Receipt DTO as the render contract. Scope-guardian's TRIM is correct; the projection function fills this placeholder.
+
+### A1. Privacy class sweep — BLOCKED → RESOLVED (supersedes §3.3, §3.4, AC #4)
+
+**Findings consolidated:** adversarial F1 (factor numerics leak via `WhyThisNow.text` interpolation + `primary_factor` discriminant as covert channel); K-in pointer to `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` (same class-level sensitivity pattern); also extends to `RecommendedActionView` raw field bleed.
+
+**Resolution.** The SurfaceClient projection enforces a **two-layer privacy class sweep**:
+
+1. **Text redaction.** `WhyThisNow.text` is produced by W2-A from `FactorRationale` rendered through a deterministic template that today interpolates raw numerics (`vector_distance: 0.83`, `decay_factor: 0.92`, `corroboration_count: 4`). For the SurfaceClient projection, W3-A defines a **second text variant** `why_this_now_surface_text: String` that:
+   - Is produced by the same template family, gated on `Actor`
+   - Replaces all `FactorRationale` numeric leaves with qualitative bands (`high`, `moderate`, `low`) before formatting
+   - Drops `vector_distance`, `decay_factor`, `feedback_history_score`, raw `signal_age_secs`, `corroboration_count`, `contradiction_count` integer leaves entirely
+   - Keeps the primary-factor noun phrase only (e.g., "Salience driven by urgency from a recent signal")
+   The User/System variant (`why_this_now.text` with numerics) stays available to `score_salience` only. SurfaceClient never reads it.
+
+2. **Discriminant gate.** `primary_factor: SalienceFactorKind` is **dropped** from `SuggestedNextStepItem` in the surface projection. The kind discriminant is information-theoretically sufficient over repeated calls to reconstruct factor distribution (adversarial F1 is correct on this). The surface needs only enough signal to render an icon/chip; we replace it with a coarse `factor_band: PrimaryFactorBand` enum:
+   ```rust
+   pub enum PrimaryFactorBand { TimeSensitive, NewInformation, OpenLoopRelated, TrustChange, Other }
+   ```
+   5 bands collapse the 10 `SalienceFactorKind` variants; correlation across calls reveals band-level only, not kind-level.
+
+3. **`RecommendedActionView` redactor.** Already specified in original §3.3 as a privacy-safe projection. Strengthened: entity IDs become resolved labels via `ClaimReceiptRedactionLevel`; raw `rationale` / `suggested_topic` / `suggested_value` / `change_summary` strings are passed through the same numeric-redactor used for `why_this_now_surface_text` so a stray numeric in an action description doesn't bypass the sweep.
+
+**Updated AC #4 (privacy class sweep):**
+- Parametric integration test enumerates every `FactorRationale` variant (10) and asserts none of: `vector_distance`, `decay_factor`, `source_authority`, `signal_age_secs`, `calendar_proximity_secs`, `feedback_history_score`, `corroboration_count`, `contradiction_count`, `open_loop_count` appear as numeric values in any SurfaceClient response field (JSON-numeric AND substring-matched in any string field).
+- Parametric integration test enumerates every `RecommendedAction` variant (6) and asserts `RecommendedActionView` does not carry raw `entity_id` / `field_path` / `payload` JSON.
+- A class-level test models `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` — every field of every response variant runs through the leak detector, not just the happy path.
+- `factors: Vec<SalienceFactor>` literal-key absence (original AC #4) is preserved.
+
+### A2. Substrate dependency reality + claim reader + render_receipt_for (supersedes §3.4, additive to §2)
+
+**Findings consolidated:** feasibility #1 (no `read_recommendation_by_claim_id`; v273 reference wrong; surfacing_decisions is denormalized); feasibility #2 (render_receipt_for service function, not the ability; N+1 cost understated); adversarial F2 (`SurfacingTier` vs `surface_class` column mapping).
+
+**Resolution.**
+
+1. **Column-level filter mapping.** Projection filters on `surfacing_decisions` v271 schema columns:
+   - `subject_kind`, `subject_id` (subject filter)
+   - `surfacing_tier ∈ {'critical', 'notable', 'background'}` (string-encoded; matches W1-A's `SurfacingTier` enum after lowercase serialization)
+   - `decision_kind = 'render'` (excludes `defer`, `suppress`, and quiet-tier rows)
+   - Orders by `salience_total` DESC, `created_at` DESC
+   - Reads `why_this_now_json`, `trigger_refs_json`, `salience_evaluation_id`, `action_signature` from the same row (denormalized — no claim-store join required for these fields)
+
+2. **`RecommendationClaim` reader path explicit.** New work item added to §2 in-scope:
+   - **`src-tauri/src/services/recommendations/render.rs`** (was placeholder, now filled): exposes `read_recommendation_for_render(claim_id, actor) -> Result<RecommendationRenderPayload>` returning the fields NOT denormalized in `surfacing_decisions`: full typed `RecommendedAction`, `TrustBand` (via `claim_store::read_claim_with_trust(claim_id)`), `evidence: Vec<EvidenceRef>`, `feedback_state`, `conversion_state`.
+   - This is the missing claim-reader feasibility flagged. It lives in `render.rs` (per scope-guardian TRIM — see A6).
+
+3. **Receipt composition: service function, not ability re-invocation.** Projection calls `services::claim_receipt::render::render_receipt_for(state, target, surface)` **directly**, NOT via the `claim_receipt` ability invocation path. Rationale: inner-ability composition raises actor-context + scope-set questions that the service-function direct call avoids by executing in the same `&AppState` context the outer ability already holds.
+
+4. **Inner-call actor context.** The inner `render_receipt_for` runs with `actor = ctx.actor()` (propagated from the outer ability's `Actor::SurfaceClient` call). The receipt's audience filter is then `audience_for_surface(surface)` per existing ADR-0108 plumbing — SurfaceClient-tier redaction applies inside the inner call without privilege elevation. Tested: parametric test asserts that a SurfaceClient outer call produces receipts with SurfaceClient-tier redaction, never System-tier.
+
+5. **N+1 batch helper.** New batch helper `render_receipts_for_batch(state, claim_ids: &[ClaimId], surface) -> Vec<ClaimReceiptSnapshot>` shipped in W3-A. Performs one substrate read for the claim set (rather than N reads + N projections). If the helper proves more scope than W3-A can absorb, the **fallback** is to ship the per-call loop with a documented L4 benchmark gate: PR comment includes wall-clock measurement of 8-item render on local SQLite; if > 50ms p95, batch helper becomes a blocker; otherwise filed as path-α Codebase Maintenance ticket.
+
+### A3. render.rs not projection.rs — RESOLVED (supersedes §2, §3.4)
+
+**Findings consolidated:** scope-guardian #2 (wave plan per-file owner table cycle 2 #5 names render.rs → W3-A); verified — render.rs exists as a 6-line placeholder.
+
+**Resolution.** Drop `services/recommendations/projection.rs` from §2 in-scope. Fill `services/recommendations/render.rs` with both:
+- `list_suggested_next_steps_projection(state, input, actor) -> Result<ListSuggestedNextStepsResponse>` (the substrate-side projection)
+- `read_recommendation_for_render(claim_id, actor)` (per A2)
+- `render_receipts_for_batch(state, claim_ids, surface)` (per A2)
+
+§3.4 wording updated: every reference to `services::recommendations::projection::list_suggested_next_steps()` becomes `services::recommendations::render::list_suggested_next_steps_projection()`. The wave plan's word "render" in `render.rs` means "surface-render projection," not "HTML render."
+
+### A4. Option A scope cost enumerated + affordance redesign (supersedes §4.3, §4.5, §9)
+
+**Findings consolidated:** adversarial F3 (Option A's tooltip primitive + a11y + locale + new pattern); feasibility #3 (affordance handler is FIRST DailyOS block view.js, not inherited); design-lens #3 + Q4 (5 affordances per row contradicts hover-reveal grammar; terminal states undesigned); design-lens Q9 (64 per-button tooltips is the wrong UI for disabled state); K-in ADR-0123 (10 typed feedback variants are the canonical surface mapping).
+
+**Resolution.**
+
+1. **Affordance cardinality reduced to 3 visible primary.** Per row:
+   - **Convert to action** (primary; corresponds to `RecommendationFeedbackDecision::Convert(ConversionTarget::Action(...))`)
+   - **Dismiss** (primary; `RecommendationFeedbackDecision::Dismiss { reason: ... }`)
+   - **More feedback…** (secondary; opens a hover-reveal subaffordance row carrying `NotUseful`, `TooNoisy`, and `Dismiss-with-reason-other` per ADR-0123's 10 variants)
+   
+   Five-variant feedback flow is preserved in the data model; visible cardinality drops to 3 to match the hover-reveal grammar from `PostMeetingIntelligence_feedbackSlot`.
+
+2. **Terminal states designed.** Each row renders one of:
+   - **`pending`** (default; ability returns `FeedbackState::Pending`): full row with 3 visible affordances
+   - **`in_flight`** (POST sent, response pending): row dims to 60% opacity; affordances disabled; aria-busy="true"
+   - **`decided_dismissed`**: row collapses to a strike-through one-liner with "Dismissed" label trailing the headline; affordances replaced by an "Undo" affordance (if `FeedbackState::Decided` is recent — within an L4-tunable echo window)
+   - **`decided_converted`**: row replaces affordance set with "Converted to action — [link to action]" confirmation; row stays visible for one render cycle then collapses on next page load
+   - **`disabled`** (W4-A gap state): see A4.3 below
+   - **`error`** (POST failed): row re-enables affordances; appends a non-dismissible inline retry chip
+
+3. **Disabled state: single block-level banner.** Replaces 64 per-button tooltips. When W4-A's feedback ability is not yet registered:
+   - Block renders the section heading + items
+   - Single banner below the section: "Feedback affordances ship in the next update." (or product-equivalent — see A11 vocabulary)
+   - Affordance buttons render with `disabled-affordance` CSS class (explicit class, not just `aria-disabled`): visible gray state, `tabindex="-1"` (NOT focusable; the banner carries the explanation), `aria-disabled="true"` for any screen reader that bypasses tabindex.
+   - No per-button tooltip.
+
+4. **View.js explicitly reframed as new pattern.** §4.5 updated to state: "W3-A introduces the first DailyOS block with a client-side affordance script. The precedent block `meeting-recommended-actions` ships server-only and explicitly defers affordance wiring (`render-functions.php:102` TODO). The cost of this new pattern — view.js bundle entry, locale string registration, ARIA labels, a11y test coverage — is W3-A scope and is enumerated in §7 CI gate inputs."
+
+5. **ARIA labels (locked):**
+   - Convert: `aria-label="Convert {headline} to an action"`
+   - Dismiss: `aria-label="Dismiss {headline}"`
+   - More feedback: `aria-label="More feedback options for {headline}"`
+   - Sub-affordance NotUseful: `aria-label="Mark {headline} as not useful"`
+   - Sub-affordance TooNoisy: `aria-label="Mark {headline} as too noisy"`
+
+6. **ADR-0123 mapping (locked).** The block's `data-feedback-kind` enum maps directly onto ADR-0123's 10 typed variants. W3-A consumes — does not extend — the existing taxonomy. If a future variant lands (e.g. ADR-0123 V1.2 adds an 11th), W3-A's block view.js handler reads the typed enum from a shared TS/PHP constant file, not a literal block. Constant file path: `wp/dailyos/blocks/suggested-next-steps/feedback-kinds.ts` (mirrors the v1.4.5 W1-A's RecommendationFeedbackDecision shape).
+
+### A5. Token namespace fix + trust-band placement + density (supersedes §1, additive to §4.3)
+
+**Findings consolidated:** design-lens #2 (`meeting-intel_chapterSection` is surface-scoped to meeting); design-lens #6 (trust-band placement unspecified); design-lens Q7 (why-this-now budget); design-lens Q8 (max_items default).
+
+**Resolution.**
+
+1. **Section wrapper class is surface-scoped:**
+   - Account / Project / Person surfaces: `entity-detail_chapterSection` (loaded from `entity-detail.module.css`)
+   - Meeting surface: `meeting-intel_chapterSection` (loaded from `meeting-intel.module.css`)
+   - Briefing surface: `daily-briefing_chapterSection` if it exists (verified by L1 grep before render.php authoring; otherwise composes generic `editorial-reveal` + `ChapterHeading_*`)
+   - Work surface: composes existing work-surface chapter pattern (L1 grep against `the-work` or `open-loops-feed` precedent — see A9)
+   
+   render.php branches on `dailyos/entityType` context (and absence-of-context for global feeds) and emits the surface-appropriate class. Original §1 parity matrix's "`meeting-intel_chapterSection` shape" reuse line is INCORRECT and revoked.
+
+2. **Trust-band placement: trails the headline.** Per `meeting-intel_currentStateItem` precedent (`meeting.html:399-401`). Trust-band indicator (ADR-0132 pill primitive) sits as a finis marker after the headline text node, before the why-this-now caption. For `needs_verification` trust band, the row applies a terracotta-accent CSS modifier (`suggested-next-steps_row--needsVerification`) that adjusts the headline color and the why-this-now caption opacity per existing ADR-0108 needs-verification convention.
+
+3. **Why-this-now: CSS `line-clamp: 2`.** Hard cap at two lines via CSS. No "more" affordance — caption is context, not primary content. If the SurfaceClient's `why_this_now_surface_text` exceeds ~140 characters, the renderer truncates with an ellipsis. Tested with a fixture carrying a 300-character why-this-now string; row height stays consistent.
+
+4. **`max_items` default = 5, ceiling = 8 (attribute-tunable).** Originally 8/8; revised per design-lens Q8. The 5/8 split:
+   - Default 5 matches editorial-reading-surface density convention
+   - Block.json attribute allows W3-B (cross-surface embedding) to bump to 8 for the work surface where the recommendation list is the primary content
+   - Ability `max_items` input ceiling stays 8 — even if a future caller requests 100, the projection truncates at 8
+
+5. **Cross-surface saturation deferred to W3-B.** Per-block `max_items` does NOT consult W2-A budget state. Cross-surface dedup (same recommendation appearing on Account + Person + Work) is W3-B's concern at the composition layer. Adversarial F6 (cross-surface saturation) is filed as a W3-B L0 constraint, not a W3-A revision.
+
+6. **theme.json token gate tightened (scope-guardian #7).** New `suggested-next-steps_*` tokens require `/plan-design-review` to **name each proposed token and confirm no existing token covers the case**. Default posture is "no new tokens"; the parity matrix is the audit record.
+
+### A6. Vocabulary fix per ADR-0083 (supersedes §1 heading rows, §4.1 attributes)
+
+**Finding:** design-lens AI-slop flag ("Suggested Next Steps" as section heading conflates ADR-0083's item-state qualifier with a section identity).
+
+**Resolution.** Per-surface section headings shift from genre labels to judgment statements:
+
+| Surface          | Original                                       | Revised (ADR-0083 chief-of-staff framing)        |
+|------------------|------------------------------------------------|--------------------------------------------------|
+| Account detail   | "Suggested next steps for this account"        | "What's next with {Account.name}"                |
+| Project detail   | "Suggested next steps for this project"        | "What's next on {Project.name}"                  |
+| Person detail    | "Suggested topics for next 1:1"                | "Open threads with {Person.name}"                |
+| Meeting prep     | "Suggested topics"                             | "What to cover" (keeps meeting-prep convention)  |
+| Work surface     | "Recommendations"                              | "Where to focus" (W3-B owns chip placement copy) |
+| Daily Briefing   | (W3-B owns embedding)                          | (W3-B owns embedding)                            |
+
+Block title in `block.json` stays `"title": "Suggested Next Steps"` (it's the developer-facing block-inserter label; never user-visible per `inserter: false`). The product-voice strings live in render.php per-surface defaults.
+
+**Empty state copy (warmer per ADR-0083 §4 confidence rule):**
+- Account / Project: "Nothing flagged right now."
+- Person: "No open threads."
+- Meeting prep: "Nothing to cover yet."
+- Work: "You're up to date."
+
+### A7. Reference HTML strategy (supersedes AC #10, §1 resolution)
+
+**Findings consolidated:** adversarial F4 (scope creep / circularity); design-lens Q1 (must be authored first); scope-guardian #1 (ACCEPT_SCOPE bundle).
+
+**Resolution.** Reference HTML lives at the **surface layer**, not primitive layer (design-lens overrides adversarial here — the parity claim requires showing how the block reads inside `entity-detail.module.css` vs `meeting-intel.module.css` contexts, which only the surface layer carries).
+
+**Strengthened AC #10:** Reference HTML lands as the **first commit** in the W3-A PR sequence, before `render.php`. The PR may use a fixup commit pattern (reference HTML commit → render.php commit → fixup squash on merge) so that during review the design-lens reviewer can compare the rendered block against the reference at the same commit. Reviewers reject a PR where `render.php` lands without a preceding reference-HTML commit.
+
+Reference HTML scope:
+- `.docs/design/reference/surfaces/account.html` — add section block matching `entity-detail_chapterSection` shape with 5-item example list
+- `.docs/design/reference/surfaces/project.html` — analogous
+- `.docs/design/reference/surfaces/person.html` — analogous, "Open threads" copy variant
+- `.docs/design/reference/surfaces/meeting.html` — add section near `Commitments & Actions` chapter (positioning per A12 IA resolution)
+- Briefing.html and work surface references owned by W3-B (per A9 work-surface block grep)
+
+### A8. Registry channel enumeration (supersedes §7, additive to AC set)
+
+**Finding:** adversarial F10 (enumerate every channel a new ability touches; memory rule "Enumerate channels before patching trust boundaries").
+
+**Resolution.** Channels enumerated by L1 grep before merge:
+
+1. **Ability registry** — auto-registered via `inventory::submit!` from the `#[ability(...)]` macro. No file edit; tested by `tools/dailyos-abilities.json` regen + `AbilityRegistry::global_checked()` assertion.
+2. **Surface scope registry** — `read.recommendations` scope must appear in the SurfaceScope allowlist. File path: `src-tauri/abilities-runtime/src/abilities/registry.rs` (verified at L1; if scope is added to a separate config file, that file too). Diff committed in W3-A PR.
+3. **WP REST endpoint allowlist** — `dailyos_runtime_client_for_block` filter resolves abilities through WordPress; verify that the WP plugin's ability-invocation allowlist (path: `wp/dailyos/includes/class-dailyos-runtime-client.php` per feasibility #5) admits `list_suggested_next_steps`. Diff committed if the allowlist file is explicit; no diff if abilities are admitted dynamically per scope.
+4. **MCP adapter scope policy** — `mcp_exposure: None` for this ability. Confirm no MCP adapter scan auto-registers; if any future MCP allowlist explicitly excludes hidden abilities, no diff. Tested: McpClient invocation returns `AbilityErrorKind::Capability`.
+5. **`tools/dailyos-abilities.json`** — regen + commit (deterministic per feasibility #4).
+6. **Per-surface scope routing** — If SurfaceClient scopes are routed per surface (TauriEntityDetail vs WP block vs Work surface), the new ability is registered for the relevant surfaces. L1 grep determines whether this is a per-surface config or a global SurfaceClient allowlist.
+
+**Additive AC:** "All six registry channels enumerated; diff committed where the channel is file-explicit; assertion test exists for each."
+
+**Additive L1 test:** Per-Actor dry-run. Enumerate all `Actor` variants (`User`, `System`, `Agent`, `Admin`, `SurfaceClient(...)`, `McpClient(...)`); for each, invoke `list_suggested_next_steps` via the registry; assert allowlist matches `[User, System, SurfaceClient]` (3 succeed, 3 fail with `Capability` error). Test lives in `abilities-runtime/src/abilities/recommendations/mod.rs::tests`.
+
+**WP-side `$scope_set` reconciliation (feasibility #5 with-note):** `class-dailyos-runtime-client.php:86` `unset()`s `$scope_set` on the `/v1/local/invoke` path. Plan's prior framing of "scope-based actor filtering at the WP transport boundary" was misleading. Enforcement is **Rust registry-side** via `iter_for(Actor::SurfaceClient{scopes})`. §4.3 updated: the WP block passes scope context for diagnostics only; the substrate enforces. AC reflects this.
+
+### A9. Work-surface parent block — DOES NOT EXIST (supersedes §4.1, §4.3 work-surface branch)
+
+**Findings consolidated:** adversarial F8 (work-surface block existence unverified); verified — no `dailyos/work-surface`; `dailyos/the-work` and `dailyos/open-loops-feed` exist instead.
+
+**Resolution.** §4.3 step 1's "parent === 'dailyos/work-surface' → SubjectRef::Global" branch is revised:
+
+- **W3-A defers the work-surface integration to W3-B.** W3-A's block.json does not declare a `parent` constraint and does not attempt to detect work-surface context.
+- When `dailyos/entityType` context is absent AND `dailyos/entityId` is absent, the block:
+  - If invoked outside an entity-detail parent: empty chip with reason `missing_subject_context` (no global-feed render)
+  - W3-B authors the work-surface integration: either extends `dailyos/the-work` to provide context, or wraps the block with a `dailyos/global-recommendations` composer block
+- Subject resolution for the global feed (SubjectRef::Global vs SubjectRef::User) is W3-B's call after L1 grep of `the-work` / `open-loops-feed` parent shapes.
+
+Original §4.3 work-surface logic is revoked. The block becomes entity-only at W3-A; W3-B adds global-feed integration on top.
+
+### A10. L4 evidence expansion (supersedes §6 L4 surface QA + AC #11)
+
+**Finding:** adversarial F9 (screenshot ritual misses real failure modes).
+
+**Resolution.** L4 surface QA evidence package expands to:
+
+1. **Screenshot grid** — empty + 1 + 3 + 5 + 8 items per each of 4 entity surfaces (account/project/person/meeting prep); 20 screenshots total
+2. **Wire-JSON snapshot** — full `ListSuggestedNextStepsResponse` JSON for a seeded 5-item fixture, committed as a golden snapshot under `wp/dailyos/tests/fixtures/suggested-next-steps/`. Privacy class-sweep test runs against this snapshot.
+3. **Tauri-vs-WP parity** — for a single seeded recommendation, capture the Tauri-rendered trust-band display and the WP-rendered trust-band display side-by-side. If a Tauri claim-receipt rendering exists for the same `ClaimId`, the trust-band visual must match (ADR-0132 pill primitive consistency). If Tauri has no equivalent surface today, document that parity is forward-deferred to v1.4.7+ MCP/Tauri-thin-surface decision (per ADR-0129 §7).
+4. **Trust-band band-by-band coverage** — for `likely_current`, `use_with_caution`, `needs_verification`, render a single-item example of each. Captured in screenshots + asserted in render.php unit tests.
+5. **Locale coverage** — currently single-locale; if a non-default locale is configured in the test harness, capture one screenshot to confirm string lookups don't break layout. Otherwise filed as path-α maintenance ticket per A14.
+
+### A11. Engagement signal explicit guards (supersedes §9 W4-C section, additive to §12 Q7)
+
+**Finding:** scope-guardian #5 SCOPE_AMBIGUOUS — disabled call sites must have explicit guard, not silent no-ops.
+
+**Resolution.** §12 Q7 RESOLVED: View.js carries call sites for `Rendered` and `Clicked` engagement signals but guards them behind an explicit feature flag check:
+
+```ts
+const ENGAGEMENT_SIGNALS_ENABLED = false; // W4-C enables this when its ability registers
+function emit_engagement_signal(kind: EngagementSignalKind, claimId: ClaimId) {
+  if (!ENGAGEMENT_SIGNALS_ENABLED) { return; /* explicit no-op — testable */ }
+  runtimeClient.invokeAbility('record_engagement', { kind, claimId });
+}
+```
+
+**Additive test:** Asserts that `emit_engagement_signal` returns the explicit no-op path when the flag is false; W4-C flip flips the flag (one-line PR in W4-C scope).
+
+### A12. Information architecture — chapter positioning (additive to §4.3, design-lens IA finding)
+
+**Finding:** design-lens IA dimension (chapter scroll position unspecified; meeting surface has potential collision with `PostMeetingIntelligence_actionItemSuggested`).
+
+**Resolution.** Per-surface chapter scroll position (referenced from `.docs/design/reference/surfaces/*.html data-chapters` attribute):
+
+- **Account / Project:** "What's next with X" chapter sits **after** the Stakeholders / People chapter and **before** Recent Activity. L1 grep of `account.html data-chapters` confirms slot.
+- **Person:** "Open threads with X" sits **after** the Relationship Summary chapter and **before** Recent Activity.
+- **Meeting prep:** "What to cover" sits **alongside** the existing `PostMeetingIntelligence` chapter, NOT a separate section. The existing block already has a "Suggested" item-state pill (`PostMeetingIntelligence_suggestedPill`); the new W3-A block embeds INTO the same chapter as a complementary list, distinct from open-loop actions. Concrete pattern: `dailyos/meeting-detail` composition renders `dailyos/meeting-recommended-actions` (open items) + `dailyos/suggested-next-steps` (new recommendations) under one chapter heading; render.php on this surface omits its own chapter heading and joins the parent's.
+- **Briefing / Work:** W3-B owns positioning (per A9).
+
+Resolves design-lens IA collision finding for the meeting surface.
+
+### A13. Magazine ending discipline (confirmation, no change to §10)
+
+**Finding:** design-lens Q10 — `MagazineEnd` ownership.
+
+**Confirmation.** Per ADR-0130 §3 block taxonomy, `MagazineEnd` is a top-level Composition block type. Inner blocks like W3-A's `dailyos/suggested-next-steps` close their own `<section>` element and the parent surface (account-detail, meeting-detail, person-detail composition) owns the `MagazineEnd` marker. This matches `meeting-recommended-actions` precedent. No render.php change required; documented for clarity.
+
+### A14. Path-α maintenance tickets (additive — defers to Codebase Maintenance project per memory rule)
+
+The following findings are real but not BLOCKING for W3-A merge. Filed as Linear tickets against project `b8e6aea4-d47e-4f3a-b03d-a05bec914aeb` ("Codebase Maintenance & Production Quality"), referenced in W3-A PR body:
+
+1. **Schema-version cliff at v1.4.7** (adversarial F5). When MCP exposure lands and wire-format breaking changes are needed, every v1.4.6 SurfaceClient caller breaks under W1-B's fail-closed pattern. Maintenance ticket: "Document SurfaceClient ↔ MCP schema_version coordination policy for v1.4.7." Resolution mode: pre-v1.4.7 L0.
+2. **Surfacing-decisions index audit** (adversarial F7). Confirm v271 carries indexes on `(subject_kind, subject_id, surfacing_tier, decision_kind, created_at)` for the projection's filter+order. If missing, add a migration in a follow-up PR. Resolution: L1 grep at W3-A merge; if missing, maintenance ticket + index migration claims v273.
+3. **Locale coverage for L4** (A10 #5). Non-default-locale screenshot if harness supports; otherwise maintenance ticket.
+
+### A15. K-in citations folded (additive to §11)
+
+ADR citations added per K-in: ADR-0102 (Abilities as Runtime Contract — canonical registration), ADR-0103 (Maintenance Ability Safety Constraints — hidden-actor pattern test template), ADR-0123 (Typed Claim Feedback Semantics — 10 variants the affordances map onto), ADR-0126 (Memory Substrate Invariants — projection invariants), ADR-0132 (Pill Primitive Dual-Existence — trust-band pill).
+
+`docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` cited in A1 (class-sweep test pattern). `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md` cited as method note (grep substrate types, not proposed names). `feedback_l0_reconcile_against_dev.md` cited — fork SHA verified clean against `public/dev` HEAD `e73ac894`.
+
+### Open questions remaining after cycle 1
+
+1. **Receipt batch helper scope.** A2 #5 leaves a fallback (per-call loop + L4 benchmark gate). Default position is to ship the batch helper; cycle-2 reviewer should confirm whether the batch helper is in W3-A scope or path-α maintenance.
+2. **Decided-state echo window length.** A4 #2 introduces a "recent decided" window during which the row stays visible with an Undo affordance. Length unspecified; L4 evidence informs (10 seconds vs page-load-scoped).
+3. **Briefing-surface chapter wrapper class.** A5 #1 says "verified by L1 grep before render.php authoring." Resolve at L1 dispatch.
+
+### Updated cycle status
+
+- Original §0–§15: preserved with sections that A1–A15 supersede flagged inline by amendment number.
+- **Cycle 1 status: REVISED, ready for cycle 2 review of a subset panel** (adversarial F1 resolution; feasibility substrate alignment + render_receipt_for; design-lens 3 blocking findings). K-in and scope-guardian likely not needed in cycle 2 unless their findings need re-litigation.
+
+---
 
 ## §0 Frame
 

--- a/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
@@ -293,16 +293,96 @@ ADR citations added per K-in: ADR-0102 (Abilities as Runtime Contract — canoni
 
 `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` cited in A1 (class-sweep test pattern). `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md` cited as method note (grep substrate types, not proposed names). `feedback_l0_reconcile_against_dev.md` cited — fork SHA verified clean against `public/dev` HEAD `e73ac894`.
 
-### Open questions remaining after cycle 1
+---
 
-1. **Receipt batch helper scope.** A2 #5 leaves a fallback (per-call loop + L4 benchmark gate). Default position is to ship the batch helper; cycle-2 reviewer should confirm whether the batch helper is in W3-A scope or path-α maintenance.
-2. **Decided-state echo window length.** A4 #2 introduces a "recent decided" window during which the row stays visible with an Undo affordance. Length unspecified; L4 evidence informs (10 seconds vs page-load-scoped).
-3. **Briefing-surface chapter wrapper class.** A5 #1 says "verified by L1 grep before render.php authoring." Resolve at L1 dispatch.
+## Cycle 2 amendments (2026-05-26 evening) — class-sweep + cycle-2 reviewer tightenings
+
+Cycle 2 panel: adversarial APPROVE-with-tightening; feasibility APPROVE with 4 framing fixes; design-lens CYCLE_3 with 3 blockers + 3 advisories.
+
+**Class pattern flagged across reviewers:** the cycle-1 amendments-at-top pattern produced **in-document contradictions** (original sections retain old text superseded by amendments). Design-lens hit it on §3.3 `primary_factor` and block.json `maxItems`; adversarial hit it on §4.3 work-surface text. Per memory rule "same-shape findings twice = class-wide sweep," cycle 2 performs an **inline sweep** of the originals so a reader of any single section gets the correct contract without needing to cross-reference amendments.
+
+### A16. Echo window + collapse mechanic + use_with_caution modifier + banner copy (resolves design-lens cycle-2 blockers + Open Q #2)
+
+**Resolution.**
+
+1. **Decided-state echo window: server-side bounded.**
+   - `FeedbackState::Decided` carries `decided_at: DateTime<Utc>` (already present in cycle-1 contracts — ADR-0123 V1.1)
+   - Server-side hard ceiling: **30 seconds** after `decided_at` the row drops from the projection regardless of client state (combines adversarial's 60s cap and design-lens's session-scoped preference at a middle-ground)
+   - Client-side Undo affordance disappears at 30s even if user keeps the tab open
+   - L4 evidence captures the 30s timeout behavior (timer-based test, not a flake)
+   - **A2 projection rule extends:** rows with `Decided` feedback older than 30s are filtered out by the projection before SurfaceClient render
+
+2. **`decided_dismissed` row-collapse mechanic.**
+   - CSS transition on `max-height` and `opacity` over 200ms
+   - Class: `suggested-next-steps_row--collapsing` applied on Dismiss click; row animates to `max-height: 0; opacity: 0;` then a server-side re-render on next page load drops it from the projection (per #1 above)
+   - Reduced-motion preference (`@media (prefers-reduced-motion: reduce)`) snaps instead of animating
+
+3. **`use_with_caution` row treatment.**
+   - **Indicator-level class only** — no row-level modifier. The trust-band pill (ADR-0132) carries its own `TrustBandIndicator_useWithCaution` class for the pill color/copy.
+   - Row layout is unchanged from `likely_current` rows
+   - `needs_verification` is the only trust band that gets a row-level modifier (`suggested-next-steps_row--needsVerification` per A5 #2) — terracotta-accent treatment + opacity adjustment on the why-this-now caption
+   - Three-band coverage: `likely_current` → default row; `use_with_caution` → default row + cautionary pill; `needs_verification` → modifier row + needs-verification pill
+
+4. **Disabled banner string (replaces A4 #3 placeholder).**
+   - User-visible copy: **"Feedback opens on the next sync."**
+   - No "update," "release," "ship," or wave-name leakage
+   - Banner uses `dailyos-info-chip` class (existing primitive — confirmed by L1 grep before render)
+   - aria-live="polite" so screen readers announce the state when navigating into the affordance row
+
+5. **Keyboard disclosure for hover-reveal sub-affordance row.**
+   - "More feedback…" button is a focusable `<button>` with `aria-expanded="false"` initially, `aria-controls="<row-id>-more-feedback"`
+   - Click OR `Enter`/`Space` keyboard activation toggles `aria-expanded` and reveals the sub-affordance row
+   - Sub-affordance row uses `aria-hidden="true"` when collapsed; `aria-hidden="false"` when expanded
+   - The hover-reveal is a CSS enhancement (mouse users see it on hover); the button is the canonical disclosure trigger
+   - Tab order: primary affordances → "More feedback…" button → (when expanded) sub-affordances → next row
+
+6. **Touch fallback (path-α maintenance).**
+   - Today's WP Studio surface is desktop-only; touch is forward-deferred
+   - Filed as Codebase Maintenance ticket: "Cross-device hover-reveal fallback for `dailyos/suggested-next-steps` and similar v1.4.x blocks" — resolution mode = pre-cross-device-surface L0
+   - W3-A's keyboard-disclosure pattern (#5 above) is the touch-compatible disclosure today (tap = focus + activate)
+
+### A17. Framing fixes (resolves feasibility cycle-2 PARTIALs)
+
+1. **A2 #4 framing — `SurfaceContext`, not actor.** Reword: `render_receipt_for(state, target, surface)` takes `SurfaceContext`, not `Actor`. Privacy enforcement happens via `audience_for_surface(surface)` derived FROM the outer ability's actor. The mechanism still propagates SurfaceClient-tier redaction; the framing now matches the function signature.
+
+2. **A4 #4 framing — first feedback-POST affordance, not first view.js.** Reword: "W3-A is the first DailyOS block with a **client-side feedback-POST affordance script**. The view.js bundle pattern is established (7 existing blocks: `evidence-drawer`, `entity-intake`, `projects-index`, `people-index`, `source-management`, `accounts-index`, `account-overview`) but none currently POST feedback claims. W3-A introduces the new affordance category." The CI-gate inputs list in §7 retains the view.js bundle entry but reframes the cost as "feedback affordance category," not "view.js bundle as a new pattern."
+
+3. **A2 #5 receipt batch helper resolution (Open Q #1).** **Decision: batch helper ships in W3-A.** Authoring scope is small (one new function returning `Vec<ClaimReceiptSnapshot>` with a single `WHERE claim_id IN (...)` substrate read) and the L4 benchmark gate fallback adds CI complexity without removing the work. The per-call loop is filed as path-α maintenance only if the batch helper proves out-of-scope at L1 dispatch (unlikely; explicit gate).
+
+### A18. Additive scope items (resolves feasibility cycle-2 PARTIALs)
+
+1. **§2 in-scope additive:** `wp/dailyos/blocks/suggested-next-steps/style.css` contains a new `.disabled-affordance` CSS class (confirmed by L1 grep that no existing class with this name exists in `wp/dailyos/`).
+
+2. **§6 test plan pinned:** PHPUnit with mocked runtime client is the **in-scope** integration pattern; cross-process Tauri-loopback-in-CI harness is **out-of-scope** for W3-A. Mock pattern is consistent with existing block tests (`wp/dailyos/tests/blocks/AccountDetailBlockTest.php` precedent).
+
+3. **A12 work surface fallback if W3-B delayed.** If W3-B is materially delayed and the work surface has no recommendations slot, W3-A's block stays unembedded on the work surface. The user-visible behavior at W3-A merge is: 4 entity surfaces render the block; work surface does not. This is the explicit holding pattern; the wave plan W3-A → W3-B sequencing (`v1.4.6-waves.md:527`) makes the holding period bounded.
+
+### A19. Inline section sweep (class-pattern resolution)
+
+Cycle 2 sweeps the in-document contradictions flagged by design-lens and adversarial. The following original sections are **edited inline** to match the amendment contract — readers no longer need to cross-reference the amendments to get the correct shape:
+
+| Original section | Edited inline at cycle 2 | Source amendment |
+|------------------|--------------------------|------------------|
+| §3.3 `SuggestedNextStepItem` struct | `primary_factor: SalienceFactorKind` removed; `factor_band: PrimaryFactorBand` added; `why_this_now` renamed to `why_this_now_surface_text` | A1 |
+| §3.4 step heading + projection function name | renamed to `services::recommendations::render::list_suggested_next_steps_projection`; column names locked | A2/A3/A17 |
+| §4.1 block.json | `maxItems` default `8` → `5`; `headingLabel` notes per ADR-0083 vocabulary; `parent` constraint omitted (no work-surface reference) | A5/A6/A9 |
+| §4.3 render-functions.php algorithm | work-surface branch removed; entity-detail vs meeting-intel wrapper class per surface; trust-band placement + line-clamp + terminal states + 3-primary affordance pattern | A4/A5/A6/A9 |
+| §4.5 editor/view scripts | reframed as new feedback-POST affordance category; A16 keyboard disclosure + aria pattern + disabled banner | A4/A16/A17 |
+| §6 Integration test bullet | pin PHPUnit-mocked-runtime; cross-process harness out-of-scope | A18 |
+| §11 K-in citations | 5 missing ADRs + class-sweep solution + reconcile-against-dev solution added | A15 |
+
+After A19, every section reads consistently with the amendments. If a future cycle needs further revision, **inline edits are the primary path**, not new amendments-at-top — amendment cycle reserves for genuinely new resolutions (A16 etc.).
+
+### Open questions remaining after cycle 2
+
+1. **Briefing-surface chapter wrapper class.** A5 #1 deferred to L1 grep. Resolve at L1 dispatch (not blocking L0 approval).
+
+(Cycle-1 Open Q #1 receipt batch helper — RESOLVED by A17 #3 as W3-A in-scope. Cycle-1 Open Q #2 echo window — RESOLVED by A16 #1 as 30s server-side ceiling. Both removed from open list.)
 
 ### Updated cycle status
 
-- Original §0–§15: preserved with sections that A1–A15 supersede flagged inline by amendment number.
-- **Cycle 1 status: REVISED, ready for cycle 2 review of a subset panel** (adversarial F1 resolution; feasibility substrate alignment + render_receipt_for; design-lens 3 blocking findings). K-in and scope-guardian likely not needed in cycle 2 unless their findings need re-litigation.
+- **A1–A18 amendments + A19 inline sweep complete.** Every original section now matches its governing amendment.
+- **Cycle 2 status: REVISED, ready for cycle 3 design-lens-only verification.** Adversarial + feasibility leaned APPROVE in cycle 2; design-lens is the only remaining gate. If cycle 3 closes design-lens's 3 blockers (struct contradiction → A19, maxItems default → A19, echo window → A16), L0 approve.
 
 ---
 
@@ -365,18 +445,23 @@ L0 design review (`/plan-design-review`) explicitly owns the reference-HTML-firs
 
 | File / surface                                                                                                                  | Owner   |
 |----------------------------------------------------------------------------------------------------------------------------------|---------|
-| `src-tauri/abilities-runtime/src/abilities/recommendations/list_suggested_next_steps.rs` (or extension of `mod.rs`)              | W3-A    |
-| `src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs` — additive: list-projection DTO                          | W3-A    |
-| `src-tauri/src/services/recommendations/projection.rs` (new) — substrate-side projection from `surfacing_decisions` + claim store | W3-A    |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/list_suggested_next_steps.rs` (new ability) or extension of `mod.rs`  | W3-A    |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs` — additive: list-projection DTO (incl. `PrimaryFactorBand`, `SuggestedNextStepItem`, `ListSuggestedNextStepsResponse`, `RecommendedActionView`) | W3-A    |
+| `src-tauri/src/services/recommendations/render.rs` — fill existing 6-line placeholder with `list_suggested_next_steps_projection`, `read_recommendation_for_render`, `render_receipts_for_batch` (per A3 + A17 #3) | W3-A    |
 | `src-tauri/src/services/context.rs` — wire new read handle (additive trait method)                                                | W3-A    |
-| `tools/dailyos-abilities.json` — regen after new ability lands                                                                   | W3-A    |
+| `tools/dailyos-abilities.json` — regen after new ability lands (deterministic per feasibility-confirmed `emit_ability_inventory`) | W3-A    |
 | `wp/dailyos/blocks/suggested-next-steps/block.json`                                                                              | W3-A    |
 | `wp/dailyos/blocks/suggested-next-steps/render.php` + `render-functions.php`                                                     | W3-A    |
-| `wp/dailyos/blocks/suggested-next-steps/style.css` (block CSS module)                                                            | W3-A    |
-| `wp/dailyos/theme/theme.json` — additive only, with token-name resolution from L0 design review                                  | W3-A    |
-| `.docs/design/reference/surfaces/{account,project,person}.html` — author reference sections (per §1)                              | W3-A    |
-| `wp/dailyos/tests/blocks/suggested-next-steps/` (PHPUnit or render-fixture tests)                                                 | W3-A    |
-| Integration fixture proving WP-block-calls-ability path                                                                          | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/style.css` — includes new `disabled-affordance` class (A18 #1) and `suggested-next-steps_*` tokens (A5) | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/view.js` — feedback-POST affordance handler + hover-reveal disclosure (new affordance category; bundle pattern established — A17 #2) | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/feedback-kinds.ts` — ADR-0123 10-variant mapping constants (A4 #6) | W3-A    |
+| `wp/dailyos/theme/theme.json` — additive only, each new token named + design-review-confirmed (A5 #6)                            | W3-A    |
+| `.docs/design/reference/surfaces/{account,project,person,meeting}.html` — author reference sections (per A7; lands as first commit in PR sequence) | W3-A    |
+| `wp/dailyos/tests/blocks/suggested-next-steps/` — PHPUnit with mocked runtime client (A18 #2)                                     | W3-A    |
+| Integration fixture proving WP-block-calls-ability path — PHPUnit-mocked-runtime pattern (A18 #2); cross-process Tauri harness out-of-scope | W3-A    |
+| Privacy class-sweep test (A1 #4): parametric over all 10 `FactorRationale` variants and all 6 `RecommendedAction` variants       | W3-A    |
+| Per-Actor dry-run test (A8): enumerate all `Actor` variants through the registry, assert allowlist matches `[User, System, SurfaceClient]` | W3-A    |
+| Registry channel diffs where file-explicit (A8 enumerated 6 channels — confirm at L1 grep)                                       | W3-A    |
 
 ### Out of scope
 
@@ -447,19 +532,29 @@ pub struct ListSuggestedNextStepsResponse {
 pub struct SuggestedNextStepItem {
     pub claim_id: ClaimId,                       // stable id for feedback callbacks
     pub headline: String,                        // product-safe (no PII bleed from raw evidence text)
-    pub why_this_now: String,                    // pre-rendered text from WhyThisNow.text (W2-A produces)
-    pub primary_factor: SalienceFactorKind,      // for chip / icon rendering only — NOT full factor breakdown
+    pub why_this_now_surface_text: String,       // SurfaceClient-redacted variant per A1; numerics → qualitative bands
+    pub factor_band: PrimaryFactorBand,          // 5-band collapse of 10 SalienceFactorKind variants (A1 #2)
     pub recommended_action: RecommendedActionView, // privacy-safe view (see §3.4)
-    pub trust_band: TrustBand,                   // for trust-band primitive rendering (ADR-0108)
+    pub trust_band: TrustBand,                   // for trust-band primitive rendering (ADR-0108, ADR-0132)
     pub receipt: ClaimReceiptSnapshot,           // Shared Receipt DTO per v1.4.4 invariant (v1.4.6-waves.md:543)
-    pub feedback_state: FeedbackState,           // for affordance state (pending vs decided)
+    pub feedback_state: FeedbackState,           // includes decided_at: DateTime<Utc> per ADR-0123 V1.1 (A16 #1)
     pub conversion_state: ConversionState,       // for "already converted" affordance state
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum PrimaryFactorBand {
+    TimeSensitive,     // collapses Urgency, Timing
+    NewInformation,    // collapses Novelty, Freshness
+    OpenLoopRelated,   // collapses OpenLoopRelevance
+    TrustChange,       // collapses Trust, Corroboration, Contradiction
+    Other,             // collapses Importance, UserFit
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum RecommendedActionView {
-    ScheduleMeeting { entity_label: String, when_window: String }, // no raw rationale; rationale flows through why_this_now
+    ScheduleMeeting { entity_label: String, when_window: String }, // no raw rationale; rationale flows through why_this_now_surface_text
     SendMessage    { entity_label: String, channel: String },
     ReviewClaim    { claim_label: String },
     UpdateRecord   { entity_label: String, field_label: String },
@@ -468,28 +563,38 @@ pub enum RecommendedActionView {
 }
 ```
 
-**Privacy boundaries (load-bearing — codex security review hits this hardest):**
+**Privacy boundaries (load-bearing — class sweep per A1):**
 
-- `RecommendedActionView` is the **projection** of `RecommendedAction` for surfaces — **never** ships the raw enum payload to a `SurfaceClient`. Entity IDs become resolved labels via the same redaction layer the receipt projection uses (`ClaimReceiptRedactionLevel`).
-- `SuggestedNextStepItem` carries `primary_factor` only, **never** the full `Vec<SalienceFactor>`. Full factor breakdown stays inside `score_salience` (User/System actors only). The hidden-ability contract is preserved (`v1.4.6-waves.md:941`).
+- `RecommendedActionView` is the **projection** of `RecommendedAction` for surfaces — **never** ships the raw enum payload to a `SurfaceClient`. Entity IDs become resolved labels via the same redaction layer the receipt projection uses (`ClaimReceiptRedactionLevel`). String fields run through the same numeric-redactor used for `why_this_now_surface_text` (A1 #3).
+- `SuggestedNextStepItem` carries `factor_band` (5-band collapse), **NOT** `primary_factor` (the 10-variant discriminant). Full `Vec<SalienceFactor>` stays inside `score_salience` (User/System actors only). The hidden-ability contract is preserved (`v1.4.6-waves.md:941`).
+- `why_this_now_surface_text` is the SurfaceClient-redacted variant — numerics replaced with qualitative bands (`high` / `moderate` / `low`); raw `vector_distance`, `decay_factor`, `feedback_history_score`, integer counts dropped. The User/System variant with numerics stays available only to `score_salience` callers.
 - `provenance` flows through `ClaimReceiptSnapshot.provenance` (the receipt's resolved view), not as a raw envelope on the item.
-- `feedback_state` and `conversion_state` ship as-is — they are part of the claim's lifecycle and are surface-safe.
+- `feedback_state` and `conversion_state` ship as-is — they are part of the claim's lifecycle and are surface-safe. `decided_at` timestamp gates server-side row drop at 30s (A16 #1).
 
-**Hidden-ability sweep test (codex security panel):** the W3-A integration fixture MUST include a test that, given a SurfaceClient invocation, the response JSON does NOT contain any of: `factors` array, raw `RecommendedAction` payload fields not surfaced in `RecommendedActionView`, raw evidence source paths, prompt/provider-looking strings.
+**Privacy class-sweep test (per A1 updated AC #4):** the integration fixture asserts (a) no `factors` array, no `primary_factor` field name, no raw `RecommendedAction` payload fields appear in any SurfaceClient response; (b) parametric over all 10 `FactorRationale` variants — none of `vector_distance`, `decay_factor`, `source_authority`, `signal_age_secs`, `calendar_proximity_secs`, `feedback_history_score`, `corroboration_count`, `contradiction_count`, `open_loop_count` appear as JSON numerics OR substring-matched in any string field; (c) parametric over all 6 `RecommendedAction` variants — `RecommendedActionView` carries no raw `entity_id` / `field_path` / `payload` JSON. Models `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md`.
 
 ### §3.4 Substrate-side projection rules
 
 The new `services::recommendations::projection::list_suggested_next_steps()` function:
 
-1. **Filters** `surfacing_decisions` to `tier ∈ {Critical, Notable, Background}` and `kind = Render` (Quiet, Defer, Suppress excluded for surfaces — `v1.4.6-waves.md:544`).
-2. **Joins** with the claim store for `RecommendationClaim` rows matching the `subject` filter.
-3. **Orders** by salience `total` descending, then by `created_at` descending as tiebreaker.
-4. **Truncates** to `max_items` (default 8, ceiling 8).
-5. **Maps** `RecommendedAction` → `RecommendedActionView` via redaction layer.
-6. **Invokes** existing `claim_receipt` projection per claim to populate `receipt` field — re-using v1.4.4 Shared Receipt DTO, not authoring a parallel one (`v1.4.6-waves.md:543`).
-7. **Returns** the privacy-safe response.
+**Function:** `services::recommendations::render::list_suggested_next_steps_projection(state, input, actor) -> Result<ListSuggestedNextStepsResponse>` (per A3; lives in the existing `render.rs` placeholder).
 
-Salience scoring is NOT recomputed at projection time — it reads the already-stored evaluation from W1-B's path (`services/recommendations/salience.rs::score_salience`). The hidden-ability contract calls the same substrate read; this ability projects the surface-safe subset.
+1. **Filters** `surfacing_decisions` (v271) by SQL columns:
+   - `subject_kind = ?` AND `subject_id = ?` (when `input.subject` is `Some`)
+   - `surfacing_tier IN ('critical', 'notable', 'background')` (lowercase string-encoded per v271 CHECK constraint; excludes `'quiet'`)
+   - `decision_kind = 'render'` (excludes `'defer'`, `'suppress'`)
+   - `created_at >= now() - INTERVAL '30 seconds'` for decided rows OR `feedback_state = 'pending'` (A16 #1 — server-side echo window ceiling)
+2. **Reads denormalized fields** from `surfacing_decisions` directly: `salience_total`, `why_this_now_json` (parsed to `WhyThisNow`), `trigger_refs_json`, `salience_evaluation_id`, `action_signature`. No claim-store join needed for these.
+3. **Calls `read_recommendation_for_render(claim_id, actor)`** (new function in `render.rs` per A2 #2) for the fields NOT in `surfacing_decisions`: full typed `RecommendedAction`, `TrustBand`, `evidence: Vec<EvidenceRef>`, `feedback_state` (full `Decided` variant with `decided_at`), `conversion_state`.
+4. **Orders** by `salience_total DESC`, then `created_at DESC` as tiebreaker.
+5. **Truncates** to `max_items` (default 5, ceiling 8 per A5 #4).
+6. **Maps `RecommendedAction` → `RecommendedActionView`** via the redaction layer (A1 #3).
+7. **Computes `factor_band: PrimaryFactorBand`** from `WhyThisNow.primary_factor` via the 5-band collapse table in §3.3.
+8. **Generates `why_this_now_surface_text`** by re-rendering the W2-A template gated on actor — numerics → qualitative bands, raw integer leaves dropped (A1 #1).
+9. **Calls `render_receipts_for_batch(state, claim_ids, surface)`** (new helper in `render.rs` per A2 #5 + A17 #3) to populate `receipt` field for all items in one substrate read — replaces the N+1 per-call pattern. Inner privacy enforcement flows via `SurfaceContext` derived from outer actor (A17 #1); audience is `audience_for_surface(surface)` per ADR-0108.
+10. **Returns** the privacy-safe `ListSuggestedNextStepsResponse`.
+
+Salience scoring is NOT recomputed at projection time — it reads `salience_total` from the `surfacing_decisions` row written by W1-B. The hidden `score_salience` ability (User/System only) calls the same substrate read but returns the full factor breakdown; this projection returns the surface-safe subset (`factor_band` + redacted `why_this_now_surface_text`).
 
 ### §3.5 Provenance envelope
 
@@ -516,7 +621,7 @@ Output ships with full `Provenance` envelope per ADR-0105. Schema version `1` fo
     "supports": { "html": false, "reusable": false, "inserter": false },
     "usesContext": [ "dailyos/entityType", "dailyos/entityId" ],
     "attributes": {
-        "maxItems":  { "type": "number", "default": 8 },
+        "maxItems":  { "type": "number", "default": 5 },
         "headingLabel": { "type": "string" }
     },
     "render": "file:./render.php"
@@ -524,10 +629,11 @@ Output ships with full `Provenance` envelope per ADR-0105. Schema version `1` fo
 ```
 
 Notes:
-- `inserter: false` — block is inserted by composition (W3-B), not directly by editor
-- `usesContext` mirrors `meeting-recommended-actions:9` precedent — block resolves entity from outer context provided by `dailyos/{account,project,person,meeting}-detail` and from a future `dailyos/work-surface` wrapper (W3-B scope)
-- `headingLabel` attribute lets the parent surface override the section heading ("Suggested next steps for this account" vs "Suggested topics for next 1:1")
-- `parent` constraint deliberately omitted at W3-A — W3-B configures it once embedding pages are confirmed
+- `inserter: false` — block is inserted by composition (W3-B), not directly by editor; the `title` field is the developer-facing block-inserter label, never user-visible
+- `usesContext` mirrors `meeting-recommended-actions:9` precedent — block resolves entity from outer context provided by `dailyos/{account,project,person,meeting}-detail` parents
+- `headingLabel` attribute lets the parent surface override the section heading per ADR-0083 vocabulary (A6); defaults are hardcoded per-surface in `render-functions.php` ("What's next with {Account.name}", "What's next on {Project.name}", "Open threads with {Person.name}", "What to cover" for meeting prep)
+- `parent` constraint deliberately omitted at W3-A — work-surface integration deferred to W3-B per A9 (`dailyos/work-surface` does not exist; `the-work` and `open-loops-feed` blocks exist instead). W3-A's block is entity-only at merge.
+- `maxItems` default `5` matches the editorial-reading-surface density convention; ceiling `8` is enforced server-side (A5 #4). W3-B may bump default to 8 for the work surface where the recommendation list is the primary content.
 
 ### §4.2 `render.php` shape (terse stub)
 
@@ -541,44 +647,71 @@ return dailyos_suggested_next_steps_render( $attributes ?? [], $block ?? null );
 
 ### §4.3 `render-functions.php` algorithm
 
-Mirrors `meeting-recommended-actions/render-functions.php` precedent. Differences:
+Inherits structural pattern from `meeting-recommended-actions/render-functions.php`. Per-surface specifics:
 
 1. **Subject resolution.** Resolve `SubjectRef` from `$block->context`:
    - `dailyos/entityType = 'account'` + `dailyos/entityId = '...'` → `SubjectRef::Account(...)`
    - `'project'`, `'person'`, `'meeting'` → analogous
-   - Missing context with `parent === 'dailyos/work-surface'` → `SubjectRef::Global` (or `SubjectRef::User` per W3-B confirmation)
-   - All other missing context → empty chip `missing_subject_context`
+   - All other missing context → empty chip `missing_subject_context`. Work-surface integration deferred to W3-B (A9) — block does not attempt global-feed resolution at W3-A.
 
-2. **Ability call.** `$runtime_client->invoke_ability('list_suggested_next_steps', [...input...], $scope_set)` with `surface = surface_for_context(...)`.
+2. **Ability call.** `$runtime_client->invoke_ability('list_suggested_next_steps', [...input...], $scope_set)` with `surface = surface_for_context(...)`. Note: `$scope_set` is informational only — the `/v1/local/invoke` transport `unset()`s it; enforcement is Rust registry-side per A8 + A17 #1.
 
-3. **Error handling** per `meeting-recommended-actions:46–65`:
+3. **Section wrapper class (per-surface — A5 #1):**
+   - Account / Project / Person → `entity-detail_chapterSection`
+   - Meeting → `meeting-intel_chapterSection`
+   - Briefing → resolved at L1 grep against existing briefing chapter pattern; default fallback composes `editorial-reveal` + `ChapterHeading_*`
+
+4. **Section heading.** `editorial-reveal` + `ChapterHeading_*` family. Default `headingLabel` (per ADR-0083 vocabulary per A6, hardcoded in render-functions.php with `$entity_type` switch):
+   - Account → `"What's next with {Account.name}"`
+   - Project → `"What's next on {Project.name}"`
+   - Person → `"Open threads with {Person.name}"`
+   - Meeting prep → `"What to cover"` (no name interpolation; chapter joins parent's per A12)
+   - Entity-name interpolation uses the resolved label from the same redaction layer as `RecommendedActionView` (A1 #3). If the resolved label exceeds 40 characters, truncate with ellipsis at word boundary; no row-wrap.
+
+5. **Error handling** per `meeting-recommended-actions:46–65`:
    - Runtime unavailable → empty chip `runtime_unavailable`
    - WP_Error / `ok === false` → empty chip `envelope_error`
-   - Empty items list → empty chip `no_recommendations` (label varies by surface — "No suggested next steps." for accounts/projects, "No suggested topics." for person/meeting)
+   - Empty items list → empty chip `no_recommendations` with surface-specific copy (A6): Account/Project → `"Nothing flagged right now."`, Person → `"No open threads."`, Meeting prep → `"Nothing to cover yet."`
 
-4. **Per-item rendering:**
-   - Section heading: `editorial-reveal` + `ChapterHeading_*` family with `attributes.headingLabel` (or surface default)
-   - Per-row: trust-band primitive (server-rendered per ADR-0108 audience filter from `receipt.trust`), headline, why-this-now caption, recommended-action view, action affordance ("Convert to action" / "Dismiss" / "Not useful")
-   - Provenance summary inline-or-drawer: link to `evidence-drawer` block where it exists, otherwise inline truncated source list
-   - Each affordance carries `data-claim-id="..."` + `data-feedback-kind="dismiss|accept|notUseful|tooNoisy|convert"` for the W4-A feedback handler (see §9)
+6. **Per-item rendering:**
+   - Row class: `suggested-next-steps_row`. For `trust_band = needs_verification`, additionally applies `suggested-next-steps_row--needsVerification` modifier (terracotta-accent treatment per A5 #2 + A16 #3). For `likely_current` and `use_with_caution`, no row-level modifier — only the ADR-0132 trust-band pill carries band-specific class (A16 #3).
+   - **Trust-band placement:** trails the headline text node as a finis marker (per `meeting-intel_currentStateItem` precedent, `meeting.html:399-401`). Pill rendered server-side from `receipt.trust` via ADR-0108 audience filter.
+   - **Headline:** text from `SuggestedNextStepItem.headline`; primary visual weight.
+   - **Why-this-now caption:** `<p class="suggested-next-steps_whyThisNow">` with CSS `line-clamp: 2`; content from `why_this_now_surface_text` (A1-redacted).
+   - **Recommended-action view:** rendered from `RecommendedActionView` variant.
+   - **Provenance summary:** inline truncated source list; links to `evidence-drawer` block where the parent surface composes one (DOS-689 precedent).
+   - **Affordance row:** 3 primary visible buttons per A4 #1 — `Convert to action`, `Dismiss`, `More feedback…` (focusable button with `aria-expanded` toggling the hover-reveal sub-affordance row per A16 #5).
+   - **Sub-affordance row (revealed on click/hover):** `Mark as not useful`, `Mark as too noisy`, `Dismiss with reason…` (which opens a small reason picker mapping to `DismissReason::NotRelevant | AlreadyKnew | WrongSubject | Other(BoundedNote)`).
+   - **ADR-0123 mapping:** affordance `data-feedback-kind` values map directly to ADR-0123's 10 typed `RecommendationFeedbackDecision` variants. Constant file: `wp/dailyos/blocks/suggested-next-steps/feedback-kinds.ts`.
+   - **Terminal-state CSS classes** (per A4 #2 + A16 #2):
+     - `pending` → default
+     - `in_flight` → row class `suggested-next-steps_row--inFlight`; opacity 60%; `aria-busy="true"`; affordances disabled
+     - `decided_dismissed` → `suggested-next-steps_row--collapsing` animates `max-height` + `opacity` over 200ms (snap if `prefers-reduced-motion: reduce`). Server drops row at next render once `now() - decided_at > 30s` (A16 #1)
+     - `decided_converted` → row replaces affordance set with confirmation chip "Converted to action — {action-link}"; same 30s server-side drop
+     - `disabled` → block-level banner (A4 #3 + A16 #4) "Feedback opens on the next sync."; affordances render with class `disabled-affordance` (W3-A authors this class per A18 #1), `tabindex="-1"`, `aria-disabled="true"`; no per-button tooltip
+     - `error` → affordances re-enable; inline non-dismissible retry chip below the row
 
-5. **Always-visible empty chip** when `items === []`, per `v1.4.6-waves.md:544` invariant — "§10 invariant — never silent-hidden" (`meeting-recommended-actions:163`).
+7. **Always-visible empty chip** when `items === []`, per `v1.4.6-waves.md:544` invariant — "§10 invariant — never silent-hidden" (`meeting-recommended-actions:163`).
 
 ### §4.4 Style module
 
 - New file: `wp/dailyos/blocks/suggested-next-steps/style.css`
-- Class namespace: `suggested-next-steps_*` (matches `meeting-intel_*` precedent shape)
-- Composes existing primitives where possible; new classes only where the parity matrix gap forces them
-- Block stylesheet enqueue follows existing wp-block-themes pattern (registered via `register_block_type_from_metadata`)
+- Class namespace: `suggested-next-steps_*` (matches the surface-prefix convention per NAMING.md when the pattern is unique to that surface)
+- Composes existing primitives — `ChapterHeading_*`, `editorial-reveal`, `dailyos-empty-chip`, ADR-0132 trust-band pill, ADR-0108 evidence drawer — per A5 #1 + #6
+- New tokens required: `suggested-next-steps_row`, `suggested-next-steps_row--needsVerification`, `suggested-next-steps_row--inFlight`, `suggested-next-steps_row--collapsing`, `suggested-next-steps_whyThisNow`, `disabled-affordance` (per A18 #1). Each new token verified by `/plan-design-review` to confirm no existing token covers it (per A5 #6).
+- Block stylesheet enqueue via `register_block_type_from_metadata`
 
 ### §4.5 Editor / view scripts
 
-Per wave plan: `editor/view files only if the block needs interactive controls` (`v1.4.6-waves.md:942`). W3-A view script needs:
+W3-A introduces a `view.js` carrying the first DailyOS block client-side **feedback-POST affordance** script. The `view.js` bundle pattern itself is established in 7 existing blocks (`evidence-drawer`, `entity-intake`, `projects-index`, `people-index`, `source-management`, `accounts-index`, `account-overview`) — what's new is the affordance category (per A17 #2).
 
-- **Client-side affordance handler** — POSTs to a feedback ability (W4-A) via the WP REST endpoint that bridges to the abilities runtime
-- During the W4-A gap (see §9), the click handler is registered but **either** disabled (button shows `aria-disabled="true"` until feedback ability lands) **or** stubbed to a no-op endpoint that returns `200 not_yet_implemented`
+`view.js` responsibilities:
 
-W3-A authors the affordance markup + handler. The decision between disabled vs no-op stub is an L0 question (see §12).
+- **Hover-reveal disclosure** of the secondary affordance row (mouse). Canonical trigger is the focusable `More feedback…` button with `aria-expanded` (A16 #5) — keyboard and touch users disclose via button activation, mouse users disclose via hover. CSS owns the hover; JS owns the toggle.
+- **Affordance POST handler** — on click of `Convert / Dismiss / Mark as not useful / Mark as too noisy / Dismiss-with-reason`, POSTs to the W4-A `submit_recommendation_feedback` ability via the `/v1/local/invoke` transport. During the W4-A gap, the handler is feature-flagged off (A11-style explicit guard) and the affordances render in disabled state per the §4.3 step 6 `disabled` terminal-state class.
+- **Engagement signal emission** — `Rendered` on mount + `Clicked` on affordance click — also feature-flagged off until W4-C lands (A11). Guards are explicit, not silent no-ops.
+- **Terminal-state class swap on click** — adds `suggested-next-steps_row--inFlight` before the POST; on response, swaps to `--collapsing` or `--error` as appropriate; CSS owns the animation.
+- **Touch fallback** — keyboard-disclosure pattern works for touch (tap = focus + activate). Cross-device-specific touch refinements are path-α maintenance (A16 #6).
 
 ---
 
@@ -587,17 +720,21 @@ W3-A authors the affordance markup + handler. The decision between disabled vs n
 Plain-language ACs, traceable to the wave plan invariants and DOS-298 description.
 
 1. **Ability ships and is registered.** `list_suggested_next_steps` appears in `tools/dailyos-abilities.json` (regen committed in same PR), and `AbilityRegistry::global_checked()` exposes it to `Actor::SurfaceClient` with scope `read.recommendations`. `cargo test recommendations::list_suggested_next_steps` passes.
-2. **Block renders for the four entity surfaces.** Test fixture proves `dailyos/suggested-next-steps` inside `dailyos/{account,project,person,meeting}-detail` parents produces non-empty HTML with the expected class names when seeded recommendations exist for that subject.
-3. **Empty state ships visible chip.** Each surface's empty render produces `dailyos-empty-chip` with a machine-readable reason (`no_recommendations`, `missing_subject_context`, `runtime_unavailable`, `envelope_error`). No silent hiding — `v1.4.6-waves.md:544`.
-4. **Hidden-ability sweep passes.** Integration test asserts SurfaceClient JSON response contains no `factors` array, no raw `RecommendedAction` payload, no envelope copy. `score_salience` actor allowlist unchanged.
-5. **Trust band renders per claim.** Each item's `receipt.trust.band` flows through the existing trust-band primitive; trust display matches the receipt's actor-filtered view (ADR-0108).
-6. **Why-this-now is product-safe.** No raw evidence-source paths, no prompt/provider-looking strings, no PII bleed. Test asserts against a fixture with seeded sensitive content.
+2. **Block renders for the four entity surfaces.** Test fixture proves `dailyos/suggested-next-steps` inside `dailyos/{account,project,person,meeting}-detail` parents produces non-empty HTML with the expected class names when seeded recommendations exist for that subject. Section wrapper class is `entity-detail_chapterSection` for account/project/person; `meeting-intel_chapterSection` for meeting (A5 #1).
+3. **Empty state ships visible chip.** Each surface's empty render produces `dailyos-empty-chip` with a machine-readable reason (`no_recommendations`, `missing_subject_context`, `runtime_unavailable`, `envelope_error`). Surface-specific copy per A6 ("Nothing flagged right now." / "No open threads." / "Nothing to cover yet."). No silent hiding — `v1.4.6-waves.md:544`.
+4. **Privacy class-sweep passes (A1).** Parametric integration test over all 10 `FactorRationale` variants and all 6 `RecommendedAction` variants. SurfaceClient JSON response contains no `factors` array, no `primary_factor` field, no raw `RecommendedAction` payload, no envelope copy, and no `FactorRationale` numerics appear as JSON numerics OR substring-matched in any string field. `score_salience` actor allowlist unchanged (`[User, System]` only).
+5. **Trust band renders per claim.** Each item's `receipt.trust.band` flows through the ADR-0132 pill primitive trailing the headline. `likely_current` and `use_with_caution` render with indicator-only class; `needs_verification` adds the `suggested-next-steps_row--needsVerification` row modifier (A5 #2 + A16 #3).
+6. **Why-this-now is privacy-safe (A1).** `why_this_now_surface_text` carries the SurfaceClient-redacted variant; numerics replaced with qualitative bands. CSS `line-clamp: 2` enforces visual budget. Test asserts against a fixture with seeded sensitive content.
 7. **Receipt is the Shared Receipt DTO.** Each item carries `ClaimReceiptSnapshot`, not a parallel receipt struct. `cargo clippy -- -D warnings` enforces (grep CI on `RecommendationReceipt|RecRow` per `v1.4.6-waves.md:543`).
 8. **No W2 table reads from the block.** Static grep in CI: `wp/dailyos/blocks/suggested-next-steps/**` contains no references to `surfacing_decisions`, `triggers_log`, or any other W2 table name.
 9. **No new migrations.** Empty migrations diff in the PR (per `v1.4.6-waves.md:464`).
-10. **Reference HTML lands** for account/project/person surfaces — sections added to `.docs/design/reference/surfaces/{account,project,person}.html` matching the block's rendered shape. Visual parity matrix in §1 of this packet is updated from "gap" to "matches reference: lines X-Y".
-11. **L4 surface QA runs BEFORE L2** per `v1.4.6-waves.md:440`. `/qa-only` evidence (screenshots of empty + non-empty + over-budget states) is attached to the Linear ticket before L2 dispatch.
-12. **Cycle hygiene.** Full validation: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit && phpunit (wp/dailyos/tests)`.
+10. **Reference HTML lands FIRST in PR sequence (A7).** Reference sections added to `.docs/design/reference/surfaces/{account,project,person,meeting}.html` as the first commit in the W3-A PR; `render.php` follows. Reviewers reject a PR where `render.php` lands without a preceding reference-HTML commit. Visual parity matrix in §1 is updated from "gap" to "matches reference: lines X-Y".
+11. **L4 surface QA runs BEFORE L2 (A10).** `/qa-only` evidence attached to DOS-298 before L2 dispatch: 20-screenshot grid, wire-JSON snapshot, Tauri-vs-WP parity (or forward-defer note per ADR-0129 §7), trust-band band-by-band coverage, 30s echo-window timing test.
+12. **Registry channels enumerated (A8).** 6 channels confirmed at L1; per-Actor dry-run test asserts `[User, System, SurfaceClient]` allowlist exactly.
+13. **Affordances map to ADR-0123 10 variants (A4 #6).** Constant file `feedback-kinds.ts` ships; `data-feedback-kind` values match the 10 typed `RecommendationFeedbackDecision` variants.
+14. **Decided-state echo window enforced server-side (A16 #1).** Rows with `Decided` feedback older than 30 seconds are filtered out by the projection regardless of client state. Time-skipped test verifies.
+15. **All cycle-1/2 amendments reflected in original sections.** A19 sweep complete: every section reads consistently with its governing amendment without cross-reference.
+16. **Cycle hygiene.** Full validation: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit && phpunit (wp/dailyos/tests)`.
 
 ---
 
@@ -605,30 +742,41 @@ Plain-language ACs, traceable to the wave plan invariants and DOS-298 descriptio
 
 ### Unit (Rust)
 
-- `list_suggested_next_steps` golden wire-shape fixture (mirrors `recommendation_contract_golden_wire_shape` test pattern in `services/recommendations/contracts.rs:441`)
-- Hidden-actor denial: `Actor::McpClient` denied before reader
+- `list_suggested_next_steps_projection` golden wire-shape fixture (mirrors `recommendation_contract_golden_wire_shape` test pattern in `services/recommendations/contracts.rs:441`)
+- Hidden-actor denial: `Actor::McpClient` denied before reader; per-Actor dry-run test per A8 (3 succeed, 3 fail with `Capability` error)
 - Surface actor allowed with `read.recommendations` scope; denied without scope
-- Subject filtering: `SubjectRef::Account(x)` returns only account-x recommendations; `None` returns global feed
-- `max_items` ceiling respected (request 100, response capped at 8)
-- Privacy-safe response: parametric test asserts no leakage of raw factors / raw payload / raw evidence sources / prompt strings
+- Subject filtering: `SubjectRef::Account(x)` returns only account-x recommendations; `None` returns empty (work-surface integration deferred to W3-B per A9)
+- `max_items` ceiling respected (request 100, response capped at 8); default = 5 when attribute unset
+- **Privacy class-sweep test (A1 #4):** parametric over all 10 `FactorRationale` variants — none of `vector_distance`, `decay_factor`, `source_authority`, `signal_age_secs`, `calendar_proximity_secs`, `feedback_history_score`, `corroboration_count`, `contradiction_count`, `open_loop_count` appear as JSON numerics OR substring-matched in any string field; parametric over all 6 `RecommendedAction` variants — `RecommendedActionView` carries no raw `entity_id` / `field_path` / `payload`. Asserts `primary_factor` field name absent; `factors` array absent.
+- Inner `render_receipts_for_batch` privacy: parametric test asserts SurfaceClient outer actor produces receipts with SurfaceClient-tier redaction (per A2 #4 + A17 #1)
+- 30s decided-row drop: time-skipped test asserts `Decided` row older than 30s is filtered out by projection (A16 #1)
 
 ### Unit (PHP)
 
 - `dailyos_suggested_next_steps_extract_items()` parser handles ability response shape (`response.ability.data.items`, `response.data.items`, fallback to raw)
-- Empty chip variants render with correct reason codes
-- Section heading uses `attributes.headingLabel` when set, surface default otherwise
-- Affordance markup carries `data-claim-id` + `data-feedback-kind` for every item
+- Empty chip variants render with correct reason codes (`missing_subject_context`, `runtime_unavailable`, `envelope_error`, `no_recommendations`)
+- Section heading uses `attributes.headingLabel` when set, A6 surface defaults otherwise
+- Section wrapper class per surface: `entity-detail_chapterSection` for account/project/person; `meeting-intel_chapterSection` for meeting (A5 #1)
+- Affordance markup carries `data-claim-id` + `data-feedback-kind` for every item; mapping matches ADR-0123 10 variants per `feedback-kinds.ts` constants
+- ARIA labels per affordance (A4 #5)
+- Terminal-state class swap: `--inFlight`, `--collapsing`, `--needsVerification` modifiers applied correctly
+- Trust-band placement: pill trails headline (`meeting.html:399-401` precedent)
+- Disabled-state banner string: "Feedback opens on the next sync." with `aria-live="polite"` (A16 #4)
 
 ### Integration
 
-- End-to-end fixture: WP block render → runtime client filter → ability invocation → projection from seeded substrate → rendered HTML matches snapshot
-- Snapshot tests for: empty state, single-item, max-items-truncated, over-budget-with-defer
+- **PHPUnit-mocked-runtime pattern (A18 #2 — in-scope):** End-to-end fixture: WP block render → runtime client mocked to return canned envelope → rendered HTML matches snapshot. Cross-process Tauri-loopback-in-CI harness is **out-of-scope** for W3-A.
+- Snapshot tests for: empty state, single-item, max-items=5 default, max-items=8 ceiling, decided-dismissed in collapse animation, decided-converted with confirmation chip, error state with retry chip, disabled state with banner
 
 ### L4 surface QA (before L2)
 
 - `/qa-only` walks Account, Project, Person, Meeting surfaces in the local WP install
-- Captures screenshots for empty + 1 + 3 + 8 recommendation counts
-- Verifies trust band rendering, why-this-now caption, feedback affordance presence (and disabled-state if W4-A gap holds)
+- **Screenshot grid (A10 #1):** empty + 1 + 3 + 5 + 8 recommendation counts × 4 entity surfaces = 20 screenshots
+- **Wire-JSON snapshot (A10 #2):** full `ListSuggestedNextStepsResponse` JSON for a seeded 5-item fixture committed as a golden snapshot under `wp/dailyos/tests/fixtures/suggested-next-steps/`
+- **Tauri-vs-WP parity (A10 #3):** side-by-side trust-band visual comparison for a single seeded recommendation; if Tauri has no equivalent surface today, document forward-defer to v1.4.7+ MCP/Tauri-thin-surface decision per ADR-0129 §7
+- **Trust-band band-by-band coverage (A10 #4):** `likely_current`, `use_with_caution` (indicator-only — A16 #3), `needs_verification` (with row-modifier — A5 #2) — single-item example of each
+- **Locale coverage:** single-locale baseline; non-default-locale screenshot if harness supports (otherwise path-α per A14 #3)
+- **30s echo window timing test:** capture a `decided_dismissed` state, wait 30s, capture again — verify row dropped
 - Attaches evidence to DOS-298 ticket comment before L2 dispatch
 
 ---
@@ -709,39 +857,49 @@ W4-C (DOS-462 / engagement.rs) wants to record `Rendered`, `Clicked`, `Dismissed
 
 ## §11 K-in citations
 
-K-in grep results from `docs/solutions/` + `.docs/decisions/` (parallel `ce-learnings-researcher` pending; preliminary scan below):
+K-in grep results from `docs/solutions/` + `.docs/decisions/` (final list confirmed by `ce-learnings-researcher` at cycle 0):
 
 | Source                                                                                                              | Relevance                                                                                                                                          |
 |---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| ADR-0102 — Abilities as Runtime Contract                                                                            | All abilities follow `AbilityOutput<T>` shape with single envelope on the wrapper                                                                  |
-| ADR-0105 — Provenance as First-Class Output                                                                         | Envelope lives once; field attributions reference into it                                                                                          |
-| ADR-0108 — Provenance Rendering and Privacy                                                                         | Actor-filtered render; trust-band rendering rules; 64KB serialized cap                                                                             |
-| ADR-0111 — Surface-Independent Ability Invocation                                                                   | `SurfaceClient` actor class; scope-based actor filtering; bridge-per-surface invocation                                                            |
+| ADR-0102 — Abilities as Runtime Contract                                                                            | Canonical ability registration via `#[ability(...)]` macro + `inventory::submit!`; `[SurfaceClient, System]` allowlist pattern                     |
+| ADR-0103 — Maintenance Ability Safety Constraints                                                                   | Hidden-from-clients actor allowlist pattern (model for preserving `score_salience` invariant; test template for A8 dry-run)                        |
+| ADR-0105 — Provenance as First-Class Output                                                                         | Envelope lives once; field attributions reference into it. `ClaimReceiptSnapshot` is the canonical DTO W3-A consumes                                |
+| ADR-0108 — Provenance Rendering and Privacy                                                                         | Actor-filtered render; trust-band rendering rules; 64KB serialized cap. `audience_for_surface(surface)` enforcement path                            |
+| ADR-0111 — Surface-Independent Ability Invocation                                                                   | `SurfaceClient` actor class; scope-based actor filtering; `dailyos_runtime_client_for_block` filter is the canonical WP-to-substrate seam            |
+| ADR-0123 — Typed Claim Feedback Semantics (V1.1)                                                                    | 10 typed `RecommendationFeedbackDecision` variants W3-A affordances map onto; `decided_at` timestamp on `Decided` variant (A16 #1)                  |
 | ADR-0125 — Claim Anatomy, Temporal Scope, Sensitivity, TypeRegistry                                                 | `RecommendationClaim` metadata: temporal=State, sensitivity=Internal, freshness=Medium, commit=Replace, allowed_actor=Agent (see contracts.rs:421) |
+| ADR-0126 — Memory Substrate Invariants                                                                              | Projection invariants over claim store; any new projection function (W3-A's `list_suggested_next_steps_projection`) must conform                    |
 | ADR-0129 — Composable Surfaces                                                                                      | WP as primary surface; blocks are typed projections; WP MCP via Abilities API + MCP Adapter                                                        |
 | ADR-0130 — Surface-Independent Composition Contract                                                                 | §3.1 custom-block fallback projection (relevant if W3-B uses Composition wrapper); §2 size guard                                                   |
+| ADR-0132 — Pill Primitive Dual-Existence                                                                            | Trust-band pill primitive — W3-A reuses (not authors); placement trails headline per A5 #2                                                          |
 | DOS-689 (Evidence Drawer block) — `wp/dailyos/blocks/evidence-drawer/`                                              | Server-rendered provenance summary + client toggle drawer pattern. W3-A links to evidence drawer where present.                                    |
-| `wp/dailyos/blocks/meeting-recommended-actions/`                                                                    | The dominant block precedent — `usesContext` + runtime_client filter + scope filter + empty-chip-never-silent invariant                            |
+| `wp/dailyos/blocks/meeting-recommended-actions/`                                                                    | Block precedent — `usesContext` + runtime_client filter + empty-chip-never-silent invariant. W3-A inherits structure; affordance category is new   |
+| `wp/dailyos/blocks/{evidence-drawer,entity-intake,projects-index,people-index,source-management,accounts-index,account-overview}/view.js` | 7 existing `view.js` precedents — bundle pattern is established; W3-A's `view.js` introduces feedback-POST as new affordance category (A17 #2) |
 | `services/recommendations/contracts.rs`                                                                             | RecommendationClaim type + RecommendedAction enum + SurfacingDecision + WhyThisNow                                                                 |
-| `abilities-runtime/src/abilities/recommendations/mod.rs`                                                            | `score_salience` ability — hidden-from-clients invariant W3-A MUST preserve                                                                        |
-| `abilities-runtime/src/abilities/claim_receipt/`                                                                    | Shared Receipt DTO that W3-A reuses for `SuggestedNextStepItem.receipt`                                                                            |
+| `abilities-runtime/src/abilities/recommendations/mod.rs`                                                            | `score_salience` ability — hidden-from-clients invariant W3-A MUST preserve (User/System only; SurfaceClient excluded)                              |
+| `abilities-runtime/src/abilities/claim_receipt/`                                                                    | Shared Receipt DTO that W3-A reuses for `SuggestedNextStepItem.receipt`; `render_receipt_for(state, target, surface)` service function (A17 #1)     |
+| `src-tauri/src/migrations/271_recommendation_surfacing.sql`                                                          | v271 schema W3-A projection filters against — `surfacing_tier` + `decision_kind` lowercase string-encoded; 4 indexes already present                |
+| `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md`                                | Class-level sensitivity-leak test pattern modeled in A1 #4 — leak detector runs against every field of every response variant, not just happy path |
+| `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`                            | Method note: grep substrate types (`RecommendationClaim`, `ClaimReceiptSnapshot`), not proposed names (`SuggestedNextStepItem`)                     |
+| `feedback_l0_reconcile_against_dev.md`                                                                              | Fork SHA verified clean against `public/dev` HEAD `e73ac894` at cycle 1 (A15)                                                                       |
 
-**No `docs/solutions/` entries found for "suggested next steps", "recommendation surface", "block producer", or "projection ability".** Gap is substrate-bound; surfacing/WP binding is W3-A scope.
-
-`ce-learnings-researcher` will run in parallel during L0 review to confirm no hits I missed.
+**No `docs/solutions/` entries found for "suggested next steps", "recommendation surface", "block producer", or "projection ability".** Gap is substrate-bound; surfacing/WP binding is W3-A scope. K-in cycle-0 verdict: **NO REINVENTION DETECTED**, conditional on the 11+ primitives above being cited and consumed — all cited in this section.
 
 ---
 
 ## §12 Open questions (L0 panel decides)
 
-1. **Feedback affordance pattern** (load-bearing — see §9). Option A (disabled-with-tooltip), Option B (skeleton ability), or Option C (reorder waves)?
-2. **theme.json token strategy.** Reuse existing tokens only (matrix §1), or add a `suggested-next-steps_*` token family? Design review decides; default is reuse.
-3. **Work-surface subject resolution.** Work-surface block context resolves to `SubjectRef::Global` or `SubjectRef::User`? Affects projection filter behavior. Plan to confirm with W3-B L0.
-4. **Reference HTML scope.** Does W3-A author full reference sections in account.html / project.html / person.html, or minimal reference snippets that W3-B fills in? Default: minimal sections that the block can be visually verified against; W3-B integrates them into composition.
-5. **`headingLabel` default per surface.** Hardcode in render-functions.php or thread via `usesContext` from outer block? Default: hardcoded in render-functions.php with `dailyos/entityType` switch (matches `meeting-recommended-actions` precedent).
-6. **`max_items` ceiling = 8.** Sane? If L4 surface QA on 8-item dense states regresses scannability, tune down to 5. Decision deferred to L4 evidence.
-7. **Engagement signal firing** (see §9 W4-C). Same pattern as feedback — disable until W4-C lands?
-8. **`score_salience` "User" actor.** Existing ability allows `Actor::User`. W3-A does NOT touch this allowlist. Confirm no path-α regression slips in via service-layer refactor.
+**Status after cycle 2:** All cycle-0 questions resolved by A1–A19 amendments. The only remaining L0 question is briefing-surface wrapper class, which is L1-resolvable.
+
+1. ~~**Feedback affordance pattern.**~~ **RESOLVED (A4 + A16 #4):** Option A (disabled affordance with single block-level banner "Feedback opens on the next sync."). Affordance markup ships server-side; click handler feature-flagged off until W4-A.
+2. ~~**theme.json token strategy.**~~ **RESOLVED (A5 #6):** Reuse first. Each new `suggested-next-steps_*` token requires design-review to name + confirm no existing token covers it.
+3. ~~**Work-surface subject resolution.**~~ **RESOLVED (A9):** `dailyos/work-surface` doesn't exist. W3-A is entity-only at merge; W3-B owns work-surface integration via `the-work` or `open-loops-feed` blocks.
+4. ~~**Reference HTML scope.**~~ **RESOLVED (A7):** Full surface-layer sections in account/project/person/meeting HTML; lands as first commit in PR sequence.
+5. ~~**`headingLabel` default per surface.**~~ **RESOLVED (A6):** Hardcoded per-surface defaults in render-functions.php via `dailyos/entityType` switch ("What's next with {Account.name}" / "Open threads with {Person.name}" / etc).
+6. ~~**`max_items` ceiling = 8.**~~ **RESOLVED (A5 #4):** default 5, ceiling 8 (attribute-tunable).
+7. ~~**Engagement signal firing.**~~ **RESOLVED (A11):** Call sites wired with explicit `ENGAGEMENT_SIGNALS_ENABLED = false` guard until W4-C flips the flag. Not silent no-ops; testable.
+8. ~~**`score_salience` actor allowlist.**~~ **CONFIRMED:** W3-A does NOT touch the allowlist. AC #4 parametric test asserts the hidden-actor invariant.
+9. **Briefing-surface chapter wrapper class.** L1-resolvable. A5 #1 default fallback (`editorial-reveal` + `ChapterHeading_*`) applies if no specific briefing chapter pattern exists.
 
 ---
 

--- a/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md
@@ -1,0 +1,500 @@
+---
+ticket: DOS-298
+title: "v1.4.6 W3-A — Suggested Next Steps block contract"
+parent_plan: ../v1.4.6-waves.md
+fork_sha: e73ac8949b0df46c33b441fc14737cee2a9c3a73
+branch: codex/v1.4.6-w3a-suggested-next-steps
+status: L0 — plan hardening, cycle 0 draft
+authors: James Giroux, Claude
+related:
+  - ADR-0129 (Composable Surfaces — WordPress Studio as Primary Surface)
+  - ADR-0130 (Surface-Independent Composition Contract)
+  - ADR-0105 (Provenance as First-Class Output)
+  - ADR-0108 (Provenance Rendering and Privacy)
+  - ADR-0111 (Surface-Independent Ability Invocation)
+  - DOS-329 (RecommendationClaim contract — landed)
+  - DOS-333 (cross-surface embedding — W3-B, blocks on W3-A)
+  - DOS-332 (recommendation feedback semantics — W4-A consumer)
+---
+
+# v1.4.6 W3-A — Suggested Next Steps block contract (DOS-298)
+
+## §0 Frame
+
+W3-A ships **two coupled deliverables in one PR**:
+
+1. A new **`SurfaceClient`-allowed read ability** under `src-tauri/abilities-runtime/src/abilities/recommendations/` that projects typed recommendations for a subject into a privacy-safe, render-ready list.
+2. A new **Gutenberg block** `dailyos/suggested-next-steps` under `wp/dailyos/blocks/suggested-next-steps/` that calls (1) via the `dailyos_runtime_client_for_block` filter and renders per-claim trust band, why-this-now, evidence/provenance summary, and feedback affordances.
+
+The block **never reads** `surfacing_decisions`, `triggers_log`, or any other W2 table directly. The ability is the only seam. This is the producer-boundary invariant the wave plan codifies (`v1.4.6-waves.md:541–558`).
+
+**Reviewer set for this packet (per `v1.4.6-waves.md:435–449` + memory rules):**
+
+- `/codex challenge` — default planning challenger
+- `/plan-eng-review` — default planning reviewer
+- `/plan-design-review` — design-mandatory for W3-A per plan
+- `/plan-devex-review` — new ability contract + producer/projection boundary
+- `ce-learnings-researcher` — K-in (parallel, mandatory)
+- **WP-skill-grounded panel** (5th slot per memory rule for `wp/dailyos/blocks/**` touches) — block.json/render.php verification
+
+Unanimous required. Path-α findings (theoretical hardening, scope adjacent) → Codebase Maintenance project; substrate plan does not block on them.
+
+---
+
+## §1 Visual parity matrix
+
+> **WP-wave rule (memory):** every WP wave packet must carry a parity matrix in §1. Visual parity is BLOCKING at L0 — not deferred to L4 verification.
+
+| Surface slot                                                  | Canonical reference                                  | Nearest existing primitive                              | W3-A action                                                                                                                       |
+|---------------------------------------------------------------|------------------------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Account detail — "Suggested next steps for this account"      | **NONE — gap**                                       | `PostMeetingIntelligence_actionItem` + `Suggested` pill | Author reference HTML in `.docs/design/reference/surfaces/account.html` as part of W3-A L0 close-out, then translate to render.php |
+| Project detail — "Suggested next steps for this project"      | **NONE — gap**                                       | Same as Account                                         | Same                                                                                                                              |
+| Person detail — "Suggested topics for next 1:1"               | **NONE — gap**                                       | `StakeholderGallery` + "Suggested" treatment            | Same                                                                                                                              |
+| Meeting prep — "Suggested topics"                             | Adjacent: `meeting.html:235` `actionItemSuggested`   | `PostMeetingIntelligence_actionItem` row + Suggested pill | Compose from existing primitives, no new tokens                                                                                 |
+| Work surface — "Recommendations" filter chip                  | **NONE — gap**                                       | Work filter chips (existing)                             | W3-B owns the chip placement; W3-A's block renders inside the chip-filtered list                                                  |
+| Daily Briefing — block embedded into briefing composition     | Adjacent: `briefing.html` open-loop chapter style    | `DailyBriefing.module.css` open-loop row patterns       | Block reuses chapter-section heading rule (`ChapterHeading_*` family) per `meeting-recommended-actions` precedent                 |
+
+**Resolution rule:** W3-A's PR MUST include reference HTML additions for the four "gap" rows above. The block's `render.php` and accompanying CSS module then translate from the reference. New theme.json tokens added only where existing tokens cannot express the visual; default posture is **token reuse**, not new primitives (memory: "audit chrome overlap before promoting new DS patterns").
+
+**Tokens expected to reuse (from `wp/dailyos/theme/theme.json` and existing reference module CSS):**
+
+- `ChapterHeading_*` family (section heading + rule)
+- `meeting-intel_chapterSection`, `meeting-intel_chapterSection--empty` shape (empty chip rules)
+- `dailyos-empty-chip` (empty-state visible chip — `meeting-recommended-actions:171`)
+- `editorial-reveal` (reveal-on-scroll wrapper)
+- TrustBand primitive (per ADR-0108 actor-filtered rendering)
+
+**Tokens to **propose adding** (only if reference work confirms a gap):**
+
+- `suggested-next-steps_*` family (row, why-this-now caption, action button row) — names finalized after reference HTML lands
+
+L0 design review (`/plan-design-review`) explicitly owns the reference-HTML-first decision.
+
+---
+
+## §2 Scope and producer authority
+
+### In scope
+
+| File / surface                                                                                                                  | Owner   |
+|----------------------------------------------------------------------------------------------------------------------------------|---------|
+| `src-tauri/abilities-runtime/src/abilities/recommendations/list_suggested_next_steps.rs` (or extension of `mod.rs`)              | W3-A    |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs` — additive: list-projection DTO                          | W3-A    |
+| `src-tauri/src/services/recommendations/projection.rs` (new) — substrate-side projection from `surfacing_decisions` + claim store | W3-A    |
+| `src-tauri/src/services/context.rs` — wire new read handle (additive trait method)                                                | W3-A    |
+| `tools/dailyos-abilities.json` — regen after new ability lands                                                                   | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/block.json`                                                                              | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/render.php` + `render-functions.php`                                                     | W3-A    |
+| `wp/dailyos/blocks/suggested-next-steps/style.css` (block CSS module)                                                            | W3-A    |
+| `wp/dailyos/theme/theme.json` — additive only, with token-name resolution from L0 design review                                  | W3-A    |
+| `.docs/design/reference/surfaces/{account,project,person}.html` — author reference sections (per §1)                              | W3-A    |
+| `wp/dailyos/tests/blocks/suggested-next-steps/` (PHPUnit or render-fixture tests)                                                 | W3-A    |
+| Integration fixture proving WP-block-calls-ability path                                                                          | W3-A    |
+
+### Out of scope
+
+- W2 surfacing policy table writes (W2-A, merged)
+- W2 trigger scanner (W2-B, merged)
+- `score_salience` ability (existing; **MUST NOT** broaden actor set — see §3.3)
+- Cross-surface embedding (DOS-333 / W3-B; blocks on W3-A merge)
+- Feedback **semantics** (DOS-332 / W4-A) — W3-A wires affordance UI + call sites; W4-A lands the feedback ability proper (see §9 cross-wave coordination)
+- MCP exposure (deferred to v1.4.7+ per `v1.4.6-waves.md:391`)
+- Engagement telemetry (W4-C)
+
+### Producer authority restatement
+
+Per `v1.4.6-waves.md:541–558`:
+
+> Producer gate: before W3 or later user-facing work starts, the lane L0 must identify the exact ability producer / projection that returns recommendation lists, surfacing state, trust, provenance, caveats, and receipt refs. If that ability is not present, W3 blocks rather than reading `surfacing_decisions` directly.
+
+**The ability is not present.** W3-A authors it. This packet is the producer-boundary identification.
+
+---
+
+## §3 Substrate contract — new SurfaceClient ability
+
+### §3.1 Ability identity
+
+- **Name:** `list_suggested_next_steps`
+- **Category:** `Read`
+- **Allowed actors:** `[User, System, SurfaceClient]` (no MCP — MCP exposure deferred to v1.4.7+)
+- **Required scopes:** `["read.recommendations"]` (same scope namespace as existing `score_salience`; v1.4.7+ MCP wrap will use `dailyos.read.recommendations` per `v1.4.6-waves.md:391`)
+- **`may_publish`:** false (read-only)
+- **`client_side_executable`:** false (substrate-side execution per ADR-0111)
+- **`mcp_exposure`:** `None`
+- **`composes`:** internally reads `surfacing_decisions` (W2-A authoritative), `claim_store`, and `claim_receipt` projection; emits actor-filtered list
+- **`signal_policy.emits_on_output_change`:** `[]` (read-only ability)
+- **Schema version:** `1`
+
+### §3.2 Input
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSuggestedNextStepsInput {
+    pub schema_version: u32,                 // pinned to 1 for v1.4.6
+    pub subject: Option<SubjectRef>,         // None = global feed (Work surface), Some(entity) = per-entity surface
+    pub surface: ClaimReceiptSurfaceContext, // routes audience filter through Shared Receipt DTO
+    pub max_items: Option<u8>,               // optional cap; default + ceiling per ADR-0130 §2 size guard
+}
+```
+
+Notes:
+- `SubjectRef` is the existing `abilities_runtime::abilities::provenance::subject::SubjectRef` enum (Account, Project, Person, Meeting, Global, User, etc.)
+- `ClaimReceiptSurfaceContext` is reused from `src-tauri/abilities-runtime/src/abilities/claim_receipt/contracts.rs:32` so receipt rendering and surface-audience filtering share one type
+- `max_items` ceiling: **8** (W3-A L0 default; tuned after L4 surface QA)
+
+### §3.3 Output
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSuggestedNextStepsResponse {
+    pub schema_version: u32,
+    pub items: Vec<SuggestedNextStepItem>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuggestedNextStepItem {
+    pub claim_id: ClaimId,                       // stable id for feedback callbacks
+    pub headline: String,                        // product-safe (no PII bleed from raw evidence text)
+    pub why_this_now: String,                    // pre-rendered text from WhyThisNow.text (W2-A produces)
+    pub primary_factor: SalienceFactorKind,      // for chip / icon rendering only — NOT full factor breakdown
+    pub recommended_action: RecommendedActionView, // privacy-safe view (see §3.4)
+    pub trust_band: TrustBand,                   // for trust-band primitive rendering (ADR-0108)
+    pub receipt: ClaimReceiptSnapshot,           // Shared Receipt DTO per v1.4.4 invariant (v1.4.6-waves.md:543)
+    pub feedback_state: FeedbackState,           // for affordance state (pending vs decided)
+    pub conversion_state: ConversionState,       // for "already converted" affordance state
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum RecommendedActionView {
+    ScheduleMeeting { entity_label: String, when_window: String }, // no raw rationale; rationale flows through why_this_now
+    SendMessage    { entity_label: String, channel: String },
+    ReviewClaim    { claim_label: String },
+    UpdateRecord   { entity_label: String, field_label: String },
+    InvestigateChange { entity_label: String, change_label: String },
+    Custom         { action_label: String },                      // payload dropped per ADR-0130 §3.1 fallback rule
+}
+```
+
+**Privacy boundaries (load-bearing — codex security review hits this hardest):**
+
+- `RecommendedActionView` is the **projection** of `RecommendedAction` for surfaces — **never** ships the raw enum payload to a `SurfaceClient`. Entity IDs become resolved labels via the same redaction layer the receipt projection uses (`ClaimReceiptRedactionLevel`).
+- `SuggestedNextStepItem` carries `primary_factor` only, **never** the full `Vec<SalienceFactor>`. Full factor breakdown stays inside `score_salience` (User/System actors only). The hidden-ability contract is preserved (`v1.4.6-waves.md:941`).
+- `provenance` flows through `ClaimReceiptSnapshot.provenance` (the receipt's resolved view), not as a raw envelope on the item.
+- `feedback_state` and `conversion_state` ship as-is — they are part of the claim's lifecycle and are surface-safe.
+
+**Hidden-ability sweep test (codex security panel):** the W3-A integration fixture MUST include a test that, given a SurfaceClient invocation, the response JSON does NOT contain any of: `factors` array, raw `RecommendedAction` payload fields not surfaced in `RecommendedActionView`, raw evidence source paths, prompt/provider-looking strings.
+
+### §3.4 Substrate-side projection rules
+
+The new `services::recommendations::projection::list_suggested_next_steps()` function:
+
+1. **Filters** `surfacing_decisions` to `tier ∈ {Critical, Notable, Background}` and `kind = Render` (Quiet, Defer, Suppress excluded for surfaces — `v1.4.6-waves.md:544`).
+2. **Joins** with the claim store for `RecommendationClaim` rows matching the `subject` filter.
+3. **Orders** by salience `total` descending, then by `created_at` descending as tiebreaker.
+4. **Truncates** to `max_items` (default 8, ceiling 8).
+5. **Maps** `RecommendedAction` → `RecommendedActionView` via redaction layer.
+6. **Invokes** existing `claim_receipt` projection per claim to populate `receipt` field — re-using v1.4.4 Shared Receipt DTO, not authoring a parallel one (`v1.4.6-waves.md:543`).
+7. **Returns** the privacy-safe response.
+
+Salience scoring is NOT recomputed at projection time — it reads the already-stored evaluation from W1-B's path (`services/recommendations/salience.rs::score_salience`). The hidden-ability contract calls the same substrate read; this ability projects the surface-safe subset.
+
+### §3.5 Provenance envelope
+
+Output ships with full `Provenance` envelope per ADR-0105. Schema version `1` for the response payload. Provenance attribution:
+
+- Subject: per-call (matches `input.subject` when present, else `SubjectRef::Global`)
+- Field attributions for each item resolve to the originating `RecommendationClaim` provenance (via `ClaimReceiptProvenance` already produced in `ClaimReceiptSnapshot`)
+- No new envelope authoring; reuse existing claim_receipt provenance plumbing
+
+---
+
+## §4 Block contract — `dailyos/suggested-next-steps`
+
+### §4.1 `block.json`
+
+```json
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "dailyos/suggested-next-steps",
+    "title": "Suggested Next Steps",
+    "category": "dailyos",
+    "description": "Recommendations for the current subject. Renders typed RecommendationClaim list with per-claim trust band, why-this-now, evidence/provenance summary, and feedback affordances.",
+    "supports": { "html": false, "reusable": false, "inserter": false },
+    "usesContext": [ "dailyos/entityType", "dailyos/entityId" ],
+    "attributes": {
+        "maxItems":  { "type": "number", "default": 8 },
+        "headingLabel": { "type": "string" }
+    },
+    "render": "file:./render.php"
+}
+```
+
+Notes:
+- `inserter: false` — block is inserted by composition (W3-B), not directly by editor
+- `usesContext` mirrors `meeting-recommended-actions:9` precedent — block resolves entity from outer context provided by `dailyos/{account,project,person,meeting}-detail` and from a future `dailyos/work-surface` wrapper (W3-B scope)
+- `headingLabel` attribute lets the parent surface override the section heading ("Suggested next steps for this account" vs "Suggested topics for next 1:1")
+- `parent` constraint deliberately omitted at W3-A — W3-B configures it once embedding pages are confirmed
+
+### §4.2 `render.php` shape (terse stub)
+
+```php
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) { return ''; }
+require_once __DIR__ . '/render-functions.php';
+return dailyos_suggested_next_steps_render( $attributes ?? [], $block ?? null );
+```
+
+### §4.3 `render-functions.php` algorithm
+
+Mirrors `meeting-recommended-actions/render-functions.php` precedent. Differences:
+
+1. **Subject resolution.** Resolve `SubjectRef` from `$block->context`:
+   - `dailyos/entityType = 'account'` + `dailyos/entityId = '...'` → `SubjectRef::Account(...)`
+   - `'project'`, `'person'`, `'meeting'` → analogous
+   - Missing context with `parent === 'dailyos/work-surface'` → `SubjectRef::Global` (or `SubjectRef::User` per W3-B confirmation)
+   - All other missing context → empty chip `missing_subject_context`
+
+2. **Ability call.** `$runtime_client->invoke_ability('list_suggested_next_steps', [...input...], $scope_set)` with `surface = surface_for_context(...)`.
+
+3. **Error handling** per `meeting-recommended-actions:46–65`:
+   - Runtime unavailable → empty chip `runtime_unavailable`
+   - WP_Error / `ok === false` → empty chip `envelope_error`
+   - Empty items list → empty chip `no_recommendations` (label varies by surface — "No suggested next steps." for accounts/projects, "No suggested topics." for person/meeting)
+
+4. **Per-item rendering:**
+   - Section heading: `editorial-reveal` + `ChapterHeading_*` family with `attributes.headingLabel` (or surface default)
+   - Per-row: trust-band primitive (server-rendered per ADR-0108 audience filter from `receipt.trust`), headline, why-this-now caption, recommended-action view, action affordance ("Convert to action" / "Dismiss" / "Not useful")
+   - Provenance summary inline-or-drawer: link to `evidence-drawer` block where it exists, otherwise inline truncated source list
+   - Each affordance carries `data-claim-id="..."` + `data-feedback-kind="dismiss|accept|notUseful|tooNoisy|convert"` for the W4-A feedback handler (see §9)
+
+5. **Always-visible empty chip** when `items === []`, per `v1.4.6-waves.md:544` invariant — "§10 invariant — never silent-hidden" (`meeting-recommended-actions:163`).
+
+### §4.4 Style module
+
+- New file: `wp/dailyos/blocks/suggested-next-steps/style.css`
+- Class namespace: `suggested-next-steps_*` (matches `meeting-intel_*` precedent shape)
+- Composes existing primitives where possible; new classes only where the parity matrix gap forces them
+- Block stylesheet enqueue follows existing wp-block-themes pattern (registered via `register_block_type_from_metadata`)
+
+### §4.5 Editor / view scripts
+
+Per wave plan: `editor/view files only if the block needs interactive controls` (`v1.4.6-waves.md:942`). W3-A view script needs:
+
+- **Client-side affordance handler** — POSTs to a feedback ability (W4-A) via the WP REST endpoint that bridges to the abilities runtime
+- During the W4-A gap (see §9), the click handler is registered but **either** disabled (button shows `aria-disabled="true"` until feedback ability lands) **or** stubbed to a no-op endpoint that returns `200 not_yet_implemented`
+
+W3-A authors the affordance markup + handler. The decision between disabled vs no-op stub is an L0 question (see §12).
+
+---
+
+## §5 Acceptance criteria
+
+Plain-language ACs, traceable to the wave plan invariants and DOS-298 description.
+
+1. **Ability ships and is registered.** `list_suggested_next_steps` appears in `tools/dailyos-abilities.json` (regen committed in same PR), and `AbilityRegistry::global_checked()` exposes it to `Actor::SurfaceClient` with scope `read.recommendations`. `cargo test recommendations::list_suggested_next_steps` passes.
+2. **Block renders for the four entity surfaces.** Test fixture proves `dailyos/suggested-next-steps` inside `dailyos/{account,project,person,meeting}-detail` parents produces non-empty HTML with the expected class names when seeded recommendations exist for that subject.
+3. **Empty state ships visible chip.** Each surface's empty render produces `dailyos-empty-chip` with a machine-readable reason (`no_recommendations`, `missing_subject_context`, `runtime_unavailable`, `envelope_error`). No silent hiding — `v1.4.6-waves.md:544`.
+4. **Hidden-ability sweep passes.** Integration test asserts SurfaceClient JSON response contains no `factors` array, no raw `RecommendedAction` payload, no envelope copy. `score_salience` actor allowlist unchanged.
+5. **Trust band renders per claim.** Each item's `receipt.trust.band` flows through the existing trust-band primitive; trust display matches the receipt's actor-filtered view (ADR-0108).
+6. **Why-this-now is product-safe.** No raw evidence-source paths, no prompt/provider-looking strings, no PII bleed. Test asserts against a fixture with seeded sensitive content.
+7. **Receipt is the Shared Receipt DTO.** Each item carries `ClaimReceiptSnapshot`, not a parallel receipt struct. `cargo clippy -- -D warnings` enforces (grep CI on `RecommendationReceipt|RecRow` per `v1.4.6-waves.md:543`).
+8. **No W2 table reads from the block.** Static grep in CI: `wp/dailyos/blocks/suggested-next-steps/**` contains no references to `surfacing_decisions`, `triggers_log`, or any other W2 table name.
+9. **No new migrations.** Empty migrations diff in the PR (per `v1.4.6-waves.md:464`).
+10. **Reference HTML lands** for account/project/person surfaces — sections added to `.docs/design/reference/surfaces/{account,project,person}.html` matching the block's rendered shape. Visual parity matrix in §1 of this packet is updated from "gap" to "matches reference: lines X-Y".
+11. **L4 surface QA runs BEFORE L2** per `v1.4.6-waves.md:440`. `/qa-only` evidence (screenshots of empty + non-empty + over-budget states) is attached to the Linear ticket before L2 dispatch.
+12. **Cycle hygiene.** Full validation: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit && phpunit (wp/dailyos/tests)`.
+
+---
+
+## §6 Test plan
+
+### Unit (Rust)
+
+- `list_suggested_next_steps` golden wire-shape fixture (mirrors `recommendation_contract_golden_wire_shape` test pattern in `services/recommendations/contracts.rs:441`)
+- Hidden-actor denial: `Actor::McpClient` denied before reader
+- Surface actor allowed with `read.recommendations` scope; denied without scope
+- Subject filtering: `SubjectRef::Account(x)` returns only account-x recommendations; `None` returns global feed
+- `max_items` ceiling respected (request 100, response capped at 8)
+- Privacy-safe response: parametric test asserts no leakage of raw factors / raw payload / raw evidence sources / prompt strings
+
+### Unit (PHP)
+
+- `dailyos_suggested_next_steps_extract_items()` parser handles ability response shape (`response.ability.data.items`, `response.data.items`, fallback to raw)
+- Empty chip variants render with correct reason codes
+- Section heading uses `attributes.headingLabel` when set, surface default otherwise
+- Affordance markup carries `data-claim-id` + `data-feedback-kind` for every item
+
+### Integration
+
+- End-to-end fixture: WP block render → runtime client filter → ability invocation → projection from seeded substrate → rendered HTML matches snapshot
+- Snapshot tests for: empty state, single-item, max-items-truncated, over-budget-with-defer
+
+### L4 surface QA (before L2)
+
+- `/qa-only` walks Account, Project, Person, Meeting surfaces in the local WP install
+- Captures screenshots for empty + 1 + 3 + 8 recommendation counts
+- Verifies trust band rendering, why-this-now caption, feedback affordance presence (and disabled-state if W4-A gap holds)
+- Attaches evidence to DOS-298 ticket comment before L2 dispatch
+
+---
+
+## §7 CI gate inputs (L1 deliverables — memory rule)
+
+> Memory: "CI gate inputs are L1 deliverables, not verification steps." Every artifact below ships in the same PR as the feature.
+
+| Artifact                                                                                          | Owner | Notes                                                            |
+|---------------------------------------------------------------------------------------------------|-------|------------------------------------------------------------------|
+| `tools/dailyos-abilities.json` regenerated to include `list_suggested_next_steps`                 | W3-A  | Run regen script in PR; commit alongside ability                 |
+| Ability allowlist entry (SurfaceClient scope policy registry)                                     | W3-A  | If gated by a scope registry file, update in same PR             |
+| Integration fixture (Rust → WP) end-to-end test                                                   | W3-A  | Lives in `wp/dailyos/tests/` per existing PHP test convention    |
+| Block `style.css` enqueued via `register_block_type_from_metadata`                                | W3-A  | Required for visual parity gate                                  |
+| theme.json token additions (if any) registered                                                    | W3-A  | Subject to L0 design review confirming gap                        |
+| Reference HTML additions in `.docs/design/reference/surfaces/{account,project,person}.html`       | W3-A  | Visual parity gate                                                |
+| W2-table-read grep guard (CI lint)                                                                | W3-A  | Add to existing lint script; fail PR if matches                  |
+| Hidden-ability sweep test (`factors` / raw payload leakage)                                       | W3-A  | Privacy gate                                                      |
+| L2-status declaration in commit messages                                                          | W3-A  | `L2-status: passed` (mandatory per memory + `.githooks/commit-msg`) |
+| L4 evidence attached to DOS-298 before L2 dispatch                                                | W3-A  | `/qa-only` screenshots                                            |
+
+---
+
+## §8 Migration disposition
+
+**No new migrations.** Per `v1.4.6-waves.md:464`: W3 row reads "(none expected — UI consuming W1+W2 contracts)". Next available slot v274 stays reserved for W4 lanes.
+
+If L0 review surfaces an unexpected storage need, the wave plan amendment process applies (see Engineering Ladder K-channel) before claiming v274.
+
+---
+
+## §9 Cross-wave coordination
+
+### W3-A → W3-B handoff
+
+- W3-A merges first (`v1.4.6-waves.md:527`)
+- W3-B (DOS-333) consumes the block + the ability; embeds across surfaces; adds work-surface filter chip wrapper
+- W3-B does NOT modify ability contract or block contract — additive composition only
+
+### W3-A → W4-A coordination (FEEDBACK GAP)
+
+**This is the load-bearing coordination concern.** W4-A owns `services/recommendations/feedback.rs` and the feedback ability proper (`v1.4.6-waves.md:241`). W3-A renders feedback affordances. Two viable patterns:
+
+| Option | Pattern | Tradeoff                                                                                                      |
+|--------|---------|---------------------------------------------------------------------------------------------------------------|
+| A      | Affordance markup + view.js handler render, but click is `aria-disabled="true"` + tooltip "Feedback coming in W4-A". | Cleanest privacy posture; honest UI. W4-A enables the handler in a follow-up PR. |
+| B      | W3-A authors a **minimal feedback ability skeleton** (Pending → Decided{Dismiss} only, no echo signals); W4-A fills in semantics. | Affordance works at W3-A merge; W4-A scope grows but no UI churn.                 |
+| C      | Coordinate so W4-A's `submit_recommendation_feedback` ability lands FIRST as a pre-W3 dependency.                    | Reorders waves — friction. Wave plan ordering says W3 < W4.                       |
+
+**Recommendation:** **Option A** (disabled-with-tooltip).
+- Honest about state of system
+- Preserves W3-A as a clean producer-boundary PR (no scope leak)
+- W4-A's job becomes "enable the existing UI" — minimal-surface UI work in W4
+
+L0 panel decides. This is the single highest-leverage open question.
+
+### W3-A → W4-C (engagement telemetry)
+
+W4-C (DOS-462 / engagement.rs) wants to record `Rendered`, `Clicked`, `Dismissed`, `Ignored` signals against `RenderSurface`. The block's render path is a natural emission point. W3-A's view.js handler should fire a `Rendered` signal on mount and `Clicked` on affordance click — but this depends on the same W4 ability landing.
+
+**Treatment:** Same as feedback — W3-A wires the call sites and disables them until W4-C lands. Track as L0 open question parallel to the feedback gap.
+
+---
+
+## §10 Out of scope (restatement)
+
+- W2 surfacing policy / trigger scanner work (W2 merged)
+- `score_salience` actor broadening (stays User/System only — preserved per `v1.4.6-waves.md:941`)
+- Cross-surface embedding (W3-B)
+- Feedback semantics + ability behavior (W4-A)
+- Engagement telemetry behavior (W4-C)
+- MCP exposure (v1.4.7+)
+- Deviation baselines (W4-B)
+- Recommendation eval harness (W5)
+- Migration work (none in W3)
+
+---
+
+## §11 K-in citations
+
+K-in grep results from `docs/solutions/` + `.docs/decisions/` (parallel `ce-learnings-researcher` pending; preliminary scan below):
+
+| Source                                                                                                              | Relevance                                                                                                                                          |
+|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ADR-0102 — Abilities as Runtime Contract                                                                            | All abilities follow `AbilityOutput<T>` shape with single envelope on the wrapper                                                                  |
+| ADR-0105 — Provenance as First-Class Output                                                                         | Envelope lives once; field attributions reference into it                                                                                          |
+| ADR-0108 — Provenance Rendering and Privacy                                                                         | Actor-filtered render; trust-band rendering rules; 64KB serialized cap                                                                             |
+| ADR-0111 — Surface-Independent Ability Invocation                                                                   | `SurfaceClient` actor class; scope-based actor filtering; bridge-per-surface invocation                                                            |
+| ADR-0125 — Claim Anatomy, Temporal Scope, Sensitivity, TypeRegistry                                                 | `RecommendationClaim` metadata: temporal=State, sensitivity=Internal, freshness=Medium, commit=Replace, allowed_actor=Agent (see contracts.rs:421) |
+| ADR-0129 — Composable Surfaces                                                                                      | WP as primary surface; blocks are typed projections; WP MCP via Abilities API + MCP Adapter                                                        |
+| ADR-0130 — Surface-Independent Composition Contract                                                                 | §3.1 custom-block fallback projection (relevant if W3-B uses Composition wrapper); §2 size guard                                                   |
+| DOS-689 (Evidence Drawer block) — `wp/dailyos/blocks/evidence-drawer/`                                              | Server-rendered provenance summary + client toggle drawer pattern. W3-A links to evidence drawer where present.                                    |
+| `wp/dailyos/blocks/meeting-recommended-actions/`                                                                    | The dominant block precedent — `usesContext` + runtime_client filter + scope filter + empty-chip-never-silent invariant                            |
+| `services/recommendations/contracts.rs`                                                                             | RecommendationClaim type + RecommendedAction enum + SurfacingDecision + WhyThisNow                                                                 |
+| `abilities-runtime/src/abilities/recommendations/mod.rs`                                                            | `score_salience` ability — hidden-from-clients invariant W3-A MUST preserve                                                                        |
+| `abilities-runtime/src/abilities/claim_receipt/`                                                                    | Shared Receipt DTO that W3-A reuses for `SuggestedNextStepItem.receipt`                                                                            |
+
+**No `docs/solutions/` entries found for "suggested next steps", "recommendation surface", "block producer", or "projection ability".** Gap is substrate-bound; surfacing/WP binding is W3-A scope.
+
+`ce-learnings-researcher` will run in parallel during L0 review to confirm no hits I missed.
+
+---
+
+## §12 Open questions (L0 panel decides)
+
+1. **Feedback affordance pattern** (load-bearing — see §9). Option A (disabled-with-tooltip), Option B (skeleton ability), or Option C (reorder waves)?
+2. **theme.json token strategy.** Reuse existing tokens only (matrix §1), or add a `suggested-next-steps_*` token family? Design review decides; default is reuse.
+3. **Work-surface subject resolution.** Work-surface block context resolves to `SubjectRef::Global` or `SubjectRef::User`? Affects projection filter behavior. Plan to confirm with W3-B L0.
+4. **Reference HTML scope.** Does W3-A author full reference sections in account.html / project.html / person.html, or minimal reference snippets that W3-B fills in? Default: minimal sections that the block can be visually verified against; W3-B integrates them into composition.
+5. **`headingLabel` default per surface.** Hardcode in render-functions.php or thread via `usesContext` from outer block? Default: hardcoded in render-functions.php with `dailyos/entityType` switch (matches `meeting-recommended-actions` precedent).
+6. **`max_items` ceiling = 8.** Sane? If L4 surface QA on 8-item dense states regresses scannability, tune down to 5. Decision deferred to L4 evidence.
+7. **Engagement signal firing** (see §9 W4-C). Same pattern as feedback — disable until W4-C lands?
+8. **`score_salience` "User" actor.** Existing ability allows `Actor::User`. W3-A does NOT touch this allowlist. Confirm no path-α regression slips in via service-layer refactor.
+
+---
+
+## §13 Risk register
+
+| Risk                                                                                                                          | Severity | Mitigation                                                                                                                                                       |
+|-------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Hidden-ability leakage — `factors` array slips into `SuggestedNextStepItem` via refactor                                       | HIGH     | Privacy sweep test (AC #4); codex security panel reviews the projection function                                                                                  |
+| W4-A feedback ability gap (see §9) leaves W3-A shipping non-functional affordances                                             | MED      | Option A (disabled+tooltip) gives honest UI posture; doc'd in PR body                                                                                             |
+| Parallel-wave migration slot collision                                                                                         | LOW      | W3 reserves none; W4 lanes claim v274+ per memory rule on parallel-wave slot reservations                                                                          |
+| Trust-band rendering drift between Tauri and WP surfaces                                                                       | MED      | Use `ClaimReceiptSnapshot.trust` from Shared Receipt DTO — single source of truth per `v1.4.6-waves.md:543`                                                       |
+| Visual parity gap — block ships before reference HTML lands → reviewers can't verify                                           | HIGH     | Reference HTML is an AC (#10); BLOCKS L2                                                                                                                          |
+| Block performance — ability call per-page-load adds latency                                                                    | LOW      | Read-only ability over already-stored substrate; per-call cost is single SQL + projection; benchmark in L4 if regression flagged                                  |
+| Editor / view scripts not needed in W3-A but added speculatively                                                               | LOW      | Memory: "no half-finished implementations" — W3-A view.js exists only if §4.5 click handler decision lands on Option B; otherwise affordance markup is server-only |
+
+---
+
+## §14 Definition of Done
+
+Per CLAUDE.md DoD section:
+
+1. Each AC in §5 validated against real seeded data (W2 surfacing decisions for the four entity classes; per-subject and global feed)
+2. End-to-end flow: WP block invokes ability → projection over substrate → renders trust band + why-this-now + receipt provenance — verified in local WP install
+3. No stubs, TODOs, or "Phase 2" deferrals — except the feedback-affordance disabled state (which is the explicit Option A pattern, documented and bounded)
+4. `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit && phpunit (wp tests)` all green
+5. L2-status declared in code commits (memory rule)
+6. L4 evidence captured before L2 dispatch (`v1.4.6-waves.md:440`)
+7. K-out: any new class-pattern findings filed via `/ce-compound mode:headless` at retro close
+
+---
+
+## §15 Reviewer routing summary
+
+| Reviewer                                  | What they own                                                                                  |
+|-------------------------------------------|------------------------------------------------------------------------------------------------|
+| `/codex challenge`                        | Adversarial — try to break the producer-boundary invariant and the hidden-ability privacy contract |
+| `/plan-eng-review`                        | Architecture, ability shape, projection algorithm, test plan, CI gate inputs                   |
+| `/plan-design-review`                     | Reference HTML strategy, token reuse, parity matrix, affordance pattern                        |
+| `/plan-devex-review`                      | New ability ergonomics, schema-version policy, MCP-future-compat, claim_receipt reuse           |
+| `ce-learnings-researcher` (parallel K-in) | Confirm no `docs/solutions/` or `.docs/decisions/` precedent missed                            |
+| WP-skill-grounded reviewer (5th panel)    | block.json shape, `usesContext` correctness, render.php server-render correctness, style.css enqueue path |
+
+Unanimous APPROVE required. Path-α findings (theoretical hardening) routed to Codebase Maintenance project per memory rule.

--- a/src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs
@@ -1,14 +1,20 @@
 //! Recommendation ability contracts.
 
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::abilities::claim_receipt::{ClaimReceiptSnapshot, ClaimReceiptSurfaceContext};
+use crate::abilities::provenance::SubjectRef;
 use crate::abilities::registry::ActorKind;
 use crate::abilities::trust::types::TrustBand;
 
 pub const SCORE_SALIENCE_ABILITY_NAME: &str = "score_salience";
 pub const SCORE_SALIENCE_SCHEMA_VERSION: u32 = 1;
 pub const SCORE_SALIENCE_SCOPE: &str = "read.recommendations";
+pub const LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME: &str = "list_suggested_next_steps";
+pub const LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION: u16 = 1;
+pub const LIST_SUGGESTED_NEXT_STEPS_SCOPE: &str = SCORE_SALIENCE_SCOPE;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
@@ -26,6 +32,190 @@ pub struct ScoreSalienceReadRequest {
     pub schema_version: u32,
     pub claim_id: ClaimId,
     pub actor: ActorKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSuggestedNextStepsInput {
+    pub schema_version: u16,
+    pub subject: Option<SubjectRef>,
+    pub surface: ClaimReceiptSurfaceContext,
+    pub max_items: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSuggestedNextStepsResponse {
+    pub schema_version: u16,
+    pub items: Vec<SuggestedNextStepItem>,
+    #[schemars(with = "String")]
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuggestedNextStepItem {
+    pub claim_id: ClaimId,
+    pub headline: String,
+    pub why_this_now_surface_text: String,
+    pub factor_band: PrimaryFactorBand,
+    pub recommended_action: RecommendedActionView,
+    pub trust_band: TrustBand,
+    pub receipt: ClaimReceiptSnapshot,
+    pub feedback_state: FeedbackState,
+    pub conversion_state: ConversionState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum PrimaryFactorBand {
+    TimeSensitive,
+    NewInformation,
+    OpenLoopRelated,
+    TrustChange,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum RecommendedActionView {
+    ScheduleMeeting {
+        entity_label: String,
+        when_window: String,
+    },
+    SendMessage {
+        entity_label: String,
+        channel: String,
+    },
+    ReviewClaim {
+        claim_label: String,
+    },
+    UpdateRecord {
+        entity_label: String,
+        field_label: String,
+    },
+    InvestigateChange {
+        entity_label: String,
+        change_label: String,
+    },
+    Custom {
+        action_label: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum FeedbackState {
+    Pending,
+    Decided(RecommendationFeedbackDecision),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum RecommendationFeedbackDecision {
+    Accept {
+        #[schemars(with = "String")]
+        at: DateTime<Utc>,
+    },
+    Dismiss {
+        #[schemars(with = "String")]
+        at: DateTime<Utc>,
+        reason: DismissReason,
+    },
+    NotUseful {
+        #[schemars(with = "String")]
+        at: DateTime<Utc>,
+    },
+    TooNoisy {
+        #[schemars(with = "String")]
+        at: DateTime<Utc>,
+    },
+    Convert {
+        #[schemars(with = "String")]
+        at: DateTime<Utc>,
+        into: ConversionTarget,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum DismissReason {
+    NotRelevant,
+    AlreadyKnew,
+    WrongSubject,
+    Other(BoundedNote),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(transparent)]
+pub struct BoundedNote(String);
+
+impl BoundedNote {
+    pub const MAX_CHARS: usize = 200;
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for BoundedNote {
+    type Error = BoundedNoteError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let actual = value.chars().count();
+        if actual > Self::MAX_CHARS {
+            return Err(BoundedNoteError::TooLong {
+                max: Self::MAX_CHARS,
+                actual,
+            });
+        }
+        Ok(Self(value))
+    }
+}
+
+impl<'de> Deserialize<'de> for BoundedNote {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)
+            .and_then(|value| Self::try_from(value).map_err(serde::de::Error::custom))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BoundedNoteError {
+    #[error("recommendation feedback note is {actual} characters; maximum is {max}")]
+    TooLong { max: usize, actual: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ConversionTarget {
+    Action(String),
+    ClaimCorrection(ClaimId),
+    ReviewQueue(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum ConversionState {
+    NotConverted,
+    ConvertedToAction { action_id: String },
+    ConvertedToClaimCorrection { claim_id: ClaimId },
+    ConvertedToReviewQueue { queue_item_id: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -124,6 +314,18 @@ pub enum FactorRationale {
 pub enum SalienceReadError {
     #[error("unsupported schema_version `{0}` for score_salience")]
     UnsupportedSchemaVersion(u32),
+    #[error("claim `{0}` not found")]
+    ClaimNotFound(String),
+    #[error("claim `{0}` is not visible to the current actor")]
+    ClaimNotVisible(String),
+    #[error("{0}")]
+    ReadFailed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SuggestedNextStepsReadError {
+    #[error("unsupported schema_version `{0}` for list_suggested_next_steps")]
+    UnsupportedSchemaVersion(u16),
     #[error("claim `{0}` not found")]
     ClaimNotFound(String),
     #[error("claim `{0}` is not visible to the current actor")]

--- a/src-tauri/abilities-runtime/src/abilities/recommendations/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/recommendations/mod.rs
@@ -3,10 +3,14 @@
 pub mod contracts;
 
 pub use contracts::{
-    ClaimId, FactorRationale, SalienceFactor, SalienceFactorKind, SaliencePersistence,
-    SalienceReadError, SalienceScore, ScoreSalienceInput, ScoreSalienceReadRequest,
-    ScoreSalienceResponse, SCORE_SALIENCE_ABILITY_NAME, SCORE_SALIENCE_SCHEMA_VERSION,
-    SCORE_SALIENCE_SCOPE,
+    BoundedNote, ClaimId, ConversionState, ConversionTarget, DismissReason, FactorRationale,
+    FeedbackState, ListSuggestedNextStepsInput, ListSuggestedNextStepsResponse, PrimaryFactorBand,
+    RecommendationFeedbackDecision, RecommendedActionView, SalienceFactor, SalienceFactorKind,
+    SaliencePersistence, SalienceReadError, SalienceScore, ScoreSalienceInput,
+    ScoreSalienceReadRequest, ScoreSalienceResponse, SuggestedNextStepItem,
+    SuggestedNextStepsReadError, LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME,
+    LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION, LIST_SUGGESTED_NEXT_STEPS_SCOPE,
+    SCORE_SALIENCE_ABILITY_NAME, SCORE_SALIENCE_SCHEMA_VERSION, SCORE_SALIENCE_SCOPE,
 };
 
 use dailyos_abilities_macro::ability;
@@ -55,6 +59,38 @@ pub async fn score_salience(
     finalize_output(ctx, schema_version, response)
 }
 
+#[ability(
+    name = "list_suggested_next_steps",
+    category = Read,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [User, System, SurfaceClient],
+    allowed_modes = [Live, Evaluate],
+    requires_confirmation = false,
+    may_publish = false,
+    required_scopes = ["read.recommendations"],
+    mcp_exposure = None,
+    client_side_executable = false,
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn list_suggested_next_steps(
+    ctx: &AbilityContext<'_>,
+    input: ListSuggestedNextStepsInput,
+) -> AbilityResult<ListSuggestedNextStepsResponse> {
+    validate_list_suggested_next_steps_schema_version(input.schema_version)?;
+    let schema_version = input.schema_version;
+    let subject = input.subject.clone().unwrap_or(SubjectRef::Global);
+    let response = ctx
+        .services()
+        .list_suggested_next_steps(input, ctx.actor.kind())
+        .await
+        .map_err(suggested_next_steps_read_error)?;
+
+    finalize_list_suggested_next_steps_output(ctx, schema_version, subject, response)
+}
+
 fn validate_schema_version(schema_version: u32) -> Result<(), AbilityError> {
     if schema_version == SCORE_SALIENCE_SCHEMA_VERSION {
         Ok(())
@@ -63,6 +99,21 @@ fn validate_schema_version(schema_version: u32) -> Result<(), AbilityError> {
             kind: AbilityErrorKind::Validation,
             message: format!(
                 "unsupported schema_version `{schema_version}` for `{SCORE_SALIENCE_ABILITY_NAME}`"
+            ),
+        })
+    }
+}
+
+fn validate_list_suggested_next_steps_schema_version(
+    schema_version: u16,
+) -> Result<(), AbilityError> {
+    if schema_version == LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!(
+                "unsupported schema_version `{schema_version}` for `{LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME}`"
             ),
         })
     }
@@ -88,6 +139,26 @@ fn read_error(error: SalienceReadError) -> AbilityError {
     }
 }
 
+fn suggested_next_steps_read_error(error: SuggestedNextStepsReadError) -> AbilityError {
+    match error {
+        SuggestedNextStepsReadError::UnsupportedSchemaVersion(schema_version) => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!(
+                "unsupported schema_version `{schema_version}` for `{LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME}`"
+            ),
+        },
+        SuggestedNextStepsReadError::ClaimNotFound(claim_id)
+        | SuggestedNextStepsReadError::ClaimNotVisible(claim_id) => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("claim_not_found: {claim_id}"),
+        },
+        SuggestedNextStepsReadError::ReadFailed(message) => AbilityError {
+            kind: AbilityErrorKind::HardError(message.clone()),
+            message: format!("suggested_next_steps_read_failed: {message}"),
+        },
+    }
+}
+
 fn finalize_output(
     ctx: &AbilityContext<'_>,
     schema_version: u32,
@@ -105,11 +176,48 @@ fn finalize_output(
     builder.finalize(response).map_err(provenance_error)
 }
 
+fn finalize_list_suggested_next_steps_output(
+    ctx: &AbilityContext<'_>,
+    schema_version: u16,
+    subject: SubjectRef,
+    response: ListSuggestedNextStepsResponse,
+) -> AbilityResult<ListSuggestedNextStepsResponse> {
+    let mut builder = ProvenanceBuilder::new(list_suggested_next_steps_provenance_config(
+        ctx,
+        schema_version,
+    ));
+    let subject_attribution = SubjectAttribution::direct_confident(subject);
+    builder.set_subject(subject_attribution.clone());
+    builder
+        .attribute_subtree(
+            FieldPath::root(),
+            FieldAttribution::constant(subject_attribution),
+        )
+        .map_err(provenance_error)?;
+    builder.finalize(response).map_err(provenance_error)
+}
+
 fn provenance_config(ctx: &AbilityContext<'_>, schema_version: u32) -> ProvenanceBuilderConfig {
     let mut config =
         ProvenanceBuilderConfig::new(SCORE_SALIENCE_ABILITY_NAME, ctx.services().clock.now());
     config.ability_version = AbilityVersion::new(1, 0);
     config.ability_schema_version = SchemaVersion(schema_version);
+    config.actor = provenance_actor(&ctx.actor);
+    config.mode = AbilityExecutionMode::from(ctx.mode());
+    config.category = AbilityCategory::Read;
+    config
+}
+
+fn list_suggested_next_steps_provenance_config(
+    ctx: &AbilityContext<'_>,
+    schema_version: u16,
+) -> ProvenanceBuilderConfig {
+    let mut config = ProvenanceBuilderConfig::new(
+        LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME,
+        ctx.services().clock.now(),
+    );
+    config.ability_version = AbilityVersion::new(1, 0);
+    config.ability_schema_version = SchemaVersion(u32::from(schema_version));
     config.actor = provenance_actor(&ctx.actor);
     config.mode = AbilityExecutionMode::from(ctx.mode());
     config.category = AbilityCategory::Read;
@@ -167,7 +275,7 @@ mod tests {
     use crate::sensitivity::ClaimDismissalSurface;
     use crate::services::context::{
         ExternalClients, FixedClock, SalienceReadFuture, SalienceReadHandle, SeedableRng,
-        ServiceContext,
+        ServiceContext, SuggestedNextStepsReadFuture, SuggestedNextStepsReadHandle,
     };
 
     #[derive(Default)]
@@ -196,6 +304,25 @@ mod tests {
         ) -> SalienceReadFuture<'a> {
             let error = self.error.clone();
             Box::pin(async move { Err(error) })
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingSuggestedNextStepsReader {
+        requests: Mutex<Vec<(ListSuggestedNextStepsInput, ActorKind)>>,
+    }
+
+    impl SuggestedNextStepsReadHandle for CapturingSuggestedNextStepsReader {
+        fn list_suggested_next_steps<'a>(
+            &'a self,
+            input: ListSuggestedNextStepsInput,
+            actor: ActorKind,
+        ) -> SuggestedNextStepsReadFuture<'a> {
+            self.requests
+                .lock()
+                .expect("requests lock")
+                .push((input, actor));
+            Box::pin(async { Ok(suggested_next_steps_response_fixture()) })
         }
     }
 
@@ -246,6 +373,108 @@ mod tests {
                 conversation_handle: Some(OpaqueConversationHandle::new("conv-1")),
             })
             .all(|descriptor| descriptor.name != SCORE_SALIENCE_ABILITY_NAME));
+    }
+
+    #[test]
+    fn list_suggested_next_steps_descriptor_is_surface_read_and_hidden_from_mcp() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let descriptor = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME)
+            .expect("list_suggested_next_steps ability is registered");
+
+        assert_eq!(descriptor.category, AbilityCategory::Read);
+        assert!(descriptor.policy.allowed_actors.contains(&ActorKind::User));
+        assert!(descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::System));
+        assert!(descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::SurfaceClient));
+        assert!(!descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::McpClient));
+        assert_eq!(
+            descriptor.policy.required_scopes,
+            &[LIST_SUGGESTED_NEXT_STEPS_SCOPE]
+        );
+        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::None);
+        assert!(!descriptor.policy.may_publish);
+        assert!(!descriptor.policy.client_side_executable);
+        assert!(descriptor.mutates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_suggested_next_steps_per_actor_dry_run_matches_allowlist() {
+        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]);
+        let reader = Arc::new(CapturingSuggestedNextStepsReader::default());
+
+        for actor in [Actor::User, Actor::System, surface_actor()] {
+            invoke_list_suggested_next_steps(reader.clone(), actor)
+                .await
+                .expect("allowed actor succeeds");
+        }
+
+        for actor in [Actor::Agent, Actor::Admin, mcp_actor()] {
+            let error = invoke_list_suggested_next_steps(reader.clone(), actor)
+                .await
+                .expect_err("disallowed actor is denied");
+            assert_eq!(error.kind, AbilityErrorKind::Capability);
+        }
+
+        let requests = reader.requests.lock().expect("requests lock");
+        assert_eq!(requests.len(), 3);
+        assert_eq!(requests[0].1, ActorKind::User);
+        assert_eq!(requests[1].1, ActorKind::System);
+        assert_eq!(requests[2].1, ActorKind::SurfaceClient);
+    }
+
+    #[tokio::test]
+    async fn list_suggested_next_steps_forwards_subject_filter_placeholder() {
+        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]);
+        let reader = Arc::new(CapturingSuggestedNextStepsReader::default());
+        invoke_list_suggested_next_steps_with_payload(
+            reader.clone(),
+            Actor::User,
+            json!({
+                "schemaVersion": LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+                "subject": { "account": "acct-1" },
+                "surface": "entity_detail",
+                "maxItems": 3
+            }),
+        )
+        .await
+        .expect("read succeeds");
+
+        let requests = reader.requests.lock().expect("requests lock");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].0.subject,
+            Some(SubjectRef::Account("acct-1".to_string()))
+        );
+        assert_eq!(requests[0].0.max_items, Some(3));
+    }
+
+    #[tokio::test]
+    async fn list_suggested_next_steps_schema_mismatch_is_validation_error() {
+        let reader = Arc::new(CapturingSuggestedNextStepsReader::default());
+        let error = invoke_list_suggested_next_steps_with_payload(
+            reader.clone(),
+            Actor::User,
+            json!({
+                "schemaVersion": 99,
+                "subject": null,
+                "surface": "entity_detail"
+            }),
+        )
+        .await
+        .expect_err("schema mismatch rejected");
+
+        assert_eq!(error.kind, AbilityErrorKind::Validation);
+        assert!(reader.requests.lock().expect("requests lock").is_empty());
     }
 
     #[tokio::test]
@@ -365,6 +594,71 @@ mod tests {
             .await
     }
 
+    async fn invoke_list_suggested_next_steps<R>(
+        reader: Arc<R>,
+        actor: Actor,
+    ) -> Result<serde_json::Value, AbilityError>
+    where
+        R: SuggestedNextStepsReadHandle + 'static,
+    {
+        invoke_list_suggested_next_steps_with_payload(
+            reader,
+            actor,
+            json!({
+                "schemaVersion": LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+                "subject": null,
+                "surface": "entity_detail",
+                "maxItems": 5
+            }),
+        )
+        .await
+    }
+
+    async fn invoke_list_suggested_next_steps_with_payload<R>(
+        reader: Arc<R>,
+        actor: Actor,
+        payload: serde_json::Value,
+    ) -> Result<serde_json::Value, AbilityError>
+    where
+        R: SuggestedNextStepsReadHandle + 'static,
+    {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(7);
+        let external = ExternalClients::default();
+        let services = ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("test")
+            .with_suggested_next_steps_reader(reader);
+        let provider = ReplayProvider::new(std::collections::HashMap::new());
+        let ctx = crate::abilities::AbilityContext::new(
+            &services,
+            &provider,
+            &NOOP_ABILITY_TRACER,
+            actor,
+            None,
+            ClaimDismissalSurface::Eval,
+        );
+        registry
+            .invoke_by_name_json(&ctx, LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME, payload)
+            .await
+    }
+
+    fn surface_actor() -> Actor {
+        let scopes =
+            ScopeSet::new([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]).expect("scope set");
+        Actor::SurfaceClient {
+            instance: SurfaceClientId::new("surface-1"),
+            scopes,
+        }
+    }
+
+    fn mcp_actor() -> Actor {
+        Actor::McpClient {
+            client_id: McpClientId::new("client-1"),
+            conversation_handle: Some(OpaqueConversationHandle::new("conv-1")),
+        }
+    }
+
     fn response_fixture() -> ScoreSalienceResponse {
         ScoreSalienceResponse {
             schema_version: SCORE_SALIENCE_SCHEMA_VERSION,
@@ -382,6 +676,14 @@ mod tests {
                     },
                 }],
             },
+        }
+    }
+
+    fn suggested_next_steps_response_fixture() -> ListSuggestedNextStepsResponse {
+        ListSuggestedNextStepsResponse {
+            schema_version: LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+            items: Vec::new(),
+            generated_at: Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap(),
         }
     }
 }

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -46,8 +46,10 @@ pub use crate::abilities::markdown_preview::contracts::{
     MarkdownPreviewOutput, MarkdownPreviewReadRequest,
 };
 pub use crate::abilities::recommendations::contracts::{
-    SalienceReadError, ScoreSalienceReadRequest, ScoreSalienceResponse,
+    ListSuggestedNextStepsInput, ListSuggestedNextStepsResponse, SalienceReadError,
+    ScoreSalienceReadRequest, ScoreSalienceResponse, SuggestedNextStepsReadError,
 };
+use crate::abilities::registry::ActorKind;
 pub use crate::abilities::source_management_ledger::contracts::{
     SourceManagementActionReceipt, SourceManagementActionRequest,
     SourceManagementLedgerReadRequest, SourceManagementLedgerResponse,
@@ -868,6 +870,7 @@ pub struct ServiceContext<'a> {
     workspace_graph_reader: Option<Arc<dyn WorkspaceGraphReadHandle>>,
     source_management_ledger_reader: Option<Arc<dyn SourceManagementLedgerReadHandle>>,
     salience_reader: Option<Arc<dyn SalienceReadHandle>>,
+    suggested_next_steps_reader: Option<Arc<dyn SuggestedNextStepsReadHandle>>,
     source_management_action_handler: Option<Arc<dyn SourceManagementActionHandle>>,
     workspace_intake: Option<Arc<dyn WorkspaceIntakeService>>,
 }
@@ -1251,6 +1254,22 @@ pub type SalienceReadFuture<'a> =
 
 pub trait SalienceReadHandle: Send + Sync {
     fn score_salience<'a>(&'a self, request: ScoreSalienceReadRequest) -> SalienceReadFuture<'a>;
+}
+
+pub type SuggestedNextStepsReadFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ListSuggestedNextStepsResponse, SuggestedNextStepsReadError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+pub trait SuggestedNextStepsReadHandle: Send + Sync {
+    fn list_suggested_next_steps<'a>(
+        &'a self,
+        input: ListSuggestedNextStepsInput,
+        actor: ActorKind,
+    ) -> SuggestedNextStepsReadFuture<'a>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -1960,6 +1979,7 @@ impl<'a> ServiceContext<'a> {
             workspace_graph_reader: None,
             source_management_ledger_reader: None,
             salience_reader: None,
+            suggested_next_steps_reader: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -1999,6 +2019,7 @@ impl<'a> ServiceContext<'a> {
             workspace_graph_reader: None,
             source_management_ledger_reader: None,
             salience_reader: None,
+            suggested_next_steps_reader: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -2049,6 +2070,7 @@ impl<'a> ServiceContext<'a> {
             workspace_graph_reader: None,
             source_management_ledger_reader: None,
             salience_reader: None,
+            suggested_next_steps_reader: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -2199,6 +2221,14 @@ impl<'a> ServiceContext<'a> {
 
     pub fn with_salience_reader(mut self, reader: Arc<dyn SalienceReadHandle>) -> Self {
         self.salience_reader = Some(reader);
+        self
+    }
+
+    pub fn with_suggested_next_steps_reader(
+        mut self,
+        reader: Arc<dyn SuggestedNextStepsReadHandle>,
+    ) -> Self {
+        self.suggested_next_steps_reader = Some(reader);
         self
     }
 
@@ -2493,6 +2523,20 @@ impl<'a> ServiceContext<'a> {
         };
 
         reader.score_salience(request).await
+    }
+
+    pub async fn list_suggested_next_steps(
+        &self,
+        input: ListSuggestedNextStepsInput,
+        actor: ActorKind,
+    ) -> Result<ListSuggestedNextStepsResponse, SuggestedNextStepsReadError> {
+        let Some(reader) = &self.suggested_next_steps_reader else {
+            return Err(SuggestedNextStepsReadError::ReadFailed(
+                self.missing_reader_error("suggested_next_steps_read"),
+            ));
+        };
+
+        reader.list_suggested_next_steps(input, actor).await
     }
 
     pub async fn apply_source_management_action(

--- a/src-tauri/abilities-runtime/tests/block_kit_integration_harness.rs
+++ b/src-tauri/abilities-runtime/tests/block_kit_integration_harness.rs
@@ -607,6 +607,8 @@ mod score_band_integration_fixture;
 mod source_management_integration_fixture;
 #[path = "fixtures/status_dot_integration_fixture.rs"]
 mod status_dot_integration_fixture;
+#[path = "fixtures/suggested_next_steps_integration_fixture.rs"]
+mod suggested_next_steps_integration_fixture;
 #[path = "fixtures/the_work_integration_fixture.rs"]
 mod the_work_integration_fixture;
 #[path = "fixtures/touchpoints_feed_integration_fixture.rs"]
@@ -677,6 +679,7 @@ fn expected_block_fixtures_cover_requested_ci_block() {
         projects_index_integration_fixture::projects_index_fixture(),
         recommended_actions_integration_fixture::recommended_actions_fixture(),
         source_management_integration_fixture::source_management_fixture(),
+        suggested_next_steps_integration_fixture::suggested_next_steps_fixture(),
         the_work_integration_fixture::the_work_fixture(),
         touchpoints_feed_integration_fixture::touchpoints_feed_fixture(),
         trend_strip_integration_fixture::trend_strip_fixture(),

--- a/src-tauri/abilities-runtime/tests/fixtures/suggested_next_steps_integration_fixture.rs
+++ b/src-tauri/abilities-runtime/tests/fixtures/suggested_next_steps_integration_fixture.rs
@@ -1,0 +1,17 @@
+use crate::{minimal_block_kit_fixture, BlockIntegrationFixture};
+
+pub fn suggested_next_steps_fixture() -> BlockIntegrationFixture {
+    minimal_block_kit_fixture(
+        "suggested-next-steps",
+        "section",
+        "editorial-reveal entity-detail_chapterSection SuggestedNextSteps_section SuggestedNextSteps_section--empty is-empty",
+        &[("data-dailyos-block", "suggested-next-steps")],
+        "empty-state",
+        "No subject context.",
+    )
+}
+
+crate::integration_test_block!(
+    suggested_next_steps_block_integration,
+    suggested_next_steps_fixture
+);

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -57,6 +57,7 @@ pub struct LiveMarkdownPreviewReader;
 pub struct LiveWorkspaceGraphReader;
 pub struct LiveSourceManagementLedgerReader;
 pub struct LiveSalienceReader;
+pub struct LiveSuggestedNextStepsReader;
 pub struct LiveSourceManagementActionHandler {
     signal_engine: Option<Arc<crate::signals::propagation::PropagationEngine>>,
 }
@@ -92,6 +93,7 @@ pub fn attach_live_workspace_readers_with_signal_engine(
         .with_workspace_graph_reader(Arc::new(LiveWorkspaceGraphReader))
         .with_source_management_ledger_reader(Arc::new(LiveSourceManagementLedgerReader))
         .with_salience_reader(Arc::new(LiveSalienceReader))
+        .with_suggested_next_steps_reader(Arc::new(LiveSuggestedNextStepsReader))
         .with_source_management_action_handler(Arc::new(LiveSourceManagementActionHandler {
             signal_engine: signal_engine.clone(),
         }))
@@ -384,6 +386,25 @@ impl SalienceReadHandle for LiveSalienceReader {
                     "salience read task failed: {error}"
                 ))
             })?
+        })
+    }
+}
+
+impl SuggestedNextStepsReadHandle for LiveSuggestedNextStepsReader {
+    fn list_suggested_next_steps<'a>(
+        &'a self,
+        input: runtime_salience::ListSuggestedNextStepsInput,
+        actor: abilities_runtime::abilities::registry::ActorKind,
+    ) -> SuggestedNextStepsReadFuture<'a> {
+        Box::pin(async move {
+            let state = crate::state::AppState::new();
+            crate::services::recommendations::render::list_suggested_next_steps_projection(
+                &state, input, actor,
+            )
+            .await
+            .map_err(|error| {
+                runtime_salience::SuggestedNextStepsReadError::ReadFailed(error.to_string())
+            })
         })
     }
 }

--- a/src-tauri/src/services/recommendations/render.rs
+++ b/src-tauri/src/services/recommendations/render.rs
@@ -1,6 +1,1473 @@
-//! Cross-surface render contract.
+//! Surface-safe recommendation render projection.
 //!
-//! Returns the recommendation's render payload through the Shared
-//! Receipt DTO (`services::claim_receipt::contracts::ClaimReceipt`),
-//! the same shape every other claim type uses. No parallel render
-//! contract for recommendations.
+//! This module turns W2-A `surfacing_decisions` rows into the
+//! `list_suggested_next_steps` ability response. The projection reads the
+//! denormalized surfacing row for ranking, then rehydrates only the fields the
+//! surface needs from the recommendation claim and Shared Receipt DTO.
+
+use std::collections::HashMap;
+
+use abilities_runtime::abilities::claim_receipt as runtime_receipt;
+use abilities_runtime::abilities::provenance::subject::SubjectRef;
+use abilities_runtime::abilities::provenance::trust::claim_trust_band_from_score;
+use abilities_runtime::abilities::recommendations::contracts as runtime;
+use abilities_runtime::abilities::registry::ActorKind;
+use abilities_runtime::abilities::trust::types::TrustBand;
+use abilities_runtime::sensitivity::{
+    renderable_claim_text_with_value, RenderActor, RenderSurface,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::{params, OptionalExtension};
+
+use super::contracts as app;
+use crate::db::ActionDb;
+use crate::services::claim_receipt::contracts as app_receipt;
+use crate::services::claim_receipt::privacy::{build_receipt_for_audience, Audience, PrivacyError};
+use crate::services::claim_receipt::render::audience_for_surface;
+use crate::state::AppState;
+
+const DEFAULT_MAX_ITEMS: u8 = 5;
+const MAX_ITEMS_CEILING: u8 = 8;
+const DECIDED_ECHO_WINDOW_SECS: i64 = 30;
+const SURFACING_FETCH_MULTIPLIER: usize = 4;
+
+#[derive(Debug, Clone)]
+pub struct RecommendationRenderPayload {
+    pub claim_id: app::ClaimId,
+    pub subject: SubjectRef,
+    pub headline: String,
+    pub field_path: Option<String>,
+    pub recommended_action: app::RecommendedAction,
+    pub trust_band: TrustBand,
+    pub evidence: Vec<app::EvidenceRef>,
+    pub feedback_state: app::FeedbackState,
+    pub conversion_state: app::ConversionState,
+    pub salience: Option<app::SalienceScore>,
+}
+
+#[derive(Debug, Clone)]
+struct SurfacingRenderRow {
+    claim_id: app::ClaimId,
+    why_this_now: app::WhyThisNow,
+    trigger_refs: Vec<app::TriggerRef>,
+    salience_evaluation_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectionCandidate {
+    row: SurfacingRenderRow,
+    payload: RecommendationRenderPayload,
+    primary_rationale: Option<app::FactorRationale>,
+}
+
+#[derive(Debug, Clone)]
+struct ReceiptBatchRow {
+    claim_id: String,
+    subject: SubjectRef,
+    field_path: Option<String>,
+}
+
+pub async fn list_suggested_next_steps_projection(
+    state: &AppState,
+    input: runtime::ListSuggestedNextStepsInput,
+    actor: ActorKind,
+) -> Result<runtime::ListSuggestedNextStepsResponse> {
+    if input.schema_version != runtime::LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION {
+        bail!(
+            "unsupported schema_version `{}` for `{}`",
+            input.schema_version,
+            runtime::LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME
+        );
+    }
+
+    let max_items = usize::from(
+        input
+            .max_items
+            .unwrap_or(DEFAULT_MAX_ITEMS)
+            .min(MAX_ITEMS_CEILING),
+    );
+    let generated_at = Utc::now();
+    if max_items == 0 {
+        return Ok(runtime::ListSuggestedNextStepsResponse {
+            schema_version: runtime::LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+            items: Vec::new(),
+            generated_at,
+        });
+    }
+
+    let subject_filter = subject_filter(input.subject.as_ref())?;
+    let fetch_limit = (max_items * SURFACING_FETCH_MULTIPLIER).max(max_items);
+    let candidates = state
+        .db_read(move |db| {
+            load_projection_candidates(
+                db.conn_ref(),
+                subject_filter,
+                actor,
+                generated_at,
+                max_items,
+                fetch_limit,
+            )
+            .map_err(|error| error.to_string())
+        })
+        .await
+        .map_err(|error| anyhow!("list_suggested_next_steps surfacing read failed: {error}"))?;
+
+    let claim_ids = candidates
+        .iter()
+        .map(|candidate| runtime::ClaimId(candidate.row.claim_id.0.clone()))
+        .collect::<Vec<_>>();
+    let receipts = render_receipts_for_batch(state, &claim_ids, input.surface).await;
+    let receipts_by_claim_id = receipts
+        .into_iter()
+        .filter_map(|receipt| {
+            let claim_id = receipt_claim_id(&receipt)?.to_string();
+            Some((claim_id, receipt))
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut items = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        let Some(receipt) = receipts_by_claim_id.get(&candidate.row.claim_id.0).cloned() else {
+            continue;
+        };
+        let why_this_now_surface_text =
+            why_this_now_surface_text(&candidate.row, candidate.primary_rationale.as_ref());
+        items.push(runtime::SuggestedNextStepItem {
+            claim_id: runtime::ClaimId(candidate.row.claim_id.0),
+            headline: redact_numeric_text(&candidate.payload.headline),
+            why_this_now_surface_text,
+            factor_band: factor_band(candidate.row.why_this_now.primary_factor),
+            recommended_action: recommended_action_view(&candidate.payload.recommended_action),
+            trust_band: candidate.payload.trust_band,
+            receipt,
+            feedback_state: feedback_state_to_runtime(candidate.payload.feedback_state),
+            conversion_state: conversion_state_to_runtime(candidate.payload.conversion_state),
+        });
+        if items.len() == max_items {
+            break;
+        }
+    }
+
+    Ok(runtime::ListSuggestedNextStepsResponse {
+        schema_version: runtime::LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+        items,
+        generated_at,
+    })
+}
+
+pub async fn read_recommendation_for_render(
+    claim_id: &app::ClaimId,
+    actor: ActorKind,
+) -> Result<RecommendationRenderPayload> {
+    let claim_id = claim_id.clone();
+    tokio::task::spawn_blocking(move || {
+        let db = ActionDb::open_readonly(std::sync::Arc::new(crate::db::LocalKeychain::new()))
+            .context("open recommendation render read connection")?;
+        read_recommendation_for_render_from_conn(db.conn_ref(), &claim_id, actor)?
+            .ok_or_else(|| anyhow!("recommendation claim `{}` is not visible", claim_id.0))
+    })
+    .await
+    .map_err(|error| anyhow!("recommendation render read task failed: {error}"))?
+}
+
+pub async fn render_receipts_for_batch(
+    state: &AppState,
+    claim_ids: &[runtime::ClaimId],
+    surface: runtime_receipt::ClaimReceiptSurfaceContext,
+) -> Vec<runtime_receipt::ClaimReceiptSnapshot> {
+    if claim_ids.is_empty() {
+        return Vec::new();
+    }
+    let claim_ids = claim_ids.to_vec();
+    let app_surface = ability_surface_to_app(surface);
+    state
+        .db_read(move |db| {
+            render_receipts_for_batch_from_conn(db.conn_ref(), &claim_ids, app_surface)
+                .map_err(|error| error.to_string())
+        })
+        .await
+        .unwrap_or_default()
+}
+
+fn load_projection_candidates(
+    conn: &rusqlite::Connection,
+    subject_filter: Option<(String, String)>,
+    actor: ActorKind,
+    now: DateTime<Utc>,
+    max_items: usize,
+    fetch_limit: usize,
+) -> Result<Vec<ProjectionCandidate>> {
+    if !table_exists(conn, "surfacing_decisions")? {
+        return Ok(Vec::new());
+    }
+
+    let rows = load_surfacing_rows(conn, subject_filter, fetch_limit)?;
+    let mut candidates = Vec::with_capacity(max_items);
+    for row in rows {
+        let Some(payload) = read_recommendation_for_render_from_conn(conn, &row.claim_id, actor)?
+        else {
+            continue;
+        };
+        if !feedback_visible_in_echo_window(&payload.feedback_state, now) {
+            continue;
+        }
+        let primary_rationale = load_primary_rationale(
+            conn,
+            &row.claim_id,
+            row.salience_evaluation_id.as_str(),
+            row.why_this_now.primary_factor,
+            payload.salience.as_ref(),
+        )?;
+        candidates.push(ProjectionCandidate {
+            row,
+            payload,
+            primary_rationale,
+        });
+        if candidates.len() == max_items {
+            break;
+        }
+    }
+    Ok(candidates)
+}
+
+fn load_surfacing_rows(
+    conn: &rusqlite::Connection,
+    subject_filter: Option<(String, String)>,
+    fetch_limit: usize,
+) -> Result<Vec<SurfacingRenderRow>> {
+    let limit = i64::try_from(fetch_limit).unwrap_or(i64::MAX);
+    let mut rows = Vec::new();
+    if let Some((subject_kind, subject_id)) = subject_filter {
+        let mut stmt = conn.prepare(
+            "SELECT claim_id, why_this_now_json, trigger_refs_json, salience_evaluation_id
+               FROM surfacing_decisions
+              WHERE subject_kind = ?1
+                AND subject_id = ?2
+                AND decision_kind = 'render'
+                AND surfacing_tier IN ('critical', 'notable', 'background')
+              ORDER BY salience_total DESC, created_at DESC
+              LIMIT ?3",
+        )?;
+        let mapped = stmt.query_map(params![subject_kind, subject_id, limit], surfacing_row)?;
+        for row in mapped {
+            rows.push(row?);
+        }
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT claim_id, why_this_now_json, trigger_refs_json, salience_evaluation_id
+               FROM surfacing_decisions
+              WHERE decision_kind = 'render'
+                AND surfacing_tier IN ('critical', 'notable', 'background')
+              ORDER BY salience_total DESC, created_at DESC
+              LIMIT ?1",
+        )?;
+        let mapped = stmt.query_map([limit], surfacing_row)?;
+        for row in mapped {
+            rows.push(row?);
+        }
+    }
+    Ok(rows)
+}
+
+fn surfacing_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SurfacingRenderRow> {
+    let claim_id = app::ClaimId(row.get::<_, String>(0)?);
+    let why_raw: Option<String> = row.get(1)?;
+    let trigger_raw: String = row.get(2)?;
+    let why_this_now = why_raw
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<app::WhyThisNow>(raw).ok())
+        .ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                1,
+                rusqlite::types::Type::Text,
+                "missing or invalid why_this_now_json".into(),
+            )
+        })?;
+    let trigger_refs =
+        serde_json::from_str::<Vec<app::TriggerRef>>(&trigger_raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?;
+    Ok(SurfacingRenderRow {
+        claim_id,
+        why_this_now,
+        trigger_refs,
+        salience_evaluation_id: row.get(3)?,
+    })
+}
+
+fn read_recommendation_for_render_from_conn(
+    conn: &rusqlite::Connection,
+    claim_id: &app::ClaimId,
+    actor: ActorKind,
+) -> Result<Option<RecommendationRenderPayload>> {
+    let row = conn
+        .query_row(
+            "SELECT id, subject_ref, text, field_path, metadata_json, trust_score,
+                    claim_state, surfacing_state
+               FROM intelligence_claims
+              WHERE id = ?1 AND claim_type = 'recommendation'",
+            [&claim_id.0],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<f64>>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    let Some((
+        id,
+        subject_ref,
+        text,
+        field_path,
+        metadata_json,
+        trust_score,
+        claim_state,
+        surfacing_state,
+    )) = row
+    else {
+        return Ok(None);
+    };
+
+    if !claim_visible_to_actor(actor, &claim_state, &surfacing_state) {
+        return Ok(None);
+    }
+
+    let metadata_raw = metadata_json
+        .as_deref()
+        .ok_or_else(|| anyhow!("recommendation claim `{id}` missing metadata_json"))?;
+    let metadata = serde_json::from_str::<app::RecommendationMetadataEnvelope>(metadata_raw)
+        .with_context(|| {
+            format!("recommendation claim `{id}` metadata_json did not match schema")
+        })?;
+    let subject = subject_ref_from_storage(&subject_ref)?;
+
+    Ok(Some(RecommendationRenderPayload {
+        claim_id: app::ClaimId(id),
+        subject,
+        headline: text,
+        field_path,
+        recommended_action: metadata.recommendation.recommended_action,
+        trust_band: claim_trust_band_from_score(trust_score),
+        evidence: metadata.recommendation.evidence,
+        feedback_state: metadata.recommendation.feedback_state,
+        conversion_state: metadata.recommendation.conversion_state,
+        salience: Some(metadata.recommendation.salience),
+    }))
+}
+
+fn load_primary_rationale(
+    conn: &rusqlite::Connection,
+    claim_id: &app::ClaimId,
+    evaluation_id: &str,
+    primary_factor: app::SalienceFactorKind,
+    metadata_salience: Option<&app::SalienceScore>,
+) -> Result<Option<app::FactorRationale>> {
+    if table_exists(conn, "salience_factors")? {
+        let raw = conn
+            .query_row(
+                "SELECT rationale_json
+                   FROM salience_factors
+                  WHERE claim_id = ?1
+                    AND evaluation_id = ?2
+                    AND factor_kind = ?3
+                  LIMIT 1",
+                params![
+                    &claim_id.0,
+                    evaluation_id,
+                    salience_factor_kind_storage(primary_factor)
+                ],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(raw) = raw {
+            return serde_json::from_str::<app::FactorRationale>(&raw)
+                .map(Some)
+                .map_err(Into::into);
+        }
+    }
+
+    Ok(metadata_salience.and_then(|score| {
+        score
+            .factors
+            .iter()
+            .find(|factor| factor.kind == primary_factor)
+            .map(|factor| factor.rationale.clone())
+    }))
+}
+
+fn feedback_visible_in_echo_window(
+    feedback_state: &app::FeedbackState,
+    now: DateTime<Utc>,
+) -> bool {
+    match feedback_state {
+        app::FeedbackState::Pending => true,
+        app::FeedbackState::Decided(decision) => {
+            now.signed_duration_since(feedback_decided_at(decision))
+                <= Duration::seconds(DECIDED_ECHO_WINDOW_SECS)
+        }
+    }
+}
+
+fn feedback_decided_at(decision: &app::RecommendationFeedbackDecision) -> DateTime<Utc> {
+    match decision {
+        app::RecommendationFeedbackDecision::Accept { at }
+        | app::RecommendationFeedbackDecision::Dismiss { at, .. }
+        | app::RecommendationFeedbackDecision::NotUseful { at }
+        | app::RecommendationFeedbackDecision::TooNoisy { at }
+        | app::RecommendationFeedbackDecision::Convert { at, .. } => *at,
+    }
+}
+
+fn render_receipts_for_batch_from_conn(
+    conn: &rusqlite::Connection,
+    claim_ids: &[runtime::ClaimId],
+    surface: app_receipt::SurfaceContext,
+) -> Result<Vec<runtime_receipt::ClaimReceiptSnapshot>> {
+    let batch_rows = load_receipt_batch_rows(conn, claim_ids)?;
+    let row_by_claim_id = batch_rows
+        .into_iter()
+        .map(|row| (row.claim_id.clone(), row))
+        .collect::<HashMap<_, _>>();
+    let audience = audience_for_surface(surface);
+    let mut receipts = Vec::with_capacity(claim_ids.len());
+
+    for claim_id in claim_ids {
+        let Some(row) = row_by_claim_id.get(&claim_id.0) else {
+            continue;
+        };
+        let target = app_receipt::ReceiptTarget::Claim {
+            claim_id: row.claim_id.clone(),
+            subject: row.subject.clone(),
+            field_path: row.field_path.clone(),
+        };
+        let mut receipt = match build_receipt_for_audience(&target, audience, conn) {
+            Ok(receipt) => receipt,
+            Err(PrivacyError::ClaimNotFound(_))
+            | Err(PrivacyError::NonDisclosureAudience)
+            | Err(PrivacyError::ComposedClaimDropped)
+            | Err(PrivacyError::SurfaceDrop) => continue,
+            Err(PrivacyError::Storage(error)) => return Err(error.into()),
+            Err(PrivacyError::InvalidMetadata(message)) => {
+                bail!("invalid receipt metadata: {message}")
+            }
+        };
+        receipt.surface_context = surface;
+        if matches!(audience, Audience::UserTauri) {
+            if let Some(rendered_text) =
+                render_text_for_user_tauri_surface_from_conn(conn, &row.claim_id, surface)?
+            {
+                receipt.rendered_text = Some(rendered_text);
+            }
+        }
+        receipts.push(app_receipt_to_ability(receipt));
+    }
+
+    Ok(receipts)
+}
+
+fn load_receipt_batch_rows(
+    conn: &rusqlite::Connection,
+    claim_ids: &[runtime::ClaimId],
+) -> Result<Vec<ReceiptBatchRow>> {
+    if claim_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = std::iter::repeat_n("?", claim_ids.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT id, subject_ref, field_path
+           FROM intelligence_claims
+          WHERE id IN ({placeholders})"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params = rusqlite::params_from_iter(claim_ids.iter().map(|claim_id| claim_id.0.as_str()));
+    let mapped = stmt.query_map(params, |row| {
+        let subject_raw: String = row.get(1)?;
+        let subject = subject_ref_from_storage(&subject_raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, error.into())
+        })?;
+        Ok(ReceiptBatchRow {
+            claim_id: row.get(0)?,
+            subject,
+            field_path: row.get(2)?,
+        })
+    })?;
+    let mut rows = Vec::new();
+    for row in mapped {
+        rows.push(row?);
+    }
+    Ok(rows)
+}
+
+fn render_text_for_user_tauri_surface_from_conn(
+    conn: &rusqlite::Connection,
+    claim_id: &str,
+    surface: app_receipt::SurfaceContext,
+) -> Result<Option<abilities_runtime::sensitivity::RenderableClaimText>> {
+    let claim = crate::services::claims::load_claim_by_id(conn, claim_id)?
+        .ok_or_else(|| anyhow!("claim `{claim_id}` not found for receipt render text"))?;
+    let actor = RenderActor {
+        actor: "user".to_string(),
+        user_id: None,
+    };
+    Ok(renderable_claim_text_with_value(
+        &claim,
+        &claim.text,
+        render_surface_for(surface),
+        &actor,
+    ))
+}
+
+fn why_this_now_surface_text(
+    row: &SurfacingRenderRow,
+    rationale: Option<&app::FactorRationale>,
+) -> String {
+    let rationale = rationale
+        .map(surface_rationale_summary)
+        .unwrap_or_else(|| redact_numeric_text(&row.why_this_now.text));
+    format!(
+        "Salience driven by {}: {}. Triggers: {}.",
+        factor_label(row.why_this_now.primary_factor),
+        rationale,
+        trigger_summary(if row.why_this_now.triggers.is_empty() {
+            &row.trigger_refs
+        } else {
+            &row.why_this_now.triggers
+        })
+    )
+}
+
+fn surface_rationale_summary(rationale: &app::FactorRationale) -> String {
+    match rationale {
+        app::FactorRationale::Importance {
+            trust_band,
+            source_authority,
+        } => format!(
+            "trusted source strength is {} with {} trust",
+            qualitative_band(*source_authority),
+            trust_band_label(*trust_band)
+        ),
+        app::FactorRationale::Novelty {
+            vector_distance, ..
+        } => format!(
+            "new compared with nearby memory at {} distance",
+            qualitative_band(*vector_distance)
+        ),
+        app::FactorRationale::Urgency { decay_factor, .. } => {
+            format!(
+                "deadline or time pressure is {}",
+                qualitative_band(*decay_factor)
+            )
+        }
+        app::FactorRationale::Timing {
+            signal_age_secs, ..
+        } => format!("signal timing is {}", recency_band(*signal_age_secs)),
+        app::FactorRationale::UserFit {
+            feedback_history_score,
+        } => format!(
+            "prior feedback fit is {}",
+            qualitative_band(*feedback_history_score)
+        ),
+        app::FactorRationale::Freshness { decay_factor } => {
+            format!("source timing is {}", qualitative_band(*decay_factor))
+        }
+        app::FactorRationale::Trust { trust_band } => {
+            format!("trust band is {}", trust_band_label(*trust_band))
+        }
+        app::FactorRationale::Corroboration { .. } => "supporting evidence is present".to_string(),
+        app::FactorRationale::Contradiction { .. } => {
+            "contradiction state needs review".to_string()
+        }
+        app::FactorRationale::OpenLoopRelevance { has_action, .. } => {
+            if *has_action {
+                "related open loop has an action".to_string()
+            } else {
+                "related open loop context is present".to_string()
+            }
+        }
+    }
+}
+
+fn recommended_action_view(action: &app::RecommendedAction) -> runtime::RecommendedActionView {
+    match action {
+        app::RecommendedAction::ScheduleMeeting { when_window, .. } => {
+            runtime::RecommendedActionView::ScheduleMeeting {
+                entity_label: "Entity".to_string(),
+                when_window: redact_numeric_text(when_window),
+            }
+        }
+        app::RecommendedAction::SendMessage { channel, .. } => {
+            runtime::RecommendedActionView::SendMessage {
+                entity_label: "Entity".to_string(),
+                channel: redact_numeric_text(channel),
+            }
+        }
+        app::RecommendedAction::ReviewClaim { .. } => runtime::RecommendedActionView::ReviewClaim {
+            claim_label: "Claim".to_string(),
+        },
+        app::RecommendedAction::UpdateRecord { field_path, .. } => {
+            runtime::RecommendedActionView::UpdateRecord {
+                entity_label: "Entity".to_string(),
+                field_label: field_label(field_path),
+            }
+        }
+        app::RecommendedAction::InvestigateChange { change_summary, .. } => {
+            runtime::RecommendedActionView::InvestigateChange {
+                entity_label: "Entity".to_string(),
+                change_label: redact_numeric_text(change_summary),
+            }
+        }
+        app::RecommendedAction::Custom { action_kind, .. } => {
+            runtime::RecommendedActionView::Custom {
+                action_label: action_label(action_kind),
+            }
+        }
+    }
+}
+
+fn factor_band(kind: app::SalienceFactorKind) -> runtime::PrimaryFactorBand {
+    match kind {
+        app::SalienceFactorKind::Urgency | app::SalienceFactorKind::Timing => {
+            runtime::PrimaryFactorBand::TimeSensitive
+        }
+        app::SalienceFactorKind::Novelty | app::SalienceFactorKind::Freshness => {
+            runtime::PrimaryFactorBand::NewInformation
+        }
+        app::SalienceFactorKind::OpenLoopRelevance => runtime::PrimaryFactorBand::OpenLoopRelated,
+        app::SalienceFactorKind::Trust
+        | app::SalienceFactorKind::Corroboration
+        | app::SalienceFactorKind::Contradiction => runtime::PrimaryFactorBand::TrustChange,
+        app::SalienceFactorKind::Importance | app::SalienceFactorKind::UserFit => {
+            runtime::PrimaryFactorBand::Other
+        }
+    }
+}
+
+fn redact_numeric_text(text: &str) -> String {
+    let mut redacted = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch.is_ascii_digit() {
+            while matches!(chars.peek(), Some(next) if next.is_ascii_digit() || *next == '.') {
+                chars.next();
+            }
+            redacted.push_str("value");
+        } else {
+            redacted.push(ch);
+        }
+    }
+    redacted
+}
+
+fn field_label(field_path: &str) -> String {
+    let label = field_path
+        .rsplit(['.', '['])
+        .next()
+        .unwrap_or("field")
+        .trim_matches(']')
+        .replace(['_', '-'], " ");
+    let label = redact_numeric_text(&label);
+    if label.trim().is_empty() {
+        "Record field".to_string()
+    } else {
+        label
+    }
+}
+
+fn action_label(action_kind: &str) -> String {
+    let label = redact_numeric_text(&action_kind.replace(['_', '-'], " "));
+    if label.trim().is_empty() {
+        "Custom action".to_string()
+    } else {
+        label
+    }
+}
+
+fn qualitative_band(value: f64) -> &'static str {
+    if value >= 0.75 {
+        "high"
+    } else if value >= 0.4 {
+        "moderate"
+    } else {
+        "low"
+    }
+}
+
+fn recency_band(signal_age_secs: i64) -> &'static str {
+    if signal_age_secs <= 86_400 {
+        "high"
+    } else if signal_age_secs <= 604_800 {
+        "moderate"
+    } else {
+        "low"
+    }
+}
+
+fn trust_band_label(trust_band: TrustBand) -> &'static str {
+    match trust_band {
+        TrustBand::LikelyCurrent => "likely current",
+        TrustBand::UseWithCaution => "use with caution",
+        TrustBand::NeedsVerification => "needs verification",
+        TrustBand::Unscored => "unscored",
+    }
+}
+
+fn trigger_summary(triggers: &[app::TriggerRef]) -> String {
+    let mut sources = triggers
+        .iter()
+        .map(|trigger| trigger.source.as_str())
+        .collect::<Vec<_>>();
+    sources.sort_unstable();
+    sources.dedup();
+    if sources.is_empty() {
+        "scheduled_scan".to_string()
+    } else {
+        redact_numeric_text(&sources.into_iter().take(3).collect::<Vec<_>>().join(", "))
+    }
+}
+
+fn factor_label(kind: app::SalienceFactorKind) -> &'static str {
+    match kind {
+        app::SalienceFactorKind::Importance => "importance",
+        app::SalienceFactorKind::Novelty => "novelty",
+        app::SalienceFactorKind::Urgency => "urgency",
+        app::SalienceFactorKind::Timing => "timing",
+        app::SalienceFactorKind::UserFit => "user fit",
+        app::SalienceFactorKind::Freshness => "freshness",
+        app::SalienceFactorKind::Trust => "trust",
+        app::SalienceFactorKind::Corroboration => "corroboration",
+        app::SalienceFactorKind::Contradiction => "contradiction",
+        app::SalienceFactorKind::OpenLoopRelevance => "open loop relevance",
+    }
+}
+
+fn claim_visible_to_actor(actor: ActorKind, claim_state: &str, surfacing_state: &str) -> bool {
+    match actor {
+        ActorKind::System => matches!(claim_state, "active" | "dormant"),
+        ActorKind::User | ActorKind::SurfaceClient => {
+            claim_state == "active" && surfacing_state == "active"
+        }
+        ActorKind::Agent | ActorKind::Admin | ActorKind::McpClient => false,
+    }
+}
+
+fn subject_filter(subject: Option<&SubjectRef>) -> Result<Option<(String, String)>> {
+    Ok(match subject {
+        None | Some(SubjectRef::Global) | Some(SubjectRef::Unknown) => None,
+        Some(SubjectRef::Account(id)) => Some(("account".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::Project(id)) => Some(("project".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::Person(id)) => Some(("person".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::Meeting(id)) => Some(("meeting".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::User(id)) => Some(("user".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::Multi(_)) => {
+            bail!("list_suggested_next_steps does not support multi-subject filters")
+        }
+    })
+}
+
+fn non_empty_id(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("subject id must not be empty");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn subject_ref_from_storage(raw: &str) -> Result<SubjectRef> {
+    let value = serde_json::from_str::<serde_json::Value>(raw)
+        .with_context(|| format!("invalid subject_ref JSON: {raw}"))?;
+    let kind = value
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("subject_ref missing kind"))?;
+    let id = value
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    Ok(match kind {
+        "account" => SubjectRef::Account(id),
+        "project" => SubjectRef::Project(id),
+        "person" => SubjectRef::Person(id),
+        "meeting" => SubjectRef::Meeting(id),
+        "user" => SubjectRef::User(id),
+        "global" => SubjectRef::Global,
+        _ => SubjectRef::Unknown,
+    })
+}
+
+fn salience_factor_kind_storage(kind: app::SalienceFactorKind) -> &'static str {
+    match kind {
+        app::SalienceFactorKind::Importance => "importance",
+        app::SalienceFactorKind::Novelty => "novelty",
+        app::SalienceFactorKind::Urgency => "urgency",
+        app::SalienceFactorKind::Timing => "timing",
+        app::SalienceFactorKind::UserFit => "user_fit",
+        app::SalienceFactorKind::Freshness => "freshness",
+        app::SalienceFactorKind::Trust => "trust",
+        app::SalienceFactorKind::Corroboration => "corroboration",
+        app::SalienceFactorKind::Contradiction => "contradiction",
+        app::SalienceFactorKind::OpenLoopRelevance => "open_loop_relevance",
+    }
+}
+
+fn table_exists(conn: &rusqlite::Connection, table: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT COUNT(*)
+           FROM sqlite_master
+          WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get::<_, i64>(0).map(|count| count > 0),
+    )
+    .map_err(Into::into)
+}
+
+fn ability_surface_to_app(
+    surface: runtime_receipt::ClaimReceiptSurfaceContext,
+) -> app_receipt::SurfaceContext {
+    match surface {
+        runtime_receipt::ClaimReceiptSurfaceContext::ActionsWork => {
+            app_receipt::SurfaceContext::ActionsWork
+        }
+        runtime_receipt::ClaimReceiptSurfaceContext::EntityDetail => {
+            app_receipt::SurfaceContext::EntityDetail
+        }
+        runtime_receipt::ClaimReceiptSurfaceContext::DailyBriefing => {
+            app_receipt::SurfaceContext::DailyBriefing
+        }
+        runtime_receipt::ClaimReceiptSurfaceContext::MeetingDetail => {
+            app_receipt::SurfaceContext::MeetingDetail
+        }
+        runtime_receipt::ClaimReceiptSurfaceContext::Mcp => app_receipt::SurfaceContext::Mcp,
+    }
+}
+
+fn app_surface_to_ability(
+    surface: app_receipt::SurfaceContext,
+) -> runtime_receipt::ClaimReceiptSurfaceContext {
+    match surface {
+        app_receipt::SurfaceContext::ActionsWork => {
+            runtime_receipt::ClaimReceiptSurfaceContext::ActionsWork
+        }
+        app_receipt::SurfaceContext::EntityDetail => {
+            runtime_receipt::ClaimReceiptSurfaceContext::EntityDetail
+        }
+        app_receipt::SurfaceContext::DailyBriefing => {
+            runtime_receipt::ClaimReceiptSurfaceContext::DailyBriefing
+        }
+        app_receipt::SurfaceContext::MeetingDetail => {
+            runtime_receipt::ClaimReceiptSurfaceContext::MeetingDetail
+        }
+        app_receipt::SurfaceContext::Mcp => runtime_receipt::ClaimReceiptSurfaceContext::Mcp,
+    }
+}
+
+fn render_surface_for(surface: app_receipt::SurfaceContext) -> RenderSurface {
+    match surface {
+        app_receipt::SurfaceContext::ActionsWork => RenderSurface::Action,
+        app_receipt::SurfaceContext::EntityDetail => RenderSurface::TauriEntityDetail,
+        app_receipt::SurfaceContext::DailyBriefing => RenderSurface::TauriBriefingPrep,
+        app_receipt::SurfaceContext::MeetingDetail => RenderSurface::TauriMeetingDetail,
+        app_receipt::SurfaceContext::Mcp => RenderSurface::McpTool,
+    }
+}
+
+fn app_receipt_to_ability(
+    receipt: app_receipt::ClaimReceipt,
+) -> runtime_receipt::ClaimReceiptSnapshot {
+    runtime_receipt::ClaimReceiptSnapshot {
+        target: app_target_to_ability(&receipt.target),
+        surface_context: app_surface_to_ability(receipt.surface_context),
+        rendered_text: receipt.rendered_text,
+        trust: runtime_receipt::ClaimReceiptTrust {
+            band: receipt.trust.band,
+            source_asof: receipt.trust.source_asof,
+            freshness: match receipt.trust.freshness {
+                app_receipt::Freshness::Current => runtime_receipt::ClaimReceiptFreshness::Current,
+                app_receipt::Freshness::Aging => runtime_receipt::ClaimReceiptFreshness::Aging,
+                app_receipt::Freshness::Stale => runtime_receipt::ClaimReceiptFreshness::Stale,
+                app_receipt::Freshness::Unknown => runtime_receipt::ClaimReceiptFreshness::Unknown,
+            },
+            caveat: receipt.trust.caveat,
+            rationale: receipt.trust.rationale,
+        },
+        lifecycle: runtime_receipt::ClaimReceiptLifecycle {
+            claim_state: receipt.lifecycle.claim_state,
+            surfacing_state: receipt.lifecycle.surfacing_state,
+            verification_state: receipt.lifecycle.verification_state,
+            updated_at: receipt.lifecycle.updated_at,
+        },
+        provenance: runtime_receipt::ClaimReceiptProvenance {
+            sources: receipt
+                .provenance
+                .sources
+                .into_iter()
+                .map(|source| runtime_receipt::ClaimReceiptProvenanceSource {
+                    label: source.label,
+                    source_type: source.source_type,
+                    as_of: source.as_of,
+                    href: source.href,
+                    redacted: source.redacted,
+                })
+                .collect(),
+            field_path: receipt.provenance.field_path,
+            evidence_summary: receipt.provenance.evidence_summary,
+            redaction: match receipt.provenance.redaction {
+                app_receipt::RedactionLevel::None => {
+                    runtime_receipt::ClaimReceiptRedactionLevel::None
+                }
+                app_receipt::RedactionLevel::Partial => {
+                    runtime_receipt::ClaimReceiptRedactionLevel::Partial
+                }
+                app_receipt::RedactionLevel::Full => {
+                    runtime_receipt::ClaimReceiptRedactionLevel::Full
+                }
+            },
+        },
+        actions: receipt
+            .actions
+            .into_iter()
+            .map(|action| runtime_receipt::ClaimReceiptAction {
+                action: action.action,
+                label: action.label,
+                disabled_reason: action.disabled_reason,
+            })
+            .collect(),
+    }
+}
+
+fn app_target_to_ability(
+    target: &app_receipt::ReceiptTarget,
+) -> runtime_receipt::ClaimReceiptTarget {
+    match target {
+        app_receipt::ReceiptTarget::Claim {
+            claim_id,
+            subject,
+            field_path,
+        } => runtime_receipt::ClaimReceiptTarget::Claim {
+            claim_id: claim_id.clone(),
+            subject: subject.clone(),
+            field_path: field_path.clone(),
+        },
+        app_receipt::ReceiptTarget::Proposal {
+            proposal_id,
+            subject,
+            field_path,
+        } => runtime_receipt::ClaimReceiptTarget::Proposal {
+            proposal_id: proposal_id.clone(),
+            subject: subject.clone(),
+            field_path: field_path.clone(),
+        },
+        app_receipt::ReceiptTarget::WorkItem {
+            action_id,
+            backing_claim_id,
+            subject,
+        } => runtime_receipt::ClaimReceiptTarget::WorkItem {
+            action_id: action_id.clone(),
+            backing_claim_id: backing_claim_id.clone(),
+            subject: subject.clone(),
+        },
+    }
+}
+
+fn receipt_claim_id(receipt: &runtime_receipt::ClaimReceiptSnapshot) -> Option<&str> {
+    match &receipt.target {
+        runtime_receipt::ClaimReceiptTarget::Claim { claim_id, .. } => Some(claim_id.as_str()),
+        runtime_receipt::ClaimReceiptTarget::Proposal { .. }
+        | runtime_receipt::ClaimReceiptTarget::WorkItem { .. } => None,
+    }
+}
+
+fn feedback_state_to_runtime(state: app::FeedbackState) -> runtime::FeedbackState {
+    match state {
+        app::FeedbackState::Pending => runtime::FeedbackState::Pending,
+        app::FeedbackState::Decided(decision) => {
+            runtime::FeedbackState::Decided(feedback_decision_to_runtime(decision))
+        }
+    }
+}
+
+fn feedback_decision_to_runtime(
+    decision: app::RecommendationFeedbackDecision,
+) -> runtime::RecommendationFeedbackDecision {
+    match decision {
+        app::RecommendationFeedbackDecision::Accept { at } => {
+            runtime::RecommendationFeedbackDecision::Accept { at }
+        }
+        app::RecommendationFeedbackDecision::Dismiss { at, reason } => {
+            runtime::RecommendationFeedbackDecision::Dismiss {
+                at,
+                reason: dismiss_reason_to_runtime(reason),
+            }
+        }
+        app::RecommendationFeedbackDecision::NotUseful { at } => {
+            runtime::RecommendationFeedbackDecision::NotUseful { at }
+        }
+        app::RecommendationFeedbackDecision::TooNoisy { at } => {
+            runtime::RecommendationFeedbackDecision::TooNoisy { at }
+        }
+        app::RecommendationFeedbackDecision::Convert { at, into } => {
+            runtime::RecommendationFeedbackDecision::Convert {
+                at,
+                into: conversion_target_to_runtime(into),
+            }
+        }
+    }
+}
+
+fn dismiss_reason_to_runtime(reason: app::DismissReason) -> runtime::DismissReason {
+    match reason {
+        app::DismissReason::NotRelevant => runtime::DismissReason::NotRelevant,
+        app::DismissReason::AlreadyKnew => runtime::DismissReason::AlreadyKnew,
+        app::DismissReason::WrongSubject => runtime::DismissReason::WrongSubject,
+        app::DismissReason::Other(note) => runtime::DismissReason::Other(
+            runtime::BoundedNote::try_from(note.into_inner())
+                .expect("app bounded note fits runtime"),
+        ),
+    }
+}
+
+fn conversion_target_to_runtime(target: app::ConversionTarget) -> runtime::ConversionTarget {
+    match target {
+        app::ConversionTarget::Action(action_id) => runtime::ConversionTarget::Action(action_id),
+        app::ConversionTarget::ClaimCorrection(claim_id) => {
+            runtime::ConversionTarget::ClaimCorrection(runtime::ClaimId(claim_id.0))
+        }
+        app::ConversionTarget::ReviewQueue(queue_item_id) => {
+            runtime::ConversionTarget::ReviewQueue(queue_item_id)
+        }
+    }
+}
+
+fn conversion_state_to_runtime(state: app::ConversionState) -> runtime::ConversionState {
+    match state {
+        app::ConversionState::NotConverted => runtime::ConversionState::NotConverted,
+        app::ConversionState::ConvertedToAction { action_id } => {
+            runtime::ConversionState::ConvertedToAction { action_id }
+        }
+        app::ConversionState::ConvertedToClaimCorrection { claim_id } => {
+            runtime::ConversionState::ConvertedToClaimCorrection {
+                claim_id: runtime::ClaimId(claim_id.0),
+            }
+        }
+        app::ConversionState::ConvertedToReviewQueue { queue_item_id } => {
+            runtime::ConversionState::ConvertedToReviewQueue { queue_item_id }
+        }
+    }
+}
+
+#[cfg(test)]
+mod list_suggested_next_steps_tests {
+    use super::*;
+
+    use abilities_runtime::abilities::claim_receipt::ClaimReceiptRedactionLevel;
+    use chrono::TimeZone;
+    use rusqlite::params;
+    use std::collections::HashSet;
+
+    use crate::services::recommendations::contracts::{
+        EvidenceRef, FactorRationale, RecommendationDraft, RecommendationFeedbackDecision,
+        RecommendationMetadataEnvelope, RecommendationMetadataPayload, RecommendedAction,
+        SalienceFactor, SalienceScore, TriggerKind, TriggerRef,
+        RECOMMENDATION_METADATA_SCHEMA_VERSION,
+    };
+    use crate::services::recommendations::recommendation::metadata_envelope;
+
+    async fn test_state() -> (AppState, tempfile::TempDir) {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("suggested-next-steps.db");
+        let db_service = crate::db_service::DbService::open_at_unencrypted(db_path)
+            .await
+            .expect("open test db service");
+        (AppState::test_with_db_service(db_service), tempdir)
+    }
+
+    async fn seed_recommendation(
+        state: &AppState,
+        claim_id: &str,
+        subject_id: &str,
+        action: RecommendedAction,
+        feedback_state: app::FeedbackState,
+        created_at: DateTime<Utc>,
+    ) {
+        let claim_id = claim_id.to_string();
+        let subject_id = subject_id.to_string();
+        let metadata = recommendation_metadata(&claim_id, action, feedback_state);
+        let metadata_json = serde_json::to_string(&metadata).expect("metadata serializes");
+        state
+            .db_write(move |db| {
+                db.conn_ref()
+                    .execute(
+                        "INSERT INTO intelligence_claims /* dos7-allowed: suggested next steps unit test seed */ (
+                            id, subject_ref, claim_type, field_path, topic_key, text, dedup_key,
+                            item_hash, actor, data_source, source_ref, source_asof, observed_at,
+                            created_at, provenance_json, metadata_json, claim_state, surfacing_state,
+                            demotion_reason, reactivated_at, retraction_reason, expires_at,
+                            superseded_by, trust_score, trust_computed_at, trust_version, thread_id,
+                            temporal_scope, sensitivity, verification_state, verification_reason,
+                            needs_user_decision_at, claim_version, canonical_status,
+                            non_semantic_mergeable
+                        ) VALUES (
+                            ?1, ?2, 'recommendation', 'recommendation.reviewClaim', ?1,
+                            'Review the account before the next customer conversation.',
+                            ?3, ?4, 'agent:test', 'recommendation', 'run:test', ?5, ?5,
+                            ?5, '{\"sources\":[]}', ?6, 'active', 'active',
+                            NULL, NULL, NULL, NULL, NULL, 0.82, ?5, 1, NULL, ?7,
+                            ?8, 'active', NULL, NULL, 1, 'live', 0
+                        )",
+                        params![
+                            claim_id,
+                            format!(r#"{{"kind":"account","id":"{subject_id}"}}"#),
+                            format!("dedup-{claim_id}"),
+                            format!("hash-{claim_id}"),
+                            created_at.to_rfc3339(),
+                            metadata_json,
+                            "state",
+                            "internal",
+                        ],
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            })
+            .await
+            .expect("seed recommendation");
+    }
+
+    async fn seed_surfacing_decision(
+        state: &AppState,
+        claim_id: &str,
+        subject_id: &str,
+        salience_total: f64,
+        created_at: DateTime<Utc>,
+        primary_factor: app::SalienceFactorKind,
+    ) {
+        let claim_id = claim_id.to_string();
+        let subject_id = subject_id.to_string();
+        let why_this_now = app::WhyThisNow {
+            primary_factor,
+            text: "Salience driven by urgency: decay_factor 0.92 and signal_age_secs 42."
+                .to_string(),
+            triggers: vec![TriggerRef {
+                trigger_kind: TriggerKind::SignalArrival,
+                at: created_at,
+                source: "signal_event".to_string(),
+            }],
+        };
+        let trigger_refs_json = serde_json::to_string(&why_this_now.triggers).unwrap();
+        let why_this_now_json = serde_json::to_string(&why_this_now).unwrap();
+        state
+            .db_write(move |db| {
+                db.conn_ref()
+                    .execute(
+                        "INSERT INTO surfacing_decisions (
+                            id, idempotency_key, policy_version, claim_id, decision_kind,
+                            surfacing_tier, defer_reason, defer_until, suppress_reason, budget_key,
+                            actor_kind, local_day, claim_type, sensitivity, surface_class,
+                            render_surface, subject_kind, subject_id, action_signature,
+                            salience_total, salience_evaluation_id, why_this_now_json,
+                            trigger_refs_json, evidence_signature, source_asof,
+                            source_signal_id, created_at
+                        ) VALUES (
+                            ?1, ?2, 'recommendation_surfacing_v1', ?3, 'render',
+                            'notable', NULL, NULL, NULL, 'test-budget',
+                            'system', '2026-05-26', 'recommendation', 'internal',
+                            'primary', 'briefing', 'account', ?4, 'reviewClaim',
+                            ?5, 'salience-eval-test', ?6, ?7, NULL, NULL, NULL, ?8
+                        )",
+                        params![
+                            format!("surfacing-{claim_id}"),
+                            format!("surfacing-key-{claim_id}"),
+                            claim_id,
+                            subject_id,
+                            salience_total,
+                            why_this_now_json,
+                            trigger_refs_json,
+                            created_at.to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            })
+            .await
+            .expect("seed surfacing decision");
+    }
+
+    fn recommendation_metadata(
+        claim_id: &str,
+        action: RecommendedAction,
+        feedback_state: app::FeedbackState,
+    ) -> RecommendationMetadataEnvelope {
+        let draft = RecommendationDraft {
+            subject: SubjectRef::Account("acct-1".to_string()),
+            recommended_action: action,
+            evidence: vec![EvidenceRef {
+                source: format!("claim:{claim_id}"),
+                chunk: None,
+            }],
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(Utc.with_ymd_and_hms(2026, 5, 26, 10, 0, 0).unwrap()),
+            observed_at: Utc.with_ymd_and_hms(2026, 5, 26, 10, 0, 0).unwrap(),
+            text: "Review the account before the next customer conversation.".to_string(),
+            salience: SalienceScore {
+                total: 0.91,
+                factors: vec![SalienceFactor {
+                    kind: app::SalienceFactorKind::Urgency,
+                    value: Some(0.91),
+                    weight: 0.15,
+                    rationale: FactorRationale::Urgency {
+                        deadline: Some(Utc.with_ymd_and_hms(2026, 5, 27, 12, 0, 0).unwrap()),
+                        decay_factor: 0.91,
+                    },
+                }],
+            },
+        };
+        let mut envelope = metadata_envelope(&draft);
+        envelope.recommendation = RecommendationMetadataPayload {
+            schema_version: RECOMMENDATION_METADATA_SCHEMA_VERSION,
+            recommended_action: envelope.recommendation.recommended_action,
+            evidence: envelope.recommendation.evidence,
+            salience: envelope.recommendation.salience,
+            feedback_state,
+            conversion_state: app::ConversionState::NotConverted,
+        };
+        envelope
+    }
+
+    #[test]
+    fn factor_band_collapse_table_is_deterministic_per_kind() {
+        use app::SalienceFactorKind::*;
+        let cases = [
+            (Urgency, runtime::PrimaryFactorBand::TimeSensitive),
+            (Timing, runtime::PrimaryFactorBand::TimeSensitive),
+            (Novelty, runtime::PrimaryFactorBand::NewInformation),
+            (Freshness, runtime::PrimaryFactorBand::NewInformation),
+            (
+                OpenLoopRelevance,
+                runtime::PrimaryFactorBand::OpenLoopRelated,
+            ),
+            (Trust, runtime::PrimaryFactorBand::TrustChange),
+            (Corroboration, runtime::PrimaryFactorBand::TrustChange),
+            (Contradiction, runtime::PrimaryFactorBand::TrustChange),
+            (Importance, runtime::PrimaryFactorBand::Other),
+            (UserFit, runtime::PrimaryFactorBand::Other),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(factor_band(kind), expected);
+        }
+    }
+
+    #[test]
+    fn numeric_redactor_strips_factor_rationale_numeric_leaves() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap();
+        let rationales = vec![
+            FactorRationale::Importance {
+                trust_band: TrustBand::LikelyCurrent,
+                source_authority: 0.83,
+            },
+            FactorRationale::Novelty {
+                vector_distance: 0.72,
+                neighbor_count: 12,
+            },
+            FactorRationale::Urgency {
+                deadline: Some(now),
+                decay_factor: 0.92,
+            },
+            FactorRationale::Timing {
+                signal_age_secs: 42,
+                calendar_proximity_secs: Some(3600),
+            },
+            FactorRationale::UserFit {
+                feedback_history_score: 0.61,
+            },
+            FactorRationale::Freshness { decay_factor: 0.44 },
+            FactorRationale::Trust {
+                trust_band: TrustBand::UseWithCaution,
+            },
+            FactorRationale::Corroboration {
+                corroboration_count: 4,
+            },
+            FactorRationale::Contradiction {
+                contradiction_count: 3,
+            },
+            FactorRationale::OpenLoopRelevance {
+                open_loop_count: 7,
+                has_action: true,
+            },
+        ];
+        let forbidden = [
+            "0.83",
+            "0.72",
+            "12",
+            "0.92",
+            "42",
+            "3600",
+            "0.61",
+            "0.44",
+            "4",
+            "3",
+            "7",
+            "source_authority",
+            "vector_distance",
+            "decay_factor",
+            "signal_age_secs",
+            "calendar_proximity_secs",
+            "feedback_history_score",
+            "corroboration_count",
+            "contradiction_count",
+            "open_loop_count",
+        ];
+
+        for rationale in rationales {
+            let rendered = surface_rationale_summary(&rationale);
+            for token in forbidden {
+                assert!(
+                    !rendered.contains(token),
+                    "redacted rationale `{rendered}` leaked `{token}`"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn surface_context_propagation_uses_surface_client_receipt_tier() {
+        let (state, _tempdir) = test_state().await;
+        let now = Utc::now();
+        seed_recommendation(
+            &state,
+            "claim-receipt-surface",
+            "acct-1",
+            RecommendedAction::ReviewClaim {
+                claim_id: app::ClaimId("claim-source".to_string()),
+                reason: "verify".to_string(),
+            },
+            app::FeedbackState::Pending,
+            now,
+        )
+        .await;
+        seed_surfacing_decision(
+            &state,
+            "claim-receipt-surface",
+            "acct-1",
+            0.9,
+            now,
+            app::SalienceFactorKind::Urgency,
+        )
+        .await;
+
+        let response = list_suggested_next_steps_projection(
+            &state,
+            runtime::ListSuggestedNextStepsInput {
+                schema_version: runtime::LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+                subject: Some(SubjectRef::Account("acct-1".to_string())),
+                surface: runtime_receipt::ClaimReceiptSurfaceContext::EntityDetail,
+                max_items: Some(5),
+            },
+            ActorKind::SurfaceClient,
+        )
+        .await
+        .expect("projection succeeds");
+
+        assert_eq!(response.items.len(), 1);
+        assert_eq!(
+            response.items[0].receipt.surface_context,
+            runtime_receipt::ClaimReceiptSurfaceContext::EntityDetail
+        );
+        assert_eq!(
+            response.items[0].receipt.provenance.redaction,
+            ClaimReceiptRedactionLevel::None
+        );
+    }
+
+    #[tokio::test]
+    async fn thirty_second_echo_window_filters_old_decided_rows() {
+        let (state, _tempdir) = test_state().await;
+        let now = Utc::now();
+        let old_decided_at = now - Duration::seconds(31);
+        let recent_decided_at = now - Duration::seconds(29);
+        seed_recommendation(
+            &state,
+            "claim-old-decided",
+            "acct-echo",
+            RecommendedAction::ReviewClaim {
+                claim_id: app::ClaimId("claim-old-source".to_string()),
+                reason: "verify".to_string(),
+            },
+            app::FeedbackState::Decided(RecommendationFeedbackDecision::Dismiss {
+                at: old_decided_at,
+                reason: app::DismissReason::NotRelevant,
+            }),
+            now,
+        )
+        .await;
+        seed_surfacing_decision(
+            &state,
+            "claim-old-decided",
+            "acct-echo",
+            0.99,
+            now,
+            app::SalienceFactorKind::Urgency,
+        )
+        .await;
+        seed_recommendation(
+            &state,
+            "claim-recent-decided",
+            "acct-echo",
+            RecommendedAction::ReviewClaim {
+                claim_id: app::ClaimId("claim-recent-source".to_string()),
+                reason: "verify".to_string(),
+            },
+            app::FeedbackState::Decided(RecommendationFeedbackDecision::Dismiss {
+                at: recent_decided_at,
+                reason: app::DismissReason::NotRelevant,
+            }),
+            now,
+        )
+        .await;
+        seed_surfacing_decision(
+            &state,
+            "claim-recent-decided",
+            "acct-echo",
+            0.8,
+            now,
+            app::SalienceFactorKind::Urgency,
+        )
+        .await;
+
+        let response = list_suggested_next_steps_projection(
+            &state,
+            runtime::ListSuggestedNextStepsInput {
+                schema_version: runtime::LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+                subject: Some(SubjectRef::Account("acct-echo".to_string())),
+                surface: runtime_receipt::ClaimReceiptSurfaceContext::EntityDetail,
+                max_items: Some(8),
+            },
+            ActorKind::SurfaceClient,
+        )
+        .await
+        .expect("projection succeeds");
+
+        let ids = response
+            .items
+            .iter()
+            .map(|item| item.claim_id.0.as_str())
+            .collect::<HashSet<_>>();
+        assert!(!ids.contains("claim-old-decided"));
+        assert!(ids.contains("claim-recent-decided"));
+    }
+}

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -300,6 +300,28 @@
       }
     },
     {
+      "name": "list_suggested_next_steps",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "runtime",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.recommendations"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "markdown_preview",
       "description": "",
       "category": "read",

--- a/wp/dailyos/blocks/markdown-preview/.token-mapping.json
+++ b/wp/dailyos/blocks/markdown-preview/.token-mapping.json
@@ -1,0 +1,18 @@
+[
+	{
+		"source_token": "--wp--preset--color--desk-charcoal-8",
+		"target_token": "wp--preset--color--desk-charcoal-8"
+	},
+	{
+		"source_token": "--wp--preset--color--paper-cream",
+		"target_token": "wp--preset--color--paper-cream"
+	},
+	{
+		"source_token": "--wp--preset--color--text-primary",
+		"target_token": "wp--preset--color--text-primary"
+	},
+	{
+		"source_token": "--wp--preset--color--text-secondary",
+		"target_token": "wp--preset--color--text-secondary"
+	}
+]

--- a/wp/dailyos/blocks/source-management/.token-mapping.json
+++ b/wp/dailyos/blocks/source-management/.token-mapping.json
@@ -1,0 +1,18 @@
+[
+	{
+		"source_token": "--wp--preset--color--rule-light",
+		"target_token": "wp--preset--color--rule-light"
+	},
+	{
+		"source_token": "--wp--preset--color--text-secondary",
+		"target_token": "wp--preset--color--text-secondary"
+	},
+	{
+		"source_token": "--wp--preset--color--text-tertiary",
+		"target_token": "wp--preset--color--text-tertiary"
+	},
+	{
+		"source_token": "--wp--preset--color--text-quaternary",
+		"target_token": "wp--preset--color--text-quaternary"
+	}
+]

--- a/wp/dailyos/blocks/source-management/style.css
+++ b/wp/dailyos/blocks/source-management/style.css
@@ -1,6 +1,6 @@
 .wp-block-dailyos-source-management,
 .dailyos-source-management {
-	border-block: 1px solid rgba( 18, 18, 18, 0.14 );
+	border-block: 1px solid var(--wp--preset--color--rule-light);
 	color: inherit;
 	font-family: inherit;
 	padding: 1rem 0;
@@ -31,7 +31,7 @@
 .dailyos-source-management__policy,
 .dailyos-source-management__empty,
 .dailyos-source-management__trust {
-	color: rgba( 18, 18, 18, 0.72 );
+	color: var(--wp--preset--color--text-secondary);
 	font-size: 0.875rem;
 	margin: 0;
 }
@@ -46,7 +46,7 @@
 
 .dailyos-source-management__item {
 	align-items: start;
-	border-block-start: 1px solid rgba( 18, 18, 18, 0.1 );
+	border-block-start: 1px solid var(--wp--preset--color--rule-light);
 	display: grid;
 	gap: 1rem;
 	grid-template-columns: minmax( 0, 1fr ) auto;
@@ -67,7 +67,7 @@
 }
 
 .dailyos-source-management__metaItem dt {
-	color: rgba( 18, 18, 18, 0.58 );
+	color: var(--wp--preset--color--text-tertiary);
 	font-size: 0.75rem;
 	margin: 0;
 }
@@ -78,7 +78,7 @@
 }
 
 .dailyos-source-management__runs {
-	color: rgba( 18, 18, 18, 0.64 );
+	color: var(--wp--preset--color--text-secondary);
 	font-size: 0.8125rem;
 	margin: 0 0 0.625rem 1rem;
 	padding: 0;
@@ -97,16 +97,16 @@
 
 .dailyos-source-management__action {
 	background: transparent;
-	border: 1px solid rgba( 18, 18, 18, 0.18 );
+	border: 1px solid var(--wp--preset--color--rule-light);
 	border-radius: 4px;
-	color: rgba( 18, 18, 18, 0.76 );
+	color: var(--wp--preset--color--text-secondary);
 	font: inherit;
 	font-size: 0.8125rem;
 	padding: 0.375rem 0.625rem;
 }
 
 .dailyos-source-management__action:disabled {
-	color: rgba( 18, 18, 18, 0.48 );
+	color: var(--wp--preset--color--text-quaternary);
 }
 
 @media ( max-width: 640px ) {

--- a/wp/dailyos/blocks/suggested-next-steps/.token-mapping.json
+++ b/wp/dailyos/blocks/suggested-next-steps/.token-mapping.json
@@ -1,0 +1,34 @@
+[
+	{
+		"source_token": "--wp--preset--color--rule-light",
+		"target_token": "wp--preset--color--rule-light"
+	},
+	{
+		"source_token": "--wp--preset--color--trust-needs-verification-12",
+		"target_token": "wp--preset--color--trust-needs-verification-12"
+	},
+	{
+		"source_token": "--wp--preset--color--trust-needs-verification",
+		"target_token": "wp--preset--color--trust-needs-verification"
+	},
+	{
+		"source_token": "--wp--preset--color--text-secondary",
+		"target_token": "wp--preset--color--text-secondary"
+	},
+	{
+		"source_token": "--wp--preset--color--text-tertiary",
+		"target_token": "wp--preset--color--text-tertiary"
+	},
+	{
+		"source_token": "--wp--preset--spacing--sm",
+		"target_token": "wp--preset--spacing--sm"
+	},
+	{
+		"source_token": "--wp--preset--spacing--md",
+		"target_token": "wp--preset--spacing--md"
+	},
+	{
+		"source_token": "--wp--preset--spacing--xs",
+		"target_token": "wp--preset--spacing--xs"
+	}
+]

--- a/wp/dailyos/blocks/suggested-next-steps/block.json
+++ b/wp/dailyos/blocks/suggested-next-steps/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "dailyos/suggested-next-steps",
+	"title": "Suggested Next Steps",
+	"category": "dailyos",
+	"description": "Recommendations for the current subject. Renders typed RecommendationClaim list with per-claim trust band, why-this-now, evidence/provenance summary, and feedback affordances.",
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"inserter": false
+	},
+	"usesContext": [
+		"dailyos/entityType",
+		"dailyos/entityId"
+	],
+	"attributes": {
+		"maxItems": {
+			"type": "number",
+			"default": 5
+		},
+		"headingLabel": {
+			"type": "string"
+		}
+	},
+	"render": "file:./render.php",
+	"style": "file:./style.css",
+	"viewScript": "file:./view.js"
+}

--- a/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.php
+++ b/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Feedback-kind constants for dailyos/suggested-next-steps.
+ *
+ * These strings are the PHP-side authoritative data-feedback-kind values for
+ * W3-A. They map onto ADR-0123 RecommendationFeedbackDecision variants while
+ * keeping the disabled W3-A affordance markup stable until the W4-A submit
+ * path enables writes.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+if ( ! defined( 'DAILYOS_SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS' ) ) {
+	define(
+		'DAILYOS_SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS',
+		[
+			'convert'           => [
+				'decisionKind' => 'convert',
+				'adrVariant'   => 'RecommendationFeedbackDecision::Convert',
+			],
+			'dismiss'           => [
+				'decisionKind' => 'dismiss',
+				'dismissReason' => 'notRelevant',
+				'adrVariant'   => 'RecommendationFeedbackDecision::Dismiss',
+			],
+			'dismissWithReason' => [
+				'decisionKind'  => 'dismiss',
+				'dismissReason' => 'other',
+				'adrVariant'    => 'RecommendationFeedbackDecision::Dismiss',
+				'requiresNote'  => true,
+			],
+			'notUseful'         => [
+				'decisionKind' => 'notUseful',
+				'adrVariant'   => 'RecommendationFeedbackDecision::NotUseful',
+			],
+			'tooNoisy'          => [
+				'decisionKind' => 'tooNoisy',
+				'adrVariant'   => 'RecommendationFeedbackDecision::TooNoisy',
+			],
+		]
+	);
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_feedback_kind_map' ) ) {
+	/**
+	 * Return the ADR-0123 feedback-kind map for this block.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	function dailyos_suggested_next_steps_feedback_kind_map(): array {
+		return DAILYOS_SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_feedback_kinds' ) ) {
+	/**
+	 * Return the allowed data-feedback-kind values.
+	 *
+	 * @return array<int, string>
+	 */
+	function dailyos_suggested_next_steps_feedback_kinds(): array {
+		return array_keys( dailyos_suggested_next_steps_feedback_kind_map() );
+	}
+}

--- a/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.php
+++ b/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.php
@@ -25,9 +25,9 @@ if ( ! defined( 'DAILYOS_SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS' ) ) {
 				'adrVariant'   => 'RecommendationFeedbackDecision::Convert',
 			],
 			'dismiss'           => [
-				'decisionKind' => 'dismiss',
+				'decisionKind'  => 'dismiss',
 				'dismissReason' => 'notRelevant',
-				'adrVariant'   => 'RecommendationFeedbackDecision::Dismiss',
+				'adrVariant'    => 'RecommendationFeedbackDecision::Dismiss',
 			],
 			'dismissWithReason' => [
 				'decisionKind'  => 'dismiss',

--- a/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.ts
+++ b/wp/dailyos/blocks/suggested-next-steps/feedback-kinds.ts
@@ -1,0 +1,40 @@
+/**
+ * Feedback-kind constants for dailyos/suggested-next-steps.
+ *
+ * These strings are the TypeScript-side authoritative data-feedback-kind
+ * values for W3-A. They map onto ADR-0123 RecommendationFeedbackDecision
+ * variants while the view script keeps feedback submission behind an explicit
+ * disabled guard until W4-A.
+ */
+
+export const SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS = {
+	convert: {
+		decisionKind: "convert",
+		adrVariant: "RecommendationFeedbackDecision::Convert",
+	},
+	dismiss: {
+		decisionKind: "dismiss",
+		dismissReason: "notRelevant",
+		adrVariant: "RecommendationFeedbackDecision::Dismiss",
+	},
+	dismissWithReason: {
+		decisionKind: "dismiss",
+		dismissReason: "other",
+		adrVariant: "RecommendationFeedbackDecision::Dismiss",
+		requiresNote: true,
+	},
+	notUseful: {
+		decisionKind: "notUseful",
+		adrVariant: "RecommendationFeedbackDecision::NotUseful",
+	},
+	tooNoisy: {
+		decisionKind: "tooNoisy",
+		adrVariant: "RecommendationFeedbackDecision::TooNoisy",
+	},
+} as const;
+
+export type SuggestedNextStepsFeedbackKind = keyof typeof SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS;
+
+export const SUGGESTED_NEXT_STEPS_FEEDBACK_KIND_VALUES = Object.keys(
+	SUGGESTED_NEXT_STEPS_FEEDBACK_KINDS,
+) as SuggestedNextStepsFeedbackKind[];

--- a/wp/dailyos/blocks/suggested-next-steps/render-functions.php
+++ b/wp/dailyos/blocks/suggested-next-steps/render-functions.php
@@ -1,0 +1,891 @@
+<?php
+/**
+ * Suggested Next Steps server-side render.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_feedback_kinds' ) ) {
+	require_once __DIR__ . '/feedback-kinds.php';
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render' ) ) {
+	/**
+	 * Render the suggested-next-steps inner block.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @param mixed                $block      WP_Block instance carrying context.
+	 * @return string Rendered HTML.
+	 */
+	function dailyos_suggested_next_steps_render( array $attributes, $block = null ): string {
+		$subject = dailyos_suggested_next_steps_subject_from_block( $block );
+		if ( null === $subject ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				null,
+				'',
+				'missing_subject_context',
+				__( 'No subject context.', 'dailyos' )
+			);
+		}
+
+		$runtime_client = apply_filters( 'dailyos_runtime_client_for_block', null );
+		if ( ! is_object( $runtime_client ) || ! method_exists( $runtime_client, 'invoke_ability' ) ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				$subject,
+				dailyos_suggested_next_steps_heading( $subject, $attributes, null, [] ),
+				'runtime_unavailable',
+				dailyos_suggested_next_steps_unavailable_copy()
+			);
+		}
+
+		$scope_set = apply_filters( 'dailyos_surfaceclient_resolved_scopes', [] );
+		if ( ! is_array( $scope_set ) ) {
+			$scope_set = [];
+		}
+
+		$max_items = dailyos_suggested_next_steps_max_items( $attributes );
+		$response  = $runtime_client->invoke_ability(
+			'list_suggested_next_steps',
+			[
+				'schemaVersion' => 1,
+				'subject'       => dailyos_suggested_next_steps_subject_ref( $subject ),
+				'surface'       => dailyos_suggested_next_steps_surface_context( $subject['type'] ),
+				'maxItems'      => $max_items,
+			],
+			$scope_set
+		);
+
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ( isset( $response['ok'] ) && false === $response['ok'] ) ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				$subject,
+				dailyos_suggested_next_steps_heading( $subject, $attributes, null, [] ),
+				'envelope_error',
+				dailyos_suggested_next_steps_unavailable_copy()
+			);
+		}
+
+		$items = dailyos_suggested_next_steps_extract_items( $response );
+		if ( null === $items ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				$subject,
+				dailyos_suggested_next_steps_heading( $subject, $attributes, $response, [] ),
+				'envelope_error',
+				dailyos_suggested_next_steps_unavailable_copy()
+			);
+		}
+
+		$items   = array_slice( $items, 0, $max_items );
+		$heading = dailyos_suggested_next_steps_heading( $subject, $attributes, $response, $items );
+
+		if ( [] === $items ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				$subject,
+				$heading,
+				'no_recommendations',
+				dailyos_suggested_next_steps_empty_copy( $subject['type'] )
+			);
+		}
+
+		$feedback_enabled = (bool) apply_filters( 'dailyos_suggested_next_steps_feedback_enabled', false, $subject, $attributes );
+		$rows             = '';
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$row = dailyos_suggested_next_steps_render_row( $item, $feedback_enabled, (int) $index );
+			if ( '' !== $row ) {
+				$rows .= $row;
+			}
+		}
+
+		if ( '' === $rows ) {
+			return dailyos_suggested_next_steps_render_empty_shell(
+				$subject,
+				$heading,
+				'no_recommendations',
+				dailyos_suggested_next_steps_empty_copy( $subject['type'] )
+			);
+		}
+
+		$body = '';
+		if ( ! $feedback_enabled ) {
+			$body .= '<span class="dailyos-info-chip" aria-live="polite">' . esc_html__( 'Feedback opens on the next sync.', 'dailyos' ) . '</span>';
+		}
+		$body .= '<div class="suggested-next-steps_list">';
+		$body .= $rows;
+		$body .= '</div>';
+
+		return dailyos_suggested_next_steps_render_shell( $subject, $heading, $body, count( $items ), false );
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_subject_from_block' ) ) {
+	/**
+	 * Resolve the entity subject from block context.
+	 *
+	 * @param mixed $block WP_Block-like instance.
+	 * @return array{type: string, id: string, label: string}|null
+	 */
+	function dailyos_suggested_next_steps_subject_from_block( $block ): ?array {
+		if ( ! is_object( $block ) || ! isset( $block->context ) || ! is_array( $block->context ) ) {
+			return null;
+		}
+
+		$type = isset( $block->context['dailyos/entityType'] ) ? (string) $block->context['dailyos/entityType'] : '';
+		$id   = isset( $block->context['dailyos/entityId'] ) ? (string) $block->context['dailyos/entityId'] : '';
+		if ( ! in_array( $type, [ 'account', 'project', 'person', 'meeting' ], true ) || '' === $id ) {
+			return null;
+		}
+
+		$label = '';
+		foreach ( [ 'dailyos/entityLabel', 'dailyos/entityName' ] as $key ) {
+			if ( isset( $block->context[ $key ] ) && is_string( $block->context[ $key ] ) && '' !== trim( $block->context[ $key ] ) ) {
+				$label = trim( $block->context[ $key ] );
+				break;
+			}
+		}
+
+		return [
+			'type'  => $type,
+			'id'    => $id,
+			'label' => $label,
+		];
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_subject_ref' ) ) {
+	/**
+	 * Build the runtime SubjectRef serde shape.
+	 *
+	 * @param array{type: string, id: string, label: string} $subject Subject.
+	 * @return array<string, string>
+	 */
+	function dailyos_suggested_next_steps_subject_ref( array $subject ): array {
+		return [ $subject['type'] => $subject['id'] ];
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_surface_context' ) ) {
+	/**
+	 * Map entity type to claim receipt surface context.
+	 *
+	 * @param string $entity_type Entity type.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_surface_context( string $entity_type ): string {
+		return 'meeting' === $entity_type ? 'meeting_detail' : 'entity_detail';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_max_items' ) ) {
+	/**
+	 * Resolve maxItems with the W3-A default and server ceiling.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes.
+	 * @return int
+	 */
+	function dailyos_suggested_next_steps_max_items( array $attributes ): int {
+		$max_items = isset( $attributes['maxItems'] ) && is_numeric( $attributes['maxItems'] )
+			? (int) $attributes['maxItems']
+			: 5;
+
+		if ( $max_items < 1 ) {
+			return 1;
+		}
+
+		return min( 8, $max_items );
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_extract_items' ) ) {
+	/**
+	 * Extract the items list from supported runtime envelope shapes.
+	 *
+	 * @param array<string, mixed> $response Raw runtime client response.
+	 * @return array<int, mixed>|null
+	 */
+	function dailyos_suggested_next_steps_extract_items( array $response ): ?array {
+		if (
+			isset( $response['ability'] )
+			&& is_array( $response['ability'] )
+			&& isset( $response['ability']['data'] )
+			&& is_array( $response['ability']['data'] )
+			&& isset( $response['ability']['data']['items'] )
+			&& is_array( $response['ability']['data']['items'] )
+		) {
+			return array_values( $response['ability']['data']['items'] );
+		}
+
+		if (
+			isset( $response['data'] )
+			&& is_array( $response['data'] )
+			&& isset( $response['data']['items'] )
+			&& is_array( $response['data']['items'] )
+		) {
+			return array_values( $response['data']['items'] );
+		}
+
+		if ( isset( $response['items'] ) && is_array( $response['items'] ) ) {
+			return array_values( $response['items'] );
+		}
+
+		return null;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_heading' ) ) {
+	/**
+	 * Resolve heading text from override or surface defaults.
+	 *
+	 * @param array{type: string, id: string, label: string} $subject    Subject.
+	 * @param array<string, mixed>                          $attributes Block attributes.
+	 * @param array<string, mixed>|null                     $response   Runtime response.
+	 * @param array<int, mixed>                             $items      Items.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_heading( array $subject, array $attributes, ?array $response, array $items ): string {
+		if ( isset( $attributes['headingLabel'] ) && is_string( $attributes['headingLabel'] ) && '' !== trim( $attributes['headingLabel'] ) ) {
+			return trim( $attributes['headingLabel'] );
+		}
+
+		if ( 'meeting' === $subject['type'] ) {
+			return __( 'What to cover', 'dailyos' );
+		}
+
+		$label = dailyos_suggested_next_steps_subject_label( $subject, $response, $items );
+		switch ( $subject['type'] ) {
+			case 'project':
+				return sprintf(
+					/* translators: %s: project label */
+					__( "What's next on %s", 'dailyos' ),
+					$label
+				);
+			case 'person':
+				return sprintf(
+					/* translators: %s: person label */
+					__( 'Open threads with %s', 'dailyos' ),
+					$label
+				);
+			case 'account':
+			default:
+				return sprintf(
+					/* translators: %s: account label */
+					__( "What's next with %s", 'dailyos' ),
+					$label
+				);
+		}
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_subject_label' ) ) {
+	/**
+	 * Resolve a redacted display label when present in context or response.
+	 *
+	 * @param array{type: string, id: string, label: string} $subject  Subject.
+	 * @param array<string, mixed>|null                     $response Runtime response.
+	 * @param array<int, mixed>                             $items    Items.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_subject_label( array $subject, ?array $response, array $items ): string {
+		if ( '' !== $subject['label'] ) {
+			return dailyos_suggested_next_steps_truncate_label( $subject['label'] );
+		}
+
+		$roots = [];
+		if ( is_array( $response ) ) {
+			$roots[] = $response;
+			if ( isset( $response['data'] ) && is_array( $response['data'] ) ) {
+				$roots[] = $response['data'];
+			}
+			if ( isset( $response['ability'] ) && is_array( $response['ability'] ) && isset( $response['ability']['data'] ) && is_array( $response['ability']['data'] ) ) {
+				$roots[] = $response['ability']['data'];
+			}
+		}
+
+		foreach ( $roots as $root ) {
+			foreach ( [ 'subjectLabel', 'entityLabel', 'displayLabel' ] as $key ) {
+				if ( isset( $root[ $key ] ) && is_string( $root[ $key ] ) && '' !== trim( $root[ $key ] ) ) {
+					return dailyos_suggested_next_steps_truncate_label( trim( $root[ $key ] ) );
+				}
+			}
+			if ( isset( $root['subject'] ) && is_array( $root['subject'] ) ) {
+				foreach ( [ 'label', 'displayLabel', 'name' ] as $key ) {
+					if ( isset( $root['subject'][ $key ] ) && is_string( $root['subject'][ $key ] ) && '' !== trim( $root['subject'][ $key ] ) ) {
+						return dailyos_suggested_next_steps_truncate_label( trim( $root['subject'][ $key ] ) );
+					}
+				}
+			}
+		}
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			if ( isset( $item['subjectLabel'] ) && is_string( $item['subjectLabel'] ) && '' !== trim( $item['subjectLabel'] ) ) {
+				return dailyos_suggested_next_steps_truncate_label( trim( $item['subjectLabel'] ) );
+			}
+		}
+
+		$fallbacks = [
+			'account' => __( 'this account', 'dailyos' ),
+			'project' => __( 'this project', 'dailyos' ),
+			'person'  => __( 'this person', 'dailyos' ),
+		];
+
+		return $fallbacks[ $subject['type'] ] ?? $subject['id'];
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_truncate_label' ) ) {
+	/**
+	 * Truncate a subject label at 40 characters, preferring word boundary.
+	 *
+	 * @param string $label Subject label.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_truncate_label( string $label ): string {
+		$label = trim( $label );
+		if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+			if ( mb_strlen( $label ) <= 40 ) {
+				return $label;
+			}
+			$prefix = mb_substr( $label, 0, 40 );
+		} else {
+			if ( strlen( $label ) <= 40 ) {
+				return $label;
+			}
+			$prefix = substr( $label, 0, 40 );
+		}
+
+		$space = strrpos( $prefix, ' ' );
+		if ( false !== $space && $space >= 24 ) {
+			$prefix = substr( $prefix, 0, $space );
+		}
+
+		return rtrim( $prefix ) . '...';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_empty_shell' ) ) {
+	/**
+	 * Render a visible empty-state chip.
+	 *
+	 * @param array{type: string, id: string, label: string}|null $subject Subject.
+	 * @param string                                             $heading Heading.
+	 * @param string                                             $reason  Empty reason.
+	 * @param string                                             $copy    Empty copy.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_empty_shell( ?array $subject, string $heading, string $reason, string $copy ): string {
+		$body = '<span class="dailyos-empty-chip" data-empty-reason="' . esc_attr( $reason ) . '">' . esc_html( $copy ) . '</span>';
+		return dailyos_suggested_next_steps_render_shell( $subject, $heading, $body, 0, true );
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_shell' ) ) {
+	/**
+	 * Render the reference shell for the current surface.
+	 *
+	 * @param array{type: string, id: string, label: string}|null $subject  Subject.
+	 * @param string                                             $heading  Heading.
+	 * @param string                                             $body     Inner HTML.
+	 * @param int                                                $count    Item count.
+	 * @param bool                                               $is_empty Empty state.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_shell( ?array $subject, string $heading, string $body, int $count, bool $is_empty ): string {
+		$type          = is_array( $subject ) ? $subject['type'] : 'unknown';
+		$empty_class   = $is_empty ? ' SuggestedNextSteps_section--empty is-empty' : '';
+		$surface_attr  = ' data-surface="' . esc_attr( $type ) . '"';
+		$section_attrs = ' class="SuggestedNextSteps_section' . esc_attr( $empty_class ) . '"' . $surface_attr . ' data-dailyos-block="suggested-next-steps"';
+		$chapter       = dailyos_suggested_next_steps_render_chapter_heading( $heading, $type, $count, $is_empty );
+
+		if ( 'account' === $type ) {
+			$out  = '<div id="whats-next" class="editorial-reveal entity-detail_marginLabelSection' . esc_attr( $empty_class ) . '">';
+			$out .= '<div class="entity-detail_marginLabel">What\'s<br/>Next</div>';
+			$out .= '<div class="entity-detail_marginContent">';
+			$out .= '<section' . $section_attrs . '>';
+			$out .= $chapter . $body;
+			$out .= '</section></div></div>';
+			return $out;
+		}
+
+		if ( 'project' === $type ) {
+			$out  = '<div id="whats-next" class="editorial-reveal entity-detail_chapterSection' . esc_attr( $empty_class ) . '">';
+			$out .= '<section' . $section_attrs . '>';
+			$out .= $chapter . $body;
+			$out .= '</section></div>';
+			return $out;
+		}
+
+		if ( 'person' === $type ) {
+			$out  = '<div id="open-threads" class="editorial-reveal entity-detail_chapterSectionWithPadding' . esc_attr( $empty_class ) . '">';
+			$out .= '<section' . $section_attrs . '>';
+			$out .= $chapter . $body;
+			$out .= '</section></div>';
+			return $out;
+		}
+
+		if ( 'meeting' === $type ) {
+			$out  = '<section id="what-to-cover" class="editorial-reveal meeting-intel_chapterSection SuggestedNextSteps_section' . esc_attr( $empty_class ) . '"' . $surface_attr . ' data-dailyos-block="suggested-next-steps">';
+			$out .= $chapter . $body;
+			$out .= '</section>';
+			return $out;
+		}
+
+		$out  = '<section class="editorial-reveal entity-detail_chapterSection SuggestedNextSteps_section' . esc_attr( $empty_class ) . '"' . $surface_attr . ' data-dailyos-block="suggested-next-steps">';
+		$out .= $chapter . $body;
+		$out .= '</section>';
+		return $out;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_chapter_heading' ) ) {
+	/**
+	 * Render the shared ChapterHeading markup.
+	 *
+	 * @param string $heading  Heading text.
+	 * @param string $type     Surface type.
+	 * @param int    $count    Item count.
+	 * @param bool   $is_empty Whether the body is an empty state.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_chapter_heading( string $heading, string $type, int $count, bool $is_empty ): string {
+		if ( '' === $heading ) {
+			return '';
+		}
+
+		$out  = '<div class="ChapterHeading_heading">';
+		$out .= '<hr class="ChapterHeading_rule">';
+		$out .= '<div class="ChapterHeading_titleRow">';
+		$out .= '<h2 class="ChapterHeading_title">' . esc_html( $heading ) . '</h2>';
+		$out .= '</div>';
+
+		if ( ! $is_empty ) {
+			$epigraph = dailyos_suggested_next_steps_epigraph( $type, $count );
+			if ( '' !== $epigraph ) {
+				$out .= '<p class="ChapterHeading_epigraph">' . esc_html( $epigraph ) . '</p>';
+			}
+		}
+
+		$out .= '</div>';
+		return $out;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_epigraph' ) ) {
+	/**
+	 * Render surface-specific epigraph copy matching the reference surfaces.
+	 *
+	 * @param string $type  Surface type.
+	 * @param int    $count Item count.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_epigraph( string $type, int $count ): string {
+		$count = max( 0, $count );
+		switch ( $type ) {
+			case 'account':
+				return sprintf(
+					/* translators: %d: recommendation count */
+					_n( '%d recommendation to consider this week.', '%d recommendations to consider this week.', $count, 'dailyos' ),
+					$count
+				);
+			case 'project':
+				return sprintf(
+					/* translators: %d: move count */
+					_n( '%d move to keep the project on its arc.', '%d moves to keep the project on its arc.', $count, 'dailyos' ),
+					$count
+				);
+			case 'person':
+				return sprintf(
+					/* translators: %d: thread count */
+					_n( '%d thread to carry into the next 1:1.', '%d threads to carry into the next 1:1.', $count, 'dailyos' ),
+					$count
+				);
+			case 'meeting':
+				return sprintf(
+					/* translators: %d: prep topic count */
+					_n( '%d prep topic worth landing.', '%d prep topics worth landing.', $count, 'dailyos' ),
+					$count
+				);
+			default:
+				return '';
+		}
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_row' ) ) {
+	/**
+	 * Render one recommendation row.
+	 *
+	 * @param array<string, mixed> $item             Runtime item.
+	 * @param bool                 $feedback_enabled Whether feedback is enabled.
+	 * @param int                  $index            Row index.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_row( array $item, bool $feedback_enabled, int $index ): string {
+		$claim_id = isset( $item['claimId'] ) ? (string) $item['claimId'] : '';
+		$headline = isset( $item['headline'] ) ? trim( (string) $item['headline'] ) : '';
+		if ( '' === $claim_id || '' === $headline ) {
+			return '';
+		}
+
+		$trust_band     = dailyos_suggested_next_steps_trust_band( $item );
+		$terminal_state = dailyos_suggested_next_steps_terminal_state( $item );
+		$row_classes    = [ 'suggested-next-steps_row' ];
+		if ( 'needs_verification' === $trust_band ) {
+			$row_classes[] = 'suggested-next-steps_row--needsVerification';
+		}
+		if ( 'in_flight' === $terminal_state ) {
+			$row_classes[] = 'suggested-next-steps_row--inFlight';
+		}
+		if ( 'decided_dismissed' === $terminal_state ) {
+			$row_classes[] = 'suggested-next-steps_row--collapsing';
+		}
+
+		$busy_attr = 'in_flight' === $terminal_state ? ' aria-busy="true"' : '';
+		$more_id   = dailyos_suggested_next_steps_more_id( $claim_id, $index );
+		$disabled  = ! $feedback_enabled || 'in_flight' === $terminal_state;
+
+		$out  = '<article class="' . esc_attr( implode( ' ', $row_classes ) ) . '" data-claim-id="' . esc_attr( $claim_id ) . '" data-feedback-state="' . esc_attr( $terminal_state ) . '"' . $busy_attr . '>';
+		$out .= '<header class="suggested-next-steps_rowHeader">';
+		$out .= '<h3 class="suggested-next-steps_headline">' . esc_html( $headline ) . dailyos_suggested_next_steps_render_trust_band_indicator( $trust_band ) . '</h3>';
+		$out .= '</header>';
+
+		$why = isset( $item['whyThisNowSurfaceText'] ) ? trim( (string) $item['whyThisNowSurfaceText'] ) : '';
+		if ( '' !== $why ) {
+			$out .= '<p class="suggested-next-steps_whyThisNow">' . esc_html( $why ) . '</p>';
+		}
+
+		$action = isset( $item['recommendedAction'] ) && is_array( $item['recommendedAction'] )
+			? dailyos_suggested_next_steps_render_recommended_action( $item['recommendedAction'] )
+			: '';
+		if ( '' !== $action ) {
+			$out .= '<p class="suggested-next-steps_action">' . $action . '</p>';
+		}
+
+		if ( 'decided_converted' === $terminal_state ) {
+			$out .= dailyos_suggested_next_steps_render_converted_chip( $item );
+			$out .= '</article>';
+			return $out;
+		}
+
+		if ( 'error' === $terminal_state ) {
+			$out .= '<span class="dailyos-info-chip" data-feedback-state="error">' . esc_html__( 'Feedback did not save. Try again.', 'dailyos' ) . '</span>';
+		}
+
+		$out .= '<div class="suggested-next-steps_affordances" role="group" aria-label="' . esc_attr( __( 'Feedback on this recommendation', 'dailyos' ) ) . '">';
+		$out .= dailyos_suggested_next_steps_render_button( 'convert', __( 'Convert to action', 'dailyos' ), __( 'Convert this recommendation to an action', 'dailyos' ), $disabled, '' );
+		$out .= dailyos_suggested_next_steps_render_button( 'dismiss', __( 'Dismiss', 'dailyos' ), __( 'Dismiss this recommendation', 'dailyos' ), $disabled, '' );
+		$out .= dailyos_suggested_next_steps_render_more_button( $more_id, $disabled );
+		$out .= '</div>';
+
+		$out .= '<div id="' . esc_attr( $more_id ) . '" class="suggested-next-steps_subAffordances" aria-hidden="true">';
+		$out .= dailyos_suggested_next_steps_render_button( 'notUseful', __( 'Mark as not useful', 'dailyos' ), __( 'Mark this recommendation as not useful', 'dailyos' ), $disabled, 'suggested-next-steps_subButton' );
+		$out .= dailyos_suggested_next_steps_render_button( 'tooNoisy', __( 'Mark as too noisy', 'dailyos' ), __( 'Mark this recommendation as too noisy', 'dailyos' ), $disabled, 'suggested-next-steps_subButton' );
+		$out .= dailyos_suggested_next_steps_render_button( 'dismissWithReason', __( 'Dismiss with reason', 'dailyos' ), __( 'Dismiss this recommendation with a reason', 'dailyos' ), $disabled, 'suggested-next-steps_subButton' );
+		$out .= '</div>';
+		$out .= '</article>';
+
+		return $out;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_trust_band' ) ) {
+	/**
+	 * Resolve trust band from item receipt or top-level field.
+	 *
+	 * @param array<string, mixed> $item Runtime item.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_trust_band( array $item ): string {
+		$band = '';
+		if (
+			isset( $item['receipt'] )
+			&& is_array( $item['receipt'] )
+			&& isset( $item['receipt']['trust'] )
+			&& is_array( $item['receipt']['trust'] )
+			&& isset( $item['receipt']['trust']['band'] )
+		) {
+			$band = (string) $item['receipt']['trust']['band'];
+		} elseif ( isset( $item['trustBand'] ) ) {
+			$band = (string) $item['trustBand'];
+		}
+
+		if ( ! in_array( $band, [ 'likely_current', 'use_with_caution', 'needs_verification', 'unscored' ], true ) ) {
+			return 'use_with_caution';
+		}
+
+		return $band;
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_terminal_state' ) ) {
+	/**
+	 * Normalize item lifecycle to the row data-feedback-state value.
+	 *
+	 * @param array<string, mixed> $item Runtime item.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_terminal_state( array $item ): string {
+		$feedback = $item['feedbackState'] ?? 'pending';
+		if ( is_string( $feedback ) && in_array( $feedback, [ 'pending', 'in_flight', 'decided_dismissed', 'decided_converted', 'error' ], true ) ) {
+			return $feedback;
+		}
+
+		$conversion = isset( $item['conversionState'] ) && is_array( $item['conversionState'] ) ? $item['conversionState'] : [];
+		if ( isset( $conversion['kind'] ) && is_string( $conversion['kind'] ) && 'convertedToAction' === $conversion['kind'] ) {
+			return 'decided_converted';
+		}
+
+		if ( is_array( $feedback ) && isset( $feedback['decided'] ) && is_array( $feedback['decided'] ) ) {
+			$kind = isset( $feedback['decided']['kind'] ) ? (string) $feedback['decided']['kind'] : '';
+			if ( 'convert' === $kind ) {
+				return 'decided_converted';
+			}
+			if ( in_array( $kind, [ 'dismiss', 'notUseful', 'tooNoisy' ], true ) ) {
+				return 'decided_dismissed';
+			}
+		}
+
+		return 'pending';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_trust_band_indicator' ) ) {
+	/**
+	 * Render the TrustBandIndicator finis marker.
+	 *
+	 * @param string $band Trust band.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_trust_band_indicator( string $band ): string {
+		$labels = [
+			'likely_current'     => __( 'Likely current', 'dailyos' ),
+			'use_with_caution'   => __( 'Use with caution', 'dailyos' ),
+			'needs_verification' => __( 'Needs verification', 'dailyos' ),
+			'unscored'           => __( 'Unscored', 'dailyos' ),
+		];
+		$classes = [
+			'likely_current'     => 'TrustBandIndicator_likelyCurrent',
+			'use_with_caution'   => 'TrustBandIndicator_useWithCaution',
+			'needs_verification' => 'TrustBandIndicator_needsVerification',
+			'unscored'           => 'TrustBandIndicator_unscored',
+		];
+		$label   = $labels[ $band ] ?? $labels['use_with_caution'];
+		$class   = $classes[ $band ] ?? $classes['use_with_caution'];
+
+		return '<span class="TrustBandIndicator TrustBandIndicator_indicator ' . esc_attr( $class ) . '" title="' . esc_attr( $label ) . '" aria-label="' . esc_attr( $label ) . '">&#9679;</span>';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_recommended_action' ) ) {
+	/**
+	 * Render the redacted RecommendedActionView label.
+	 *
+	 * @param array<string, mixed> $action Recommended action DTO.
+	 * @return string Escaped HTML.
+	 */
+	function dailyos_suggested_next_steps_render_recommended_action( array $action ): string {
+		$kind  = isset( $action['kind'] ) ? (string) $action['kind'] : '';
+		$parts = [];
+
+		switch ( $kind ) {
+			case 'scheduleMeeting':
+				$parts[] = __( 'Schedule meeting', 'dailyos' );
+				foreach ( [ 'entityLabel', 'whenWindow' ] as $key ) {
+					if ( isset( $action[ $key ] ) && '' !== trim( (string) $action[ $key ] ) ) {
+						$parts[] = trim( (string) $action[ $key ] );
+					}
+				}
+				break;
+			case 'sendMessage':
+				$parts[] = __( 'Send message', 'dailyos' );
+				foreach ( [ 'channel', 'entityLabel' ] as $key ) {
+					if ( isset( $action[ $key ] ) && '' !== trim( (string) $action[ $key ] ) ) {
+						$parts[] = trim( (string) $action[ $key ] );
+					}
+				}
+				break;
+			case 'reviewClaim':
+				$parts[] = __( 'Review claim', 'dailyos' );
+				if ( isset( $action['claimLabel'] ) && '' !== trim( (string) $action['claimLabel'] ) ) {
+					$parts[] = trim( (string) $action['claimLabel'] );
+				}
+				break;
+			case 'updateRecord':
+				$parts[] = __( 'Update record', 'dailyos' );
+				foreach ( [ 'entityLabel', 'fieldLabel' ] as $key ) {
+					if ( isset( $action[ $key ] ) && '' !== trim( (string) $action[ $key ] ) ) {
+						$parts[] = trim( (string) $action[ $key ] );
+					}
+				}
+				break;
+			case 'investigateChange':
+				$parts[] = __( 'Investigate change', 'dailyos' );
+				foreach ( [ 'entityLabel', 'changeLabel' ] as $key ) {
+					if ( isset( $action[ $key ] ) && '' !== trim( (string) $action[ $key ] ) ) {
+						$parts[] = trim( (string) $action[ $key ] );
+					}
+				}
+				break;
+			case 'custom':
+				if ( isset( $action['actionLabel'] ) && '' !== trim( (string) $action['actionLabel'] ) ) {
+					$parts[] = trim( (string) $action['actionLabel'] );
+				}
+				break;
+		}
+
+		$parts = array_values(
+			array_filter(
+				$parts,
+				static function ( $part ): bool {
+					return is_string( $part ) && '' !== trim( $part );
+				}
+			)
+		);
+
+		if ( [] === $parts ) {
+			return '';
+		}
+
+		return implode(
+			' &middot; ',
+			array_map(
+				static function ( string $part ): string {
+					return esc_html( $part );
+				},
+				$parts
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_button' ) ) {
+	/**
+	 * Render a feedback button.
+	 *
+	 * @param string $kind       Feedback kind.
+	 * @param string $label      Visible label.
+	 * @param string $aria_label ARIA label.
+	 * @param bool   $disabled   Disabled affordance state.
+	 * @param string $extra      Extra class.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_button( string $kind, string $label, string $aria_label, bool $disabled, string $extra ): string {
+		$classes = 'suggested-next-steps_button';
+		if ( '' !== $extra ) {
+			$classes .= ' ' . $extra;
+		}
+		if ( $disabled ) {
+			$classes .= ' disabled-affordance';
+		}
+
+		$disabled_attrs = $disabled ? ' tabindex="-1" aria-disabled="true"' : '';
+
+		$visible_label = esc_html( $label );
+		if ( 'dismissWithReason' === $kind ) {
+			$visible_label .= '&hellip;';
+		}
+
+		return '<button type="button" class="' . esc_attr( $classes ) . '" data-feedback-kind="' . esc_attr( $kind ) . '" aria-label="' . esc_attr( $aria_label ) . '"' . $disabled_attrs . '>' . $visible_label . '</button>';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_more_button' ) ) {
+	/**
+	 * Render the More feedback disclosure button.
+	 *
+	 * @param string $more_id  Controlled row ID.
+	 * @param bool   $disabled Disabled affordance state.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_more_button( string $more_id, bool $disabled ): string {
+		$classes = 'suggested-next-steps_button suggested-next-steps_buttonExpand';
+		if ( $disabled ) {
+			$classes .= ' disabled-affordance';
+		}
+		$disabled_attrs = $disabled ? ' tabindex="-1" aria-disabled="true"' : '';
+
+		return '<button type="button" class="' . esc_attr( $classes ) . '" aria-expanded="false" aria-controls="' . esc_attr( $more_id ) . '" aria-label="' . esc_attr( __( 'More feedback options', 'dailyos' ) ) . '"' . $disabled_attrs . '>' . esc_html__( 'More feedback', 'dailyos' ) . '&hellip;</button>';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render_converted_chip' ) ) {
+	/**
+	 * Render converted terminal state.
+	 *
+	 * @param array<string, mixed> $item Runtime item.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_render_converted_chip( array $item ): string {
+		$action_id = '';
+		if (
+			isset( $item['conversionState'] )
+			&& is_array( $item['conversionState'] )
+			&& isset( $item['conversionState']['actionId'] )
+		) {
+			$action_id = (string) $item['conversionState']['actionId'];
+		}
+
+		$label = __( 'Converted to action', 'dailyos' );
+		if ( '' !== $action_id ) {
+			$label .= ' - ' . $action_id;
+		}
+
+		return '<span class="dailyos-info-chip" data-feedback-state="decided_converted">' . esc_html( $label ) . '</span>';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_more_id' ) ) {
+	/**
+	 * Build a stable aria-controls target ID.
+	 *
+	 * @param string $claim_id Claim ID.
+	 * @param int    $index    Row index.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_more_id( string $claim_id, int $index ): string {
+		$base = preg_replace( '/[^A-Za-z0-9_-]+/', '-', $claim_id );
+		$base = is_string( $base ) && '' !== trim( $base ) ? trim( $base, '-' ) : 'rec-claim-' . ( $index + 1 );
+		return $base . '-more';
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_empty_copy' ) ) {
+	/**
+	 * Surface-specific empty-state copy.
+	 *
+	 * @param string $entity_type Entity type.
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_empty_copy( string $entity_type ): string {
+		switch ( $entity_type ) {
+			case 'person':
+				return __( 'No open threads.', 'dailyos' );
+			case 'meeting':
+				return __( 'Nothing to cover yet.', 'dailyos' );
+			case 'account':
+			case 'project':
+			default:
+				return __( 'Nothing flagged right now.', 'dailyos' );
+		}
+	}
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_unavailable_copy' ) ) {
+	/**
+	 * Runtime unavailable copy.
+	 *
+	 * @return string
+	 */
+	function dailyos_suggested_next_steps_unavailable_copy(): string {
+		return __( 'Recommendations unavailable.', 'dailyos' );
+	}
+}

--- a/wp/dailyos/blocks/suggested-next-steps/render-functions.php
+++ b/wp/dailyos/blocks/suggested-next-steps/render-functions.php
@@ -244,9 +244,9 @@ if ( ! function_exists( 'dailyos_suggested_next_steps_heading' ) ) {
 	 * Resolve heading text from override or surface defaults.
 	 *
 	 * @param array{type: string, id: string, label: string} $subject    Subject.
-	 * @param array<string, mixed>                          $attributes Block attributes.
-	 * @param array<string, mixed>|null                     $response   Runtime response.
-	 * @param array<int, mixed>                             $items      Items.
+	 * @param array<string, mixed>                           $attributes Block attributes.
+	 * @param array<string, mixed>|null                      $response   Runtime response.
+	 * @param array<int, mixed>                              $items      Items.
 	 * @return string
 	 */
 	function dailyos_suggested_next_steps_heading( array $subject, array $attributes, ?array $response, array $items ): string {
@@ -288,8 +288,8 @@ if ( ! function_exists( 'dailyos_suggested_next_steps_subject_label' ) ) {
 	 * Resolve a redacted display label when present in context or response.
 	 *
 	 * @param array{type: string, id: string, label: string} $subject  Subject.
-	 * @param array<string, mixed>|null                     $response Runtime response.
-	 * @param array<int, mixed>                             $items    Items.
+	 * @param array<string, mixed>|null                      $response Runtime response.
+	 * @param array<int, mixed>                              $items    Items.
 	 * @return string
 	 */
 	function dailyos_suggested_next_steps_subject_label( array $subject, ?array $response, array $items ): string {
@@ -377,9 +377,9 @@ if ( ! function_exists( 'dailyos_suggested_next_steps_render_empty_shell' ) ) {
 	 * Render a visible empty-state chip.
 	 *
 	 * @param array{type: string, id: string, label: string}|null $subject Subject.
-	 * @param string                                             $heading Heading.
-	 * @param string                                             $reason  Empty reason.
-	 * @param string                                             $copy    Empty copy.
+	 * @param string                                              $heading Heading.
+	 * @param string                                              $reason  Empty reason.
+	 * @param string                                              $copy    Empty copy.
 	 * @return string
 	 */
 	function dailyos_suggested_next_steps_render_empty_shell( ?array $subject, string $heading, string $reason, string $copy ): string {
@@ -393,10 +393,10 @@ if ( ! function_exists( 'dailyos_suggested_next_steps_render_shell' ) ) {
 	 * Render the reference shell for the current surface.
 	 *
 	 * @param array{type: string, id: string, label: string}|null $subject  Subject.
-	 * @param string                                             $heading  Heading.
-	 * @param string                                             $body     Inner HTML.
-	 * @param int                                                $count    Item count.
-	 * @param bool                                               $is_empty Empty state.
+	 * @param string                                              $heading  Heading.
+	 * @param string                                              $body     Inner HTML.
+	 * @param int                                                 $count    Item count.
+	 * @param bool                                                $is_empty Empty state.
 	 * @return string
 	 */
 	function dailyos_suggested_next_steps_render_shell( ?array $subject, string $heading, string $body, int $count, bool $is_empty ): string {
@@ -666,7 +666,7 @@ if ( ! function_exists( 'dailyos_suggested_next_steps_render_trust_band_indicato
 	 * @return string
 	 */
 	function dailyos_suggested_next_steps_render_trust_band_indicator( string $band ): string {
-		$labels = [
+		$labels  = [
 			'likely_current'     => __( 'Likely current', 'dailyos' ),
 			'use_with_caution'   => __( 'Use with caution', 'dailyos' ),
 			'needs_verification' => __( 'Needs verification', 'dailyos' ),

--- a/wp/dailyos/blocks/suggested-next-steps/render.php
+++ b/wp/dailyos/blocks/suggested-next-steps/render.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Suggested Next Steps dynamic block render entrypoint.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return '';
+}
+
+if ( ! function_exists( 'dailyos_suggested_next_steps_render' ) ) {
+	require_once __DIR__ . '/render-functions.php';
+}
+
+$attributes = isset( $attributes ) && is_array( $attributes ) ? $attributes : [];
+$block      = isset( $block ) ? $block : null;
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render functions escape output internally.
+echo dailyos_suggested_next_steps_render( $attributes, $block );

--- a/wp/dailyos/blocks/suggested-next-steps/style.css
+++ b/wp/dailyos/blocks/suggested-next-steps/style.css
@@ -1,0 +1,150 @@
+/*
+ * Suggested Next Steps block.
+ *
+ * Composes existing chapter heading, editorial reveal, empty-chip,
+ * info-chip, and TrustBandIndicator primitives. This file only owns the
+ * suggested-next-steps_* row/list/affordance tokens plus disabled-affordance.
+ */
+
+.suggested-next-steps_list {
+	display: grid;
+	gap: var(--dailyos-space-sm, 12px);
+	margin-top: var(--dailyos-space-md, 16px);
+}
+
+.suggested-next-steps_row {
+	display: block;
+	max-height: 32rem;
+	overflow: hidden;
+	padding: var(--dailyos-space-sm, 12px) 0;
+	border-top: 1px solid var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
+	opacity: 1;
+	transition:
+		max-height 200ms ease,
+		opacity 200ms ease;
+}
+
+.suggested-next-steps_row--needsVerification {
+	border-top-color: var(--wp--preset--color--trust-needs-verification-12, rgba(196, 101, 74, 0.12));
+}
+
+.suggested-next-steps_row--needsVerification .suggested-next-steps_headline {
+	color: var(--wp--preset--color--trust-needs-verification, #c4654a);
+}
+
+.suggested-next-steps_row--needsVerification .suggested-next-steps_whyThisNow {
+	opacity: 0.82;
+}
+
+.suggested-next-steps_row--inFlight {
+	opacity: 0.6;
+	pointer-events: none;
+}
+
+.suggested-next-steps_row--collapsing {
+	max-height: 0;
+	padding-top: 0;
+	padding-bottom: 0;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.suggested-next-steps_rowHeader {
+	margin: 0;
+}
+
+.suggested-next-steps_headline {
+	margin: 0;
+	color: inherit;
+	font-size: clamp(1rem, 0.96rem + 0.12vw, 1.1rem);
+	font-weight: 600;
+	line-height: 1.35;
+	letter-spacing: 0;
+}
+
+.suggested-next-steps_whyThisNow {
+	display: -webkit-box;
+	margin: var(--dailyos-space-2xs, 4px) 0 0;
+	overflow: hidden;
+	color: var(--dailyos-color-text-secondary, var(--wp--preset--color--text-secondary, currentColor));
+	font-size: var(--dailyos-font-size-sm, 0.9rem);
+	line-height: 1.45;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.suggested-next-steps_action {
+	margin: var(--dailyos-space-2xs, 4px) 0 0;
+	color: var(--dailyos-color-text-tertiary, var(--wp--preset--color--text-tertiary, currentColor));
+	font-size: var(--dailyos-font-size-xs, 0.8rem);
+	line-height: 1.4;
+}
+
+.suggested-next-steps_affordances,
+.suggested-next-steps_subAffordances {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--dailyos-space-2xs, 4px);
+	margin-top: var(--dailyos-space-xs, 8px);
+}
+
+.suggested-next-steps_button {
+	appearance: none;
+	border: 1px solid var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
+	border-radius: var(--dailyos-radius-sm, 4px);
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	font-size: var(--dailyos-font-size-xs, 0.8rem);
+	line-height: 1.2;
+	padding: 0.35rem 0.55rem;
+}
+
+.suggested-next-steps_button:focus-visible {
+	outline: 2px solid var(--dailyos-color-focus-ring, currentColor);
+	outline-offset: 2px;
+}
+
+.suggested-next-steps_buttonExpand {
+	padding-right: 0.65rem;
+}
+
+.suggested-next-steps_subAffordances {
+	max-height: 0;
+	margin-top: 0;
+	overflow: hidden;
+	opacity: 0;
+	pointer-events: none;
+	transition:
+		max-height 200ms ease,
+		margin-top 200ms ease,
+		opacity 200ms ease;
+}
+
+.suggested-next-steps_row:hover .suggested-next-steps_subAffordances,
+.suggested-next-steps_subAffordances[aria-hidden="false"] {
+	max-height: 5rem;
+	margin-top: var(--dailyos-space-xs, 8px);
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.suggested-next-steps_subButton {
+	font-size: var(--dailyos-font-size-xs, 0.8rem);
+}
+
+.disabled-affordance {
+	border-color: var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
+	color: var(--dailyos-color-text-tertiary, var(--wp--preset--color--text-tertiary, currentColor));
+	cursor: default;
+	opacity: 0.55;
+	pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.suggested-next-steps_row,
+	.suggested-next-steps_subAffordances {
+		transition: none;
+	}
+}

--- a/wp/dailyos/blocks/suggested-next-steps/style.css
+++ b/wp/dailyos/blocks/suggested-next-steps/style.css
@@ -4,20 +4,25 @@
  * Composes existing chapter heading, editorial reveal, empty-chip,
  * info-chip, and TrustBandIndicator primitives. This file only owns the
  * suggested-next-steps_* row/list/affordance tokens plus disabled-affordance.
+ *
+ * Tokens resolve through the canonical WordPress preset namespace
+ * (color and spacing presets only); raw color literals are forbidden per
+ * wp/dailyos/tests/token-mapping-manifest-gate.sh and source-to-target
+ * wiring lives in .token-mapping.json beside this file.
  */
 
 .suggested-next-steps_list {
 	display: grid;
-	gap: var(--dailyos-space-sm, 12px);
-	margin-top: var(--dailyos-space-md, 16px);
+	gap: var(--wp--preset--spacing--sm);
+	margin-top: var(--wp--preset--spacing--md);
 }
 
 .suggested-next-steps_row {
 	display: block;
 	max-height: 32rem;
 	overflow: hidden;
-	padding: var(--dailyos-space-sm, 12px) 0;
-	border-top: 1px solid var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
+	padding: var(--wp--preset--spacing--sm) 0;
+	border-top: 1px solid var(--wp--preset--color--rule-light);
 	opacity: 1;
 	transition:
 		max-height 200ms ease,
@@ -25,11 +30,11 @@
 }
 
 .suggested-next-steps_row--needsVerification {
-	border-top-color: var(--wp--preset--color--trust-needs-verification-12, rgba(196, 101, 74, 0.12));
+	border-top-color: var(--wp--preset--color--trust-needs-verification-12);
 }
 
 .suggested-next-steps_row--needsVerification .suggested-next-steps_headline {
-	color: var(--wp--preset--color--trust-needs-verification, #c4654a);
+	color: var(--wp--preset--color--trust-needs-verification);
 }
 
 .suggested-next-steps_row--needsVerification .suggested-next-steps_whyThisNow {
@@ -64,19 +69,19 @@
 
 .suggested-next-steps_whyThisNow {
 	display: -webkit-box;
-	margin: var(--dailyos-space-2xs, 4px) 0 0;
+	margin: var(--wp--preset--spacing--xs) 0 0;
 	overflow: hidden;
-	color: var(--dailyos-color-text-secondary, var(--wp--preset--color--text-secondary, currentColor));
-	font-size: var(--dailyos-font-size-sm, 0.9rem);
+	color: var(--wp--preset--color--text-secondary);
+	font-size: 0.9rem;
 	line-height: 1.45;
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2;
 }
 
 .suggested-next-steps_action {
-	margin: var(--dailyos-space-2xs, 4px) 0 0;
-	color: var(--dailyos-color-text-tertiary, var(--wp--preset--color--text-tertiary, currentColor));
-	font-size: var(--dailyos-font-size-xs, 0.8rem);
+	margin: var(--wp--preset--spacing--xs) 0 0;
+	color: var(--wp--preset--color--text-tertiary);
+	font-size: 0.8rem;
 	line-height: 1.4;
 }
 
@@ -84,25 +89,25 @@
 .suggested-next-steps_subAffordances {
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--dailyos-space-2xs, 4px);
-	margin-top: var(--dailyos-space-xs, 8px);
+	gap: var(--wp--preset--spacing--xs);
+	margin-top: var(--wp--preset--spacing--xs);
 }
 
 .suggested-next-steps_button {
 	appearance: none;
-	border: 1px solid var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
-	border-radius: var(--dailyos-radius-sm, 4px);
+	border: 1px solid var(--wp--preset--color--rule-light);
+	border-radius: 4px;
 	background: transparent;
 	color: inherit;
 	cursor: pointer;
 	font: inherit;
-	font-size: var(--dailyos-font-size-xs, 0.8rem);
+	font-size: 0.8rem;
 	line-height: 1.2;
 	padding: 0.35rem 0.55rem;
 }
 
 .suggested-next-steps_button:focus-visible {
-	outline: 2px solid var(--dailyos-color-focus-ring, currentColor);
+	outline: 2px solid currentColor;
 	outline-offset: 2px;
 }
 
@@ -125,18 +130,18 @@
 .suggested-next-steps_row:hover .suggested-next-steps_subAffordances,
 .suggested-next-steps_subAffordances[aria-hidden="false"] {
 	max-height: 5rem;
-	margin-top: var(--dailyos-space-xs, 8px);
+	margin-top: var(--wp--preset--spacing--xs);
 	opacity: 1;
 	pointer-events: auto;
 }
 
 .suggested-next-steps_subButton {
-	font-size: var(--dailyos-font-size-xs, 0.8rem);
+	font-size: 0.8rem;
 }
 
 .disabled-affordance {
-	border-color: var(--dailyos-color-border-subtle, var(--wp--preset--color--rule-light, rgba(0, 0, 0, 0.12)));
-	color: var(--dailyos-color-text-tertiary, var(--wp--preset--color--text-tertiary, currentColor));
+	border-color: var(--wp--preset--color--rule-light);
+	color: var(--wp--preset--color--text-tertiary);
 	cursor: default;
 	opacity: 0.55;
 	pointer-events: none;

--- a/wp/dailyos/blocks/suggested-next-steps/view.js
+++ b/wp/dailyos/blocks/suggested-next-steps/view.js
@@ -1,0 +1,155 @@
+/**
+ * Suggested Next Steps feedback affordance view script.
+ *
+ * W3-A ships the client-side affordance category with explicit disabled
+ * guards. W4-A flips FEEDBACK_ENABLED and wires the POST path.
+ */
+( function () {
+	'use strict';
+
+	var FEEDBACK_ENABLED = false;
+	var ENGAGEMENT_SIGNALS_ENABLED = false;
+	var REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+	function prefersReducedMotion() {
+		return (
+			window.matchMedia &&
+			window.matchMedia( REDUCED_MOTION_QUERY ).matches
+		);
+	}
+
+	function closest( node, selector ) {
+		if ( ! node || ! node.closest ) {
+			return null;
+		}
+		return node.closest( selector );
+	}
+
+	function toggleMoreFeedback( trigger ) {
+		var controls = trigger.getAttribute( 'aria-controls' );
+		if ( ! controls ) {
+			return;
+		}
+		var panel = document.getElementById( controls );
+		if ( ! panel ) {
+			return;
+		}
+
+		var isOpen = trigger.getAttribute( 'aria-expanded' ) === 'true';
+		var next = ! isOpen;
+		trigger.setAttribute( 'aria-expanded', next ? 'true' : 'false' );
+		panel.setAttribute( 'aria-hidden', next ? 'false' : 'true' );
+	}
+
+	function emitEngagementSignal( container, signal, detail ) {
+		if ( ! ENGAGEMENT_SIGNALS_ENABLED ) {
+			return;
+		}
+		window.dispatchEvent(
+			new CustomEvent( 'dailyos:suggested-next-steps:engagement', {
+				detail: {
+					container: container,
+					signal: signal,
+					payload: detail || {},
+				},
+			} )
+		);
+	}
+
+	function postFeedback( row, kind ) {
+		if ( ! FEEDBACK_ENABLED ) {
+			return Promise.resolve( { ok: false, disabled: true } );
+		}
+
+		row.classList.add( 'suggested-next-steps_row--inFlight' );
+
+		var execute =
+			window.wp &&
+			window.wp.abilities &&
+			window.wp.abilities.executeAbility;
+		if ( typeof execute !== 'function' ) {
+			return Promise.reject( new Error( 'ability_transport_unavailable' ) );
+		}
+
+		return execute( 'submit_recommendation_feedback', {
+			schemaVersion: 1,
+			claimId: row.getAttribute( 'data-claim-id' ) || '',
+			feedbackKind: kind,
+		} );
+	}
+
+	function collapseRow( row ) {
+		row.classList.remove( 'suggested-next-steps_row--inFlight' );
+		row.classList.add( 'suggested-next-steps_row--collapsing' );
+		if ( prefersReducedMotion() ) {
+			row.style.maxHeight = '0';
+			row.style.opacity = '0';
+		}
+	}
+
+	function handleAffordanceClick( container, button ) {
+		var kind = button.getAttribute( 'data-feedback-kind' );
+		var row = closest( button, '.suggested-next-steps_row' );
+		if ( ! kind || ! row ) {
+			return;
+		}
+
+		emitEngagementSignal( container, 'Clicked', {
+			claimId: row.getAttribute( 'data-claim-id' ) || '',
+			feedbackKind: kind,
+		} );
+
+		if ( ! FEEDBACK_ENABLED ) {
+			return;
+		}
+
+		postFeedback( row, kind )
+			.then( function ( response ) {
+				if ( response && response.ok ) {
+					collapseRow( row );
+					return;
+				}
+				row.classList.remove( 'suggested-next-steps_row--inFlight' );
+				row.classList.add( 'suggested-next-steps_row--error' );
+			} )
+			.catch( function () {
+				row.classList.remove( 'suggested-next-steps_row--inFlight' );
+				row.classList.add( 'suggested-next-steps_row--error' );
+			} );
+	}
+
+	function bindContainer( container ) {
+		container.addEventListener( 'click', function ( event ) {
+			var target = event.target;
+			var expand = closest( target, '.suggested-next-steps_buttonExpand' );
+			if ( expand && container.contains( expand ) ) {
+				event.preventDefault();
+				toggleMoreFeedback( expand );
+				return;
+			}
+
+			var affordance = closest( target, '[data-feedback-kind]' );
+			if ( affordance && container.contains( affordance ) ) {
+				event.preventDefault();
+				handleAffordanceClick( container, affordance );
+			}
+		} );
+
+		emitEngagementSignal( container, 'Rendered', {
+			surface: container.getAttribute( 'data-surface' ) || '',
+		} );
+	}
+
+	function init() {
+		var containers = document.querySelectorAll( '.SuggestedNextSteps_section' );
+		for ( var i = 0; i < containers.length; i++ ) {
+			bindContainer( containers[ i ] );
+		}
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/wp/dailyos/tests/blocks/SuggestedNextStepsBlockTest.php
+++ b/wp/dailyos/tests/blocks/SuggestedNextStepsBlockTest.php
@@ -30,7 +30,7 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 	}
 
 	/**
-	 * block.json declares the W3-A metadata contract.
+	 * Block.json declares the W3-A metadata contract.
 	 */
 	public function test_block_json_declares_contract(): void {
 		$block_json = json_decode(
@@ -102,7 +102,7 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 		$this->assertArrayNotHasKey( 'schema_version', $client->requests[0]['payload'] );
 		$this->assertArrayNotHasKey( 'max_items', $client->requests[0]['payload'] );
 		$this->assertSame( [ 'read.recommendations' ], $client->requests[0]['scope_set'] );
-		$this->assertStringContainsString( "What's next with Acme Corp", $html );
+		$this->assertStringContainsString( 'What&#039;s next with Acme Corp', $html );
 	}
 
 	/**
@@ -149,15 +149,15 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 	 */
 	public static function surface_provider(): array {
 		return [
-			'account' => [ 'account', 'acct-1', 'Acme Corp', 'entity-detail_marginLabelSection', "What's next with Acme Corp" ],
-			'project' => [ 'project', 'proj-1', 'Platform Unification', 'entity-detail_chapterSection', "What's next on Platform Unification" ],
+			'account' => [ 'account', 'acct-1', 'Acme Corp', 'entity-detail_marginLabelSection', 'What&#039;s next with Acme Corp' ],
+			'project' => [ 'project', 'proj-1', 'Platform Unification', 'entity-detail_chapterSection', 'What&#039;s next on Platform Unification' ],
 			'person'  => [ 'person', 'person-1', 'Jen Park', 'entity-detail_chapterSectionWithPadding', 'Open threads with Jen Park' ],
 			'meeting' => [ 'meeting', 'meeting-1', 'Renewal Review', 'meeting-intel_chapterSection', 'What to cover' ],
 		];
 	}
 
 	/**
-	 * headingLabel overrides the surface default.
+	 * HeadingLabel overrides the surface default.
 	 */
 	public function test_heading_label_override_wins(): void {
 		$client = $this->fake_runtime_client(
@@ -289,7 +289,12 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 		$this->assertStringContainsString( 'data-empty-reason="envelope_error"', $html );
 
 		$this->setUp();
-		$client = $this->fake_runtime_client( [ 'ok' => true, 'items' => [] ] );
+		$client = $this->fake_runtime_client(
+			[
+				'ok'    => true,
+				'items' => [],
+			]
+		);
 		$this->register_runtime_client_filter( $client );
 		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'person', 'person-1' ) );
 		$this->assertStringContainsString( 'data-empty-reason="no_recommendations"', $html );
@@ -424,17 +429,17 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 	 */
 	private function item( string $claim_id, string $band = 'likely_current' ): array {
 		return [
-			'claimId'                   => $claim_id,
-			'headline'                  => 'Send the H1 expansion follow-up',
-			'whyThisNowSurfaceText'     => 'Open loop since the last review.',
-			'factorBand'                => 'openLoopRelated',
-			'recommendedAction'         => [
+			'claimId'               => $claim_id,
+			'headline'              => 'Send the H1 expansion follow-up',
+			'whyThisNowSurfaceText' => 'Open loop since the last review.',
+			'factorBand'            => 'openLoopRelated',
+			'recommendedAction'     => [
 				'kind'        => 'sendMessage',
 				'entityLabel' => 'Jen Park',
 				'channel'     => 'email',
 			],
-			'trustBand'                 => $band,
-			'receipt'                   => [
+			'trustBand'             => $band,
+			'receipt'               => [
 				'trust'      => [
 					'band' => $band,
 				],
@@ -442,8 +447,8 @@ final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
 					'sources' => [],
 				],
 			],
-			'feedbackState'             => 'pending',
-			'conversionState'           => [
+			'feedbackState'         => 'pending',
+			'conversionState'       => [
 				'kind' => 'notConverted',
 			],
 		];

--- a/wp/dailyos/tests/blocks/SuggestedNextStepsBlockTest.php
+++ b/wp/dailyos/tests/blocks/SuggestedNextStepsBlockTest.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * Suggested Next Steps block tests.
+ *
+ * @package DailyOS
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../blocks/suggested-next-steps/render-functions.php';
+
+/**
+ * @covers dailyos_suggested_next_steps_render
+ * @covers dailyos_suggested_next_steps_extract_items
+ */
+final class DailyOS_SuggestedNextStepsBlockTest extends TestCase {
+	/**
+	 * Reset WP shim globals.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		if ( function_exists( 'dailyos_test_reset_globals' ) ) {
+			dailyos_test_reset_globals();
+		}
+		unset( $GLOBALS['dailyos_test_filters']['dailyos_runtime_client_for_block'] );
+		unset( $GLOBALS['dailyos_test_filters']['dailyos_surfaceclient_resolved_scopes'] );
+		unset( $GLOBALS['dailyos_test_filters']['dailyos_suggested_next_steps_feedback_enabled'] );
+	}
+
+	/**
+	 * block.json declares the W3-A metadata contract.
+	 */
+	public function test_block_json_declares_contract(): void {
+		$block_json = json_decode(
+			(string) file_get_contents( __DIR__ . '/../../blocks/suggested-next-steps/block.json' ),
+			true
+		);
+
+		$this->assertIsArray( $block_json );
+		$this->assertSame( 'dailyos/suggested-next-steps', $block_json['name'] );
+		$this->assertSame( 3, $block_json['apiVersion'] );
+		$this->assertSame( [ 'dailyos/entityType', 'dailyos/entityId' ], $block_json['usesContext'] );
+		$this->assertArrayNotHasKey( 'parent', $block_json );
+		$this->assertFalse( $block_json['supports']['html'] );
+		$this->assertFalse( $block_json['supports']['reusable'] );
+		$this->assertFalse( $block_json['supports']['inserter'] );
+		$this->assertSame( 5, $block_json['attributes']['maxItems']['default'] );
+		$this->assertSame( 'string', $block_json['attributes']['headingLabel']['type'] );
+		$this->assertSame( 'file:./render.php', $block_json['render'] );
+		$this->assertSame( 'file:./style.css', $block_json['style'] );
+		$this->assertSame( 'file:./view.js', $block_json['viewScript'] );
+	}
+
+	/**
+	 * Parser accepts all runtime response shapes named in the plan.
+	 */
+	public function test_extract_items_accepts_supported_response_shapes(): void {
+		$items = [ $this->item( 'rec-claim-1' ) ];
+
+		$this->assertSame(
+			$items,
+			dailyos_suggested_next_steps_extract_items( [ 'ability' => [ 'data' => [ 'items' => $items ] ] ] )
+		);
+		$this->assertSame(
+			$items,
+			dailyos_suggested_next_steps_extract_items( [ 'data' => [ 'items' => $items ] ] )
+		);
+		$this->assertSame(
+			$items,
+			dailyos_suggested_next_steps_extract_items( [ 'items' => $items ] )
+		);
+		$this->assertNull( dailyos_suggested_next_steps_extract_items( [ 'data' => [] ] ) );
+	}
+
+	/**
+	 * Render invokes the list ability with the camelCase W3-A payload.
+	 */
+	public function test_render_invokes_list_ability_with_subject_surface_and_capped_max_items(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'           => true,
+				'subjectLabel' => 'Acme Corp',
+				'items'        => [ $this->item( 'rec-claim-1' ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+		$this->register_scope_filter( [ 'read.recommendations' ] );
+
+		$html = dailyos_suggested_next_steps_render(
+			[ 'maxItems' => 99 ],
+			$this->block_context( 'account', 'acct-test-001' )
+		);
+
+		$this->assertSame( 1, $client->calls );
+		$this->assertSame( 'list_suggested_next_steps', $client->requests[0]['ability'] );
+		$this->assertSame( 1, $client->requests[0]['payload']['schemaVersion'] );
+		$this->assertSame( [ 'account' => 'acct-test-001' ], $client->requests[0]['payload']['subject'] );
+		$this->assertSame( 'entity_detail', $client->requests[0]['payload']['surface'] );
+		$this->assertSame( 8, $client->requests[0]['payload']['maxItems'] );
+		$this->assertArrayNotHasKey( 'schema_version', $client->requests[0]['payload'] );
+		$this->assertArrayNotHasKey( 'max_items', $client->requests[0]['payload'] );
+		$this->assertSame( [ 'read.recommendations' ], $client->requests[0]['scope_set'] );
+		$this->assertStringContainsString( "What's next with Acme Corp", $html );
+	}
+
+	/**
+	 * Missing or unsupported context renders a visible empty chip.
+	 */
+	public function test_missing_subject_context_renders_empty_chip(): void {
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'workspace', 'global' ) );
+
+		$this->assertStringContainsString( 'dailyos-empty-chip', $html );
+		$this->assertStringContainsString( 'data-empty-reason="missing_subject_context"', $html );
+	}
+
+	/**
+	 * Surface wrappers and default headings match the reference surfaces.
+	 *
+	 * @dataProvider surface_provider
+	 */
+	public function test_surface_wrappers_and_default_headings(
+		string $entity_type,
+		string $entity_id,
+		string $label,
+		string $wrapper_class,
+		string $heading
+	): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'           => true,
+				'subjectLabel' => $label,
+				'items'        => [ $this->item( 'rec-' . $entity_type ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( $entity_type, $entity_id ) );
+
+		$this->assertStringContainsString( $wrapper_class, $html );
+		$this->assertStringContainsString( $heading, $html );
+		$this->assertStringContainsString( 'data-surface="' . $entity_type . '"', $html );
+		$this->assertStringContainsString( 'SuggestedNextSteps_section', $html );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string, 2: string, 3: string, 4: string}>
+	 */
+	public static function surface_provider(): array {
+		return [
+			'account' => [ 'account', 'acct-1', 'Acme Corp', 'entity-detail_marginLabelSection', "What's next with Acme Corp" ],
+			'project' => [ 'project', 'proj-1', 'Platform Unification', 'entity-detail_chapterSection', "What's next on Platform Unification" ],
+			'person'  => [ 'person', 'person-1', 'Jen Park', 'entity-detail_chapterSectionWithPadding', 'Open threads with Jen Park' ],
+			'meeting' => [ 'meeting', 'meeting-1', 'Renewal Review', 'meeting-intel_chapterSection', 'What to cover' ],
+		];
+	}
+
+	/**
+	 * headingLabel overrides the surface default.
+	 */
+	public function test_heading_label_override_wins(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'    => true,
+				'items' => [ $this->item( 'rec-claim-1' ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render(
+			[ 'headingLabel' => 'Next best moves' ],
+			$this->block_context( 'project', 'proj-1' )
+		);
+
+		$this->assertStringContainsString( 'Next best moves', $html );
+		$this->assertStringNotContainsString( "What's next on", $html );
+	}
+
+	/**
+	 * Long subject labels are truncated before heading interpolation.
+	 */
+	public function test_default_heading_truncates_long_subject_label(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'           => true,
+				'subjectLabel' => 'Very Long Customer Account Name That Should Stop Before Overflow',
+				'items'        => [ $this->item( 'rec-claim-1' ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'account', 'acct-1' ) );
+
+		$this->assertStringContainsString( 'Very Long Customer Account Name That...', $html );
+		$this->assertStringNotContainsString( 'Should Stop Before Overflow', $html );
+	}
+
+	/**
+	 * Only needs_verification gets a row-level modifier.
+	 */
+	public function test_trust_band_row_modifier_only_for_needs_verification(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'    => true,
+				'items' => [
+					$this->item( 'rec-likely', 'likely_current' ),
+					$this->item( 'rec-caution', 'use_with_caution' ),
+					$this->item( 'rec-verify', 'needs_verification' ),
+				],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'person', 'person-1', 'Jen Park' ) );
+
+		$this->assertSame( 1, substr_count( $html, 'suggested-next-steps_row--needsVerification' ) );
+		$this->assertStringContainsString( 'TrustBandIndicator_likelyCurrent', $html );
+		$this->assertStringContainsString( 'TrustBandIndicator_useWithCaution', $html );
+		$this->assertStringContainsString( 'TrustBandIndicator_needsVerification', $html );
+	}
+
+	/**
+	 * Feedback is disabled by default until the W4-A submit path lands.
+	 */
+	public function test_disabled_feedback_state_renders_banner_and_non_focusable_affordances(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'    => true,
+				'items' => [ $this->item( 'rec-claim-1' ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'meeting', 'meeting-1' ) );
+
+		$this->assertStringContainsString( 'dailyos-info-chip', $html );
+		$this->assertStringContainsString( 'aria-live="polite"', $html );
+		$this->assertStringContainsString( 'Feedback opens on the next sync.', $html );
+		$this->assertSame( 6, substr_count( $html, 'disabled-affordance' ) );
+		$this->assertSame( 6, substr_count( $html, 'tabindex="-1"' ) );
+		$this->assertSame( 6, substr_count( $html, 'aria-disabled="true"' ) );
+	}
+
+	/**
+	 * Enabled affordances keep the reference ARIA disclosure contract.
+	 */
+	public function test_enabled_affordances_render_aria_labels_and_disclosure_controls(): void {
+		$client = $this->fake_runtime_client(
+			[
+				'ok'    => true,
+				'items' => [ $this->item( 'rec-claim-1' ) ],
+			]
+		);
+		$this->register_runtime_client_filter( $client );
+		$this->enable_feedback();
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'account', 'acct-1', 'Acme Corp' ) );
+
+		$this->assertStringNotContainsString( 'Feedback opens on the next sync.', $html );
+		$this->assertStringNotContainsString( 'disabled-affordance', $html );
+		$this->assertStringContainsString( 'aria-label="Convert this recommendation to an action"', $html );
+		$this->assertStringContainsString( 'aria-label="Dismiss this recommendation"', $html );
+		$this->assertStringContainsString( 'aria-label="More feedback options"', $html );
+		$this->assertStringContainsString( 'aria-expanded="false"', $html );
+		$this->assertStringContainsString( 'aria-controls="rec-claim-1-more"', $html );
+		$this->assertStringContainsString( 'id="rec-claim-1-more"', $html );
+		$this->assertStringContainsString( 'aria-hidden="true"', $html );
+		$this->assertStringContainsString( 'data-feedback-kind="notUseful"', $html );
+		$this->assertStringContainsString( 'data-feedback-kind="tooNoisy"', $html );
+		$this->assertStringContainsString( 'data-feedback-kind="dismissWithReason"', $html );
+	}
+
+	/**
+	 * Runtime and empty-list states render visible empty chips.
+	 */
+	public function test_runtime_errors_and_empty_items_render_visible_empty_chips(): void {
+		$client = $this->fake_runtime_client( new WP_Error( 'runtime_failed', 'Runtime failed.' ) );
+		$this->register_runtime_client_filter( $client );
+
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'account', 'acct-1' ) );
+		$this->assertStringContainsString( 'dailyos-empty-chip', $html );
+		$this->assertStringContainsString( 'data-empty-reason="envelope_error"', $html );
+
+		$this->setUp();
+		$client = $this->fake_runtime_client( [ 'ok' => false ] );
+		$this->register_runtime_client_filter( $client );
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'project', 'proj-1' ) );
+		$this->assertStringContainsString( 'data-empty-reason="envelope_error"', $html );
+
+		$this->setUp();
+		$client = $this->fake_runtime_client( [ 'ok' => true, 'items' => [] ] );
+		$this->register_runtime_client_filter( $client );
+		$html = dailyos_suggested_next_steps_render( [], $this->block_context( 'person', 'person-1' ) );
+		$this->assertStringContainsString( 'data-empty-reason="no_recommendations"', $html );
+		$this->assertStringContainsString( 'No open threads.', $html );
+	}
+
+	/**
+	 * Build a fake runtime client.
+	 *
+	 * @param mixed $response Response payload.
+	 * @return object
+	 */
+	private function fake_runtime_client( $response ): object {
+		return new class( $response ) {
+			/**
+			 * @var mixed
+			 */
+			public $response;
+			/**
+			 * @var int
+			 */
+			public int $calls = 0;
+			/**
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $requests = [];
+			/**
+			 * @param mixed $response Response payload.
+			 */
+			public function __construct( $response ) {
+				$this->response = $response;
+			}
+			/**
+			 * @param string               $ability   Ability name.
+			 * @param array<string, mixed> $payload   Payload.
+			 * @param array<int, string>   $scope_set Scope set.
+			 * @return mixed
+			 */
+			public function invoke_ability( string $ability, array $payload, array $scope_set ) {
+				++$this->calls;
+				$this->requests[] = [
+					'ability'   => $ability,
+					'payload'   => $payload,
+					'scope_set' => $scope_set,
+				];
+				return $this->response;
+			}
+		};
+	}
+
+	/**
+	 * Register the runtime-client filter.
+	 */
+	private function register_runtime_client_filter( object $client ): void {
+		add_filter(
+			'dailyos_runtime_client_for_block',
+			static function () use ( $client ) {
+				return $client;
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Register a scope-set filter.
+	 *
+	 * @param array<int, string> $scopes Scopes.
+	 */
+	private function register_scope_filter( array $scopes ): void {
+		add_filter(
+			'dailyos_surfaceclient_resolved_scopes',
+			static function () use ( $scopes ) {
+				return $scopes;
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Enable the feedback filter for affordance tests.
+	 */
+	private function enable_feedback(): void {
+		add_filter(
+			'dailyos_suggested_next_steps_feedback_enabled',
+			static function () {
+				return true;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Build a WP_Block-like context object.
+	 *
+	 * @param string $entity_type Entity type.
+	 * @param string $entity_id   Entity ID.
+	 * @param string $label       Optional label.
+	 * @return object
+	 */
+	private function block_context( string $entity_type, string $entity_id, string $label = '' ): object {
+		$context = [
+			'dailyos/entityType' => $entity_type,
+			'dailyos/entityId'   => $entity_id,
+		];
+		if ( '' !== $label ) {
+			$context['dailyos/entityLabel'] = $label;
+		}
+
+		return new class( $context ) {
+			/**
+			 * @var array<string, mixed>
+			 */
+			public array $context;
+			/**
+			 * @param array<string, mixed> $context Context.
+			 */
+			public function __construct( array $context ) {
+				$this->context = $context;
+			}
+		};
+	}
+
+	/**
+	 * Build a minimal suggested-next-step item.
+	 *
+	 * @param string $claim_id Claim ID.
+	 * @param string $band     Trust band.
+	 * @return array<string, mixed>
+	 */
+	private function item( string $claim_id, string $band = 'likely_current' ): array {
+		return [
+			'claimId'                   => $claim_id,
+			'headline'                  => 'Send the H1 expansion follow-up',
+			'whyThisNowSurfaceText'     => 'Open loop since the last review.',
+			'factorBand'                => 'openLoopRelated',
+			'recommendedAction'         => [
+				'kind'        => 'sendMessage',
+				'entityLabel' => 'Jen Park',
+				'channel'     => 'email',
+			],
+			'trustBand'                 => $band,
+			'receipt'                   => [
+				'trust'      => [
+					'band' => $band,
+				],
+				'provenance' => [
+					'sources' => [],
+				],
+			],
+			'feedbackState'             => 'pending',
+			'conversionState'           => [
+				'kind' => 'notConverted',
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

W3-A of v1.4.6 — Salience & Recommendations. Ships the producer-boundary pair for the first cross-surface recommendation rendering primitive:

- **`list_suggested_next_steps` ability** (Rust substrate) — `SurfaceClient`-allowed read projection over `surfacing_decisions` v271. Returns a privacy-redacted list of recommendations with trust band, why-this-now, receipt provenance, and feedback-state for the surface.
- **`dailyos/suggested-next-steps` block** (WordPress) — Gutenberg inner-block that calls the ability and renders trust band + why-this-now caption + 3-affordance row (Convert / Dismiss / More feedback…) + hover-reveal sub-row.
- **Reference HTML** for the four target surfaces (account / project / person / meeting prep) committed first per A7, so the WP block render translates against a visual-parity target.

Three commits, ordered: reference HTML → Rust substrate → WP block. Plan packet at `.docs/plans/v1.4.6-w3a-suggested-next-steps/lane-a-l0.md`; 19 cycle amendments (A1–A19) folded inline.

Closes W3-A of v1.4.6 (DOS-298). Unblocks DOS-333 (W3-B cross-surface embedding).

## Critical invariants verified

1. **Privacy class sweep (A1):** `SuggestedNextStepItem` exposes `factor_band: PrimaryFactorBand` only — a 5-band collapse of the 10 `SalienceFactorKind` variants. No `primary_factor` field, no `factors: Vec<SalienceFactor>` ever reaches a SurfaceClient. `why_this_now_surface_text` routes through `surface_rationale_summary` which discards all numeric leaves across all 10 `FactorRationale` variants. Parametric test at `render.rs:1275-1345` asserts none of 9 named numerics appear (JSON-numeric OR substring-matched).
2. **`score_salience` hidden-actor invariant preserved:** allowed_actors stays `[User, System]`. Regression test at `mod.rs:358-376` asserts SurfaceClient + McpClient denied.
3. **Block never reads W2 tables:** grep `surfacing_decisions|triggers_log` over `wp/dailyos/blocks/suggested-next-steps/**` returns zero.
4. **Shared Receipt DTO reused:** items carry `ClaimReceiptSnapshot` only; no parallel receipt struct.
5. **30s server-side echo window** for decided rows (A16 #1): `feedback_visible_in_echo_window` + time-skipped test at `render.rs:1397-1472`.
6. **No new migrations** — empty migrations diff.

## L0 / L2 cycle

- **L0:** 3 cycles, 5-reviewer panel converged to unanimous APPROVE. 19 amendments (A1–A19) consolidating findings; in-document inline class sweep in cycle 3 ensured every section reads consistently with its governing amendment.
- **L2:** unanimous APPROVE across 3 reviewers (ce-api-contract / ce-security / l2-bounded). Zero security findings; zero AC violations. 8 path-α maintenance tickets filed (DOS-794 → DOS-801).
- **L4 surface QA:** explicitly skipped this cycle per user direction. Documented in commit and in DOS-298. PR landing without visual evidence package; CI gates + invariant tests carry the merge.

## Validation results

- `cargo clippy --lib -- -D warnings` clean (W3-A surface clean)
- `cargo test --lib` — **3044 passed / 0 failed / 11 ignored**
- `cargo test --lib recommendations` — 50 new recommendations tests pass
- `npx tsc --noEmit -p wp/dailyos/tsconfig.json` clean
- `pnpm tsc --noEmit` clean
- `php -l` on all new PHP files: clean
- `node -c view.js` clean
- Pre-push gauntlet (clippy + cargo test --lib + pnpm tsc): passed

Note: `cargo clippy --all-targets` fails on pre-existing integration test code (`claims.rs`, `intelligence.rs`, `intel_queue.rs`, `tests/dos216_*` etc.) — none touched by W3-A; out of scope for this lane per CLAUDE.md documented validation scope (`cargo clippy --` default, not `--all-targets`).

## Path-α maintenance tickets filed (Codebase Maintenance project)

- DOS-794 parametric `RecommendedActionView` serialization test
- DOS-795 consume `feedback-kinds.php` constants in `render-functions.php`
- DOS-796 CI guard for reference-HTML vs render-functions wrapper-class parity
- DOS-797 standardize schema_version width across recommendations module
- DOS-798 SurfaceClient ↔ MCP schema_version coordination policy (pre-v1.4.7 L0 prep)
- DOS-799 `surfacing_decisions` index audit (conditional on L1 perf evidence)
- DOS-800 cross-device hover-reveal touch fallback (pre cross-device-surface L0)
- DOS-801 non-default-locale screenshot coverage (when harness gains locale support)

## §4 Security

security_auditor_invoked: true

**Exemption ID:** _none_ (auditor ran)

**Exemption rationale:** N/A — L2 dispatched `ce-security-reviewer` against the W3-A diff (privacy class sweep, actor allowlist, adversarial attack constructions). Returned APPROVE with zero findings; privacy invariant verified end-to-end. Full review captured in DOS-298 L2 comment.


## Test plan

- [ ] CI green: cargo clippy, cargo test --lib, pnpm tsc --noEmit, phpunit (block test in CI)
- [ ] CI green: PII blocklist, schema/mock sync, ADR-0101 boundary, reference fidelity gate
- [ ] Linear DOS-298 closes when merged
- [ ] After merge: start W3-B (DOS-333) on a fresh `dev`-based worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)