### PR TITLE
fix: stabilize transcript intake and background writes

### DIFF
--- a/src-tauri/src/commands/integrations.rs
+++ b/src-tauri/src/commands/integrations.rs
@@ -685,6 +685,10 @@ pub struct GranolaStatus {
     pub enabled: bool,
     pub cache_exists: bool,
     pub cache_path: String,
+    pub source: String,
+    pub companion_available: bool,
+    pub companion_message: Option<String>,
+    pub encrypted_cache_exists: bool,
     pub document_count: usize,
     pub pending_syncs: usize,
     pub failed_syncs: usize,
@@ -714,10 +718,28 @@ pub async fn get_granola_status(state: State<'_, Arc<AppState>>) -> Result<Grano
     let granola_config = config.unwrap_or_default();
     let resolved_path = crate::granola::resolve_cache_path(&granola_config);
     let cache_exists = resolved_path.is_some();
+    let encrypted_cache_exists = crate::granola::detect_encrypted_cache_path().is_some();
+    let companion_status = crate::granola::companion::CompanionClient::status();
 
-    let document_count = match &resolved_path {
-        Some(p) => crate::granola::cache::count_documents(p).unwrap_or(0),
-        None => 0,
+    let document_count = if companion_status.available {
+        crate::granola::companion::CompanionClient::new()
+            .and_then(|client| client.list_recent_notes(90).map(|notes| notes.len()))
+            .unwrap_or(0)
+    } else {
+        match &resolved_path {
+            Some(p) => crate::granola::cache::count_documents(p).unwrap_or(0),
+            None => 0,
+        }
+    };
+
+    let source = if companion_status.available {
+        "companion"
+    } else if cache_exists {
+        "cache"
+    } else if encrypted_cache_exists {
+        "encrypted_cache"
+    } else {
+        "none"
     };
 
     // Count sync states from DB (source='granola')
@@ -756,6 +778,10 @@ pub async fn get_granola_status(state: State<'_, Arc<AppState>>) -> Result<Grano
             .as_ref()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default(),
+        source: source.to_string(),
+        companion_available: companion_status.available,
+        companion_message: companion_status.message,
+        encrypted_cache_exists,
         document_count,
         pending_syncs: pending,
         failed_syncs: failed,

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -26,8 +26,49 @@ use sha2::{Digest, Sha256};
 /// `ActionDb::open()` independently — the static flag means they automatically
 /// pick up the right path without plumbing config through every thread.
 static DEV_DB_MODE: AtomicBool = AtomicBool::new(false);
+static WRITE_TRANSACTION_GATE: parking_lot::Mutex<()> = parking_lot::const_mutex(());
+static WRITE_TRANSACTION_HOLDER: parking_lot::Mutex<Option<WriteTransactionHolder>> =
+    parking_lot::const_mutex(None);
 const WORKSPACE_GRAPH_DIAGNOSTIC_KEY_DERIVATION_DOMAIN: &[u8] =
     b"DAILYOS-WORKSPACE-GRAPH-DIAGNOSTIC-HANDLE-V1\n";
+
+#[derive(Clone, Debug)]
+struct WriteTransactionHolder {
+    caller: String,
+    acquired_at: std::time::Instant,
+}
+
+struct WriteTransactionHolderGuard;
+
+impl WriteTransactionHolderGuard {
+    fn set(caller: &'static std::panic::Location<'static>) -> Self {
+        *WRITE_TRANSACTION_HOLDER.lock() = Some(WriteTransactionHolder {
+            caller: format!("{}:{}", caller.file(), caller.line()),
+            acquired_at: std::time::Instant::now(),
+        });
+        Self
+    }
+}
+
+impl Drop for WriteTransactionHolderGuard {
+    fn drop(&mut self) {
+        *WRITE_TRANSACTION_HOLDER.lock() = None;
+    }
+}
+
+fn write_transaction_holder_summary() -> String {
+    WRITE_TRANSACTION_HOLDER
+        .lock()
+        .clone()
+        .map(|holder| {
+            format!(
+                "{} held for {}ms",
+                holder.caller,
+                holder.acquired_at.elapsed().as_millis()
+            )
+        })
+        .unwrap_or_else(|| "unknown holder".to_string())
+}
 
 /// Activate dev-mode DB isolation. All subsequent `ActionDb::open()` calls
 /// will target `~/.dailyos/dailyos-dev.db` instead of `dailyos.db`.
@@ -155,6 +196,7 @@ impl ActionDb {
     /// Execute a closure within a SQLite transaction.
     /// Commits on Ok, rolls back on Err.
     #[must_use = "the closure may write to the DB; dropping this Result silently swallows transaction failure or rollback"]
+    #[track_caller]
     pub fn with_transaction<F, T>(&self, f: F) -> Result<T, String>
     where
         F: FnOnce(&Self) -> Result<T, String>,
@@ -165,6 +207,41 @@ impl ActionDb {
         if !self.conn.is_autocommit() {
             return f(self);
         }
+
+        let gate_started = std::time::Instant::now();
+        let mut next_wait_log_at = std::time::Duration::from_secs(5);
+        let wait_limit = std::time::Duration::from_secs(120);
+        let _write_gate = loop {
+            if let Some(gate) =
+                WRITE_TRANSACTION_GATE.try_lock_for(std::time::Duration::from_millis(250))
+            {
+                break gate;
+            }
+            let waited = gate_started.elapsed();
+            if waited >= next_wait_log_at {
+                log::warn!(
+                    "write transaction gate busy for {}ms before BEGIN IMMEDIATE at {}:{}; current holder: {}",
+                    waited.as_millis(),
+                    std::panic::Location::caller().file(),
+                    std::panic::Location::caller().line(),
+                    write_transaction_holder_summary(),
+                );
+                next_wait_log_at += std::time::Duration::from_secs(5);
+            }
+            if waited >= wait_limit {
+                return Err(format!(
+                    "Timed out waiting for process write transaction gate before BEGIN IMMEDIATE; waited={}ms; current holder: {}",
+                    waited.as_millis(),
+                    write_transaction_holder_summary()
+                ));
+            }
+        };
+        let _holder_guard = WriteTransactionHolderGuard::set(std::panic::Location::caller());
+        crate::latency::record_latency(
+            "action_db.write_transaction_gate_wait",
+            gate_started.elapsed().as_millis(),
+            500,
+        );
 
         self.conn
             .execute_batch("BEGIN IMMEDIATE")
@@ -410,14 +487,9 @@ impl ActionDb {
                 .map_err(Self::map_key_error)?;
             let conn = svc.open_fresh_serialized(path.clone(), encryption_key)?;
             drop(rotation_lock);
-            let db = Self { conn };
-            Self::recover_stuck_version_mutations_logged(&db);
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            let _ = db.run_guarded_init_backfill_account_domains();
-            return Ok(db);
+            // Startup initialization already runs through the global DbService.
+            // Fresh handles should not add best-effort writes outside that path.
+            return Ok(Self { conn });
         }
 
         Self::open_at(path, key_provider)

--- a/src-tauri/src/db/emails.rs
+++ b/src-tauri/src/db/emails.rs
@@ -221,22 +221,24 @@ impl ActionDb {
         if vanished_ids.is_empty() {
             return Ok(0);
         }
-        let now = Utc::now().to_rfc3339();
-        let placeholders: Vec<String> = (1..=vanished_ids.len()).map(|i| format!("?{i}")).collect();
-        let sql = format!(
-            "UPDATE emails SET resolved_at = '{}', updated_at = '{}' WHERE email_id IN ({}) AND resolved_at IS NULL",
-            now, now,
-            placeholders.join(", ")
-        );
-        let param_values: Vec<&dyn rusqlite::types::ToSql> = vanished_ids
-            .iter()
-            .map(|id| id as &dyn rusqlite::types::ToSql)
-            .collect();
-        let rows = self
-            .conn
-            .execute(&sql, param_values.as_slice())
-            .map_err(|e| format!("Failed to mark emails resolved: {e}"))?;
-        Ok(rows)
+        self.with_transaction(|tx| {
+            let now = Utc::now().to_rfc3339();
+            let placeholders: Vec<String> =
+                (1..=vanished_ids.len()).map(|i| format!("?{i}")).collect();
+            let sql = format!(
+                "UPDATE emails SET resolved_at = '{}', updated_at = '{}' WHERE email_id IN ({}) AND resolved_at IS NULL",
+                now, now,
+                placeholders.join(", ")
+            );
+            let param_values: Vec<&dyn rusqlite::types::ToSql> = vanished_ids
+                .iter()
+                .map(|id| id as &dyn rusqlite::types::ToSql)
+                .collect();
+            tx.conn
+                .execute(&sql, param_values.as_slice())
+                .map_err(|e| format!("Failed to mark emails resolved: {e}"))
+        })
+        .map_err(Into::into)
     }
 
     /// Unmark resolved emails that reappeared in inbox. Sets `resolved_at` to NULL.
@@ -246,24 +248,25 @@ impl ActionDb {
         if reappeared_ids.is_empty() {
             return Ok(0);
         }
-        let now = Utc::now().to_rfc3339();
-        let placeholders: Vec<String> = (1..=reappeared_ids.len())
-            .map(|i| format!("?{i}"))
-            .collect();
-        let sql = format!(
-            "UPDATE emails SET resolved_at = NULL, updated_at = '{}' WHERE email_id IN ({})",
-            now,
-            placeholders.join(", ")
-        );
-        let param_values: Vec<&dyn rusqlite::types::ToSql> = reappeared_ids
-            .iter()
-            .map(|id| id as &dyn rusqlite::types::ToSql)
-            .collect();
-        let rows = self
-            .conn
-            .execute(&sql, param_values.as_slice())
-            .map_err(|e| format!("Failed to unmark resolved emails: {e}"))?;
-        Ok(rows)
+        self.with_transaction(|tx| {
+            let now = Utc::now().to_rfc3339();
+            let placeholders: Vec<String> = (1..=reappeared_ids.len())
+                .map(|i| format!("?{i}"))
+                .collect();
+            let sql = format!(
+                "UPDATE emails SET resolved_at = NULL, updated_at = '{}' WHERE email_id IN ({})",
+                now,
+                placeholders.join(", ")
+            );
+            let param_values: Vec<&dyn rusqlite::types::ToSql> = reappeared_ids
+                .iter()
+                .map(|id| id as &dyn rusqlite::types::ToSql)
+                .collect();
+            tx.conn
+                .execute(&sql, param_values.as_slice())
+                .map_err(|e| format!("Failed to unmark resolved emails: {e}"))
+        })
+        .map_err(Into::into)
     }
 
     /// Get emails pending enrichment (state = 'pending' or 'failed', attempts < 3).
@@ -309,49 +312,52 @@ impl ActionDb {
         state: &str,
         enrichment: EmailEnrichmentUpdate<'_>,
     ) -> Result<(), DbError> {
-        let now = Utc::now().to_rfc3339();
-        // is_noise gets COALESCE-style "only update if AI gave a
-        // verdict" semantics via a CASE expression — Some(bool) -> 0/1,
-        // None -> keep existing column value.
-        let is_noise_param: Option<i32> = enrichment.is_noise.map(|b| if b { 1 } else { 0 });
-        self.conn
-            .execute(
-                "UPDATE emails SET
-                    enrichment_state = ?1,
-                    enrichment_attempts = enrichment_attempts + 1,
-                    last_enrichment_at = ?2,
-                    contextual_summary = COALESCE(?3, contextual_summary),
-                    entity_id = COALESCE(?4, entity_id),
-                    entity_type = COALESCE(?5, entity_type),
-                    sentiment = COALESCE(?6, sentiment),
-                    urgency = COALESCE(?7, urgency),
-                    is_noise = COALESCE(?8, is_noise),
-                    summary_context_prompt_version = CASE WHEN ?3 IS NOT NULL THEN ?9 ELSE NULL END,
-                    summary_context_trust_band = CASE WHEN ?3 IS NOT NULL THEN ?10 ELSE NULL END,
-                    summary_context_source_count = CASE WHEN ?3 IS NOT NULL THEN ?11 ELSE NULL END,
-                    summary_context_source_keys_json = CASE WHEN ?3 IS NOT NULL THEN ?12 ELSE NULL END,
-                    summary_context_generated_at = CASE WHEN ?3 IS NOT NULL THEN ?13 ELSE NULL END,
-                    updated_at = ?2
-                 WHERE email_id = ?14",
-                params![
-                    state,
-                    now,
-                    enrichment.summary,
-                    enrichment.entity_id,
-                    enrichment.entity_type,
-                    enrichment.sentiment,
-                    enrichment.urgency,
-                    is_noise_param,
-                    enrichment.summary_context_prompt_version,
-                    enrichment.summary_context_trust_band,
-                    enrichment.summary_context_source_count.map(|count| count as i64),
-                    enrichment.summary_context_source_keys_json,
-                    enrichment.summary_context_generated_at,
-                    email_id,
-                ],
-            )
-            .map_err(|e| format!("Failed to set enrichment state for {email_id}: {e}"))?;
-        Ok(())
+        self.with_transaction(|tx| {
+            let now = Utc::now().to_rfc3339();
+            // is_noise gets COALESCE-style "only update if AI gave a
+            // verdict" semantics via a CASE expression -- Some(bool) -> 0/1,
+            // None -> keep existing column value.
+            let is_noise_param: Option<i32> = enrichment.is_noise.map(|b| if b { 1 } else { 0 });
+            tx.conn
+                .execute(
+                    "UPDATE emails SET
+                        enrichment_state = ?1,
+                        enrichment_attempts = enrichment_attempts + 1,
+                        last_enrichment_at = ?2,
+                        contextual_summary = COALESCE(?3, contextual_summary),
+                        entity_id = COALESCE(?4, entity_id),
+                        entity_type = COALESCE(?5, entity_type),
+                        sentiment = COALESCE(?6, sentiment),
+                        urgency = COALESCE(?7, urgency),
+                        is_noise = COALESCE(?8, is_noise),
+                        summary_context_prompt_version = CASE WHEN ?3 IS NOT NULL THEN ?9 ELSE NULL END,
+                        summary_context_trust_band = CASE WHEN ?3 IS NOT NULL THEN ?10 ELSE NULL END,
+                        summary_context_source_count = CASE WHEN ?3 IS NOT NULL THEN ?11 ELSE NULL END,
+                        summary_context_source_keys_json = CASE WHEN ?3 IS NOT NULL THEN ?12 ELSE NULL END,
+                        summary_context_generated_at = CASE WHEN ?3 IS NOT NULL THEN ?13 ELSE NULL END,
+                        updated_at = ?2
+                     WHERE email_id = ?14",
+                    params![
+                        state,
+                        now,
+                        enrichment.summary,
+                        enrichment.entity_id,
+                        enrichment.entity_type,
+                        enrichment.sentiment,
+                        enrichment.urgency,
+                        is_noise_param,
+                        enrichment.summary_context_prompt_version,
+                        enrichment.summary_context_trust_band,
+                        enrichment.summary_context_source_count.map(|count| count as i64),
+                        enrichment.summary_context_source_keys_json,
+                        enrichment.summary_context_generated_at,
+                        email_id,
+                    ],
+                )
+                .map_err(|e| format!("Failed to set enrichment state for {email_id}: {e}"))?;
+            Ok(())
+        })
+        .map_err(Into::into)
     }
 
     /// Get all active (non-resolved) emails.
@@ -426,15 +432,18 @@ impl ActionDb {
         thread_id: &str,
         user_is_last_sender: bool,
     ) -> Result<(), DbError> {
-        let now = Utc::now().to_rfc3339();
-        self.conn
-            .execute(
-                "UPDATE emails SET user_is_last_sender = ?1, updated_at = ?2
-                 WHERE thread_id = ?3",
-                params![user_is_last_sender as i32, now, thread_id],
-            )
-            .map_err(|e| format!("Failed to update thread position for {thread_id}: {e}"))?;
-        Ok(())
+        self.with_transaction(|tx| {
+            let now = Utc::now().to_rfc3339();
+            tx.conn
+                .execute(
+                    "UPDATE emails SET user_is_last_sender = ?1, updated_at = ?2
+                     WHERE thread_id = ?3",
+                    params![user_is_last_sender as i32, now, thread_id],
+                )
+                .map_err(|e| format!("Failed to update thread position for {thread_id}: {e}"))?;
+            Ok(())
+        })
+        .map_err(Into::into)
     }
 
     /// Get email sync statistics for the sync status indicator.
@@ -537,25 +546,27 @@ impl ActionDb {
     /// singleton PK check).
     #[must_use = "check whether fetch watermark was saved before reporting sync freshness"]
     pub fn set_last_successful_fetch_at(&self) -> Result<(), DbError> {
-        let now = Utc::now().to_rfc3339();
-        let rows = self
-            .conn
-            .execute(
-                "INSERT INTO email_sync_meta (id, last_successful_fetch_at, updated_at)
-                 VALUES (1, ?1, ?1)
-                 ON CONFLICT(id) DO UPDATE SET
-                    last_successful_fetch_at = excluded.last_successful_fetch_at,
-                    updated_at = excluded.updated_at",
-                params![now],
-            )
-            .map_err(|e| format!("Failed to upsert email_sync_meta: {e}"))?;
-        if rows != 1 {
-            return Err(format!(
-                "email_sync_meta upsert affected {rows} rows; expected 1 (schema drift?)"
-            )
-            .into());
-        }
-        Ok(())
+        self.with_transaction(|tx| {
+            let now = Utc::now().to_rfc3339();
+            let rows = tx
+                .conn
+                .execute(
+                    "INSERT INTO email_sync_meta (id, last_successful_fetch_at, updated_at)
+                     VALUES (1, ?1, ?1)
+                     ON CONFLICT(id) DO UPDATE SET
+                        last_successful_fetch_at = excluded.last_successful_fetch_at,
+                        updated_at = excluded.updated_at",
+                    params![now],
+                )
+                .map_err(|e| format!("Failed to upsert email_sync_meta: {e}"))?;
+            if rows != 1 {
+                return Err(format!(
+                    "email_sync_meta upsert affected {rows} rows; expected 1 (schema drift?)"
+                ));
+            }
+            Ok(())
+        })
+        .map_err(Into::into)
     }
 
     /// Read the last successful Gmail fetch timestamp. `Ok(None)` means
@@ -930,14 +941,17 @@ impl ActionDb {
         score: f64,
         reason: &str,
     ) -> Result<(), DbError> {
-        let now = chrono::Utc::now().to_rfc3339();
-        self.conn
-            .execute(
-                "UPDATE emails SET relevance_score = ?1, score_reason = ?2, updated_at = ?3 WHERE email_id = ?4",
-                rusqlite::params![score, reason, now, email_id],
-            )
-            .map_err(|e| format!("Failed to set relevance score for {email_id}: {e}"))?;
-        Ok(())
+        self.with_transaction(|tx| {
+            let now = chrono::Utc::now().to_rfc3339();
+            tx.conn
+                .execute(
+                    "UPDATE emails SET relevance_score = ?1, score_reason = ?2, updated_at = ?3 WHERE email_id = ?4",
+                    rusqlite::params![score, reason, now, email_id],
+                )
+                .map_err(|e| format!("Failed to set relevance score for {email_id}: {e}"))?;
+            Ok(())
+        })
+        .map_err(Into::into)
     }
 
     /// Get emails sorted by relevance score (highest first), with minimum score filter.

--- a/src-tauri/src/db/signals.rs
+++ b/src-tauri/src/db/signals.rs
@@ -808,22 +808,23 @@ impl ActionDb {
         if email_ids.is_empty() {
             return Ok(0);
         }
-        let now = chrono::Utc::now().to_rfc3339();
-        let placeholders: Vec<String> = (1..=email_ids.len()).map(|i| format!("?{i}")).collect();
-        let sql = format!(
-            "UPDATE email_signals SET deactivated_at = '{}' WHERE email_id IN ({}) AND deactivated_at IS NULL",
-            now,
-            placeholders.join(", ")
-        );
-        let param_values: Vec<&dyn rusqlite::types::ToSql> = email_ids
-            .iter()
-            .map(|id| id as &dyn rusqlite::types::ToSql)
-            .collect();
-        let rows = self
-            .conn
-            .execute(&sql, param_values.as_slice())
-            .map_err(|e| format!("Failed to deactivate email signals: {e}"))?;
-        Ok(rows)
+        self.with_transaction(|tx| {
+            let now = chrono::Utc::now().to_rfc3339();
+            let placeholders: Vec<String> =
+                (1..=email_ids.len()).map(|i| format!("?{i}")).collect();
+            let sql = format!(
+                "UPDATE email_signals SET deactivated_at = '{}' WHERE email_id IN ({}) AND deactivated_at IS NULL",
+                now,
+                placeholders.join(", ")
+            );
+            let param_values: Vec<&dyn rusqlite::types::ToSql> = email_ids
+                .iter()
+                .map(|id| id as &dyn rusqlite::types::ToSql)
+                .collect();
+            tx.conn
+                .execute(&sql, param_values.as_slice())
+                .map_err(|e| format!("Failed to deactivate email signals: {e}"))
+        })
     }
 
     /// Check if a Glean document signal already exists for a URL.

--- a/src-tauri/src/granola/companion.rs
+++ b/src-tauri/src/granola/companion.rs
@@ -1,0 +1,585 @@
+//! Client for Granola's local companion IPC bridge.
+//!
+//! Granola's current desktop app can expose notes through a local socket plus
+//! metadata file. This keeps DailyOS on Granola's supported local integration
+//! path and avoids treating stale plaintext cache files as authoritative.
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use super::cache::{
+    EventTime, GoogleCalendarEvent, GranolaAttendee, GranolaContentType, GranolaDocument,
+};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const NOTE_PAGE_SIZE: usize = 100;
+const MAX_NOTES_PER_SCAN: usize = 500;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CompanionError {
+    #[error("Granola companion access is not enabled")]
+    NotConfigured,
+    #[error("Granola companion metadata is invalid: {0}")]
+    MetadataInvalid(String),
+    #[error("Granola companion socket is not available")]
+    SocketMissing,
+    #[error("Granola companion connection failed: {0}")]
+    ConnectionFailed(String),
+    #[error("Granola companion request failed: {code}: {message}")]
+    RequestFailed { code: String, message: String },
+    #[error("Granola companion response was invalid: {0}")]
+    InvalidResponse(String),
+    #[error("Granola note has no transcript or notes content")]
+    NoContent,
+}
+
+impl CompanionError {
+    pub fn is_unavailable(&self) -> bool {
+        matches!(self, Self::NotConfigured | Self::SocketMissing)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompanionStatus {
+    pub available: bool,
+    pub metadata_path: PathBuf,
+    pub socket_path: Option<PathBuf>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompanionNote {
+    pub id: String,
+    pub title: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub google_calendar_event: Option<GoogleCalendarEvent>,
+    pub attendee_emails: Vec<String>,
+}
+
+impl CompanionNote {
+    pub fn as_match_document(&self) -> GranolaDocument {
+        GranolaDocument {
+            id: self.id.clone(),
+            title: self.title.clone(),
+            created_at: self.created_at.clone(),
+            updated_at: self.updated_at.clone(),
+            content: String::new(),
+            content_type: GranolaContentType::Notes,
+            google_calendar_event: self.google_calendar_event.clone(),
+            attendee_emails: self.attendee_emails.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompanionClient {
+    metadata_path: PathBuf,
+}
+
+impl CompanionClient {
+    pub fn new() -> Result<Self, CompanionError> {
+        let metadata_path = metadata_path();
+        let metadata = read_metadata(&metadata_path)?;
+        ensure_socket_available(&metadata)?;
+        Ok(Self { metadata_path })
+    }
+
+    pub fn status() -> CompanionStatus {
+        let metadata_path = metadata_path();
+        match read_metadata(&metadata_path) {
+            Ok(metadata) => {
+                let socket_path = PathBuf::from(&metadata.socket_path);
+                if socket_path.exists() {
+                    CompanionStatus {
+                        available: true,
+                        metadata_path,
+                        socket_path: Some(socket_path),
+                        message: None,
+                    }
+                } else {
+                    CompanionStatus {
+                        available: false,
+                        metadata_path,
+                        socket_path: Some(socket_path),
+                        message: Some(
+                            "Granola companion bridge is not running. Enable Granola companion access and keep Granola open.".to_string(),
+                        ),
+                    }
+                }
+            }
+            Err(CompanionError::NotConfigured) => CompanionStatus {
+                available: false,
+                metadata_path,
+                socket_path: None,
+                message: Some(
+                    "Granola companion bridge is not enabled. Enable Granola companion access in Granola.".to_string(),
+                ),
+            },
+            Err(error) => CompanionStatus {
+                available: false,
+                metadata_path,
+                socket_path: None,
+                message: Some(error.to_string()),
+            },
+        }
+    }
+
+    pub fn list_recent_notes(&self, days_back: i32) -> Result<Vec<CompanionNote>, CompanionError> {
+        let after = (Utc::now() - chrono::Duration::days(days_back.max(1) as i64))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        self.list_notes(Some(after), None, MAX_NOTES_PER_SCAN)
+    }
+
+    pub fn list_notes_near(
+        &self,
+        start_time: &str,
+        end_time: Option<&str>,
+    ) -> Result<Vec<CompanionNote>, CompanionError> {
+        let start = parse_time(start_time).unwrap_or_else(Utc::now);
+        let end = end_time
+            .and_then(parse_time)
+            .unwrap_or_else(|| start + chrono::Duration::hours(3));
+        let after =
+            (start - chrono::Duration::hours(12)).to_rfc3339_opts(SecondsFormat::Secs, true);
+        let before = (end + chrono::Duration::days(2)).to_rfc3339_opts(SecondsFormat::Secs, true);
+        self.list_notes(Some(after), Some(before), MAX_NOTES_PER_SCAN)
+    }
+
+    pub fn fetch_document(&self, note: &CompanionNote) -> Result<GranolaDocument, CompanionError> {
+        if let Ok(text) = self.fetch_transcript_text(&note.id) {
+            if !text.trim().is_empty() {
+                return Ok(self.document_from_note(note, text, GranolaContentType::Transcript));
+            }
+        }
+
+        let notes = self.fetch_notes_text(&note.id)?;
+        if notes.trim().is_empty() {
+            return Err(CompanionError::NoContent);
+        }
+
+        Ok(self.document_from_note(note, notes, GranolaContentType::Notes))
+    }
+
+    fn list_notes(
+        &self,
+        created_after: Option<String>,
+        created_before: Option<String>,
+        max_notes: usize,
+    ) -> Result<Vec<CompanionNote>, CompanionError> {
+        let mut notes = Vec::new();
+        let mut offset = 0usize;
+
+        loop {
+            let mut params = json!({
+                "limit": NOTE_PAGE_SIZE,
+                "offset": offset,
+            });
+            if let Some(after) = created_after.as_ref() {
+                params["created_after"] = json!(after);
+            }
+            if let Some(before) = created_before.as_ref() {
+                params["created_before"] = json!(before);
+            }
+
+            let result = self.call("notes.list", params)?;
+            let page: NotesListResult = serde_json::from_value(result)
+                .map_err(|e| CompanionError::InvalidResponse(e.to_string()))?;
+
+            notes.extend(
+                page.notes
+                    .into_iter()
+                    .filter(|note| note.note_type == "meeting")
+                    .filter_map(CompanionNote::try_from_raw),
+            );
+
+            if !page.has_more || notes.len() >= max_notes {
+                notes.truncate(max_notes);
+                return Ok(notes);
+            }
+
+            offset = page.next_offset.unwrap_or(offset + NOTE_PAGE_SIZE);
+        }
+    }
+
+    fn fetch_transcript_text(&self, note_id: &str) -> Result<String, CompanionError> {
+        let result = self.call("notes.transcript.get", json!({ "id": note_id }))?;
+        let transcript: TranscriptResult = serde_json::from_value(result)
+            .map_err(|e| CompanionError::InvalidResponse(e.to_string()))?;
+        Ok(transcript
+            .transcript
+            .into_iter()
+            .map(|chunk| chunk.text)
+            .filter(|text| !text.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"))
+    }
+
+    fn fetch_notes_text(&self, note_id: &str) -> Result<String, CompanionError> {
+        let result = self.call("notes.get", json!({ "ids": [note_id] }))?;
+        let notes: NotesGetResult = serde_json::from_value(result)
+            .map_err(|e| CompanionError::InvalidResponse(e.to_string()))?;
+        let note = notes
+            .notes
+            .into_iter()
+            .next()
+            .ok_or(CompanionError::NoContent)?;
+
+        [
+            note.notes_markdown,
+            note.notes_plain,
+            note.summary_markdown,
+            note.summary_text,
+        ]
+        .into_iter()
+        .flatten()
+        .find(|text| !text.trim().is_empty())
+        .ok_or(CompanionError::NoContent)
+    }
+
+    fn document_from_note(
+        &self,
+        note: &CompanionNote,
+        content: String,
+        content_type: GranolaContentType,
+    ) -> GranolaDocument {
+        GranolaDocument {
+            id: note.id.clone(),
+            title: note.title.clone(),
+            created_at: note.created_at.clone(),
+            updated_at: note.updated_at.clone(),
+            content,
+            content_type,
+            google_calendar_event: note.google_calendar_event.clone(),
+            attendee_emails: note.attendee_emails.clone(),
+        }
+    }
+
+    fn call(&self, method: &str, params: Value) -> Result<Value, CompanionError> {
+        let metadata = read_metadata(&self.metadata_path)?;
+        ensure_socket_available(&metadata)?;
+        call_companion(&metadata, method, params)
+    }
+}
+
+fn metadata_path() -> PathBuf {
+    super::granola_dir()
+        .join("companion-cli")
+        .join("companion-cli.json")
+}
+
+fn parse_time(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok()
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionMetadata {
+    protocol_version: u32,
+    socket_path: String,
+    token: String,
+}
+
+fn read_metadata(path: &Path) -> Result<CompanionMetadata, CompanionError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            CompanionError::NotConfigured
+        } else {
+            CompanionError::MetadataInvalid(e.to_string())
+        }
+    })?;
+    let metadata: CompanionMetadata =
+        serde_json::from_str(&raw).map_err(|e| CompanionError::MetadataInvalid(e.to_string()))?;
+    if metadata.protocol_version != 1
+        || metadata.socket_path.is_empty()
+        || metadata.token.is_empty()
+    {
+        return Err(CompanionError::MetadataInvalid(
+            "unsupported metadata shape".to_string(),
+        ));
+    }
+    Ok(metadata)
+}
+
+fn ensure_socket_available(metadata: &CompanionMetadata) -> Result<(), CompanionError> {
+    if Path::new(&metadata.socket_path).exists() {
+        Ok(())
+    } else {
+        Err(CompanionError::SocketMissing)
+    }
+}
+
+#[cfg(unix)]
+fn call_companion(
+    metadata: &CompanionMetadata,
+    method: &str,
+    params: Value,
+) -> Result<Value, CompanionError> {
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(&metadata.socket_path)
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+    stream
+        .set_read_timeout(Some(REQUEST_TIMEOUT))
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+    stream
+        .set_write_timeout(Some(REQUEST_TIMEOUT))
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+
+    let reader_stream = stream
+        .try_clone()
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+    let mut reader = BufReader::new(reader_stream);
+
+    write_json_line(
+        &mut stream,
+        &json!({ "type": "auth", "token": metadata.token }),
+    )?;
+    let auth: AuthResponse = read_json_line(&mut reader)?;
+    if !auth.ok {
+        return Err(CompanionError::RequestFailed {
+            code: "UNAUTHENTICATED".to_string(),
+            message: auth
+                .error
+                .unwrap_or_else(|| "Granola companion authentication failed".to_string()),
+        });
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    write_json_line(
+        &mut stream,
+        &json!({
+            "type": "request",
+            "id": id,
+            "method": method,
+            "params": params,
+        }),
+    )?;
+
+    let response: RpcResponse = read_json_line(&mut reader)?;
+    if response.ok {
+        response
+            .result
+            .ok_or_else(|| CompanionError::InvalidResponse("missing result".to_string()))
+    } else {
+        let error = response.error.unwrap_or(RpcError {
+            code: "UNKNOWN".to_string(),
+            message: "Granola companion request failed".to_string(),
+        });
+        Err(CompanionError::RequestFailed {
+            code: error.code,
+            message: error.message,
+        })
+    }
+}
+
+#[cfg(not(unix))]
+fn call_companion(
+    _metadata: &CompanionMetadata,
+    _method: &str,
+    _params: Value,
+) -> Result<Value, CompanionError> {
+    Err(CompanionError::ConnectionFailed(
+        "Granola companion IPC is only implemented for Unix sockets".to_string(),
+    ))
+}
+
+fn write_json_line(stream: &mut impl Write, value: &Value) -> Result<(), CompanionError> {
+    serde_json::to_writer(&mut *stream, value)
+        .map_err(|e| CompanionError::InvalidResponse(e.to_string()))?;
+    stream
+        .write_all(b"\n")
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+    stream
+        .flush()
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))
+}
+
+fn read_json_line<T: for<'de> Deserialize<'de>>(
+    reader: &mut impl BufRead,
+) -> Result<T, CompanionError> {
+    let mut line = String::new();
+    let bytes = reader
+        .read_line(&mut line)
+        .map_err(|e| CompanionError::ConnectionFailed(e.to_string()))?;
+    if bytes == 0 {
+        return Err(CompanionError::ConnectionFailed(
+            "Granola companion closed the connection".to_string(),
+        ));
+    }
+    serde_json::from_str(line.trim_end())
+        .map_err(|e| CompanionError::InvalidResponse(e.to_string()))
+}
+
+impl CompanionNote {
+    fn try_from_raw(raw: CompanionNoteRaw) -> Option<Self> {
+        let title = raw.title.filter(|title| !title.trim().is_empty())?;
+        let google_calendar_event = raw
+            .calendar_event
+            .as_ref()
+            .map(|event| GoogleCalendarEvent {
+                id: event.calendar_event_id.clone(),
+                summary: event.event_title.clone(),
+                start: event
+                    .scheduled_start_time
+                    .as_ref()
+                    .map(|date_time| EventTime {
+                        date_time: Some(date_time.clone()),
+                    }),
+                end: event
+                    .scheduled_end_time
+                    .as_ref()
+                    .map(|date_time| EventTime {
+                        date_time: Some(date_time.clone()),
+                    }),
+                status: raw.status.clone(),
+                attendees: event
+                    .invitees
+                    .iter()
+                    .map(|invitee| GranolaAttendee {
+                        email: Some(invitee.email.to_lowercase()),
+                        response_status: None,
+                        is_self: None,
+                    })
+                    .collect(),
+            });
+        let attendee_emails = raw
+            .calendar_event
+            .as_ref()
+            .map(|event| {
+                event
+                    .invitees
+                    .iter()
+                    .map(|invitee| invitee.email.to_lowercase())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Some(Self {
+            id: raw.id,
+            title,
+            created_at: Some(raw.created_at),
+            updated_at: Some(raw.updated_at),
+            google_calendar_event,
+            attendee_emails,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthResponse {
+    ok: bool,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcResponse {
+    ok: bool,
+    result: Option<Value>,
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcError {
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotesListResult {
+    notes: Vec<CompanionNoteRaw>,
+    has_more: bool,
+    next_offset: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionNoteRaw {
+    id: String,
+    title: Option<String>,
+    created_at: String,
+    updated_at: String,
+    #[serde(rename = "type")]
+    note_type: String,
+    status: Option<String>,
+    calendar_event: Option<CompanionCalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionCalendarEvent {
+    event_title: Option<String>,
+    invitees: Vec<CompanionInvitee>,
+    calendar_event_id: Option<String>,
+    scheduled_start_time: Option<String>,
+    scheduled_end_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionInvitee {
+    email: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptResult {
+    transcript: Vec<TranscriptChunk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptChunk {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotesGetResult {
+    notes: Vec<NoteDetail>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NoteDetail {
+    notes_plain: Option<String>,
+    notes_markdown: Option<String>,
+    summary_text: Option<String>,
+    summary_markdown: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn companion_note_maps_calendar_fields_for_matching() {
+        let raw = CompanionNoteRaw {
+            id: "11111111-1111-1111-1111-111111111111".to_string(),
+            title: Some("Customer check-in".to_string()),
+            created_at: "2026-05-26T14:00:00Z".to_string(),
+            updated_at: "2026-05-26T15:00:00Z".to_string(),
+            note_type: "meeting".to_string(),
+            status: Some("done".to_string()),
+            calendar_event: Some(CompanionCalendarEvent {
+                event_title: Some("Customer check-in".to_string()),
+                invitees: vec![CompanionInvitee {
+                    email: "user@example.com".to_string(),
+                }],
+                calendar_event_id: Some("cal-123@example.com".to_string()),
+                scheduled_start_time: Some("2026-05-26T14:00:00Z".to_string()),
+                scheduled_end_time: Some("2026-05-26T15:00:00Z".to_string()),
+            }),
+        };
+
+        let note = CompanionNote::try_from_raw(raw).expect("valid note maps");
+        let doc = note.as_match_document();
+
+        assert_eq!(doc.title, "Customer check-in");
+        assert_eq!(
+            doc.google_calendar_event
+                .as_ref()
+                .and_then(|event| event.id.as_deref()),
+            Some("cal-123@example.com")
+        );
+        assert_eq!(doc.attendee_emails, vec!["user@example.com"]);
+    }
+}

--- a/src-tauri/src/granola/mod.rs
+++ b/src-tauri/src/granola/mod.rs
@@ -1,11 +1,11 @@
 //! Granola integration for local cache transcript sync.
 //!
-//! Reads meeting data from Granola's local cache file at
-//! `~/Library/Application Support/Granola/cache-v*.json`.
-//! No API keys or authentication required — purely local file access.
+//! Reads meeting data from Granola's local companion bridge when available,
+//! with a legacy fallback to `~/Library/Application Support/Granola/cache-v*.json`.
 //! The cache filename is auto-detected (highest version number wins).
 
 pub mod cache;
+pub mod companion;
 pub mod matcher;
 pub mod poller;
 
@@ -41,10 +41,11 @@ impl Default for GranolaConfig {
 }
 
 /// Return the Granola Application Support directory.
-fn granola_dir() -> PathBuf {
-    dirs::home_dir()
+pub(crate) fn granola_dir() -> PathBuf {
+    dirs::data_dir()
+        .or_else(dirs::home_dir)
         .unwrap_or_default()
-        .join("Library/Application Support/Granola")
+        .join("Granola")
 }
 
 /// Find the highest-versioned `cache-v*.json` in the Granola directory.
@@ -61,6 +62,28 @@ pub fn detect_cache_path() -> Option<PathBuf> {
             let version = name
                 .strip_prefix("cache-v")?
                 .strip_suffix(".json")?
+                .parse::<u32>()
+                .ok()?;
+            Some((version, e.path()))
+        })
+        .max_by_key(|(v, _)| *v)
+        .map(|(_, path)| path)
+}
+
+/// Find the highest-versioned encrypted `cache-v*.json.enc` in the Granola directory.
+/// DailyOS does not read this directly; it is used to explain why the legacy
+/// plain JSON fallback may be stale while Granola still has current data.
+pub fn detect_encrypted_cache_path() -> Option<PathBuf> {
+    let dir = granola_dir();
+    let entries = std::fs::read_dir(&dir).ok()?;
+
+    entries
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            let version = name
+                .strip_prefix("cache-v")?
+                .strip_suffix(".json.enc")?
                 .parse::<u32>()
                 .ok()?;
             Some((version, e.path()))

--- a/src-tauri/src/granola/poller.rs
+++ b/src-tauri/src/granola/poller.rs
@@ -1,8 +1,9 @@
-//! Granola polling loop — reads local cache file and syncs transcripts.
+//! Granola polling loop — reads Granola companion IPC or local cache and syncs transcripts.
 //!
-//! Runs as a background task. Unlike Quill (which connects to an MCP server),
-//! Granola reads a local JSON file so there's no connection/fetch step.
-//! The state machine is mainly for tracking and retry on AI pipeline failures.
+//! Runs as a background task. The preferred source is Granola's companion IPC
+//! bridge; the legacy plaintext JSON cache remains as a fallback for older
+//! Granola installs. The state machine is mainly for tracking and retry on AI
+//! pipeline failures.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,7 +15,10 @@ use tauri::{AppHandle, Emitter};
 use crate::state::AppState;
 
 use super::cache;
+use super::companion;
 use super::matcher;
+
+const COMPANION_SCAN_DAYS_BACK: i32 = 90;
 
 /// Background loop that polls the Granola cache file for new transcripts.
 ///
@@ -49,21 +53,7 @@ pub async fn run_granola_poller(state: Arc<AppState>, app_handle: AppHandle) {
 
         let poll_interval = Duration::from_secs((config.poll_interval_minutes as u64) * 60);
 
-        // Read and process the cache
-        let cache_path = match super::resolve_cache_path(&config) {
-            Some(p) => p,
-            None => {
-                log::debug!("Granola poller: no cache file found");
-                tokio::select! {
-                    _ = tokio::time::sleep(poll_interval) => {}
-                    _ = state.integrations.granola_poller_wake.notified() => {
-                        log::info!("Granola poller: woken by signal (meeting ended)");
-                    }
-                }
-                continue;
-            }
-        };
-        match poll_once(&state, &app_handle, &cache_path) {
+        match poll_once_prefer_companion(&state, &app_handle, &config) {
             Ok(events) => {
                 // Re-run entity linking with the post-transcript context for
                 // each meeting we successfully ingested. The calendar poller
@@ -104,6 +94,89 @@ pub async fn run_granola_poller(state: Arc<AppState>, app_handle: AppHandle) {
     }
 }
 
+fn poll_once_prefer_companion(
+    state: &AppState,
+    app_handle: &AppHandle,
+    config: &super::GranolaConfig,
+) -> Result<Vec<crate::types::CalendarEvent>, String> {
+    if companion::CompanionClient::status().available {
+        match poll_once_companion(state, app_handle, COMPANION_SCAN_DAYS_BACK) {
+            Ok(events) => return Ok(events),
+            Err(error) => {
+                log::warn!(
+                    "Granola poller: companion source failed, falling back to cache: {}",
+                    error
+                );
+            }
+        }
+    }
+
+    let cache_path = super::resolve_cache_path(config).ok_or_else(|| {
+        let companion_message = companion::CompanionClient::status()
+            .message
+            .unwrap_or_else(|| "Granola companion bridge is unavailable".to_string());
+        if super::detect_encrypted_cache_path().is_some() {
+            format!(
+                "{companion_message}; legacy plaintext cache is unavailable or stale while encrypted cache exists"
+            )
+        } else {
+            format!("{companion_message}; Granola cache file not found")
+        }
+    })?;
+
+    poll_once(state, app_handle, &cache_path)
+}
+
+fn poll_once_companion(
+    state: &AppState,
+    app_handle: &AppHandle,
+    days_back: i32,
+) -> Result<Vec<crate::types::CalendarEvent>, String> {
+    let client = companion::CompanionClient::new().map_err(|e| e.to_string())?;
+    let notes = client
+        .list_recent_notes(days_back)
+        .map_err(|e| e.to_string())?;
+    if notes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let meetings_for_matching =
+        state.with_db(|db| get_recent_meetings_for_matching(db, days_back))?;
+
+    let mut synced = 0;
+    let mut linkable_events = Vec::new();
+
+    for note in &notes {
+        let match_doc = note.as_match_document();
+        let Some(matched) = matcher::match_to_meeting(&match_doc, &meetings_for_matching) else {
+            continue;
+        };
+
+        let doc = match client.fetch_document(note) {
+            Ok(doc) => doc,
+            Err(error) => {
+                log::warn!(
+                    "Granola companion: failed to fetch note content for '{}': {}",
+                    note.title,
+                    error
+                );
+                continue;
+            }
+        };
+
+        if let Some(event) = sync_matched_document(state, app_handle, &doc, &matched)? {
+            synced += 1;
+            linkable_events.push(event);
+        }
+    }
+
+    if synced > 0 {
+        log::info!("Granola companion poller: synced {} documents", synced);
+    }
+
+    Ok(linkable_events)
+}
+
 /// Single poll cycle: read cache, match documents, sync new ones.
 ///
 /// Returns the calendar events for meetings whose transcripts were
@@ -120,11 +193,7 @@ fn poll_once(
     }
 
     // Get recent meetings from DB for matching (last 90 days)
-    let meetings_for_matching = {
-        let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            .map_err(|e| format!("DB open failed: {e}"))?;
-        get_recent_meetings_for_matching(&db, 90)?
-    };
+    let meetings_for_matching = state.with_db(|db| get_recent_meetings_for_matching(db, 90))?;
 
     let mut synced = 0;
     let mut linkable_events: Vec<crate::types::CalendarEvent> = Vec::new();
@@ -137,91 +206,8 @@ fn poll_once(
             None => continue,
         };
 
-        // Resolve sync row for this meeting/source. Unlike the previous behavior
-        // (which skipped any existing row), we must resume non-completed rows so
-        // app restarts don't strand pending Granola transcripts forever.
-        let sync_id = {
-            let db =
-                crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-                    .map_err(|e| format!("DB open failed: {e}"))?;
-
-            match db
-                .get_quill_sync_state_by_source(&matched.meeting_id, "granola")
-                .map_err(|e| e.to_string())?
-            {
-                Some(existing) => {
-                    if !should_process_existing_sync(&existing) {
-                        continue;
-                    }
-
-                    // Reset any stale in-flight/failed row so this poll cycle can resume it.
-                    if existing.state != "pending" {
-                        #[allow(
-                            clippy::let_underscore_must_use,
-                            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                        )]
-                        // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
-                        let _ = crate::quill::sync::transition_state(
-                            &db,
-                            &existing.id,
-                            "pending",
-                            None,
-                            None,
-                            None,
-                            Some("Granola resume/retry"),
-                        );
-                    }
-                    existing.id
-                }
-                None => db
-                    .insert_quill_sync_state_with_source(&matched.meeting_id, "granola")
-                    .map_err(|e| e.to_string())?,
-            }
-        };
-
-        // Process through the shared transcript pipeline
-        let content_kind = match doc.content_type {
-            cache::GranolaContentType::Transcript => {
-                crate::processor::transcript::TranscriptContentKind::Transcript
-            }
-            cache::GranolaContentType::Notes => {
-                crate::processor::transcript::TranscriptContentKind::Notes
-            }
-        };
-        let result = process_granola_document(
-            state,
-            &sync_id,
-            &matched.meeting_id,
-            &doc.content,
-            content_kind,
-        );
-
-        match &result {
-            Ok((dest, _)) => {
-                log::info!(
-                    "Granola sync: processed '{}' → {} ({} chars, {:?})",
-                    doc.title,
-                    dest,
-                    doc.content.len(),
-                    matched.method,
-                );
-                synced += 1;
-            }
-            Err(e) => {
-                log::warn!("Granola sync: processing failed for '{}': {}", doc.title, e);
-            }
-        }
-
-        // Notify frontend with normalized payload (fallback to meeting ID if unavailable).
-        emit_transcript_processed(state, app_handle, &matched.meeting_id);
-
-        if let Ok((_, calendar_event)) = result {
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            let _ =
-                crate::notification::notify_transcript_ready(app_handle, &doc.title, None, state);
+        if let Some(calendar_event) = sync_matched_document(state, app_handle, doc, &matched)? {
+            synced += 1;
             linkable_events.push(calendar_event);
         }
     }
@@ -231,6 +217,133 @@ fn poll_once(
     }
 
     Ok(linkable_events)
+}
+
+fn sync_matched_document(
+    state: &AppState,
+    app_handle: &AppHandle,
+    doc: &cache::GranolaDocument,
+    matched: &matcher::GranolaMatchResult,
+) -> Result<Option<crate::types::CalendarEvent>, String> {
+    let Some(sync_id) = prepare_poll_sync_id(state, &matched.meeting_id)? else {
+        return Ok(None);
+    };
+
+    let content_kind = match doc.content_type {
+        cache::GranolaContentType::Transcript => {
+            crate::processor::transcript::TranscriptContentKind::Transcript
+        }
+        cache::GranolaContentType::Notes => {
+            crate::processor::transcript::TranscriptContentKind::Notes
+        }
+    };
+    let result = process_granola_document(
+        state,
+        &sync_id,
+        &matched.meeting_id,
+        &doc.content,
+        content_kind,
+    );
+
+    match &result {
+        Ok((dest, _)) => {
+            log::info!(
+                "Granola sync: processed '{}' → {} ({} chars, {:?})",
+                doc.title,
+                dest,
+                doc.content.len(),
+                matched.method,
+            );
+        }
+        Err(e) => {
+            log::warn!("Granola sync: processing failed for '{}': {}", doc.title, e);
+        }
+    }
+
+    emit_transcript_processed(state, app_handle, &matched.meeting_id);
+
+    if let Ok((_, calendar_event)) = result {
+        #[allow(
+            clippy::let_underscore_must_use,
+            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+        )]
+        let _ = crate::notification::notify_transcript_ready(app_handle, &doc.title, None, state);
+        return Ok(Some(calendar_event));
+    }
+
+    Ok(None)
+}
+
+fn prepare_poll_sync_id(state: &AppState, meeting_id: &str) -> Result<Option<String>, String> {
+    // Resolve sync row for this meeting/source. Unlike the previous behavior
+    // (which skipped any existing row), we must resume non-completed rows so
+    // app restarts don't strand pending Granola transcripts forever.
+    state.with_db(|db| {
+        match db
+            .get_quill_sync_state_by_source(meeting_id, "granola")
+            .map_err(|e| e.to_string())?
+        {
+            Some(existing) => {
+                if !should_process_existing_sync(&existing) {
+                    return Ok(None);
+                }
+
+                // Reset any stale in-flight/failed row so this poll cycle can resume it.
+                if existing.state != "pending" {
+                    #[allow(
+                        clippy::let_underscore_must_use,
+                        reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                    )]
+                    // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
+                    let _ = crate::quill::sync::transition_state(
+                        db,
+                        &existing.id,
+                        "pending",
+                        None,
+                        None,
+                        None,
+                        Some("Granola resume/retry"),
+                    );
+                }
+                Ok(Some(existing.id))
+            }
+            None => db
+                .insert_quill_sync_state_with_source(meeting_id, "granola")
+                .map(Some)
+                .map_err(|e| e.to_string()),
+        }
+    })
+}
+
+fn prepare_manual_sync_id(state: &AppState, meeting_id: &str) -> Result<String, String> {
+    let meeting_id = meeting_id.to_string();
+    state.with_db(move |db| {
+        match db
+            .get_quill_sync_state_by_source(&meeting_id, "granola")
+            .map_err(|e| e.to_string())?
+        {
+            Some(existing) => {
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                )]
+                // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
+                let _ = crate::quill::sync::transition_state(
+                    db,
+                    &existing.id,
+                    "pending",
+                    None,
+                    None,
+                    None,
+                    Some("Manual sync trigger"),
+                );
+                Ok(existing.id)
+            }
+            None => db
+                .insert_quill_sync_state_with_source(&meeting_id, "granola")
+                .map_err(|e| e.to_string()),
+        }
+    })
 }
 
 /// Process a Granola document through the shared transcript pipeline.
@@ -250,10 +363,7 @@ fn process_granola_document(
     content_kind: crate::processor::transcript::TranscriptContentKind,
 ) -> Result<(String, crate::types::CalendarEvent), String> {
     // Phase 1: Read data with lock, then drop
-    let (calendar_event, workspace, profile, ai_config) = {
-        let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            .map_err(|e| format!("DB open failed: {e}"))?;
-
+    let (calendar_event, workspace, profile, ai_config) = state.with_db(|db| {
         let meeting = db
             .get_meeting_by_id(meeting_id)
             .map_err(|e| e.to_string())?
@@ -263,7 +373,7 @@ fn process_granola_document(
         // Hydrate linked entities + attendees so the processor routes the
         // markdown to the right account dir and emits entity IDs in the
         // YAML frontmatter.
-        crate::processor::transcript::enrich_meeting_from_db(&mut calendar_event, &db);
+        crate::processor::transcript::enrich_meeting_from_db(&mut calendar_event, db);
 
         let (workspace, profile, ai_config) = {
             let config_guard = state.config.read();
@@ -285,7 +395,7 @@ fn process_granola_document(
         )]
         // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
         let _ = crate::quill::sync::transition_state(
-            &db,
+            db,
             sync_id,
             "processing",
             None,
@@ -294,8 +404,8 @@ fn process_granola_document(
             None,
         );
 
-        (calendar_event, workspace, profile, ai_config)
-    }; // DB lock dropped
+        Ok((calendar_event, workspace, profile, ai_config))
+    })?; // DB lock dropped
 
     // Step 2: Run AI pipeline WITHOUT holding the DB mutex
     let result = crate::quill::sync::process_fetched_transcript_without_db_with_kind(
@@ -311,28 +421,25 @@ fn process_granola_document(
     // Phase 3: Re-acquire lock to write results
     match result {
         Ok(tr) => {
-            let db =
-                crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-                    .map_err(|e| format!("DB open failed: {e}"))?;
+            let dest = state.with_db(|db| {
+                let dest = tr.destination.as_deref().unwrap_or("").to_string();
+                let processed_at = chrono::Utc::now().to_rfc3339();
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                )]
+                // dos7-allowed: transcript-db-write - transcript metadata write; not workspace-file ingestion
+                let _ = db.update_meeting_transcript_metadata(
+                    &calendar_event.id,
+                    &dest,
+                    &processed_at,
+                    tr.summary.as_deref(),
+                );
 
-            let dest = tr.destination.as_deref().unwrap_or("");
-            let processed_at = chrono::Utc::now().to_rfc3339();
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            // dos7-allowed: transcript-db-write - transcript metadata write; not workspace-file ingestion
-            let _ = db.update_meeting_transcript_metadata(
-                &calendar_event.id,
-                dest,
-                &processed_at,
-                tr.summary.as_deref(),
-            );
-
-            // Write captures (wins, risks, decisions) extracted by AI
-            let meeting_account_id = resolve_meeting_account_id(&db, &calendar_event.id);
-            let account = calendar_event.account.as_deref();
-            for win in &tr.wins {
+                // Write captures (wins, risks, decisions) extracted by AI
+                let meeting_account_id = resolve_meeting_account_id(db, &calendar_event.id);
+                let account = calendar_event.account.as_deref();
+                for win in &tr.wins {
                 #[allow(
                     clippy::let_underscore_must_use,
                     reason = "intentional best-effort discard; preserves existing non-blocking behavior"
@@ -462,35 +569,40 @@ fn process_granola_document(
                 );
             }
 
-            // Transition sync state to completed
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
-            let _ = crate::quill::sync::transition_state(
-                &db,
-                sync_id,
-                "completed",
-                None,
-                None,
-                Some(dest),
-                None,
-            );
-
-            Ok((dest.to_string(), calendar_event))
-        }
-        Err(error) => {
-            if let Ok(db) =
-                crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            {
+                // Transition sync state to completed
                 #[allow(
                     clippy::let_underscore_must_use,
                     reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                 )]
                 // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
                 let _ = crate::quill::sync::transition_state(
-                    &db,
+                    db,
+                    sync_id,
+                    "completed",
+                    None,
+                    None,
+                    Some(&dest),
+                    None,
+                );
+
+                Ok(dest)
+            })?;
+
+            Ok((dest, calendar_event))
+        }
+        Err(error) => {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = state.with_db(|db| {
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                )]
+                // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
+                let _ = crate::quill::sync::transition_state(
+                    db,
                     sync_id,
                     "failed",
                     None,
@@ -503,8 +615,9 @@ fn process_granola_document(
                     reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                 )]
                 // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
-                let _ = crate::quill::sync::advance_attempt(&db, sync_id);
-            }
+                let _ = crate::quill::sync::advance_attempt(db, sync_id);
+                Ok(())
+            });
             Err(error)
         }
     }
@@ -568,17 +681,20 @@ fn get_recent_meetings_for_matching(
 }
 
 /// Emit transcript-processed event with full MeetingOutcomeData payload when available.
-fn emit_transcript_processed(_state: &AppState, app_handle: &AppHandle, meeting_id: &str) {
-    let payload = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-        .ok()
-        .and_then(|db| {
-            db.get_meeting_by_id(meeting_id)
+fn emit_transcript_processed(state: &AppState, app_handle: &AppHandle, meeting_id: &str) {
+    let meeting_id = meeting_id.to_string();
+    let payload = state
+        .with_db(|db| {
+            Ok(db
+                .get_meeting_by_id(&meeting_id)
                 .ok()
                 .flatten()
                 .and_then(|meeting| {
-                    crate::services::meetings::collect_meeting_outcomes_from_db(&db, &meeting)
-                })
-        });
+                    crate::services::meetings::collect_meeting_outcomes_from_db(db, &meeting)
+                }))
+        })
+        .ok()
+        .flatten();
 
     match payload {
         Some(outcome) => {
@@ -593,7 +709,7 @@ fn emit_transcript_processed(_state: &AppState, app_handle: &AppHandle, meeting_
                 clippy::let_underscore_must_use,
                 reason = "intentional best-effort discard; preserves existing non-blocking behavior"
             )]
-            let _ = app_handle.emit("transcript-processed", &meeting_id.to_string());
+            let _ = app_handle.emit("transcript-processed", &meeting_id);
         }
     }
 }
@@ -607,17 +723,26 @@ pub fn run_granola_backfill(state: &AppState, days_back: i32) -> Result<(usize, 
         .map(|c| c.granola.clone())
         .unwrap_or_default();
 
+    if companion::CompanionClient::status().available {
+        match run_granola_companion_backfill(state, days_back) {
+            Ok(result) => return Ok(result),
+            Err(error) => {
+                log::warn!(
+                    "Granola backfill: companion source failed, falling back to cache: {}",
+                    error
+                );
+            }
+        }
+    }
+
     let cache_path =
         super::resolve_cache_path(&granola_config).ok_or("Granola cache file not found")?;
 
     let documents = cache::read_cache(&cache_path)?;
     let eligible = documents.len();
 
-    let meetings_for_matching = {
-        let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            .map_err(|e| format!("DB open failed: {e}"))?;
-        get_recent_meetings_for_matching(&db, days_back)?
-    };
+    let meetings_for_matching =
+        state.with_db(|db| get_recent_meetings_for_matching(db, days_back))?;
 
     let mut created = 0;
 
@@ -628,30 +753,62 @@ pub fn run_granola_backfill(state: &AppState, days_back: i32) -> Result<(usize, 
             None => continue,
         };
 
-        let already_synced = {
-            let db =
-                crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-                    .map_err(|e| format!("DB open failed: {e}"))?;
-            db.get_quill_sync_state_by_source(&matched.meeting_id, "granola")
-                .map_err(|e| e.to_string())?
-                .is_some()
-        };
-
-        if already_synced {
-            continue;
-        }
-
-        let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            .map_err(|e| format!("DB open failed: {e}"))?;
-        if db
-            .insert_quill_sync_state_with_source(&matched.meeting_id, "granola")
-            .is_ok()
-        {
+        if insert_backfill_sync_state_if_missing(state, &matched.meeting_id)? {
             created += 1;
         }
     }
 
     Ok((created, eligible))
+}
+
+fn run_granola_companion_backfill(
+    state: &AppState,
+    days_back: i32,
+) -> Result<(usize, usize), String> {
+    let client = companion::CompanionClient::new().map_err(|e| e.to_string())?;
+    let notes = client
+        .list_recent_notes(days_back)
+        .map_err(|e| e.to_string())?;
+    let eligible = notes.len();
+
+    let meetings_for_matching =
+        state.with_db(|db| get_recent_meetings_for_matching(db, days_back))?;
+
+    let mut created = 0;
+
+    for note in &notes {
+        let doc = note.as_match_document();
+        let match_result = matcher::match_to_meeting(&doc, &meetings_for_matching);
+        let matched = match match_result {
+            Some(m) => m,
+            None => continue,
+        };
+
+        if insert_backfill_sync_state_if_missing(state, &matched.meeting_id)? {
+            created += 1;
+        }
+    }
+
+    Ok((created, eligible))
+}
+
+fn insert_backfill_sync_state_if_missing(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<bool, String> {
+    let meeting_id = meeting_id.to_string();
+    state.with_db(move |db| {
+        if db
+            .get_quill_sync_state_by_source(&meeting_id, "granola")
+            .map_err(|e| e.to_string())?
+            .is_some()
+        {
+            return Ok(false);
+        }
+        db.insert_quill_sync_state_with_source(&meeting_id, "granola")
+            .map(|_| true)
+            .map_err(|e| e.to_string())
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -689,18 +846,16 @@ pub fn trigger_granola_sync_for_meeting(
         .map(|c| c.granola.clone())
         .unwrap_or_default();
 
-    let cache_path =
-        super::resolve_cache_path(&granola_config).ok_or("Granola cache file not found")?;
-    let documents = cache::read_cache(&cache_path)?;
-
     // Check for existing sync state
     if !force {
-        let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-            .map_err(|e| format!("Database unavailable: {e}"))?;
-        if let Some(existing) = db
-            .get_quill_sync_state_by_source(meeting_id, "granola")
-            .map_err(|e| e.to_string())?
-        {
+        let existing_sync_state = {
+            let meeting_id = meeting_id.to_string();
+            state.with_db(move |db| {
+                db.get_quill_sync_state_by_source(&meeting_id, "granola")
+                    .map_err(|e| e.to_string())
+            })?
+        };
+        if let Some(existing) = existing_sync_state {
             match existing.state.as_str() {
                 "completed" => {
                     return Ok((
@@ -730,12 +885,14 @@ pub fn trigger_granola_sync_for_meeting(
     }
 
     // Get meeting from DB for matching
-    let db = crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-        .map_err(|e| format!("Database unavailable: {e}"))?;
-    let meeting = db
-        .get_meeting_by_id(meeting_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Meeting {} not found", meeting_id))?;
+    let meeting = {
+        let meeting_id = meeting_id.to_string();
+        state.with_db(move |db| {
+            db.get_meeting_by_id(&meeting_id)
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("Meeting {} not found", meeting_id))
+        })?
+    };
 
     let meetings_for_matching = vec![(
         meeting.id.clone(),
@@ -743,36 +900,37 @@ pub fn trigger_granola_sync_for_meeting(
         meeting.start_time.clone(),
     )];
 
+    match trigger_companion_sync_for_meeting(
+        state,
+        app_handle,
+        meeting_id,
+        &meeting,
+        &meetings_for_matching,
+    ) {
+        Ok(Some(result)) => return Ok(result),
+        Ok(None) => {}
+        Err(error) => {
+            log::warn!(
+                "Granola manual sync: companion source failed, falling back to cache: {}",
+                error
+            );
+        }
+    }
+
+    let cache_path = super::resolve_cache_path(&granola_config).ok_or_else(|| {
+        if super::detect_encrypted_cache_path().is_some() {
+            "Granola companion bridge is unavailable and the legacy plaintext cache has no usable data; Granola is writing an encrypted cache that DailyOS does not read directly".to_string()
+        } else {
+            "Granola cache file not found".to_string()
+        }
+    })?;
+    let documents = cache::read_cache(&cache_path)?;
+
     // Try to match a Granola document
     for doc in &documents {
         let match_result = matcher::match_to_meeting(doc, &meetings_for_matching);
         if let Some(matched) = match_result {
-            // Create or update sync state
-            let sync_id = match db
-                .get_quill_sync_state_by_source(&matched.meeting_id, "granola")
-                .map_err(|e| e.to_string())?
-            {
-                Some(existing) => {
-                    #[allow(
-                        clippy::let_underscore_must_use,
-                        reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                    )]
-                    // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
-                    let _ = crate::quill::sync::transition_state(
-                        &db,
-                        &existing.id,
-                        "pending",
-                        None,
-                        None,
-                        None,
-                        Some("Manual sync trigger"),
-                    );
-                    existing.id
-                }
-                None => db
-                    .insert_quill_sync_state_with_source(&matched.meeting_id, "granola")
-                    .map_err(|e| e.to_string())?,
-            };
+            let sync_id = prepare_manual_sync_id(state, &matched.meeting_id)?;
 
             let content_kind = match doc.content_type {
                 cache::GranolaContentType::Transcript => {
@@ -808,12 +966,81 @@ pub fn trigger_granola_sync_for_meeting(
     Ok((
         ManualGranolaSyncResult {
             status: ManualGranolaSyncStatus::NotFound,
-            message: "No matching Granola document found".to_string(),
+            message: no_matching_granola_document_message(&documents),
             document_title: None,
             content_type: None,
         },
         None,
     ))
+}
+
+fn trigger_companion_sync_for_meeting(
+    state: &AppState,
+    app_handle: &AppHandle,
+    meeting_id: &str,
+    meeting: &crate::db::DbMeeting,
+    meetings_for_matching: &[(String, String, String)],
+) -> Result<Option<(ManualGranolaSyncResult, Option<crate::types::CalendarEvent>)>, String> {
+    let client = match companion::CompanionClient::new() {
+        Ok(client) => client,
+        Err(error) if error.is_unavailable() => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    let notes = client
+        .list_notes_near(&meeting.start_time, meeting.end_time.as_deref())
+        .map_err(|e| e.to_string())?;
+
+    for note in &notes {
+        let match_doc = note.as_match_document();
+        let Some(matched) = matcher::match_to_meeting(&match_doc, meetings_for_matching) else {
+            continue;
+        };
+
+        let doc = client.fetch_document(note).map_err(|e| e.to_string())?;
+        let sync_id = prepare_manual_sync_id(state, &matched.meeting_id)?;
+
+        let content_kind = match doc.content_type {
+            cache::GranolaContentType::Transcript => {
+                crate::processor::transcript::TranscriptContentKind::Transcript
+            }
+            cache::GranolaContentType::Notes => {
+                crate::processor::transcript::TranscriptContentKind::Notes
+            }
+        };
+
+        return match process_granola_document(
+            state,
+            &sync_id,
+            meeting_id,
+            &doc.content,
+            content_kind,
+        ) {
+            Ok((_, calendar_event)) => {
+                emit_transcript_processed(state, app_handle, meeting_id);
+                Ok(Some((
+                    ManualGranolaSyncResult {
+                        status: ManualGranolaSyncStatus::Attached,
+                        message: "Transcript synced successfully".to_string(),
+                        document_title: Some(doc.title),
+                        content_type: Some(doc.content_type),
+                    },
+                    Some(calendar_event),
+                )))
+            }
+            Err(e) => Err(format!("Granola sync failed: {}", e)),
+        };
+    }
+
+    Ok(None)
+}
+
+fn no_matching_granola_document_message(documents: &[cache::GranolaDocument]) -> String {
+    if documents.is_empty() && super::detect_encrypted_cache_path().is_some() {
+        "No matching Granola document found. Granola's plaintext cache is empty while an encrypted cache exists; enable Granola companion access so DailyOS can read current notes.".to_string()
+    } else {
+        "No matching Granola document found".to_string()
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/intel_queue.rs
+++ b/src-tauri/src/intel_queue.rs
@@ -535,7 +535,7 @@ pub struct IntelligenceUpdatedPayload {
 
 /// Progressive enrichment progress event payload.
 ///
-/// Emitted after each dimension completes and is written to DB,
+/// Emitted after each dimension completes and the UI cache is updated,
 /// so the frontend can show incremental progress and refresh data.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -752,6 +752,11 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
         // Dev mode isolation: pause background processing while dev sandbox is active
         if crate::db::is_dev_db_mode() {
             continue;
+        }
+
+        if state.is_database_recovery_required() {
+            log::warn!("IntelProcessor: stopped because database recovery is required");
+            break;
         }
 
         // skip processing entirely while a schema-epoch migration
@@ -1154,7 +1159,6 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     continue;
                 }
             };
-            let ctx = state.live_service_context();
             let prepared = match compose_enrichment_intelligence(
                 &state,
                 &db,
@@ -1182,22 +1186,14 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     continue;
                 }
             };
-            if let Err(e) = db.with_transaction(|tx| {
-                apply_enrichment_side_writes(&ctx, tx, input, &prepared)?;
-                crate::services::intelligence::upsert_assessment_from_enrichment_in_active_transaction(
-                    &ctx,
-                    tx,
-                    &state.signals.engine,
-                    crate::services::intelligence::EnrichmentAssessmentUpsert {
-                        entity_type: &input.entity_type,
-                        entity_id: &input.entity_id,
-                        intel: prepared.intelligence(),
-                        projection_intel: prepared.projection_intelligence(),
-                        projection_data_source: parsed.producer.projection_data_source(),
-                        cleared_dimensions: prepared.cleared_dimensions(),
-                    },
-                )
-            }) {
+            if let Err(e) = persist_enrichment_write_results_via_db_service(
+                &state,
+                input,
+                &prepared,
+                parsed.producer,
+            )
+            .await
+            {
                 finalization_failures.push(QueueRefreshFailure::new(
                     &request.entity_id,
                     "write_results",
@@ -1211,9 +1207,8 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                 continue;
             }
             let written_intel = prepared.into_intelligence();
-            if let Err(e) = run_enrichment_finalize_post_commit(
+            if let Err(e) = run_enrichment_finalize_post_commit_via_db_service(
                 &state,
-                &db,
                 input,
                 &written_intel,
                 &parsed.inferred_relationships,
@@ -1221,7 +1216,9 @@ pub async fn run_intel_processor(state: Arc<AppState>, app: AppHandle) {
                     is_background: is_background_priority(request.priority),
                     producer: parsed.producer,
                 },
-            ) {
+            )
+            .await
+            {
                 finalization_failures.push(QueueRefreshFailure::new(
                     &request.entity_id,
                     "finalize",
@@ -1945,28 +1942,29 @@ fn run_parallel_enrichment(
                     all_raw_output.push_str(&raw_output);
                     all_raw_output.push('\n');
 
-                    // Per-dimension DB write + event emission
+                    // Per-dimension UI cache write + event emission
                     if let Some(handle) = app_handle {
-                        write_progressive_dimension(
+                        if write_progressive_dimension(
                             &input.entity_id,
                             &input.entity_type,
                             input.relationship.as_deref(),
                             &combined,
-                        );
-                        #[allow(
-                            clippy::let_underscore_must_use,
-                            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                        )]
-                        let _ = handle.emit(
-                            "enrichment-progress",
-                            EnrichmentProgress {
-                                entity_id: input.entity_id.clone(),
-                                entity_type: input.entity_type.clone(),
-                                completed: succeeded,
-                                total: total_dimensions,
-                                last_dimension: dim_name,
-                            },
-                        );
+                        ) {
+                            #[allow(
+                                clippy::let_underscore_must_use,
+                                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                            )]
+                            let _ = handle.emit(
+                                "enrichment-progress",
+                                EnrichmentProgress {
+                                    entity_id: input.entity_id.clone(),
+                                    entity_type: input.entity_type.clone(),
+                                    completed: succeeded,
+                                    total: total_dimensions,
+                                    last_dimension: dim_name,
+                                },
+                            );
+                        }
                     }
                 }
             }
@@ -2072,17 +2070,17 @@ fn run_parallel_enrichment(
     })
 }
 
-/// Write the current progressive state of intelligence to DB after a dimension completes.
+/// Write the current progressive state of intelligence to the UI cache after a dimension completes.
 ///
 /// Opens a short-lived DB connection, reads existing entity_assessment, merges the
-/// new combined state, and writes back. Non-fatal on error — the committed
+/// new combined state, and writes back. Non-fatal on error -- the committed
 /// enrichment persistence path is the authoritative write.
 fn write_progressive_dimension(
     entity_id: &str,
     entity_type: &str,
     relationship: Option<&str>,
     combined: &IntelligenceJson,
-) {
+) -> bool {
     let db = match crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())) {
         Ok(db) => db,
         Err(e) => {
@@ -2091,7 +2089,7 @@ fn write_progressive_dimension(
                 entity_id,
                 e
             );
-            return;
+            return false;
         }
     };
 
@@ -2102,10 +2100,14 @@ fn write_progressive_dimension(
     let rng = crate::services::context::SystemRng;
     let ext = crate::services::context::ExternalClients::default();
     let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-    if let Err(e) = crate::services::intelligence::upsert_assessment_snapshot(&ctx, &db, &merged) {
+    if let Err(e) =
+        crate::services::intelligence::upsert_progressive_assessment_snapshot(&ctx, &db, &merged)
+    {
         log::warn!("[I575] Progressive write failed for {}: {}", entity_id, e);
+        false
     } else {
         log::debug!("[I575] Progressive write succeeded for {}", entity_id,);
+        true
     }
 }
 
@@ -2706,6 +2708,422 @@ pub fn apply_enrichment_side_writes(
     Ok(())
 }
 
+pub(crate) async fn persist_enrichment_write_results_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    prepared: &PreparedEnrichment,
+    producer: EnrichmentProducer,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let input_for_write = input.clone();
+    let prepared_for_write = prepared.clone();
+    state
+        .db_write(move |db| {
+            let engine = Arc::clone(&state_for_write.signals.engine);
+            let ctx = state_for_write.live_service_context();
+            db.with_transaction(|tx| {
+                apply_enrichment_side_writes(&ctx, tx, &input_for_write, &prepared_for_write)?;
+                crate::services::intelligence::upsert_assessment_from_enrichment_in_active_transaction(
+                    &ctx,
+                    tx,
+                    &engine,
+                    crate::services::intelligence::EnrichmentAssessmentUpsert {
+                        entity_type: &input_for_write.entity_type,
+                        entity_id: &input_for_write.entity_id,
+                        intel: prepared_for_write.intelligence(),
+                        projection_intel: prepared_for_write.projection_intelligence(),
+                        projection_data_source: producer.projection_data_source(),
+                        cleared_dimensions: prepared_for_write.cleared_dimensions(),
+                    },
+                )
+            })
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+pub(crate) async fn run_enrichment_finalize_post_commit_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    intel: &IntelligenceJson,
+    inferred_relationships: &[InferredRelationship],
+    mode: FinalizeMode,
+) -> Result<(), String> {
+    let side_effect_producer = match mode {
+        FinalizeMode::QueueWorker { producer, .. } | FinalizeMode::ManualRefresh { producer } => {
+            producer
+        }
+        FinalizeMode::TrustRecompute => EnrichmentProducer::Pty,
+    };
+    let materialize_visible_side_effects_before_export =
+        !matches!(mode, FinalizeMode::TrustRecompute);
+
+    if materialize_visible_side_effects_before_export {
+        run_enrichment_post_commit_side_effects_via_db_service(
+            state,
+            input,
+            intel,
+            side_effect_producer,
+        )
+        .await?;
+    }
+
+    match mode {
+        FinalizeMode::QueueWorker {
+            is_background,
+            producer,
+        } => {
+            if producer.is_glean() {
+                run_shared_glean_finalization_via_db_service(state, input, intel).await?;
+                spawn_queue_worker_supplemental_glean_finalize(state, input, is_background);
+            }
+        }
+        FinalizeMode::TrustRecompute => {
+            run_finalize_trust_recompute_via_db_service(state, input).await?;
+        }
+        FinalizeMode::ManualRefresh { producer } => {
+            if producer.is_glean() {
+                run_shared_glean_finalization_via_db_service(state, input, intel).await?;
+            }
+        }
+    }
+
+    fenced_write_enrichment_intelligence_via_db_service(state, input, intel).await?;
+
+    if !materialize_visible_side_effects_before_export {
+        run_enrichment_post_commit_side_effects_via_db_service(
+            state,
+            input,
+            intel,
+            side_effect_producer,
+        )
+        .await?;
+    }
+
+    if !inferred_relationships.is_empty() {
+        upsert_inferred_relationships_via_db_service(state, input, inferred_relationships).await?;
+    }
+
+    if matches!(mode, FinalizeMode::QueueWorker { .. }) {
+        if let Some(app) = state.app_handle() {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = app.emit(
+                "intelligence-updated",
+                IntelligenceUpdatedPayload {
+                    entity_id: input.entity_id.clone(),
+                    entity_type: input.entity_type.clone(),
+                },
+            );
+        }
+    }
+
+    invalidate_and_requeue_meeting_preps_via_db_service(state, &input.entity_id).await?;
+    record_enrichment_success_via_db_service(state, &input.entity_id).await?;
+
+    if matches!(mode, FinalizeMode::QueueWorker { .. }) {
+        on_enrichment_complete_via_db_service(state, input).await?;
+    }
+
+    Ok(())
+}
+
+async fn run_enrichment_post_commit_side_effects_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    intel: &IntelligenceJson,
+    producer: EnrichmentProducer,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let input_for_write = input.clone();
+    let intel_for_write = intel.clone();
+    let side_effect_producer = producer.side_effect_producer();
+    state
+        .db_write(move |db| {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = crate::reports::invalidation::mark_reports_stale(
+                db,
+                &input_for_write.entity_id,
+            );
+
+            if input_for_write.entity_type == "account" {
+                let ctx = state_for_write.live_service_context();
+                if let Err(error) =
+                    crate::services::enrichment_side_effects::sync_account_enrichment_side_effects_for_producer(
+                        &ctx,
+                        db,
+                        state_for_write.signals.engine.as_ref(),
+                        &input_for_write.entity_id,
+                        &intel_for_write,
+                        side_effect_producer,
+                    )
+                {
+                    log::warn!(
+                        "IntelProcessor: enrichment side-effect sync failed for {}: {}",
+                        input_for_write.entity_id,
+                        error
+                    );
+                    if producer.is_glean() {
+                        return Err(format!(
+                            "{} enrichment side-effect sync failed for {}: {}",
+                            producer.materialization_label(),
+                            input_for_write.entity_id,
+                            error
+                        ));
+                    }
+                }
+            }
+
+            Ok(())
+        })
+        .await
+        .map_err(String::from)?;
+
+    if input.entity_type == "person" {
+        regenerate_person_files_via_db_service(state, input).await?;
+    }
+
+    enqueue_parent_refresh_after_child_update(state, input).await?;
+
+    log::debug!(
+        "IntelProcessor: wrote intelligence for {} to DB + post-commit file cache",
+        input.entity_id,
+    );
+    Ok(())
+}
+
+async fn regenerate_person_files_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+) -> Result<(), String> {
+    let workspace = input.workspace.clone();
+    let entity_id = input.entity_id.clone();
+    state
+        .db_read(move |db| {
+            if let Ok(Some(person)) = db.get_person(&entity_id) {
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                )]
+                let _ = crate::people::write_person_markdown(&workspace, &person, db);
+                #[allow(
+                    clippy::let_underscore_must_use,
+                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                )]
+                let _ = crate::people::write_person_dashboard_json(&workspace, &person, db);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn enqueue_parent_refresh_after_child_update(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+) -> Result<(), String> {
+    let entity_type = input.entity_type.clone();
+    let entity_id = input.entity_id.clone();
+    let parent_id = state
+        .db_read(move |db| {
+            if entity_type == "account" {
+                Ok(db
+                    .get_account(&entity_id)
+                    .ok()
+                    .flatten()
+                    .and_then(|account| account.parent_id))
+            } else if entity_type == "project" {
+                Ok(db
+                    .get_project(&entity_id)
+                    .ok()
+                    .flatten()
+                    .and_then(|project| project.parent_id))
+            } else {
+                Ok(None)
+            }
+        })
+        .await
+        .map_err(String::from)?;
+
+    if let Some(parent_id) = parent_id {
+        let entity_type = input.entity_type.clone();
+        let priority = IntelPriority::ContentChange;
+        #[allow(
+            clippy::let_underscore_must_use,
+            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+        )]
+        let _ = state.intel_queue.enqueue(IntelRequest {
+            entity_id: parent_id.clone(),
+            entity_type: entity_type.clone(),
+            priority,
+            requested_at: std::time::Instant::now(),
+            retry_count: 0,
+        });
+        state.integrations.intel_queue_wake.notify_one();
+        log::info!(
+            "IntelProcessor: enqueued parent {} for portfolio refresh after child {} update",
+            parent_id,
+            input.entity_id,
+        );
+    }
+
+    Ok(())
+}
+
+async fn run_shared_glean_finalization_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    intel: &IntelligenceJson,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let input_for_write = input.clone();
+    let intel_for_write = intel.clone();
+    state
+        .db_write(move |db| {
+            run_shared_glean_finalization(
+                state_for_write.as_ref(),
+                db,
+                &input_for_write,
+                &intel_for_write,
+            )
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn run_finalize_trust_recompute_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let input_for_write = input.clone();
+    state
+        .db_write(move |db| {
+            run_finalize_trust_recompute(state_for_write.as_ref(), db, &input_for_write)
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn fenced_write_enrichment_intelligence_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    intel: &IntelligenceJson,
+) -> Result<(), String> {
+    let entity_dir = input.entity_dir.clone();
+    let intel_for_write = intel.clone();
+    let entity_context = format!("entity={} source=ai_enrichment", intel.entity_id);
+    state
+        .db_write(move |db| {
+            crate::intelligence::write_fence::post_commit_fenced_write(
+                db,
+                &entity_dir,
+                &intel_for_write,
+                &entity_context,
+            );
+            Ok(())
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn upsert_inferred_relationships_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+    inferred_relationships: &[InferredRelationship],
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let entity_type = input.entity_type.clone();
+    let entity_id = input.entity_id.clone();
+    let inferred_for_write = inferred_relationships.to_vec();
+    state
+        .db_write(move |db| {
+            let ctx = state_for_write.live_service_context();
+            crate::services::intelligence::upsert_inferred_relationships_from_enrichment(
+                &ctx,
+                db,
+                state_for_write.signals.engine.as_ref(),
+                &entity_type,
+                &entity_id,
+                &inferred_for_write,
+            )
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+async fn invalidate_and_requeue_meeting_preps_via_db_service(
+    state: &Arc<AppState>,
+    entity_id: &str,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let entity_id_for_write = entity_id.to_string();
+    state
+        .db_write(move |db| {
+            invalidate_and_requeue_meeting_preps_with_db(
+                state_for_write.as_ref(),
+                db,
+                &entity_id_for_write,
+            );
+            Ok(())
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn record_enrichment_success_via_db_service(
+    state: &Arc<AppState>,
+    entity_id: &str,
+) -> Result<(), String> {
+    let entity_id_for_write = entity_id.to_string();
+    state
+        .db_write(move |db| {
+            crate::self_healing::feedback::record_enrichment_success(db, &entity_id_for_write);
+            Ok(())
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn on_enrichment_complete_via_db_service(
+    state: &Arc<AppState>,
+    input: &EnrichmentInput,
+) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    let entity_id = input.entity_id.clone();
+    let entity_type = input.entity_type.clone();
+    state
+        .db_write(move |db| {
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = crate::self_healing::scheduler::on_enrichment_complete(
+                db,
+                Some(state_for_write.embedding_model.as_ref()),
+                &entity_id,
+                &entity_type,
+                &state_for_write.intel_queue,
+                Some(state_for_write.signals.engine.as_ref()),
+            );
+            #[allow(
+                clippy::let_underscore_must_use,
+                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+            )]
+            let _ = crate::connectivity::record_sync_success(db.conn_ref(), "claude_code");
+            Ok(())
+        })
+        .await
+        .map_err(String::from)
+}
+
 fn apply_enrichment_stakeholder_side_writes(
     db: &crate::db::ActionDb,
     input: &EnrichmentInput,
@@ -3277,18 +3695,28 @@ fn spawn_queue_worker_supplemental_glean_finalize(
             .await
         {
             Ok(signals) => {
-                if let Ok(db) =
-                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
+                let state_for_write = std::sync::Arc::clone(&state_for_spawn);
+                let engine_for_write = std::sync::Arc::clone(&engine);
+                let entity_type_for_write = entity_type.clone();
+                let entity_id_for_write = entity_id.clone();
+                match state_for_spawn
+                    .db_write(move |db| {
+                        let ctx = state_for_write.live_service_context();
+                        crate::services::intelligence::upsert_health_outlook_signals(
+                            &ctx,
+                            db,
+                            &engine_for_write,
+                            &entity_type_for_write,
+                            &entity_id_for_write,
+                            &signals,
+                        )
+                    })
+                    .await
                 {
-                    let ctx = state_for_spawn.live_service_context();
-                    if let Err(e) = crate::services::intelligence::upsert_health_outlook_signals(
-                        &ctx,
-                        &db,
-                        &engine,
-                        &entity_type,
-                        &entity_id,
-                        &signals,
-                    ) {
+                    Ok(()) => {
+                        log::info!("[DOS-15] Leading signals persisted for {}", entity_id);
+                    }
+                    Err(e) => {
                         log::warn!(
                             "[DOS-15] upsert_health_outlook_signals failed for {}: {}",
                             entity_id,
@@ -3304,8 +3732,6 @@ fn spawn_queue_worker_supplemental_glean_finalize(
                             ls_start.elapsed().as_millis() as u64,
                             is_background,
                         );
-                    } else {
-                        log::info!("[DOS-15] Leading signals persisted for {}", entity_id);
                     }
                 }
             }
@@ -3332,43 +3758,44 @@ fn spawn_queue_worker_supplemental_glean_finalize(
         // failures leave peer_benchmark unset without user-visible noise.
         match provider.enrich_peer_benchmark(&entity_name).await {
             Ok(peer_benchmark) => {
-                if let Ok(db) =
-                    crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-                {
-                    match db.get_entity_intelligence(&entity_id) {
-                        Ok(Some(mut current)) => {
-                            let ctx = state_for_spawn.live_service_context();
-                            let outlook = current
-                                .agreement_outlook
-                                .get_or_insert_with(Default::default);
-                            outlook.peer_benchmark = Some(peer_benchmark);
-                            if let Err(e) =
+                let state_for_write = std::sync::Arc::clone(&state_for_spawn);
+                let entity_id_for_write = entity_id.clone();
+                match state_for_spawn
+                    .db_write(move |db| {
+                        match db
+                            .get_entity_intelligence(&entity_id_for_write)
+                            .map_err(|e| format!("reading assessment failed: {e}"))?
+                        {
+                            Some(mut current) => {
+                                let ctx = state_for_write.live_service_context();
+                                let outlook = current
+                                    .agreement_outlook
+                                    .get_or_insert_with(Default::default);
+                                outlook.peer_benchmark = Some(peer_benchmark);
                                 crate::services::intelligence::upsert_assessment_snapshot(
-                                    &ctx, &db, &current,
+                                    &ctx, db, &current,
                                 )
-                            {
-                                log::warn!(
-                                    "[DOS-204] Persisting peer_benchmark failed for {}: {}",
-                                    entity_id,
-                                    e
-                                );
-                            } else {
-                                log::info!("[DOS-204] Peer benchmark persisted for {}", entity_id);
+                                .map_err(|e| format!("persisting peer_benchmark failed: {e}"))?;
+                                Ok(true)
                             }
+                            None => Ok(false),
                         }
-                        Ok(None) => {
-                            log::debug!(
-                                "[DOS-204] No assessment row for {}; skipping peer_benchmark write",
-                                entity_id
-                            );
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "[DOS-204] Reading assessment for {} failed: {}",
-                                entity_id,
-                                e
-                            );
-                        }
+                    })
+                    .await
+                {
+                    Ok(true) => log::info!("[DOS-204] Peer benchmark persisted for {}", entity_id),
+                    Ok(false) => {
+                        log::debug!(
+                            "[DOS-204] No assessment row for {}; skipping peer_benchmark write",
+                            entity_id
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[DOS-204] Peer benchmark persistence failed for {}: {}",
+                            entity_id,
+                            e
+                        );
                     }
                 }
             }

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -405,28 +405,29 @@ impl GleanIntelligenceProvider {
                             }
                         }
 
-                        // Progressive DB write + event emission
+                        // Progressive UI cache write + event emission
                         if let Some(handle) = app_handle {
-                            write_progressive_glean_dimension(
+                            if write_progressive_glean_dimension(
                                 entity_id,
                                 entity_type,
                                 relationship,
                                 &combined,
-                            );
-                            #[allow(
-                                clippy::let_underscore_must_use,
-                                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                            )]
-                            let _ = handle.emit(
-                                "enrichment-progress",
-                                EnrichmentProgress {
-                                    entity_id: entity_id.to_string(),
-                                    entity_type: entity_type.to_string(),
-                                    completed: succeeded,
-                                    total: total_dimensions,
-                                    last_dimension: dim_name,
-                                },
-                            );
+                            ) {
+                                #[allow(
+                                    clippy::let_underscore_must_use,
+                                    reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                                )]
+                                let _ = handle.emit(
+                                    "enrichment-progress",
+                                    EnrichmentProgress {
+                                        entity_id: entity_id.to_string(),
+                                        entity_type: entity_type.to_string(),
+                                        completed: succeeded,
+                                        total: total_dimensions,
+                                        last_dimension: dim_name,
+                                    },
+                                );
+                            }
                         }
                     }
                 }
@@ -1075,7 +1076,7 @@ fn extract_domains_for_glean_enrichment(_intel: &mut IntelligenceJson) {
     // This hook is in place for easy future enhancement.
 }
 
-/// Write progressive dimension state to DB during Glean parallel enrichment.
+/// Write progressive dimension state to the UI cache during Glean parallel enrichment.
 ///
 /// Similar to `write_progressive_dimension` in `intel_queue.rs` but for the Glean path.
 /// Non-fatal on error — the final merge+write after all dimensions is authoritative.
@@ -1084,7 +1085,7 @@ fn write_progressive_glean_dimension(
     entity_type: &str,
     relationship: Option<&str>,
     combined: &IntelligenceJson,
-) {
+) -> bool {
     let db = match crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())) {
         Ok(db) => db,
         Err(e) => {
@@ -1093,7 +1094,7 @@ fn write_progressive_glean_dimension(
                 entity_id,
                 e
             );
-            return;
+            return false;
         }
     };
 
@@ -1109,14 +1110,18 @@ fn write_progressive_glean_dimension(
     let rng = crate::services::context::SystemRng;
     let ext = crate::services::context::ExternalClients::default();
     let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-    if let Err(e) = crate::services::intelligence::upsert_assessment_snapshot(&ctx, &db, &merged) {
+    if let Err(e) =
+        crate::services::intelligence::upsert_progressive_assessment_snapshot(&ctx, &db, &merged)
+    {
         log::warn!(
             "[I575] Glean progressive write failed for {}: {}",
             entity_id,
             e
         );
+        false
     } else {
         log::debug!("[I575] Glean progressive write succeeded for {}", entity_id,);
+        true
     }
 }
 
@@ -1661,36 +1666,38 @@ pub fn upsert_products_to_db(
     account_id: &str,
     products: Vec<(String, Option<String>, Option<f64>, Option<String>)>,
 ) -> Result<usize, String> {
-    let mut count = 0;
-    for (product_type, tier, arr, billing_terms) in products {
-        match db.upsert_product_classification(
-            account_id,
-            &product_type,
-            tier.as_deref(),
-            arr,
-            billing_terms.as_deref(),
-            "Salesforce",
-        ) {
-            Ok(_) => {
-                count += 1;
-                log::info!(
-                    "I651: Upserted product {} ({:?} tier, ${:?} ARR) for {}",
-                    product_type,
-                    tier,
-                    arr,
-                    account_id
-                );
-            }
-            Err(e) => {
-                log::warn!(
-                    "I651: Failed to upsert product {} for {}: {}",
-                    product_type,
-                    account_id,
-                    e
-                );
-                return Err(format!("Product upsert failed for {}: {}", product_type, e));
+    db.with_transaction(|tx| {
+        let mut count = 0;
+        for (product_type, tier, arr, billing_terms) in products {
+            match tx.upsert_product_classification(
+                account_id,
+                &product_type,
+                tier.as_deref(),
+                arr,
+                billing_terms.as_deref(),
+                "Salesforce",
+            ) {
+                Ok(_) => {
+                    count += 1;
+                    log::info!(
+                        "I651: Upserted product {} ({:?} tier, ${:?} ARR) for {}",
+                        product_type,
+                        tier,
+                        arr,
+                        account_id
+                    );
+                }
+                Err(e) => {
+                    log::warn!(
+                        "I651: Failed to upsert product {} for {}: {}",
+                        product_type,
+                        account_id,
+                        e
+                    );
+                    return Err(format!("Product upsert failed for {}: {}", product_type, e));
+                }
             }
         }
-    }
-    Ok(count)
+        Ok(count)
+    })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -136,6 +136,19 @@ use tokio::sync::mpsc;
 const SCHEDULER_CHANNEL_SIZE: usize = 32;
 const RUNTIME_EVIDENCE_BACKFILL_INITIAL_DELAY_MS: u64 = 10_000;
 const RUNTIME_EVIDENCE_BACKFILL_SLICE_PAUSE_MS: u64 = 15_000;
+const RUNTIME_EVIDENCE_BACKFILL_MAINTENANCE_ENV: &str = "DAILYOS_RUN_RUNTIME_EVIDENCE_BACKFILL";
+
+fn env_flag_enabled(key: &str) -> bool {
+    std::env::var(key)
+        .map(|value| {
+            let value = value.trim();
+            !value.is_empty()
+                && !value.eq_ignore_ascii_case("0")
+                && !value.eq_ignore_ascii_case("false")
+                && !value.eq_ignore_ascii_case("no")
+        })
+        .unwrap_or(false)
+}
 
 async fn run_runtime_evidence_backfill_slice(init_state: &Arc<AppState>) -> bool {
     let runtime_evidence_backfill = init_state
@@ -220,8 +233,73 @@ async fn run_runtime_evidence_backfill_slice(init_state: &Arc<AppState>) -> bool
     }
 }
 
+async fn runtime_evidence_backfill_266_resume_pending(init_state: &Arc<AppState>) -> bool {
+    let result = init_state
+        .db_read(
+            crate::services::runtime_evidence_backfill::runtime_evidence_backfill_266_resume_pending,
+        )
+        .await;
+
+    match result {
+        Ok(pending) => pending,
+        Err(error) => {
+            init_state
+                .recover_db_service_after_access_error(
+                    &error,
+                    "Runtime evidence backfill startup probe",
+                )
+                .await;
+            log::warn!("[runtime_evidence_backfill] startup probe failed: {error}");
+            false
+        }
+    }
+}
+
+async fn maybe_spawn_runtime_evidence_backfill(
+    init_state: &Arc<AppState>,
+    background_workers_disabled: bool,
+) {
+    let maintenance_requested = env_flag_enabled(RUNTIME_EVIDENCE_BACKFILL_MAINTENANCE_ENV);
+    let resume_pending = runtime_evidence_backfill_266_resume_pending(init_state).await;
+
+    if resume_pending && !maintenance_requested {
+        log::warn!(
+            "[runtime_evidence_backfill] deferred in-progress v266 resume; set {RUNTIME_EVIDENCE_BACKFILL_MAINTENANCE_ENV}=1 with background workers disabled to run it"
+        );
+        return;
+    }
+
+    if maintenance_requested && !background_workers_disabled {
+        log::warn!(
+            "[runtime_evidence_backfill] maintenance run requires background workers disabled; deferred"
+        );
+        return;
+    }
+
+    if background_workers_disabled && !maintenance_requested {
+        return;
+    }
+
+    let runtime_backfill_state = init_state.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(
+            RUNTIME_EVIDENCE_BACKFILL_INITIAL_DELAY_MS,
+        ))
+        .await;
+        while run_runtime_evidence_backfill_slice(&runtime_backfill_state).await {
+            tokio::time::sleep(std::time::Duration::from_millis(
+                RUNTIME_EVIDENCE_BACKFILL_SLICE_PAUSE_MS,
+            ))
+            .await;
+        }
+    });
+}
+
 async fn run_db_service_startup_tasks(init_state: Arc<AppState>) {
-    if crate::pty::background_workers_disabled() {
+    let background_workers_disabled = crate::pty::background_workers_disabled();
+    maybe_spawn_runtime_evidence_backfill(&init_state, background_workers_disabled).await;
+
+    if background_workers_disabled {
         log::info!(
             "Startup background maintenance skipped because background workers are disabled"
         );
@@ -312,19 +390,6 @@ async fn run_db_service_startup_tasks(init_state: Arc<AppState>) {
         }
     }
 
-    let runtime_backfill_state = init_state.clone();
-    tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(
-            RUNTIME_EVIDENCE_BACKFILL_INITIAL_DELAY_MS,
-        ))
-        .await;
-        while run_runtime_evidence_backfill_slice(&runtime_backfill_state).await {
-            tokio::time::sleep(std::time::Duration::from_millis(
-                RUNTIME_EVIDENCE_BACKFILL_SLICE_PAUSE_MS,
-            ))
-            .await;
-        }
-    });
     crate::services::invalidation_jobs::drain_pending_claim_recomputes(&init_state).await;
     crate::services::invalidation_jobs::drain_pending_targeted_claim_repairs(&init_state).await;
     let repair_worker_state = init_state.clone();

--- a/src-tauri/src/linear/poller.rs
+++ b/src-tauri/src/linear/poller.rs
@@ -47,7 +47,7 @@ pub async fn run_linear_poller(state: Arc<AppState>) {
         match client.fetch_my_issues().await {
             Ok(issues) => {
                 let count = issues.len();
-                if let Err(e) = crate::linear::sync::upsert_issues(&state, &issues) {
+                if let Err(e) = crate::linear::sync::upsert_issues(&state, issues).await {
                     log::warn!("Linear poller: issue sync failed: {}", e);
                 } else {
                     log::info!("Linear poller: synced {} issues", count);
@@ -60,7 +60,7 @@ pub async fn run_linear_poller(state: Arc<AppState>) {
         match client.fetch_my_projects().await {
             Ok(projects) => {
                 let count = projects.len();
-                if let Err(e) = crate::linear::sync::upsert_projects(&state, &projects) {
+                if let Err(e) = crate::linear::sync::upsert_projects(&state, projects).await {
                     log::warn!("Linear poller: project sync failed: {}", e);
                 } else {
                     log::info!("Linear poller: synced {} projects", count);

--- a/src-tauri/src/linear/sync.rs
+++ b/src-tauri/src/linear/sync.rs
@@ -3,18 +3,29 @@
 use crate::db::ActionDb;
 use crate::linear::client::{LinearIssue, LinearProject};
 use crate::state::AppState;
+use std::sync::Arc;
 
 /// Upsert Linear issues into the database and emit signals for state changes.
-pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), String> {
-    let db = ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-        .map_err(|e| format!("DB open failed: {e}"))?;
+pub async fn upsert_issues(state: &Arc<AppState>, issues: Vec<LinearIssue>) -> Result<(), String> {
+    let state_for_write = Arc::clone(state);
+    state
+        .db_write(move |db| upsert_issues_in_db(state_for_write.as_ref(), db, &issues))
+        .await
+        .map_err(String::from)
+}
+
+fn upsert_issues_in_db(
+    state: &AppState,
+    db: &ActionDb,
+    issues: &[LinearIssue],
+) -> Result<(), String> {
     let conn = db.conn_ref();
     let signal_ctx = state.live_service_context().with_actor("linear_sync");
 
     for issue in issues {
         // Capture old state for signal comparison
         let previous =
-            crate::services::linear_issue_signals::PreviousLinearIssueState::load(&db, &issue.id)
+            crate::services::linear_issue_signals::PreviousLinearIssueState::load(db, &issue.id)
                 .unwrap_or(None);
         let synced_at = chrono::Utc::now().to_rfc3339();
 
@@ -46,7 +57,7 @@ pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), Str
 
         crate::services::linear_issue_signals::emit_issue_change_signals(
             &signal_ctx,
-            &db,
+            db,
             &state.signals.engine,
             issue,
             previous.as_ref(),
@@ -80,7 +91,7 @@ pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), Str
                     reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                 )]
                 let _ = crate::signals::bus::emit_signal_and_propagate(
-                    &db,
+                    db,
                     &state.signals.engine,
                     entity_type,
                     entity_id,
@@ -99,7 +110,7 @@ pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), Str
                         reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                     )]
                     let _ = crate::signals::bus::emit_signal_and_propagate(
-                        &db,
+                        db,
                         &state.signals.engine,
                         entity_type,
                         entity_id,
@@ -124,7 +135,7 @@ pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), Str
                         reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                     )]
                     let _ = crate::signals::bus::emit_signal_and_propagate(
-                        &db,
+                        db,
                         &state.signals.engine,
                         entity_type,
                         entity_id,
@@ -142,9 +153,17 @@ pub fn upsert_issues(state: &AppState, issues: &[LinearIssue]) -> Result<(), Str
 }
 
 /// Upsert Linear projects into the database.
-pub fn upsert_projects(_state: &AppState, projects: &[LinearProject]) -> Result<(), String> {
-    let db = ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-        .map_err(|e| format!("DB open failed: {e}"))?;
+pub async fn upsert_projects(
+    state: &Arc<AppState>,
+    projects: Vec<LinearProject>,
+) -> Result<(), String> {
+    state
+        .db_write(move |db| upsert_projects_in_db(db, &projects))
+        .await
+        .map_err(String::from)
+}
+
+fn upsert_projects_in_db(db: &ActionDb, projects: &[LinearProject]) -> Result<(), String> {
     let conn = db.conn_ref();
 
     for project in projects {

--- a/src-tauri/src/prepare/email_enrich.rs
+++ b/src-tauri/src/prepare/email_enrich.rs
@@ -431,34 +431,34 @@ fn parse_enrichment_response(
 ///
 /// This two-phase approach avoids holding the DB mutex during PTY calls
 /// which can take 60s each.
-pub fn enrich_pending_emails_two_phase(
+pub async fn enrich_pending_emails_two_phase(
     state: &crate::state::AppState,
     workspace: &Path,
     ai_config: &AiModelConfig,
     limit: usize,
 ) -> usize {
     // Phase 1: Get pending emails + resolve entities (short DB lock)
-    let pending: Vec<(DbEmail, Option<String>, Option<String>)> = {
-        let db =
-            match crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new())) {
-                Ok(d) => d,
-                Err(_) => return 0,
-            };
-        let emails = match db.get_pending_enrichment(limit) {
-            Ok(e) => e,
-            Err(e) => {
-                log::warn!("email_enrich: failed to get pending emails: {e}");
-                return 0;
-            }
-        };
-        emails
-            .into_iter()
-            .map(|email| {
-                let (eid, etype) = resolve_entity(&db, &email);
-                (email, eid, etype)
-            })
-            .collect()
-    }; // DB lock released here
+    let pending: Vec<(DbEmail, Option<String>, Option<String>)> = match state
+        .db_read(move |db| {
+            let emails = db
+                .get_pending_enrichment(limit)
+                .map_err(|e| format!("email_enrich: failed to get pending emails: {e}"))?;
+            Ok(emails
+                .into_iter()
+                .map(|email| {
+                    let (eid, etype) = resolve_entity(db, &email);
+                    (email, eid, etype)
+                })
+                .collect())
+        })
+        .await
+    {
+        Ok(pending) => pending,
+        Err(e) => {
+            log::warn!("{e}");
+            return 0;
+        }
+    }; // DB read released here
 
     if pending.is_empty() {
         return 0;
@@ -494,19 +494,31 @@ pub fn enrich_pending_emails_two_phase(
         }
         // Build context prompt — needs DB for relationship context
         let prompt = {
-            let db = match crate::db::ActionDb::open(std::sync::Arc::new(
-                crate::db::LocalKeychain::new(),
-            )) {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-            build_enrichment_prompt(
-                &db,
-                email,
-                entity_id.as_deref(),
-                entity_type.as_deref(),
-                active_preset.as_ref(),
-            )
+            let email_for_prompt = email.clone();
+            let entity_id_for_prompt = entity_id.clone();
+            let entity_type_for_prompt = entity_type.clone();
+            let preset_for_prompt = active_preset.clone();
+            match state
+                .db_read(move |db| {
+                    Ok(build_enrichment_prompt(
+                        db,
+                        &email_for_prompt,
+                        entity_id_for_prompt.as_deref(),
+                        entity_type_for_prompt.as_deref(),
+                        preset_for_prompt.as_ref(),
+                    ))
+                })
+                .await
+            {
+                Ok(prompt) => prompt,
+                Err(e) => {
+                    log::warn!(
+                        "email_enrich: failed to build enrichment prompt for {}: {e}",
+                        email.email_id
+                    );
+                    continue;
+                }
+            }
         };
 
         let pty = PtyManager::for_tier(ModelTier::Extraction, ai_config)
@@ -554,36 +566,20 @@ pub fn enrich_pending_emails_two_phase(
             Err(e) => Err(format!("AI enrichment failed for {}: {e}", email.email_id)),
         };
 
-        // Phase 3: Persist result (short DB lock per email)
-        if let Ok(db) =
-            crate::db::ActionDb::open(std::sync::Arc::new(crate::db::LocalKeychain::new()))
-        {
-            match ai_result {
+        // Phase 3: Persist result (short DB write per email)
+        let email_id_for_write = email.email_id.clone();
+        let persist_result = state
+            .db_write(move |db| match ai_result {
                 Ok(result) => {
                     let update = result.as_db_update();
-                    if let Err(e) = db.set_enrichment_state(&email.email_id, "enriched", update) {
-                        log::warn!(
-                            "email_enrich: failed to persist enrichment for {}: {e}",
-                            email.email_id
-                        );
-                    } else {
-                        enriched_count += 1;
-                        if let Some(app_handle) = state.app_handle() {
-                            #[allow(
-                                clippy::let_underscore_must_use,
-                                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                            )]
-                            let _ = app_handle.emit(
-                                "email-enrichment-progress",
-                                EmailEnrichmentProgressPayload {
-                                    completed: enriched_count,
-                                    total: total_pending,
-                                    last_email_id: email.email_id.clone(),
-                                    last_email_subject: email.subject.clone().unwrap_or_default(),
-                                },
-                            );
-                        }
-                    }
+                    db.set_enrichment_state(&email_id_for_write, "enriched", update)
+                        .map_err(|e| {
+                            format!(
+                                "email_enrich: failed to persist enrichment for {}: {e}",
+                                email_id_for_write
+                            )
+                        })?;
+                    Ok(true)
                 }
                 Err(e) => {
                     log::warn!("email_enrich: {e}");
@@ -604,23 +600,50 @@ pub fn enrich_pending_emails_two_phase(
                         clippy::let_underscore_must_use,
                         reason = "intentional best-effort discard; preserves existing non-blocking behavior"
                     )]
-                    let _ = db.set_enrichment_state(&email.email_id, "failed", empty);
-                    if let Some(app_handle) = state.app_handle() {
-                        #[allow(
-                            clippy::let_underscore_must_use,
-                            reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-                        )]
-                        let _ = app_handle.emit(
-                            "email-enrichment-progress",
-                            EmailEnrichmentProgressPayload {
-                                completed: enriched_count,
-                                total: total_pending,
-                                last_email_id: email.email_id.clone(),
-                                last_email_subject: email.subject.clone().unwrap_or_default(),
-                            },
-                        );
-                    }
+                    let _ = db.set_enrichment_state(&email_id_for_write, "failed", empty);
+                    Ok(false)
                 }
+            })
+            .await;
+
+        match persist_result {
+            Ok(true) => {
+                enriched_count += 1;
+                if let Some(app_handle) = state.app_handle() {
+                    #[allow(
+                        clippy::let_underscore_must_use,
+                        reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                    )]
+                    let _ = app_handle.emit(
+                        "email-enrichment-progress",
+                        EmailEnrichmentProgressPayload {
+                            completed: enriched_count,
+                            total: total_pending,
+                            last_email_id: email.email_id.clone(),
+                            last_email_subject: email.subject.clone().unwrap_or_default(),
+                        },
+                    );
+                }
+            }
+            Ok(false) => {
+                if let Some(app_handle) = state.app_handle() {
+                    #[allow(
+                        clippy::let_underscore_must_use,
+                        reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+                    )]
+                    let _ = app_handle.emit(
+                        "email-enrichment-progress",
+                        EmailEnrichmentProgressPayload {
+                            completed: enriched_count,
+                            total: total_pending,
+                            last_email_id: email.email_id.clone(),
+                            last_email_subject: email.subject.clone().unwrap_or_default(),
+                        },
+                    );
+                }
+            }
+            Err(e) => {
+                log::warn!("{e}");
             }
         }
     }

--- a/src-tauri/src/prepare/orchestrate.rs
+++ b/src-tauri/src/prepare/orchestrate.rs
@@ -332,7 +332,8 @@ pub async fn prepare_today(state: &AppState, workspace: &Path) -> Result<(), Exe
                 .unwrap_or_default()
         };
         let enriched =
-            super::email_enrich::enrich_pending_emails_two_phase(state, workspace, &ai_config, 20);
+            super::email_enrich::enrich_pending_emails_two_phase(state, workspace, &ai_config, 20)
+                .await;
         if enriched > 0 {
             log::info!("prepare_today: enriched {} emails", enriched);
         }
@@ -1733,7 +1734,8 @@ pub async fn refresh_emails_with_retry_batch(
             ExecutionError::ConfigurationError("Orchestration permit closed".to_string())
         })?;
         let enriched =
-            super::email_enrich::enrich_pending_emails_two_phase(state, workspace, &ai_config, 20);
+            super::email_enrich::enrich_pending_emails_two_phase(state, workspace, &ai_config, 20)
+                .await;
         drop(_enrich_permit);
         if enriched > 0 {
             log::info!("refresh_emails: enriched {} emails", enriched);

--- a/src-tauri/src/services/derived_state.rs
+++ b/src-tauri/src/services/derived_state.rs
@@ -1068,68 +1068,9 @@ pub(crate) fn upsert_entity_intelligence_legacy_snapshot(
     db: &ActionDb,
     intel: &crate::intelligence::IntelligenceJson,
 ) -> Result<(), rusqlite::Error> {
+    upsert_entity_assessment_row(db, intel, true)?;
+
     let conn = db.conn_ref();
-
-    let dimensions_json = serde_json::to_string(&intel.dimensions_blob()).ok();
-    conn.execute(
-        "INSERT INTO entity_assessment (
-            entity_id, entity_type, enriched_at, source_file_count,
-            next_meeting_readiness_json, success_metrics, open_commitments,
-            relationship_depth, health_json, org_health_json, consistency_status,
-            consistency_findings_json, consistency_checked_at,
-            portfolio_json, network_json, user_edits_json, source_manifest_json,
-            dimensions_json, success_plan_signals_json, pull_quote
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
-        ON CONFLICT(entity_id) DO UPDATE SET
-            entity_type = excluded.entity_type,
-            enriched_at = excluded.enriched_at,
-            source_file_count = excluded.source_file_count,
-            next_meeting_readiness_json = excluded.next_meeting_readiness_json,
-            success_metrics = excluded.success_metrics,
-            open_commitments = excluded.open_commitments,
-            relationship_depth = excluded.relationship_depth,
-            health_json = excluded.health_json,
-            org_health_json = excluded.org_health_json,
-            consistency_status = excluded.consistency_status,
-            consistency_findings_json = excluded.consistency_findings_json,
-            consistency_checked_at = excluded.consistency_checked_at,
-            portfolio_json = excluded.portfolio_json,
-            network_json = excluded.network_json,
-            user_edits_json = excluded.user_edits_json,
-            source_manifest_json = excluded.source_manifest_json,
-            dimensions_json = excluded.dimensions_json,
-            success_plan_signals_json = excluded.success_plan_signals_json,
-            pull_quote = excluded.pull_quote",
-        rusqlite::params![
-            intel.entity_id,
-            intel.entity_type,
-            intel.enriched_at,
-            intel.source_file_count,
-            serde_json::to_string(&intel.next_meeting_readiness).ok(),
-            serde_json::to_string(&intel.success_metrics).ok(),
-            serde_json::to_string(&intel.open_commitments).ok(),
-            serde_json::to_string(&intel.relationship_depth).ok(),
-            intel.health.as_ref().and_then(|v| serde_json::to_string(v).ok()),
-            intel
-                .org_health
-                .as_ref()
-                .and_then(|v| serde_json::to_string(v).ok()),
-            serde_json::to_string(&intel.consistency_status).ok(),
-            serde_json::to_string(&intel.consistency_findings).ok(),
-            intel.consistency_checked_at,
-            serde_json::to_string(&intel.portfolio).ok(),
-            serde_json::to_string(&intel.network).ok(),
-            serde_json::to_string(&intel.user_edits).ok(),
-            serde_json::to_string(&intel.source_manifest).ok(),
-            dimensions_json,
-            intel
-                .success_plan_signals
-                .as_ref()
-                .and_then(|v| serde_json::to_string(v).ok()),
-            intel.pull_quote,
-        ],
-    )?;
-
     conn.execute(
         "DELETE FROM intelligence_feedback WHERE entity_id = ?1 AND entity_type = ?2 \
          AND field NOT LIKE 'account_field_conflict:%'",
@@ -1156,6 +1097,119 @@ pub(crate) fn upsert_entity_intelligence_legacy_snapshot(
         );
     }
 
+    Ok(())
+}
+
+/// Lightweight UI cache writer for progressive enrichment updates.
+///
+/// This intentionally skips claim projection, feedback cleanup, health
+/// projection, and side-effect signals. The final enrichment commit owns those
+/// authoritative writes.
+pub(crate) fn upsert_entity_intelligence_progressive_snapshot(
+    db: &ActionDb,
+    intel: &crate::intelligence::IntelligenceJson,
+) -> Result<(), rusqlite::Error> {
+    upsert_entity_assessment_row(db, intel, false)
+}
+
+fn upsert_entity_assessment_row(
+    db: &ActionDb,
+    intel: &crate::intelligence::IntelligenceJson,
+    update_enriched_at: bool,
+) -> Result<(), rusqlite::Error> {
+    let conn = db.conn_ref();
+
+    let dimensions_json = serde_json::to_string(&intel.dimensions_blob()).ok();
+    let enriched_at = if update_enriched_at && !intel.enriched_at.trim().is_empty() {
+        Some(intel.enriched_at.as_str())
+    } else {
+        None
+    };
+    let update_sql = if update_enriched_at {
+        "entity_type = excluded.entity_type,
+            enriched_at = excluded.enriched_at,
+            source_file_count = excluded.source_file_count,
+            next_meeting_readiness_json = excluded.next_meeting_readiness_json,
+            success_metrics = excluded.success_metrics,
+            open_commitments = excluded.open_commitments,
+            relationship_depth = excluded.relationship_depth,
+            health_json = excluded.health_json,
+            org_health_json = excluded.org_health_json,
+            consistency_status = excluded.consistency_status,
+            consistency_findings_json = excluded.consistency_findings_json,
+            consistency_checked_at = excluded.consistency_checked_at,
+            portfolio_json = excluded.portfolio_json,
+            network_json = excluded.network_json,
+            user_edits_json = excluded.user_edits_json,
+            source_manifest_json = excluded.source_manifest_json,
+            dimensions_json = excluded.dimensions_json,
+            success_plan_signals_json = excluded.success_plan_signals_json,
+            pull_quote = excluded.pull_quote"
+    } else {
+        "entity_type = excluded.entity_type,
+            source_file_count = excluded.source_file_count,
+            next_meeting_readiness_json = excluded.next_meeting_readiness_json,
+            success_metrics = excluded.success_metrics,
+            open_commitments = excluded.open_commitments,
+            relationship_depth = excluded.relationship_depth,
+            health_json = excluded.health_json,
+            org_health_json = excluded.org_health_json,
+            consistency_status = excluded.consistency_status,
+            consistency_findings_json = excluded.consistency_findings_json,
+            consistency_checked_at = excluded.consistency_checked_at,
+            portfolio_json = excluded.portfolio_json,
+            network_json = excluded.network_json,
+            user_edits_json = excluded.user_edits_json,
+            source_manifest_json = excluded.source_manifest_json,
+            dimensions_json = excluded.dimensions_json,
+            success_plan_signals_json = excluded.success_plan_signals_json,
+            pull_quote = excluded.pull_quote"
+    };
+    let sql = format!(
+        "INSERT INTO entity_assessment (
+            entity_id, entity_type, enriched_at, source_file_count,
+            next_meeting_readiness_json, success_metrics, open_commitments,
+            relationship_depth, health_json, org_health_json, consistency_status,
+            consistency_findings_json, consistency_checked_at,
+            portfolio_json, network_json, user_edits_json, source_manifest_json,
+            dimensions_json, success_plan_signals_json, pull_quote
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+        ON CONFLICT(entity_id) DO UPDATE SET {update_sql}"
+    );
+    conn.execute(
+        &sql,
+        rusqlite::params![
+            intel.entity_id,
+            intel.entity_type,
+            enriched_at,
+            intel.source_file_count,
+            serde_json::to_string(&intel.next_meeting_readiness).ok(),
+            serde_json::to_string(&intel.success_metrics).ok(),
+            serde_json::to_string(&intel.open_commitments).ok(),
+            serde_json::to_string(&intel.relationship_depth).ok(),
+            intel
+                .health
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok()),
+            intel
+                .org_health
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok()),
+            serde_json::to_string(&intel.consistency_status).ok(),
+            serde_json::to_string(&intel.consistency_findings).ok(),
+            intel.consistency_checked_at,
+            serde_json::to_string(&intel.portfolio).ok(),
+            serde_json::to_string(&intel.network).ok(),
+            serde_json::to_string(&intel.user_edits).ok(),
+            serde_json::to_string(&intel.source_manifest).ok(),
+            dimensions_json,
+            intel
+                .success_plan_signals
+                .as_ref()
+                .and_then(|v| serde_json::to_string(v).ok()),
+            intel.pull_quote,
+        ],
+    )?;
     Ok(())
 }
 

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 
 use crate::db::ActionDb;
 use crate::intel_queue::{
-    apply_enrichment_side_writes, compose_enrichment_intelligence, gather_enrichment_input,
-    run_enrichment, run_enrichment_finalize_post_commit, FinalizeMode, IntelPriority, IntelRequest,
+    compose_enrichment_intelligence, gather_enrichment_input,
+    persist_enrichment_write_results_via_db_service, run_enrichment,
+    run_enrichment_finalize_post_commit_via_db_service, FinalizeMode, IntelPriority, IntelRequest,
 };
 use crate::pty::AiUsageContext;
 use crate::services::context::ServiceContext;
@@ -1911,22 +1912,10 @@ pub async fn enrich_entity(
             return Err(manual_refresh_error("write_results", &e));
         }
     };
-    if let Err(e) = db.with_transaction(|tx| {
-        apply_enrichment_side_writes(ctx, tx, &input, &prepared)?;
-        upsert_assessment_from_enrichment_in_active_transaction(
-            ctx,
-            tx,
-            &state.signals.engine,
-            EnrichmentAssessmentUpsert {
-                entity_type: &input.entity_type,
-                entity_id: &input.entity_id,
-                intel: prepared.intelligence(),
-                projection_intel: prepared.projection_intelligence(),
-                projection_data_source: parsed.producer.projection_data_source(),
-                cleared_dimensions: prepared.cleared_dimensions(),
-            },
-        )
-    }) {
+    if let Err(e) =
+        persist_enrichment_write_results_via_db_service(state, &input, &prepared, parsed.producer)
+            .await
+    {
         emit_manual_refresh_failed_best_effort(
             ctx,
             app_handle,
@@ -1939,16 +1928,17 @@ pub async fn enrich_entity(
         return Err(manual_refresh_error("write_results", &e));
     }
     let final_intel = prepared.into_intelligence();
-    if let Err(e) = run_enrichment_finalize_post_commit(
+    if let Err(e) = run_enrichment_finalize_post_commit_via_db_service(
         state,
-        &db,
         &input,
         &final_intel,
         &parsed.inferred_relationships,
         FinalizeMode::ManualRefresh {
             producer: parsed.producer,
         },
-    ) {
+    )
+    .await
+    {
         emit_manual_refresh_failed_best_effort(
             ctx,
             app_handle,
@@ -2927,6 +2917,25 @@ pub fn upsert_assessment_snapshot(
     })?;
 
     Ok(())
+}
+
+/// Persist a partial enrichment snapshot for UI progress refreshes only.
+///
+/// Progressive dimension updates are not authoritative evidence. Keep them out
+/// of claim projection, feedback cleanup, and side-effect signal paths so a
+/// slow multi-dimension refresh cannot create write amplification while the
+/// final enrichment commit is still pending.
+pub fn upsert_progressive_assessment_snapshot(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    intel: &crate::intelligence::IntelligenceJson,
+) -> Result<(), String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    db.with_transaction(|tx| {
+        crate::services::derived_state::upsert_entity_intelligence_progressive_snapshot(tx, intel)
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    })
 }
 
 /// Persist the Glean leading-signals JSON blob on `entity_assessment`
@@ -5106,6 +5115,72 @@ mod tests {
         assert_eq!(report.generated_projection_claims_withdrawn, 1);
         assert_eq!(report.generated_projection_recompute_jobs_enqueued, 1);
         assert_eq!(active_generated_risk_count(&db, account_id), 0);
+    }
+
+    #[test]
+    fn progressive_snapshot_does_not_advance_freshness_domains_or_claims() {
+        let db = test_db();
+        let engine = PropagationEngine::default();
+        let account_id = "acc-progressive-cache-only";
+        seed_account(&db, account_id);
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(53);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+        let final_intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-22T12:00:00Z".to_string(),
+            executive_assessment: Some("Authoritative committed summary.".to_string()),
+            ..Default::default()
+        };
+
+        upsert_assessment_from_enrichment(&ctx, &db, &engine, "account", account_id, &final_intel)
+            .expect("commit authoritative assessment");
+
+        let progressive_intel = IntelligenceJson {
+            executive_assessment_render_policy: None,
+            entity_id: account_id.to_string(),
+            entity_type: "account".to_string(),
+            enriched_at: "2026-05-27T12:00:00Z".to_string(),
+            executive_assessment: Some("Partial in-flight summary.".to_string()),
+            domains: vec!["partial.example".to_string()],
+            ..Default::default()
+        };
+
+        upsert_progressive_assessment_snapshot(&ctx, &db, &progressive_intel)
+            .expect("write progressive UI cache");
+
+        let enriched_at: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT enriched_at FROM entity_assessment WHERE entity_id = ?1",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("read enriched_at");
+        assert_eq!(enriched_at.as_deref(), Some("2026-05-22T12:00:00Z"));
+
+        let partial_domain_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*) FROM account_domains WHERE account_id = ?1 AND domain = 'partial.example'",
+                params![account_id],
+                |row| row.get(0),
+            )
+            .expect("count partial domains");
+        assert_eq!(partial_domain_count, 0);
+
+        let progressive_claim_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT COUNT(*) FROM intelligence_claims WHERE data_source = 'ai_enrichment_progressive'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count progressive claims");
+        assert_eq!(progressive_claim_count, 0);
     }
 
     #[test]

--- a/src-tauri/src/services/invalidation_jobs.rs
+++ b/src-tauri/src/services/invalidation_jobs.rs
@@ -253,6 +253,10 @@ pub async fn drain_pending_claim_recomputes(state: &Arc<AppState>) {
 pub async fn run_claim_recompute_worker(state: Arc<AppState>) {
     let worker_id = format!("claim-recompute-worker-{}", uuid::Uuid::new_v4());
     loop {
+        if state.is_database_recovery_required() {
+            log::warn!("Claim recompute worker stopped: database recovery required");
+            break;
+        }
         let worker_id_for_db = worker_id.clone();
         let result = state
             .db_write(move |db| {
@@ -323,6 +327,10 @@ pub async fn drain_pending_targeted_claim_repairs(state: &Arc<AppState>) {
 pub async fn run_targeted_claim_repair_worker(state: Arc<AppState>) {
     let worker_id = format!("targeted-repair-worker-{}", uuid::Uuid::new_v4());
     loop {
+        if state.is_database_recovery_required() {
+            log::warn!("Targeted claim repair worker stopped: database recovery required");
+            break;
+        }
         let worker_id_for_db = worker_id.clone();
         let result = state
             .db_write(move |db| {

--- a/src-tauri/src/services/runtime_evidence_backfill.rs
+++ b/src-tauri/src/services/runtime_evidence_backfill.rs
@@ -35,6 +35,8 @@ pub const RUNTIME_EVIDENCE_BACKFILL_266_ENTITY_OFFSET_KEY: &str =
     "runtime_evidence_backfill_266_entity_offset";
 pub const RUNTIME_EVIDENCE_BACKFILL_266_ACTION_OFFSET_KEY: &str =
     "runtime_evidence_backfill_266_action_offset";
+pub const RUNTIME_EVIDENCE_BACKFILL_266_STORAGE_HALTED_AT_KEY: &str =
+    "runtime_evidence_backfill_266_storage_halted_at";
 
 const RUNTIME_EVIDENCE_BACKFILL_266_ENTITY_BATCH_SIZE: usize = 50;
 const RUNTIME_EVIDENCE_BACKFILL_266_ACTION_BATCH_SIZE: usize = 10;
@@ -86,6 +88,14 @@ pub fn run_runtime_evidence_backfill_if_pending(
     if !account_fact_pending && !entity_intelligence_pending {
         return Ok(None);
     }
+    if entity_intelligence_pending
+        && migration_state_value(db, RUNTIME_EVIDENCE_BACKFILL_266_STORAGE_HALTED_AT_KEY)?.is_some()
+    {
+        return Err(
+            "runtime evidence backfill 266 is paused after a prior storage-health failure"
+                .to_string(),
+        );
+    }
 
     if account_fact_pending {
         record_marker(
@@ -115,6 +125,7 @@ pub fn run_runtime_evidence_backfill_if_pending(
             offset,
             RUNTIME_EVIDENCE_BACKFILL_266_ACTION_BATCH_SIZE,
         )?;
+        halt_on_storage_health_errors(ctx, db, &report.errors)?;
         record_marker(
             db,
             RUNTIME_EVIDENCE_BACKFILL_266_ACTION_OFFSET_KEY,
@@ -133,6 +144,7 @@ pub fn run_runtime_evidence_backfill_if_pending(
             offset,
             RUNTIME_EVIDENCE_BACKFILL_266_ENTITY_BATCH_SIZE,
         )?;
+        halt_on_storage_health_errors(ctx, db, &report.errors)?;
         record_marker(
             db,
             RUNTIME_EVIDENCE_BACKFILL_266_ENTITY_OFFSET_KEY,
@@ -171,6 +183,50 @@ pub fn run_runtime_evidence_backfill_if_pending(
         action_claim_report,
         completed,
     }))
+}
+
+pub fn runtime_evidence_backfill_266_resume_pending(db: &ActionDb) -> Result<bool, String> {
+    if !migration_state_exists(db)? {
+        return Ok(false);
+    }
+    let requested =
+        migration_state_value(db, RUNTIME_EVIDENCE_BACKFILL_266_REQUESTED_AT_KEY)?.is_some();
+    let started =
+        migration_state_value(db, RUNTIME_EVIDENCE_BACKFILL_266_STARTED_AT_KEY)?.is_some();
+    let completed =
+        migration_state_value(db, RUNTIME_EVIDENCE_BACKFILL_266_COMPLETED_AT_KEY)?.is_some();
+
+    Ok(requested && started && !completed)
+}
+
+pub fn error_indicates_storage_health_failure(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("disk i/o error")
+        || lower.contains("file is not a database")
+        || lower.contains("database disk image is malformed")
+        || lower.contains("sqlite_notadb")
+        || lower.contains("sqlcipher key verification failed")
+}
+
+fn halt_on_storage_health_errors(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    errors: &[String],
+) -> Result<(), String> {
+    if !errors
+        .iter()
+        .any(|error| error_indicates_storage_health_failure(error))
+    {
+        return Ok(());
+    }
+    let halted_at = ctx.clock.now().timestamp();
+    record_marker(
+        db,
+        RUNTIME_EVIDENCE_BACKFILL_266_STORAGE_HALTED_AT_KEY,
+        halted_at,
+    )
+    .map_err(|error| format!("runtime evidence backfill storage halt marker failed: {error}"))?;
+    Err("runtime evidence backfill halted after storage-health failure".to_string())
 }
 
 fn migration_state_exists(db: &ActionDb) -> Result<bool, String> {
@@ -359,6 +415,58 @@ mod tests {
                 .expect("completion read")
                 .is_some()
         );
+    }
+
+    #[test]
+    fn storage_health_error_detection_catches_sqlite_corruption_signals() {
+        for message in [
+            "SQLite error: disk I/O error",
+            "file is not a database",
+            "rusqlite error: database disk image is malformed",
+            "SQLITE_NOTADB while opening DB",
+            "SQLCipher key verification failed (database unreadable): disk I/O error",
+        ] {
+            assert!(error_indicates_storage_health_failure(message), "{message}");
+        }
+        assert!(!error_indicates_storage_health_failure(
+            "database is locked"
+        ));
+    }
+
+    #[test]
+    fn runtime_evidence_backfill_266_resume_pending_only_after_started_marker() {
+        let db = test_db();
+
+        assert!(!runtime_evidence_backfill_266_resume_pending(&db).expect("initial check"));
+
+        record_marker(&db, RUNTIME_EVIDENCE_BACKFILL_266_REQUESTED_AT_KEY, 1)
+            .expect("request marker");
+        assert!(!runtime_evidence_backfill_266_resume_pending(&db).expect("requested check"));
+
+        record_marker(&db, RUNTIME_EVIDENCE_BACKFILL_266_STARTED_AT_KEY, 2)
+            .expect("started marker");
+        assert!(runtime_evidence_backfill_266_resume_pending(&db).expect("started check"));
+
+        record_marker(&db, RUNTIME_EVIDENCE_BACKFILL_266_COMPLETED_AT_KEY, 3)
+            .expect("completed marker");
+        assert!(!runtime_evidence_backfill_266_resume_pending(&db).expect("completed check"));
+    }
+
+    #[test]
+    fn runtime_evidence_backfill_stops_when_storage_health_marker_exists() {
+        let db = test_db();
+        record_marker(&db, RUNTIME_EVIDENCE_BACKFILL_266_REQUESTED_AT_KEY, 1)
+            .expect("request marker");
+        record_marker(&db, RUNTIME_EVIDENCE_BACKFILL_266_STORAGE_HALTED_AT_KEY, 2)
+            .expect("halt marker");
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 22, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(25);
+        let ext = ExternalClients::default();
+        let ctx = test_ctx(&clock, &rng, &ext);
+
+        let error = run_runtime_evidence_backfill_if_pending(&ctx, &db)
+            .expect_err("halted backfill must not resume on startup");
+        assert!(error.contains("paused after a prior storage-health failure"));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1462,6 +1462,15 @@ impl AppState {
         error: &DbAccessError,
         context: &'static str,
     ) -> bool {
+        if db_access_error_requires_manual_recovery(error) {
+            let message = error.to_string();
+            self.set_database_recovery_required("database_storage_health", message.clone());
+            log::warn!(
+                "{context}: database recovery required after storage-health error: {message}"
+            );
+            return false;
+        }
+
         if !db_access_error_needs_pool_reopen(error) {
             return false;
         }
@@ -1617,6 +1626,13 @@ impl AppState {
 fn db_access_error_needs_pool_reopen(error: &DbAccessError) -> bool {
     let message = error.to_string().to_ascii_lowercase();
     message.contains("file is not a database") || message.contains("sqlite_notadb")
+}
+
+fn db_access_error_requires_manual_recovery(error: &DbAccessError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("disk i/o error")
+        || message.contains("database disk image is malformed")
+        || message.contains("sqlcipher key verification failed")
 }
 
 impl Default for AppState {
@@ -2203,5 +2219,30 @@ mod tests {
 
         assert!(!changed);
         assert!(!config.google.enabled);
+    }
+
+    #[test]
+    fn storage_health_errors_require_recovery_without_pool_reopen() {
+        let state = AppState::default();
+        let error = crate::db_service::DbAccessError::from(
+            "commit projection claim failed: rusqlite error: database disk image is malformed",
+        );
+
+        let recovered = tauri::async_runtime::block_on(
+            state.recover_db_service_after_access_error(&error, "test"),
+        );
+
+        assert!(!recovered);
+        let status = state.get_database_recovery_status();
+        assert!(status.required);
+        assert_eq!(status.reason, "database_storage_health");
+    }
+
+    #[test]
+    fn notadb_errors_remain_pool_reopen_candidates() {
+        let error = crate::db_service::DbAccessError::from("file is not a database");
+
+        assert!(!db_access_error_requires_manual_recovery(&error));
+        assert!(db_access_error_needs_pool_reopen(&error));
     }
 }

--- a/src-tauri/tests/startup_background_db_access_lint_test.rs
+++ b/src-tauri/tests/startup_background_db_access_lint_test.rs
@@ -15,6 +15,8 @@ fn startup_background_workers_use_app_state_db_service_paths() {
         "src/processor/embeddings.rs",
         "src/hygiene/loop_runner.rs",
         "src/proactive/scanner.rs",
+        "src/prepare/email_enrich.rs",
+        "src/linear/sync.rs",
     ];
     let forbidden_needles = [
         "ActionDb::open(",

--- a/src/features/settings-ui/connectors/GranolaConnector.tsx
+++ b/src/features/settings-ui/connectors/GranolaConnector.tsx
@@ -12,6 +12,10 @@ interface GranolaStatusData {
   enabled: boolean;
   cacheExists: boolean;
   cachePath: string;
+  source: "companion" | "cache" | "encrypted_cache" | "none";
+  companionAvailable: boolean;
+  companionMessage: string | null;
+  encryptedCacheExists: boolean;
   documentCount: number;
   pendingSyncs: number;
   failedSyncs: number;
@@ -46,13 +50,17 @@ export default function GranolaConnection() {
 
   const statusLabel = !status
     ? "Loading..."
-    : !status.cacheExists
-      ? "Cache not found"
-      : `Cache found (${status.documentCount} documents)`;
+    : status.companionAvailable
+      ? `Granola connected (${status.documentCount} notes)`
+      : status.cacheExists
+        ? `Legacy cache found (${status.documentCount} documents)`
+        : status.encryptedCacheExists
+          ? "Granola access unavailable"
+          : "Granola not found";
 
   const statusColor = !status
     ? "var(--color-text-tertiary)"
-    : !status.cacheExists
+    : !status.companionAvailable && !status.cacheExists
       ? "var(--color-spice-terracotta)"
       : "var(--color-garden-olive)";
 
@@ -61,7 +69,7 @@ export default function GranolaConnection() {
       <div className={surface.intro}>
         <SettingsSectionLabel>Granola Transcripts</SettingsSectionLabel>
         <p className={`${formRowStyles.description} ${surface.introDescription}`}>
-          Sync meeting notes from Granola&apos;s local cache (no API key required)
+          Sync meeting notes from Granola&apos;s local companion access, with legacy cache fallback
         </p>
       </div>
 
@@ -72,7 +80,7 @@ export default function GranolaConnection() {
           </span>
           <p className={surface.settingDescription}>
             {status?.enabled
-              ? "Notes will sync from Granola cache"
+              ? "Notes will sync from Granola when local access is available"
               : "Granola transcript sync is turned off"}
           </p>
         </div>
@@ -88,11 +96,25 @@ export default function GranolaConnection() {
 
       {status?.enabled && (
         <>
-          {!status.cacheExists && (
+          {!status.companionAvailable && status.encryptedCacheExists && (
+            <div className={surface.callout}>
+              <p className={surface.calloutLabel}>Access Needed</p>
+              <p className={surface.calloutText}>
+                Granola is writing protected local data. Enable Granola companion access so DailyOS can read current notes.
+              </p>
+              {status.companionMessage && (
+                <p className={`${surface.calloutText} ${surface.calloutTextSpaced}`}>
+                  {status.companionMessage}
+                </p>
+              )}
+            </div>
+          )}
+
+          {!status.cacheExists && !status.encryptedCacheExists && (
             <div className={surface.callout}>
               <p className={surface.calloutLabel}>Not Found</p>
               <p className={surface.calloutText}>
-                Granola must be installed and have recorded at least one meeting for its local cache to exist.
+                Granola must be installed and have recorded at least one meeting.
               </p>
               <p className={`${surface.calloutText} ${surface.calloutTextSpaced}`}>
                 Expected path: <span className={surface.inlineCode}>~/Library/Application Support/Granola/</span>
@@ -134,7 +156,7 @@ export default function GranolaConnection() {
             <div className={surface.settingCopy}>
               <span className={surface.settingTitle}>Poll interval</span>
               <p className={surface.settingDescription}>
-                How often to check the Granola cache for new notes
+                How often to check Granola for new notes
               </p>
             </div>
             <select
@@ -163,7 +185,7 @@ export default function GranolaConnection() {
             <div className={surface.settingCopy}>
               <span className={surface.settingTitle}>Historical backfill</span>
               <p className={surface.settingDescription}>
-                Match Granola cache documents to past meetings (last {BACKFILL_DAYS} days)
+                Match Granola notes to past meetings (last {BACKFILL_DAYS} days)
               </p>
             </div>
             <SettingsButton

--- a/src/pages/MeetingDetailPage.tsx
+++ b/src/pages/MeetingDetailPage.tsx
@@ -501,7 +501,7 @@ export default function MeetingDetailPage() {
     }
   }, [meetingId, data, meetingMeta, loadMeetingIntelligence]);
 
-  const handlePasteTranscript = useCallback(async () => {
+  const handlePasteTranscript = useCallback(() => {
     if (!meetingId || !data) return;
     const trimmed = pasteText.trim();
     if (!trimmed) {
@@ -509,52 +509,66 @@ export default function MeetingDetailPage() {
       return;
     }
 
-    setPasting(true);
-    try {
-      const calendarEvent: CalendarEvent = {
-        id: meetingMeta?.id || meetingId,
-        title: meetingMeta?.title || data.title,
-        start: meetingMeta?.startTime || new Date().toISOString(),
-        end:
-          meetingMeta?.endTime ||
-          meetingMeta?.startTime ||
-          new Date().toISOString(),
-        type:
-          (meetingMeta?.meetingType as CalendarEvent["type"]) ?? "internal",
-        attendees: [],
-        isAllDay: false,
-      };
-      const result = await invoke<{
-        status: string;
-        message?: string;
-        summary?: string;
-      }>("attach_meeting_transcript_text", {
-        text: trimmed,
-        format: pasteFormat,
-        meeting: calendarEvent,
-      });
+    const submittedFormat = pasteFormat;
+    const calendarEvent: CalendarEvent = {
+      id: meetingMeta?.id || meetingId,
+      title: meetingMeta?.title || data.title,
+      start: meetingMeta?.startTime || new Date().toISOString(),
+      end:
+        meetingMeta?.endTime ||
+        meetingMeta?.startTime ||
+        new Date().toISOString(),
+      type:
+        (meetingMeta?.meetingType as CalendarEvent["type"]) ?? "internal",
+      attendees: [],
+      isAllDay: false,
+    };
 
-      if (result.status !== "success") {
-        toast.error("Transcript processing failed", {
-          description: result.message || result.status,
+    setPasting(true);
+    setPasteOpen(false);
+    toast.loading("Processing pasted transcript…", {
+      id: "paste-transcript",
+      description: "You can keep working while outcomes are extracted.",
+    });
+
+    void (async () => {
+      try {
+        const result = await invoke<{
+          status: string;
+          message?: string;
+          summary?: string;
+        }>("attach_meeting_transcript_text", {
+          text: trimmed,
+          format: submittedFormat,
+          meeting: calendarEvent,
         });
-      } else if (!result.summary) {
-        toast.warning("No outcomes extracted", {
-          description: result.message || "AI extraction returned empty",
+
+        if (result.status !== "success") {
+          toast.error("Transcript processing failed", {
+            id: "paste-transcript",
+            description: result.message || result.status,
+          });
+        } else if (!result.summary) {
+          toast.warning("No outcomes extracted", {
+            id: "paste-transcript",
+            description: result.message || "AI extraction returned empty",
+          });
+        } else {
+          setPasteText("");
+          toast.success("Transcript processed", { id: "paste-transcript" });
+        }
+        await loadMeetingIntelligence();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error("Failed to paste transcript:", msg);
+        toast.error("Failed to paste transcript", {
+          id: "paste-transcript",
+          description: msg,
         });
-      } else {
-        toast.success("Transcript processed");
+      } finally {
+        setPasting(false);
       }
-      setPasteOpen(false);
-      setPasteText("");
-      await loadMeetingIntelligence();
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error("Failed to paste transcript:", msg);
-      toast.error("Failed to paste transcript", { description: msg });
-    } finally {
-      setPasting(false);
-    }
+    })();
   }, [
     meetingId,
     data,
@@ -1769,7 +1783,7 @@ Thanks!`;
         subject={draft.subject}
         body={draft.body}
       />
-      <Dialog open={pasteOpen} onOpenChange={(o) => { if (!pasting) setPasteOpen(o); }}>
+      <Dialog open={pasteOpen} onOpenChange={setPasteOpen}>
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>Paste Transcript</DialogTitle>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3086,6 +3086,10 @@ export interface GranolaStatus {
   enabled: boolean;
   cacheExists: boolean;
   cachePath: string;
+  source: "companion" | "cache" | "encrypted_cache" | "none";
+  companionAvailable: boolean;
+  companionMessage: string | null;
+  encryptedCacheExists: boolean;
   documentCount: number;
   pendingSyncs: number;
   failedSyncs: number;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,7 @@
 # Lessons
 
+- 2026-05-26: Granola cache detection must treat filename versioning and storage mechanism as separate contracts. `cache-v*.json` catches version bumps, but not the newer encrypted cache path; prefer Granola's companion IPC/MCP access and make stale plaintext cache fallback explicit.
+- 2026-05-26: Treat "lock storm resolved" as unproven until a normal app startup with background workers runs cleanly. Deferring a corrupting backfill fixes storage safety, but independent writable `ActionDb` handles and long `db_write` finalization closures can still starve the SQLite writer.
 - 2026-05-25: Do not edit Rust backend files while `pnpm tauri dev` is writing to the production SQLCipher database. Tauri dev hot-restarts can terminate active WAL writers during runtime backfills or enrichment, producing real btree corruption even when earlier `quick_check` passes. Stop the app, patch and test, then restart once.
 - 2026-05-25: Runtime evidence backfills must include open-loop/action evidence even if actions are not yet a first-class entity subject. Treat actions as claim-backed `open_loop` / `commitment` evidence attached to their owning entity, and prevent runtime readers from synthesizing them directly from raw action rows.
 - 2026-05-25: A producer audit should include a production-data inventory by evidence class before marking coverage complete. Sparse fixture success can hide populated legacy tables whose semantics never reach the runtime, especially source refs, action sources, meeting-derived intelligence, and feedback/suppression rows.


### PR DESCRIPTION
## Summary

This PR keeps transcript intake moving without freezing the app or amplifying background database pressure. Granola now prefers the local companion bridge, falls back to the legacy plaintext cache, and surfaces a clear access-needed state when Granola has protected local data but companion access is unavailable.

Meeting transcript paste now behaves like the sync paths: after the user submits pasted text, the modal closes and the existing transcript pipeline continues in the background. If the background command fails, the pasted text remains available for retry.

The background write changes reduce SQLite writer contention by keeping progressive enrichment writes to UI-cache state until final commit, routing final enrichment writes through the DB service, deferring interrupted runtime-evidence backfill unless explicit maintenance mode is enabled, and marking storage-health failures as requiring recovery.

## Validation

- `git diff --check`
- `pnpm tsc --noEmit`
- `cargo test granola --lib` (19 passed)
- pre-push: `cargo clippy -- -D warnings`
- pre-push: `cargo test --lib` (3047 passed, 11 ignored)
- pre-push: `pnpm tsc --noEmit`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)

## §4 Security

`security_auditor_invoked: true`

Security review required because this PR touches service, command, intelligence, and background write paths. Local L2 was not rerun after the final PR-body correction; merge is gated on the GitHub L2 checks.