### PR TITLE
feat(meetings-writer): typed write substrate for Lane B of v1.4.8 (DOS-775)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -237,6 +237,15 @@ while IFS= read -r file; do
   esac
 done <<< "$STAGED_FILES"
 
+# Meetings-writer boundary gate (Lane B of v1.4.8). Reject raw INSERT/UPDATE
+# on the meetings table outside the writer substrate's allowlist. Defers all
+# logic to scripts/check_meetings_writer_boundary.sh so the rule lives in one
+# place.
+if ! bash "${CWD}/scripts/check_meetings_writer_boundary.sh" --staged 2>&1; then
+  append_error "❌ meetings_writer boundary: raw meetings INSERT/UPDATE outside services::meetings_writer."
+  append_error "   Route through services::meetings_writer::write() with a typed WriteRequest."
+fi
+
 # 7. PII blocklist scan (cheap, always runs).
 #
 # Batched: one `git diff --cached` invocation parses per-file content via the

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -237,15 +237,6 @@ while IFS= read -r file; do
   esac
 done <<< "$STAGED_FILES"
 
-# Meetings-writer boundary gate (Lane B of v1.4.8). Reject raw INSERT/UPDATE
-# on the meetings table outside the writer substrate's allowlist. Defers all
-# logic to scripts/check_meetings_writer_boundary.sh so the rule lives in one
-# place.
-if ! bash "${CWD}/scripts/check_meetings_writer_boundary.sh" --staged 2>&1; then
-  append_error "❌ meetings_writer boundary: raw meetings INSERT/UPDATE outside services::meetings_writer."
-  append_error "   Route through services::meetings_writer::write() with a typed WriteRequest."
-fi
-
 # 7. PII blocklist scan (cheap, always runs).
 #
 # Batched: one `git diff --cached` invocation parses per-file content via the

--- a/scripts/check_meetings_writer_boundary.sh
+++ b/scripts/check_meetings_writer_boundary.sh
@@ -43,7 +43,6 @@ is_allowlisted_file() {
     src-tauri/src/devtools/*)                        return 0 ;;
     src-tauri/src/demo.rs)                           return 0 ;;
     src-tauri/tests/*)                               return 0 ;;
-    src-tauri/src/services/meetings.rs)              return 0 ;;
     *_test.rs|*_tests.rs)                            return 0 ;;
   esac
   return 1

--- a/scripts/check_meetings_writer_boundary.sh
+++ b/scripts/check_meetings_writer_boundary.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scripts/check_meetings_writer_boundary.sh
+#
+# Lane B of v1.4.8 (Meetings Substrate v2) — enforce that every meeting-row
+# INSERT/UPDATE outside the explicit allowlist routes through
+# `services::meetings_writer`.
+#
+# Allowlisted paths (raw INSERT/UPDATE on `meetings` permitted):
+#   - src-tauri/src/services/meetings_writer/**     (the writer substrate itself)
+#   - src-tauri/src/db/meetings.rs                  (canonical DB functions adapters call)
+#   - src-tauri/src/db/accounts.rs                  (meeting_type reclassification)
+#   - src-tauri/src/db/data_lifecycle.rs            (privacy scrubs + lifecycle)
+#   - src-tauri/src/db/claim_invalidation.rs        (legacy seed for migration tests)
+#   - src-tauri/src/db/mod_tests.rs                 (unit-test fixtures)
+#   - src-tauri/src/migrations.rs                   (schema migrations)
+#   - src-tauri/migrations/**                       (.sql migrations)
+#   - src-tauri/src/devtools/**                     (devtools seeding)
+#   - src-tauri/src/demo.rs                         (demo seeding)
+#   - tests/**, *_test.rs, *_tests.rs               (test code)
+#   - inside `#[cfg(test)] mod tests { ... }` blocks (production files with test-only seeds)
+#
+# Anything else writing `INSERT INTO meetings` or `UPDATE meetings SET ...`
+# directly through `conn.execute` / `.prepare` is a substrate bypass.
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+EXIT=0
+
+is_allowlisted_file() {
+  local file="$1"
+  case "$file" in
+    src-tauri/src/services/meetings_writer/*)        return 0 ;;
+    src-tauri/src/db/meetings.rs)                    return 0 ;;
+    src-tauri/src/db/accounts.rs)                    return 0 ;;
+    src-tauri/src/db/data_lifecycle.rs)              return 0 ;;
+    src-tauri/src/db/claim_invalidation.rs)          return 0 ;;
+    src-tauri/src/db/mod_tests.rs)                   return 0 ;;
+    src-tauri/src/migrations.rs)                     return 0 ;;
+    src-tauri/migrations/*)                          return 0 ;;
+    src-tauri/src/devtools/*)                        return 0 ;;
+    src-tauri/src/demo.rs)                           return 0 ;;
+    src-tauri/tests/*)                               return 0 ;;
+    src-tauri/src/services/meetings.rs)              return 0 ;;
+    *_test.rs|*_tests.rs)                            return 0 ;;
+  esac
+  return 1
+}
+
+# Check whether a given line number in a Rust file falls inside a
+# `#[cfg(test)] mod ... { ... }` block. Approximation: walk backward through
+# the file looking for the nearest `#[cfg(test)]` annotation; if one exists
+# before this line, treat the line as test-scoped. Cheap and accurate enough
+# for an advisory gate.
+is_inside_test_module() {
+  local file="$1"
+  local line_no="$2"
+  awk -v target="$line_no" '
+    /^[[:space:]]*#\[cfg\(test\)\]/ { last_test = NR }
+    NR == target {
+      if (last_test > 0) { print "yes" } else { print "no" }
+      exit
+    }
+  ' "$file"
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  if is_allowlisted_file "$file"; then
+    return 0
+  fi
+
+  # Grep raw INSERT/UPDATE on meetings; collect (line, content) tuples.
+  local matches
+  matches="$(grep -n -E 'INSERT INTO meetings|UPDATE meetings SET|UPDATE meetings\b' "$file" 2>/dev/null || true)"
+  [ -z "$matches" ] && return 0
+
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    local line_no
+    line_no="$(printf '%s' "$match" | cut -d: -f1)"
+    local in_test
+    in_test="$(is_inside_test_module "$file" "$line_no")"
+    if [ "$in_test" = "yes" ]; then
+      continue
+    fi
+    if [ $EXIT -eq 0 ]; then
+      echo "Raw meetings-row INSERT/UPDATE found outside services/meetings_writer/." >&2
+      echo "Route through services::meetings_writer::write() with a WriteRequest." >&2
+      echo "" >&2
+    fi
+    printf '%s:%s\n' "$file" "$match" >&2
+    EXIT=1
+  done <<< "$matches"
+}
+
+if [ "${1:-}" = "--staged" ]; then
+  STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)"
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    case "$file" in *.rs) scan_file "$file" ;; esac
+  done <<< "$STAGED_FILES"
+else
+  while IFS= read -r file; do
+    scan_file "$file"
+  done < <(find src-tauri/src -name "*.rs" -type f)
+fi
+
+exit $EXIT

--- a/src-tauri/src/backfill_meetings.rs
+++ b/src-tauri/src/backfill_meetings.rs
@@ -356,35 +356,28 @@ fn create_meeting_record(db: &ActionDb, meeting: &DiscoveredMeeting) -> Result<(
         _ => (absolute_path, None),
     };
 
-    // Insert meeting record
-    conn.execute(
-        "INSERT INTO meetings (
-            id, title, meeting_type, start_time, created_at,
-            notes_path
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![
-            &meeting_id,
-            &meeting.title,
-            meeting_type,
-            &start_time,
-            &created_at_str,
-            &notes_path,
-        ],
-    )
-    .map_err(|e| e.to_string())?;
-
-    // Ensure child table rows exist (3-table schema invariant)
-    conn.execute(
-        "INSERT OR IGNORE INTO meeting_prep (meeting_id) VALUES (?1)",
-        params![&meeting_id],
-    )
-    .map_err(|e| e.to_string())?;
-    conn.execute(
-        "INSERT OR IGNORE INTO meeting_transcripts (meeting_id, transcript_path)
-         VALUES (?1, ?2)",
-        params![&meeting_id, &transcript_path],
-    )
-    .map_err(|e| e.to_string())?;
+    // Route the meeting row through the BackfillWriter adapter so historical
+    // backfill obeys the substrate invariant matrix (intelligence_state
+    // defaults to 'archived' for backfilled rows).
+    let write_req = crate::services::meetings_writer::WriteRequest {
+        source: crate::services::meetings_writer::MeetingSource::Backfill,
+        id: meeting_id.clone(),
+        title: meeting.title.clone(),
+        meeting_type: meeting_type.to_string(),
+        start_time: start_time.clone(),
+        end_time: None,
+        calendar_event_id: None,
+        attendees: None,
+        description: None,
+        notes_path: notes_path.clone(),
+        transcript_path: transcript_path.clone(),
+        prep_context_json: None,
+        user_agenda_json: None,
+        user_notes: None,
+        intelligence_state: None,
+    };
+    let _ = created_at_str; // upsert sets created_at at write time
+    crate::services::meetings_writer::write(db, &write_req).map_err(|e| e.to_string())?;
 
     // Link to entity via meeting_entities table
     conn.execute(

--- a/src-tauri/src/backfill_meetings.rs
+++ b/src-tauri/src/backfill_meetings.rs
@@ -7,7 +7,7 @@
 use crate::db::ActionDb;
 use crate::types::Config;
 use crate::util::slugify;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::NaiveDate;
 use regex::Regex;
 use rusqlite::params;
 use std::collections::HashSet;
@@ -341,9 +341,6 @@ fn create_meeting_record(db: &ActionDb, meeting: &DiscoveredMeeting) -> Result<(
         .and_utc()
         .to_rfc3339();
 
-    let created_at: DateTime<Utc> = Utc::now();
-    let created_at_str = created_at.to_rfc3339();
-
     // Get absolute path for notes_path / transcript_path
     let absolute_path = meeting
         .file_path
@@ -376,7 +373,6 @@ fn create_meeting_record(db: &ActionDb, meeting: &DiscoveredMeeting) -> Result<(
         user_notes: None,
         intelligence_state: None,
     };
-    let _ = created_at_str; // upsert sets created_at at write time
     crate::services::meetings_writer::write(db, &write_req).map_err(|e| e.to_string())?;
 
     // Link to entity via meeting_entities table

--- a/src-tauri/src/prepare/orchestrate.rs
+++ b/src-tauri/src/prepare/orchestrate.rs
@@ -778,7 +778,30 @@ pub async fn prepare_today(state: &AppState, workspace: &Path) -> Result<(), Exe
                     has_new_signals: None,
                     last_viewed_at: None,
                 };
-                if let Err(e) = db.upsert_meeting(&db_meeting) {
+                // Routes through ReconcileWriter because the upstream data
+                // (incomplete calendar JSON from the timeline fallback path)
+                // doesn't always carry end_time / attendees that CalendarWriter
+                // requires. ReconcileWriter accepts optional fields and
+                // preserves the lenient upsert semantics this path has always
+                // had.
+                let write_req = crate::services::meetings_writer::WriteRequest {
+                    source: crate::services::meetings_writer::MeetingSource::Reconcile,
+                    id: db_meeting.id.clone(),
+                    title: db_meeting.title.clone(),
+                    meeting_type: db_meeting.meeting_type.clone(),
+                    start_time: db_meeting.start_time.clone(),
+                    end_time: db_meeting.end_time.clone(),
+                    calendar_event_id: db_meeting.calendar_event_id.clone(),
+                    attendees: db_meeting.attendees.clone(),
+                    description: db_meeting.description.clone(),
+                    notes_path: db_meeting.notes_path.clone(),
+                    transcript_path: db_meeting.transcript_path.clone(),
+                    prep_context_json: db_meeting.prep_context_json.clone(),
+                    user_agenda_json: db_meeting.user_agenda_json.clone(),
+                    user_notes: db_meeting.user_notes.clone(),
+                    intelligence_state: db_meeting.intelligence_state.clone(),
+                };
+                if let Err(e) = crate::services::meetings_writer::write(&db, &write_req) {
                     log::warn!("prepare_today: failed to upsert meeting '{}': {}", title, e);
                     continue;
                 }
@@ -1226,7 +1249,26 @@ pub async fn prepare_week(state: &AppState, workspace: &Path) -> Result<(), Exec
                         has_new_signals: None,
                         last_viewed_at: None,
                     };
-                    if let Err(e) = db.upsert_meeting(&db_meeting) {
+                    // ReconcileWriter for the same reason as prepare_today
+                    // above — incomplete calendar JSON, lenient upsert semantics.
+                    let write_req = crate::services::meetings_writer::WriteRequest {
+                        source: crate::services::meetings_writer::MeetingSource::Reconcile,
+                        id: db_meeting.id.clone(),
+                        title: db_meeting.title.clone(),
+                        meeting_type: db_meeting.meeting_type.clone(),
+                        start_time: db_meeting.start_time.clone(),
+                        end_time: db_meeting.end_time.clone(),
+                        calendar_event_id: db_meeting.calendar_event_id.clone(),
+                        attendees: db_meeting.attendees.clone(),
+                        description: db_meeting.description.clone(),
+                        notes_path: db_meeting.notes_path.clone(),
+                        transcript_path: db_meeting.transcript_path.clone(),
+                        prep_context_json: db_meeting.prep_context_json.clone(),
+                        user_agenda_json: db_meeting.user_agenda_json.clone(),
+                        user_notes: db_meeting.user_notes.clone(),
+                        intelligence_state: db_meeting.intelligence_state.clone(),
+                    };
+                    if let Err(e) = crate::services::meetings_writer::write(&db, &write_req) {
                         log::warn!("prepare_week: failed to upsert meeting '{}': {}", title, e);
                         continue;
                     }

--- a/src-tauri/src/services/meetings.rs
+++ b/src-tauri/src/services/meetings.rs
@@ -26,7 +26,25 @@ pub fn upsert_meeting_for_reconcile(
 ) -> Result<(), String> {
     ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     db.with_transaction(|tx| {
-        tx.upsert_meeting(meeting).map_err(|e| e.to_string())?;
+        let write_req = crate::services::meetings_writer::WriteRequest {
+            source: crate::services::meetings_writer::MeetingSource::Reconcile,
+            id: meeting.id.clone(),
+            title: meeting.title.clone(),
+            meeting_type: meeting.meeting_type.clone(),
+            start_time: meeting.start_time.clone(),
+            end_time: meeting.end_time.clone(),
+            calendar_event_id: meeting.calendar_event_id.clone(),
+            attendees: meeting.attendees.clone(),
+            description: meeting.description.clone(),
+            notes_path: meeting.notes_path.clone(),
+            transcript_path: meeting.transcript_path.clone(),
+            prep_context_json: meeting.prep_context_json.clone(),
+            user_agenda_json: meeting.user_agenda_json.clone(),
+            user_notes: meeting.user_notes.clone(),
+            intelligence_state: meeting.intelligence_state.clone(),
+        };
+        crate::services::meetings_writer::write(tx, &write_req)
+            .map_err(|e| e.to_string())?;
         crate::services::signals::emit(
             ctx,
             tx,
@@ -1116,17 +1134,25 @@ async fn mutate_meeting_entities_and_refresh_briefing(
                         start_time,
                         meeting_type,
                     } => {
-                        db.ensure_meeting_in_history(crate::db::EnsureMeetingHistoryInput {
-                            id: &meeting_id,
-                            title: &meeting_title,
-                            meeting_type: &meeting_type,
-                            start_time: &start_time,
+                        let write_req = crate::services::meetings_writer::WriteRequest {
+                            source: crate::services::meetings_writer::MeetingSource::Manual,
+                            id: meeting_id.clone(),
+                            title: meeting_title.clone(),
+                            meeting_type: meeting_type.clone(),
+                            start_time: start_time.clone(),
                             end_time: None,
                             calendar_event_id: None,
                             attendees: None,
                             description: None,
-                        })
-                        .map_err(|e| e.to_string())?;
+                            notes_path: None,
+                            transcript_path: None,
+                            prep_context_json: None,
+                            user_agenda_json: None,
+                            user_notes: None,
+                            intelligence_state: None,
+                        };
+                        crate::services::meetings_writer::write(db, &write_req)
+                            .map_err(|e| e.to_string())?;
 
                         db.clear_meeting_entities(&meeting_id)
                             .map_err(|e| e.to_string())?;
@@ -1218,17 +1244,25 @@ async fn mutate_meeting_entities_and_refresh_briefing(
                         start_time,
                         meeting_type,
                     } => {
-                        db.ensure_meeting_in_history(crate::db::EnsureMeetingHistoryInput {
-                            id: &meeting_id,
-                            title: &meeting_title,
-                            meeting_type: &meeting_type,
-                            start_time: &start_time,
+                        let write_req = crate::services::meetings_writer::WriteRequest {
+                            source: crate::services::meetings_writer::MeetingSource::Manual,
+                            id: meeting_id.clone(),
+                            title: meeting_title.clone(),
+                            meeting_type: meeting_type.clone(),
+                            start_time: start_time.clone(),
                             end_time: None,
                             calendar_event_id: None,
                             attendees: None,
                             description: None,
-                        })
-                        .map_err(|e| e.to_string())?;
+                            notes_path: None,
+                            transcript_path: None,
+                            prep_context_json: None,
+                            user_agenda_json: None,
+                            user_notes: None,
+                            intelligence_state: None,
+                        };
+                        crate::services::meetings_writer::write(db, &write_req)
+                            .map_err(|e| e.to_string())?;
 
                         db.link_meeting_entity(&meeting_id, &entity_id, &entity_type)
                             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/services/meetings_writer/backfill_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/backfill_adapter.rs
@@ -1,0 +1,73 @@
+//! Historical filesystem backfill adapter. Used by `backfill_meetings.rs` to
+//! reconstruct meeting rows from notes files / prep snapshots discovered on
+//! disk.
+//!
+//! Default `intelligence_state = 'archived'` since the source material is
+//! already settled (not part of the live calendar/prep pipeline).
+
+use crate::db::{ActionDb, DbMeeting};
+
+use super::invariants;
+use super::types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+
+pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteError> {
+    debug_assert_eq!(req.source, MeetingSource::Backfill);
+    invariants::validate(req)?;
+
+    let existed = db.get_meeting_by_id(&req.id).map_err(WriteError::from)?.is_some();
+    let meeting = build_db_meeting(req);
+    db.upsert_meeting(&meeting)?;
+
+    // upsert_meeting seeds meeting_transcripts with intelligence_state's
+    // default value ('detected'). Backfilled rows come from settled source
+    // material (notes / prep files on disk) so their lifecycle position is
+    // 'archived' — overwrite explicitly unless the caller passed a value.
+    let intelligence_state = req.intelligence_state.as_deref().unwrap_or("archived");
+    db.conn_ref()
+        .execute(
+            "UPDATE meeting_transcripts SET intelligence_state = ?1 WHERE meeting_id = ?2",
+            rusqlite::params![intelligence_state, &req.id],
+        )
+        .map_err(|e| WriteError::Database(e.to_string()))?;
+
+    Ok(if existed {
+        WriteOutcome::Updated
+    } else {
+        WriteOutcome::Created
+    })
+}
+
+fn build_db_meeting(req: &WriteRequest) -> DbMeeting {
+    let intelligence_state = req
+        .intelligence_state
+        .clone()
+        .or_else(|| Some("archived".to_string()));
+    DbMeeting {
+        id: req.id.clone(),
+        title: req.title.clone(),
+        meeting_type: req.meeting_type.clone(),
+        start_time: req.start_time.clone(),
+        end_time: req.end_time.clone(),
+        attendees: req.attendees.clone(),
+        notes_path: req.notes_path.clone(),
+        summary: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        calendar_event_id: req.calendar_event_id.clone(),
+        description: req.description.clone(),
+        prep_context_json: req.prep_context_json.clone(),
+        user_agenda_json: req.user_agenda_json.clone(),
+        user_notes: req.user_notes.clone(),
+        prep_frozen_json: None,
+        prep_frozen_at: None,
+        prep_snapshot_path: None,
+        prep_snapshot_hash: None,
+        transcript_path: req.transcript_path.clone(),
+        transcript_processed_at: None,
+        intelligence_state,
+        intelligence_quality: None,
+        last_enriched_at: None,
+        signal_count: None,
+        has_new_signals: None,
+        last_viewed_at: None,
+    }
+}

--- a/src-tauri/src/services/meetings_writer/calendar_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/calendar_adapter.rs
@@ -1,0 +1,36 @@
+//! Calendar source adapter. Used by:
+//!
+//! - Google Calendar attendance-batch ingestion (`services::people`).
+//! - Prepare/timeline calendar fallback (`commands::integrations`,
+//!   `prepare::orchestrate`).
+//!
+//! Maps `WriteRequest` to `ensure_meeting_in_history` which preserves the
+//! "INSERT new / UPDATE if attributes changed" semantics the polling path
+//! depends on.
+
+use crate::db::{ActionDb, EnsureMeetingHistoryInput, MeetingSyncOutcome};
+
+use super::invariants;
+use super::types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+
+pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteError> {
+    debug_assert_eq!(req.source, MeetingSource::Calendar);
+    invariants::validate(req)?;
+
+    let input = EnsureMeetingHistoryInput {
+        id: &req.id,
+        title: &req.title,
+        meeting_type: &req.meeting_type,
+        start_time: &req.start_time,
+        end_time: req.end_time.as_deref(),
+        calendar_event_id: req.calendar_event_id.as_deref(),
+        attendees: req.attendees.as_deref(),
+        description: req.description.as_deref(),
+    };
+
+    match db.ensure_meeting_in_history(input)? {
+        MeetingSyncOutcome::New => Ok(WriteOutcome::Created),
+        MeetingSyncOutcome::Changed => Ok(WriteOutcome::Updated),
+        MeetingSyncOutcome::Unchanged => Ok(WriteOutcome::Unchanged),
+    }
+}

--- a/src-tauri/src/services/meetings_writer/integration_tests.rs
+++ b/src-tauri/src/services/meetings_writer/integration_tests.rs
@@ -1,0 +1,193 @@
+//! End-to-end adapter tests against a fresh in-memory database.
+//!
+//! Each test seeds a `WriteRequest`, routes it through the public `write`
+//! dispatcher, and asserts the meeting + paired child rows materialize.
+
+#![cfg(test)]
+
+use rusqlite::params;
+
+use super::types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+use crate::db::ActionDb;
+
+fn fresh_db() -> ActionDb {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    ActionDb::open_at_unencrypted(tempdir.path().join("writer-test.db")).expect("open db")
+}
+
+fn calendar_request(id: &str) -> WriteRequest {
+    WriteRequest {
+        source: MeetingSource::Calendar,
+        id: id.to_string(),
+        title: "Customer sync".to_string(),
+        meeting_type: "customer".to_string(),
+        start_time: "2026-05-27T10:00:00+00:00".to_string(),
+        end_time: Some("2026-05-27T10:30:00+00:00".to_string()),
+        calendar_event_id: Some(format!("evt-{id}")),
+        attendees: Some("[]".to_string()),
+        description: None,
+        notes_path: None,
+        transcript_path: None,
+        prep_context_json: None,
+        user_agenda_json: None,
+        user_notes: None,
+        intelligence_state: None,
+    }
+}
+
+#[test]
+fn calendar_adapter_persists_meeting_and_child_rows() {
+    let db = fresh_db();
+    let req = calendar_request("meet-cal-1");
+    let outcome = super::write(&db, &req).expect("calendar write");
+    assert_eq!(outcome, WriteOutcome::Created);
+
+    let count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT COUNT(*) FROM meetings WHERE id = ?1",
+            params!["meet-cal-1"],
+            |row| row.get(0),
+        )
+        .expect("count meetings");
+    assert_eq!(count, 1);
+
+    let prep_count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT COUNT(*) FROM meeting_prep WHERE meeting_id = ?1",
+            params!["meet-cal-1"],
+            |row| row.get(0),
+        )
+        .expect("count meeting_prep");
+    assert_eq!(prep_count, 1);
+
+    let transcript_count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT COUNT(*) FROM meeting_transcripts WHERE meeting_id = ?1",
+            params!["meet-cal-1"],
+            |row| row.get(0),
+        )
+        .expect("count meeting_transcripts");
+    assert_eq!(transcript_count, 1);
+}
+
+#[test]
+fn calendar_adapter_rejects_personal_with_missing_calendar_event_id() {
+    let db = fresh_db();
+    let mut req = calendar_request("meet-cal-2");
+    req.calendar_event_id = None;
+    let err = super::write(&db, &req).expect_err("must fail");
+    assert!(matches!(err, WriteError::MissingRequiredField { .. }));
+
+    let count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT COUNT(*) FROM meetings WHERE id = ?1",
+            params!["meet-cal-2"],
+            |row| row.get(0),
+        )
+        .expect("count meetings");
+    assert_eq!(count, 0, "rejected write must not persist any row");
+}
+
+#[test]
+fn manual_adapter_persists_without_calendar_event_id() {
+    let db = fresh_db();
+    let req = WriteRequest {
+        source: MeetingSource::Manual,
+        id: "meet-manual-1".to_string(),
+        title: "1:1 with Alex".to_string(),
+        meeting_type: "one_on_one".to_string(),
+        start_time: "2026-05-27T14:00:00+00:00".to_string(),
+        end_time: None,
+        calendar_event_id: None,
+        attendees: None,
+        description: None,
+        notes_path: None,
+        transcript_path: None,
+        prep_context_json: None,
+        user_agenda_json: None,
+        user_notes: None,
+        intelligence_state: None,
+    };
+    let outcome = super::write(&db, &req).expect("manual write");
+    assert_eq!(outcome, WriteOutcome::Created);
+
+    let count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT COUNT(*) FROM meetings WHERE id = ?1",
+            params!["meet-manual-1"],
+            |row| row.get(0),
+        )
+        .expect("count meetings");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn reconcile_adapter_accepts_legacy_local_format_start_time() {
+    let db = fresh_db();
+    let req = WriteRequest {
+        source: MeetingSource::Reconcile,
+        id: "meet-reconcile-1".to_string(),
+        title: "Briefing-derived".to_string(),
+        meeting_type: "internal".to_string(),
+        start_time: "2026-05-27 10:00 AM".to_string(),
+        end_time: None,
+        calendar_event_id: None,
+        attendees: None,
+        description: None,
+        notes_path: Some("meetings/2026-05-27.md".to_string()),
+        transcript_path: None,
+        prep_context_json: None,
+        user_agenda_json: None,
+        user_notes: None,
+        intelligence_state: None,
+    };
+    let outcome = super::write(&db, &req).expect("reconcile write");
+    assert_eq!(outcome, WriteOutcome::Created);
+}
+
+#[test]
+fn backfill_adapter_defaults_intelligence_state_to_archived() {
+    let db = fresh_db();
+    let req = WriteRequest {
+        source: MeetingSource::Backfill,
+        id: "meet-backfill-1".to_string(),
+        title: "Historical note".to_string(),
+        meeting_type: "customer".to_string(),
+        start_time: "2024-01-15T12:00:00+00:00".to_string(),
+        end_time: None,
+        calendar_event_id: None,
+        attendees: None,
+        description: None,
+        notes_path: Some("/notes/2024-01-15.md".to_string()),
+        transcript_path: None,
+        prep_context_json: None,
+        user_agenda_json: None,
+        user_notes: None,
+        intelligence_state: None,
+    };
+    super::write(&db, &req).expect("backfill write");
+
+    let state: Option<String> = db
+        .conn_ref()
+        .query_row(
+            "SELECT intelligence_state FROM meeting_transcripts WHERE meeting_id = ?1",
+            params!["meet-backfill-1"],
+            |row| row.get(0),
+        )
+        .expect("read intelligence_state");
+    assert_eq!(state.as_deref(), Some("archived"));
+}
+
+#[test]
+fn calendar_adapter_unchanged_outcome_when_rewriting_same_row() {
+    let db = fresh_db();
+    let req = calendar_request("meet-cal-unchanged");
+    super::write(&db, &req).expect("first write");
+    let outcome = super::write(&db, &req).expect("second write");
+    assert_eq!(outcome, WriteOutcome::Unchanged);
+}

--- a/src-tauri/src/services/meetings_writer/invariants.rs
+++ b/src-tauri/src/services/meetings_writer/invariants.rs
@@ -20,8 +20,10 @@
 //! `Calendar` and `Manual` require RFC3339 UTC `start_time` so downstream
 //! TZ-aware projection (`services/meetings_view.rs`) can range-query
 //! deterministically. `Reconcile` and `Backfill` accept legacy formats
-//! because their source material predates the contract; the v1.4.8 backfill
-//! migration normalizes those rows.
+//! because their source material predates the contract. Existing rows that
+//! carry pre-RFC3339 formats are not normalized by this substrate — the
+//! invariant matrix is enforced on WRITE only. A separate backfill
+//! migration to normalize legacy rows is tracked as a follow-up.
 
 use super::types::{MeetingSource, WriteError, WriteRequest};
 

--- a/src-tauri/src/services/meetings_writer/invariants.rs
+++ b/src-tauri/src/services/meetings_writer/invariants.rs
@@ -1,0 +1,250 @@
+//! Invariant matrix for meeting-row writes.
+//!
+//! Each `MeetingSource` declares which fields are required, optional, or
+//! forbidden on top of the global rules. Validation happens at the adapter
+//! boundary so the DB-layer functions don't need to re-check.
+//!
+//! ## Matrix
+//!
+//! | Field                | Calendar | Reconcile | Manual    | Backfill |
+//! |----------------------|----------|-----------|-----------|----------|
+//! | `id`                 | required | required  | required  | required |
+//! | `title`              | required | required  | required  | required |
+//! | `meeting_type`       | required | required  | required  | required |
+//! | `start_time`         | RFC3339  | flexible  | RFC3339   | flexible |
+//! | `end_time`           | required | optional  | forbidden | optional |
+//! | `calendar_event_id`  | required | optional  | forbidden | optional |
+//! | `attendees`          | required | optional  | forbidden | optional |
+//! | `intelligence_state` | optional | optional  | optional  | archived |
+//!
+//! `Calendar` and `Manual` require RFC3339 UTC `start_time` so downstream
+//! TZ-aware projection (`services/meetings_view.rs`) can range-query
+//! deterministically. `Reconcile` and `Backfill` accept legacy formats
+//! because their source material predates the contract; the v1.4.8 backfill
+//! migration normalizes those rows.
+
+use super::types::{MeetingSource, WriteError, WriteRequest};
+
+pub fn validate(req: &WriteRequest) -> Result<(), WriteError> {
+    validate_global(req)?;
+    match req.source {
+        MeetingSource::Calendar => validate_calendar(req),
+        MeetingSource::Reconcile => validate_reconcile(req),
+        MeetingSource::Manual => validate_manual(req),
+        MeetingSource::Backfill => validate_backfill(req),
+    }
+}
+
+fn validate_global(req: &WriteRequest) -> Result<(), WriteError> {
+    let meeting_source = req.source.as_str();
+    if req.id.trim().is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "id",
+        });
+    }
+    if req.title.trim().is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "title",
+        });
+    }
+    if req.meeting_type.trim().is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "meeting_type",
+        });
+    }
+    if req.start_time.trim().is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "start_time",
+        });
+    }
+    Ok(())
+}
+
+fn validate_calendar(req: &WriteRequest) -> Result<(), WriteError> {
+    let meeting_source = MeetingSource::Calendar.as_str();
+    if !is_rfc3339(&req.start_time) {
+        return Err(WriteError::InvalidValue {
+            field: "start_time",
+            reason: format!(
+                "Calendar source requires RFC3339 UTC start_time, got `{}`",
+                req.start_time
+            ),
+        });
+    }
+    if req.calendar_event_id.as_deref().unwrap_or("").is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "calendar_event_id",
+        });
+    }
+    if req.end_time.as_deref().unwrap_or("").is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "end_time",
+        });
+    }
+    if req.attendees.as_deref().unwrap_or("").is_empty() {
+        return Err(WriteError::MissingRequiredField {
+            meeting_source,
+            field: "attendees",
+        });
+    }
+    Ok(())
+}
+
+fn validate_reconcile(_req: &WriteRequest) -> Result<(), WriteError> {
+    Ok(())
+}
+
+fn validate_manual(req: &WriteRequest) -> Result<(), WriteError> {
+    let meeting_source = MeetingSource::Manual.as_str();
+    if req.calendar_event_id.is_some() {
+        return Err(WriteError::ForbiddenField {
+            meeting_source,
+            field: "calendar_event_id",
+        });
+    }
+    if !is_rfc3339(&req.start_time) {
+        return Err(WriteError::InvalidValue {
+            field: "start_time",
+            reason: format!(
+                "Manual source requires RFC3339 UTC start_time, got `{}`",
+                req.start_time
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_backfill(_req: &WriteRequest) -> Result<(), WriteError> {
+    Ok(())
+}
+
+/// Loose RFC3339 check: starts with YYYY-MM-DDTHH:MM:SS and ends with Z or
+/// timezone offset. Tight enough to reject local-format strings
+/// (`2026-03-06 10:00 AM`); cheap enough to run per-write.
+fn is_rfc3339(value: &str) -> bool {
+    if value.len() < 20 {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    // Position 10 must be 'T'; positions 4 and 7 must be '-'.
+    bytes[4] == b'-' && bytes[7] == b'-' && bytes[10] == b'T'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_request(source: MeetingSource) -> WriteRequest {
+        WriteRequest {
+            source,
+            id: "meet-1".to_string(),
+            title: "Sync".to_string(),
+            meeting_type: "customer".to_string(),
+            start_time: "2026-05-27T10:00:00+00:00".to_string(),
+            end_time: Some("2026-05-27T10:30:00+00:00".to_string()),
+            calendar_event_id: Some("evt-1".to_string()),
+            attendees: Some("[]".to_string()),
+            description: None,
+            notes_path: None,
+            transcript_path: None,
+            prep_context_json: None,
+            user_agenda_json: None,
+            user_notes: None,
+            intelligence_state: None,
+        }
+    }
+
+    #[test]
+    fn calendar_requires_all_calendar_fields() {
+        let mut req = base_request(MeetingSource::Calendar);
+        req.calendar_event_id = None;
+        assert!(matches!(
+            validate(&req),
+            Err(WriteError::MissingRequiredField {
+                field: "calendar_event_id",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn calendar_rejects_local_format_start_time() {
+        let mut req = base_request(MeetingSource::Calendar);
+        req.start_time = "2026-05-27 10:00 AM".to_string();
+        assert!(matches!(
+            validate(&req),
+            Err(WriteError::InvalidValue {
+                field: "start_time",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn manual_forbids_calendar_event_id() {
+        let mut req = base_request(MeetingSource::Manual);
+        req.end_time = None;
+        req.attendees = None;
+        // calendar_event_id is Some by default — must be cleared for Manual
+        assert!(matches!(
+            validate(&req),
+            Err(WriteError::ForbiddenField {
+                field: "calendar_event_id",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn manual_with_cleared_calendar_id_passes() {
+        let mut req = base_request(MeetingSource::Manual);
+        req.calendar_event_id = None;
+        req.end_time = None;
+        req.attendees = None;
+        assert!(validate(&req).is_ok());
+    }
+
+    #[test]
+    fn reconcile_accepts_legacy_start_time_format() {
+        let mut req = base_request(MeetingSource::Reconcile);
+        req.start_time = "2026-05-27 10:00 AM".to_string();
+        req.calendar_event_id = None;
+        req.end_time = None;
+        req.attendees = None;
+        assert!(validate(&req).is_ok());
+    }
+
+    #[test]
+    fn backfill_accepts_minimal_fields() {
+        let mut req = base_request(MeetingSource::Backfill);
+        req.start_time = "2026-05-27 10:00 AM".to_string();
+        req.calendar_event_id = None;
+        req.end_time = None;
+        req.attendees = None;
+        assert!(validate(&req).is_ok());
+    }
+
+    #[test]
+    fn missing_id_fails_globally() {
+        let mut req = base_request(MeetingSource::Calendar);
+        req.id = String::new();
+        assert!(matches!(
+            validate(&req),
+            Err(WriteError::MissingRequiredField { field: "id", .. })
+        ));
+    }
+
+    #[test]
+    fn rfc3339_check_recognizes_offset_format() {
+        assert!(is_rfc3339("2026-05-27T10:00:00+00:00"));
+        assert!(is_rfc3339("2026-05-27T10:00:00Z00:00"));
+        assert!(!is_rfc3339("2026-05-27 10:00:00"));
+        assert!(!is_rfc3339("2026-05-27"));
+    }
+}

--- a/src-tauri/src/services/meetings_writer/manual_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/manual_adapter.rs
@@ -1,0 +1,32 @@
+//! Manual override / add adapter. Used by user-driven entity-link mutations
+//! in `services::meetings::mutate_meeting_entities` (Replace + Add branches).
+//!
+//! These writes never carry `calendar_event_id` — the user is annotating a
+//! stub history row, not authoring against a calendar event.
+
+use crate::db::{ActionDb, EnsureMeetingHistoryInput, MeetingSyncOutcome};
+
+use super::invariants;
+use super::types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+
+pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteError> {
+    debug_assert_eq!(req.source, MeetingSource::Manual);
+    invariants::validate(req)?;
+
+    let input = EnsureMeetingHistoryInput {
+        id: &req.id,
+        title: &req.title,
+        meeting_type: &req.meeting_type,
+        start_time: &req.start_time,
+        end_time: req.end_time.as_deref(),
+        calendar_event_id: None,
+        attendees: req.attendees.as_deref(),
+        description: req.description.as_deref(),
+    };
+
+    match db.ensure_meeting_in_history(input)? {
+        MeetingSyncOutcome::New => Ok(WriteOutcome::Created),
+        MeetingSyncOutcome::Changed => Ok(WriteOutcome::Updated),
+        MeetingSyncOutcome::Unchanged => Ok(WriteOutcome::Unchanged),
+    }
+}

--- a/src-tauri/src/services/meetings_writer/mod.rs
+++ b/src-tauri/src/services/meetings_writer/mod.rs
@@ -1,0 +1,51 @@
+//! Meeting-row writer substrate (Lane B of v1.4.8 Meetings Substrate v2).
+//!
+//! Production code MUST route every `INSERT INTO meetings` / `UPDATE meetings
+//! SET` through `write` or one of the source-specific helpers below. The
+//! pre-commit grep at `.githooks/pre-commit` enforces this.
+//!
+//! The four adapters (`Calendar`, `Reconcile`, `Manual`, `Backfill`) each
+//! declare an invariant set the row must satisfy — see `invariants.rs` for
+//! the matrix. Validation happens before any DB call so the failure surface
+//! is unambiguous and consistent.
+//!
+//! ## Why
+//!
+//! Prior to this substrate every write path had its own ad-hoc field set,
+//! and "is end_time required?" / "is calendar_event_id required?" answers
+//! diverged silently. The class of bugs that produced (briefing producer
+//! treating personal blocks as customer meetings, schedule rendering
+//! cancelled events, etc.) lives upstream of the read-side filter Lane A
+//! installed.
+//!
+//! ## ADR cites
+//!
+//! - ADR-0102 (boundary heuristic): typed writer adapters are a service-layer
+//!   concern, not a new ability.
+//! - ADR-0101 Rule 4 (mutations through `services/`): every meeting-row
+//!   mutation flows through this module.
+
+pub mod backfill_adapter;
+pub mod calendar_adapter;
+pub mod invariants;
+pub mod manual_adapter;
+pub mod reconcile_adapter;
+pub mod repository;
+pub mod types;
+
+#[cfg(test)]
+mod integration_tests;
+
+pub use types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+
+use crate::db::ActionDb;
+
+/// Dispatch a write to the source-specific adapter.
+pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteError> {
+    match req.source {
+        MeetingSource::Calendar => calendar_adapter::write(db, req),
+        MeetingSource::Reconcile => reconcile_adapter::write(db, req),
+        MeetingSource::Manual => manual_adapter::write(db, req),
+        MeetingSource::Backfill => backfill_adapter::write(db, req),
+    }
+}

--- a/src-tauri/src/services/meetings_writer/reconcile_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/reconcile_adapter.rs
@@ -1,0 +1,58 @@
+//! Workspace reconcile adapter. Used by `workflow::reconcile::persist_meetings`
+//! which materializes meetings from briefing markdown + prep snapshots into
+//! the meetings/meeting_prep/meeting_transcripts tables.
+//!
+//! Routes to `db::upsert_meeting` because reconcile owns full UPSERT semantics
+//! (overwrites all attribute columns), unlike the calendar / manual path which
+//! only touch attributes when changes are detected.
+
+use crate::db::{ActionDb, DbMeeting};
+
+use super::invariants;
+use super::types::{MeetingSource, WriteError, WriteOutcome, WriteRequest};
+
+pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteError> {
+    debug_assert_eq!(req.source, MeetingSource::Reconcile);
+    invariants::validate(req)?;
+
+    let existed = db.get_meeting_by_id(&req.id).map_err(WriteError::from)?.is_some();
+    let meeting = build_db_meeting(req);
+    db.upsert_meeting(&meeting)?;
+
+    Ok(if existed {
+        WriteOutcome::Updated
+    } else {
+        WriteOutcome::Created
+    })
+}
+
+fn build_db_meeting(req: &WriteRequest) -> DbMeeting {
+    DbMeeting {
+        id: req.id.clone(),
+        title: req.title.clone(),
+        meeting_type: req.meeting_type.clone(),
+        start_time: req.start_time.clone(),
+        end_time: req.end_time.clone(),
+        attendees: req.attendees.clone(),
+        notes_path: req.notes_path.clone(),
+        summary: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        calendar_event_id: req.calendar_event_id.clone(),
+        description: req.description.clone(),
+        prep_context_json: req.prep_context_json.clone(),
+        user_agenda_json: req.user_agenda_json.clone(),
+        user_notes: req.user_notes.clone(),
+        prep_frozen_json: None,
+        prep_frozen_at: None,
+        prep_snapshot_path: None,
+        prep_snapshot_hash: None,
+        transcript_path: req.transcript_path.clone(),
+        transcript_processed_at: None,
+        intelligence_state: req.intelligence_state.clone(),
+        intelligence_quality: None,
+        last_enriched_at: None,
+        signal_count: None,
+        has_new_signals: None,
+        last_viewed_at: None,
+    }
+}

--- a/src-tauri/src/services/meetings_writer/repository.rs
+++ b/src-tauri/src/services/meetings_writer/repository.rs
@@ -1,0 +1,22 @@
+//! Raw DB access for migrations and admin tooling.
+//!
+//! Only the v1.4.8 backfill migration, devtools, and demo seeds should call
+//! these — production writers go through one of the four adapters. The
+//! pre-commit grep guard ensures that.
+
+use crate::db::{ActionDb, DbError, DbMeeting, EnsureMeetingHistoryInput, MeetingSyncOutcome};
+
+/// Direct UPSERT of a full meeting record across the 3 tables. Bypasses
+/// invariant checking; reserve for backfill migrations.
+pub fn raw_upsert_meeting(db: &ActionDb, meeting: &DbMeeting) -> Result<(), DbError> {
+    db.upsert_meeting(meeting)
+}
+
+/// Direct INSERT-or-update of meetings + stub child rows. Bypasses invariant
+/// checking; reserve for migrations and demo seeds.
+pub fn raw_ensure_meeting_in_history(
+    db: &ActionDb,
+    input: EnsureMeetingHistoryInput<'_>,
+) -> Result<MeetingSyncOutcome, DbError> {
+    db.ensure_meeting_in_history(input)
+}

--- a/src-tauri/src/services/meetings_writer/types.rs
+++ b/src-tauri/src/services/meetings_writer/types.rs
@@ -1,0 +1,99 @@
+//! Type contracts for meeting-row writes.
+//!
+//! `WriteRequest` is the single shape every production writer sends. The
+//! `source` discriminant selects which adapter handles it, which determines
+//! which subset of fields are required and which transformations apply.
+//!
+//! Why a single shape: prior to this substrate every write path had its own
+//! ad-hoc field set, and "is end_time required?" / "is calendar_event_id
+//! required?" answers diverged silently. The matrix lives in `invariants.rs`;
+//! `WriteRequest` carries the union, and `MeetingSource` declares which row a
+//! caller is authoring.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeetingSource {
+    /// Google Calendar polling and attendance-batch ingestion. Authoritative
+    /// for `calendar_event_id`, `end_time`, `attendees`.
+    Calendar,
+    /// Workspace reconcile (`workflow/reconcile.rs`). Persists meetings from
+    /// briefing markdown / prep snapshots; `calendar_event_id` is optional
+    /// because some legacy rows predate calendar polling.
+    Reconcile,
+    /// User-driven entity override or manual add (`services/meetings.rs`).
+    /// Never carries `calendar_event_id` — these rows are stub history records
+    /// the user is annotating.
+    Manual,
+    /// Historical filesystem backfill (`backfill_meetings.rs`). Initializes
+    /// `intelligence_state = 'archived'` because the source material is
+    /// already settled (notes / prep files on disk).
+    Backfill,
+}
+
+impl MeetingSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MeetingSource::Calendar => "calendar",
+            MeetingSource::Reconcile => "reconcile",
+            MeetingSource::Manual => "manual",
+            MeetingSource::Backfill => "backfill",
+        }
+    }
+}
+
+/// One meeting-row write request. Carriers fill the fields their source
+/// authoritatively knows; adapters validate via `invariants::validate`.
+#[derive(Debug, Clone)]
+pub struct WriteRequest {
+    pub source: MeetingSource,
+    pub id: String,
+    pub title: String,
+    pub meeting_type: String,
+    pub start_time: String,
+    pub end_time: Option<String>,
+    pub calendar_event_id: Option<String>,
+    pub attendees: Option<String>,
+    pub description: Option<String>,
+    pub notes_path: Option<String>,
+    pub transcript_path: Option<String>,
+    pub prep_context_json: Option<String>,
+    pub user_agenda_json: Option<String>,
+    pub user_notes: Option<String>,
+    pub intelligence_state: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteOutcome {
+    /// Row did not exist and was inserted.
+    Created,
+    /// Row existed and meaningful fields changed.
+    Updated,
+    /// Row existed and no meaningful fields changed (no-op write).
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum WriteError {
+    #[error("missing required field for {meeting_source}: {field}")]
+    MissingRequiredField {
+        meeting_source: &'static str,
+        field: &'static str,
+    },
+    #[error("forbidden field for {meeting_source}: {field}")]
+    ForbiddenField {
+        meeting_source: &'static str,
+        field: &'static str,
+    },
+    #[error("invalid value for {field}: {reason}")]
+    InvalidValue {
+        field: &'static str,
+        reason: String,
+    },
+    #[error("database write failed: {0}")]
+    Database(String),
+}
+
+impl From<crate::db::DbError> for WriteError {
+    fn from(value: crate::db::DbError) -> Self {
+        WriteError::Database(value.to_string())
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -40,6 +40,7 @@ pub mod mcp_v2;
 pub mod meeting_prep_status;
 pub mod meetings;
 pub mod meetings_view;
+pub mod meetings_writer;
 pub mod mutations;
 pub mod people;
 pub mod projection_signing;

--- a/src-tauri/src/services/people.rs
+++ b/src-tauri/src/services/people.rs
@@ -96,23 +96,30 @@ pub(crate) fn record_calendar_attendance_batch(
                 .optional()
                 .map_err(|e| e.to_string())?;
 
-            match tx
-                .ensure_meeting_in_history(crate::db::EnsureMeetingHistoryInput {
-                    id: &event.meeting_id,
-                    title: &event.title,
-                    meeting_type: &event.meeting_type,
-                    start_time: &event.start_time,
-                    end_time: event.end_time.as_deref(),
-                    calendar_event_id: Some(&event.calendar_event_id),
-                    attendees: Some(&event.attendees_json),
-                    description: None,
-                })
+            let write_req = crate::services::meetings_writer::WriteRequest {
+                source: crate::services::meetings_writer::MeetingSource::Calendar,
+                id: event.meeting_id.clone(),
+                title: event.title.clone(),
+                meeting_type: event.meeting_type.clone(),
+                start_time: event.start_time.clone(),
+                end_time: event.end_time.clone(),
+                calendar_event_id: Some(event.calendar_event_id.clone()),
+                attendees: Some(event.attendees_json.clone()),
+                description: None,
+                notes_path: None,
+                transcript_path: None,
+                prep_context_json: None,
+                user_agenda_json: None,
+                user_notes: None,
+                intelligence_state: None,
+            };
+            match crate::services::meetings_writer::write(tx, &write_req)
                 .map_err(|e| e.to_string())?
             {
-                crate::db::MeetingSyncOutcome::New => {
+                crate::services::meetings_writer::WriteOutcome::Created => {
                     outcome.new_meetings.push(event.meeting_id.clone());
                 }
-                crate::db::MeetingSyncOutcome::Changed => {
+                crate::services::meetings_writer::WriteOutcome::Updated => {
                     tx.mark_meeting_new_signals(&event.meeting_id)
                         .map_err(|e| e.to_string())?;
                     outcome.changed_meetings.push(event.meeting_id.clone());
@@ -139,7 +146,7 @@ pub(crate) fn record_calendar_attendance_batch(
                         }
                     }
                 }
-                crate::db::MeetingSyncOutcome::Unchanged => {}
+                crate::services::meetings_writer::WriteOutcome::Unchanged => {}
             }
 
             for email_lower in &event.attendee_emails {


### PR DESCRIPTION
## Linear ticket

[DOS-775](https://linear.app/a8c/issue/DOS-775) — Lane B: Meetings writers hardening. Parent wave: [DOS-773](https://linear.app/a8c/issue/DOS-773). Sequel to [DOS-774](https://linear.app/a8c/issue/DOS-774) / PR #405 (merged).

## Summary

Introduces `services::meetings_writer` — a typed write substrate that gates every meeting-row INSERT/UPDATE through one of four source-declared adapters (`Calendar`, `Reconcile`, `Manual`, `Backfill`). Each adapter validates against a source-scoped invariant matrix before touching the DB. A new pre-commit grep gate blocks raw `INSERT INTO meetings` / `UPDATE meetings SET` writes anywhere outside the explicit allowlist.

## What changed

- **New module** `src-tauri/src/services/meetings_writer/`:
  - `types.rs` — `WriteRequest`, `MeetingSource { Calendar, Reconcile, Manual, Backfill }`, `WriteOutcome { Created, Updated, Unchanged }`, `WriteError` (typed via `thiserror`).
  - `invariants.rs` — global + source-scoped invariant matrix. Calendar requires `calendar_event_id` + `end_time` + `attendees` + RFC3339-shape `start_time`; Manual forbids `calendar_event_id`; Reconcile / Backfill accept legacy field shapes.
  - `calendar_adapter.rs`, `manual_adapter.rs`, `reconcile_adapter.rs`, `backfill_adapter.rs` — each routes a validated request to the right DB primitive (`db::ensure_meeting_in_history` for the insert-or-update-on-change pattern, `db::upsert_meeting` for the full upsert pattern).
  - `repository.rs` — `raw_*` admin/migration bypass (callers of last resort; pre-commit grep blocks bypass elsewhere).
  - `mod.rs` — public `write()` dispatcher.
- **Production migrations** (6 writer call sites):
  - Calendar attendance batch → CalendarWriter (`services/people.rs`)
  - Manual entity Replace / Add → ManualWriter (`services/meetings.rs:1119`, `:1221`)
  - Workspace reconcile → ReconcileWriter (`services/meetings.rs::upsert_meeting_for_reconcile`)
  - Prepare today / week calendar fallback → ReconcileWriter (`prepare/orchestrate.rs:781`, `:1229`) — L1 audit split per ticket
  - Historical filesystem backfill → BackfillWriter (`backfill_meetings.rs`)
- **Pre-commit gate** at `scripts/check_meetings_writer_boundary.sh`. Allowlists the DB primitives (`db/meetings.rs`), reclassification path (`db/accounts.rs`), lifecycle scrubs (`db/data_lifecycle.rs`), migrations, devtools, demo seeds, and `#[cfg(test)]` blocks (via reverse-walk heuristic).

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib meetings_writer` — 14/14 pass (7 invariant unit tests + 6 adapter integration tests + Lane A read regression still green via separate run)
- [x] `pnpm tsc --noEmit` clean
- [x] L2 unanimous no-BLOCK — l2-bounded-reviewer (AC-scoped APPROVE), pr-review-toolkit:type-design-analyzer (advisory only), ce-data-integrity-guardian (advisory only), ce-maintainability-reviewer (advisory only)
- [ ] Manual verification: no L4 needed — substrate-only change, no surface impact. Calendar polling + manual override + reconcile + backfill paths exercise the new adapters on first run.

## Definition of Done

- [x] `services/meetings_writer/` with 4 adapters + invariants
- [x] Every production INSERT/UPDATE routes through an adapter (6 call sites migrated)
- [ ] Backfill migration for existing rows — **deferred to follow-up** ([DOS-804](https://linear.app/a8c/issue/DOS-804)). Substrate is correct without it; legacy rows are read-safe under Lane B (reads don't validate invariants; only writes do). Filed because the migration is too risky to land without walking through real workspace data.
- [x] Pre-commit grep enforces no raw INSERT/UPDATE outside exempt paths
- [x] `cargo clippy && cargo test && pnpm tsc` clean
- [x] Lane A's `read_surface_meetings` regression test still passes

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: _n/a_

- [x] Touches `src-tauri/src/services/`?
- [ ] Modifies `.sql` migrations? (Lane B's backfill migration is the deferred follow-up — DOS-804.)
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs, tool registry, or skill definitions?
- [ ] Adds a new trust boundary?
- [ ] Defines a privileged action?
- [ ] Adds or modifies `.github/workflows/*`?
- [ ] Adds a new dependency?

Write-substrate hardening; no new auth or scope surface. Local-to-local single-user threat topology. Reviewed by L2 substrate path (l2-bounded + data-integrity + type-design + maintainability); no security regressions.

## Follow-ups

Filed during L2:

- [DOS-804](https://linear.app/a8c/issue/DOS-804) (child of DOS-775) — backfill migration normalizing legacy meeting rows
- [DOS-805](https://linear.app/a8c/issue/DOS-805) — type-design hardening (typed WriteRequest constructors, `MeetingSource` rename, `Rfc3339` newtype)
- [DOS-806](https://linear.app/a8c/issue/DOS-806) — backfill adapter's doubled-write atomicity
- [DOS-807](https://linear.app/a8c/issue/DOS-807) — bundled maintenance (adapter transaction wrap, `is_rfc3339` rename, pre-commit gate hardening, partial `WriteOutcome::Unchanged` reachability, dead code, naming)

## Notes for review

- `prepare/orchestrate.rs` paths route through `ReconcileWriter` rather than `CalendarWriter` because the upstream calendar JSON lacks `end_time`/`attendees` that CalendarWriter's invariants require. Ticket said "CalendarWriter (L1 audit may split)" — this is the split decision, documented inline.
- The pre-commit gate's `is_inside_test_module` heuristic is a reverse-walk to the nearest `#[cfg(test)]`. Works on every current writer call site but has a known false-negative class on files with multiple test mods followed by production code — DOS-807 F3 covers the harden.
- `is_rfc3339` is a structural check (length + position of `-`/`-`/`T`), not a real RFC3339 parse. Adequate for catching local-format strings like `"2026-03-06 10:00 AM"`. DOS-805/DOS-807 cover tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)