### PR TITLE
v1.4.6 W4-A: Recommendation feedback loop (DOS-332)

### DIFF
--- a/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
@@ -1,0 +1,325 @@
+---
+ticket: DOS-332
+title: "v1.4.6 W4-A — Recommendation feedback loop"
+parent_plan: ../v1.4.6-waves.md
+fork_sha: 2a6ec716
+branch: codex/v1.4.6-w4a-recommendation-feedback
+status: L0 — plan hardening, cycle 0 draft
+authors: James Giroux, Claude
+related:
+  - ADR-0123 (Typed Claim Feedback Semantics — 10 variants, V1.1)
+  - ADR-0102 (Abilities as Runtime Contract)
+  - ADR-0105 (Provenance as First-Class Output)
+  - ADR-0125 (Claim Anatomy / Sensitivity / TypeRegistry)
+  - DOS-332 (this ticket)
+  - DOS-298 (W3-A — Suggested Next Steps block contract, merged)
+  - DOS-331 (W2-A — Surfacing policy, merged; owns cooldown state)
+  - DOS-329 (W1-A — RecommendationClaim contract, merged; owns FeedbackState shape)
+---
+
+# v1.4.6 W4-A — Recommendation feedback loop (DOS-332)
+
+## §0 Frame
+
+W4-A is **substrate-only**. Per the UI Surface Deferral Amendment (2026-05-27), v1.4.6 continues with backend wiring while WP and Tauri surfaces wait for production readiness + redesign respectively. W4-A delivers the feedback ability + service path so that *when* a surface ships its affordance, the producer is ready.
+
+Scope per `v1.4.6-waves.md:1005-1022`:
+
+1. Fill the placeholder at `src-tauri/src/services/recommendations/feedback.rs` (today: 7-line docblock — see read at L0).
+2. Author the recommendation-feedback wrapper API: `record_recommendation_feedback(claim_id, decision, context) -> FeedbackState`.
+3. Map each `RecommendationFeedbackDecision` variant (Accept / Dismiss{reason} / NotUseful / TooNoisy / Convert) onto:
+   - the existing `FeedbackAction` enum + `services::claims::record_claim_feedback` write path (for truth-feedback semantics) OR
+   - the surfacing cooldown state (for ranking-only feedback, never trust)
+4. Ship the typed `FeedbackState::Pending → FeedbackState::Decided(...)` transition on the `RecommendationClaim`.
+5. Tests verify each variant produces the documented ADR-0123 action and the right downstream effect (trust vs surfacing vs ranking).
+
+**No new tables.** `claim_feedback` is the existing storage. ADR-0123's 10-variant enum is fixed; W4-A consumes it.
+
+**No new ADR.** This is a wrapper around existing primitives.
+
+**No UI dependency.** W3-A's WP block has affordance markup but disabled handler (Option A). When this lane ships, the block's `dailyos_suggested_next_steps_feedback_enabled` filter flips to true. DOS-802's Tauri surface follows the same pattern when it eventually lands.
+
+**Reviewer routing (per CLAUDE.md L0 default + W4-A wave-plan W4-A-specific):**
+
+- `/codex challenge` — adversarial planning reviewer (parallel)
+- `ce-feasibility-reviewer` — substrate alignment (claim_feedback shape, FeedbackAction surface, cooldown state)
+- `ce-scope-guardian-reviewer` — confirm no parallel tables, no new ADR, no UI scope creep
+- `ce-learnings-researcher` — K-in mandatory parallel (look for prior feedback-mapping work, ADR-0123 amendments, prior feedback solution memories)
+
+No `ce-design-lens-reviewer` — substrate-only. No `ce-security-lens-reviewer` — W4-A doesn't touch actor exposure or telemetry (W4-C does; this lane doesn't).
+
+---
+
+## §1 The mapping (proposed; reviewer-challengeable)
+
+Five `RecommendationFeedbackDecision` variants → ADR-0123 actions OR surfacing-state writes. **This is the load-bearing design decision of W4-A.**
+
+| `RecommendationFeedbackDecision` | Maps to | Rationale |
+|---|---|---|
+| `Accept { at }` | `FeedbackAction::ConfirmCurrent` via `record_claim_feedback` | User confirms the recommendation is valid; reinforces source + agent reliability. Salience UserFit factor weights up on next compute. |
+| `Dismiss { at, reason: NotRelevant }` | `FeedbackAction::WrongSubject` via `record_claim_feedback` | Per ADR-0123 §5: WrongSubject tombstones the claim on the asserted subject; source not punished. Matches "not relevant to this entity." |
+| `Dismiss { at, reason: AlreadyKnew }` | Surfacing cooldown only (no `claim_feedback` write) | User isn't disputing the recommendation's truth — just doesn't need it surfaced. Bumps the cooldown on `(subject, action_signature)` per W2-A's surfacing policy. Does NOT downweight source or claim. |
+| `Dismiss { at, reason: WrongSubject }` | `FeedbackAction::WrongSubject` via `record_claim_feedback` | Direct mapping; linker reliability hit, source untouched. |
+| `Dismiss { at, reason: Other(BoundedNote) }` | Surfacing cooldown only + note logged to `claim_feedback` payload | Reason unknown; safest interpretation is "don't surface again on this subject" without truth-judgment. The note is captured for future analysis but doesn't drive any automatic semantic action. |
+| `NotUseful { at }` | Surfacing cooldown only (no `claim_feedback` write) | Per DOS-332 AC: "Dismissed and not-useful recommendations reduce salience without necessarily reducing source trust." Treated as ranking-only signal — surfacing cooldown extends, UserFit downweights via W1-B salience re-compute. |
+| `TooNoisy { at }` | Surfacing cooldown only (no `claim_feedback` write) | Per DOS-332 AC: "Too-noisy feedback updates surfacing thresholds/cooldowns rather than treating the claim as false." Extends cooldown more aggressively than NotUseful; possibly flags the entire subject's surfacing tier (subject becomes more conservative). |
+| `Convert { at, into: Action(action_id) }` | `FeedbackAction::ConfirmCurrent` + open-loop attachment | Conversion is the strongest positive signal. The recommendation becomes an action (existing open-loop infrastructure); ConfirmCurrent reinforces the source. |
+| `Convert { at, into: ClaimCorrection(claim_id) }` | `FeedbackAction::MarkOutdated` on the original + new claim proposal | The user is saying "the recommendation was based on outdated info; here's the corrected claim." MarkOutdated demotes the trigger claim; the corrected claim_id is the new ground truth. |
+| `Convert { at, into: ReviewQueue(queue_item_id) }` | No `claim_feedback` write; existing review-queue routing applies | Per DOS-336 (review queue) the existing claim-review-queue lifecycle handles this. W4-A only emits the queue-item id — review queue owns the conversion semantics. |
+
+**Cooldown-only writes go through W2-A's surfacing-policy service**, not through a new path. W4-A imports the cooldown API from `services::recommendations::surfacing` (which W2-A owns) and calls it with `(subject, action_signature, reason, decided_at)`.
+
+**Updated `FeedbackState` after the call:** every variant transitions `Pending → Decided(<the variant>)` on the `RecommendationClaim`. The claim's `feedback_state` column updates atomically with the underlying action (whether that's a `claim_feedback` insert, a cooldown bump, or both).
+
+---
+
+## §2 Scope + producer authority
+
+### In scope
+
+| File / surface | Owner |
+|---|---|
+| `src-tauri/src/services/recommendations/feedback.rs` (fill 7-line placeholder) | W4-A |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/` — new `submit_recommendation_feedback` ability | W4-A |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs` — additive input/output types for the new ability | W4-A |
+| `src-tauri/abilities-runtime/src/abilities/recommendations/mod.rs` — register ability | W4-A |
+| `src-tauri/src/services/context.rs` — wire feedback handle | W4-A |
+| `tools/dailyos-abilities.json` — regen | W4-A |
+| Rust unit tests covering all 10 mapping rows above (parametric) | W4-A |
+| Integration test: full Pending → Decided cycle with seeded `RecommendationClaim` | W4-A |
+
+### Out of scope
+
+- WP block UI changes (block already has affordance markup gated by `dailyos_suggested_next_steps_feedback_enabled`; flip after W4-A merges OR in a follow-up depending on WP surface readiness — see UI Surface Deferral)
+- Tauri React UI (DOS-802 parked)
+- New tables / migrations (use `claim_feedback` + W2-A cooldown state)
+- New ADR-0123 variants (consume the 10 existing)
+- Engagement telemetry path (W4-C lane)
+- Deviation detection (W4-B lane)
+- Salience re-compute timing changes (W1-B owns; W4-A emits the feedback that re-compute consumes on next cycle)
+
+### Producer authority restatement
+
+Wave plan §line 1015-1020:
+- Claim model: feedback writes through service path (existing `record_claim_feedback`)
+- Provenance: user feedback affects future salience factor weights (UserFit factor — W1-B re-compute consumes)
+- Signals: emit existing claim-feedback signals; no new signal types
+- Runtime: wired from W3-A action handlers (when UI flips on)
+- Feedback loop: this IS the feedback loop primitive
+
+---
+
+## §3 Ability contract
+
+### §3.1 Identity
+
+- **Name:** `submit_recommendation_feedback`
+- **Category:** `Write`
+- **Allowed actors:** `[User, SurfaceClient]` — the user OR a surface acting on the user's explicit click. NOT `System` (no automatic feedback), NOT `Agent` / `Admin`, NOT `McpClient`.
+- **`required_scopes`:** `["write.recommendations"]` (NEW scope; needs to be registered in the surface scope policy — see §5 channel enumeration)
+- **`may_publish`:** false (writes don't publish to other surfaces; downstream effects are async via salience re-compute and surfacing-state mutation)
+- **`mcp_exposure`:** `None`
+- **`composes`:** `[claim_receipt]` (reads the receipt to verify the claim is in `Pending` feedback state before mutating; rejects double-feedback)
+- **`signal_policy.emits_on_output_change`:** `[RecommendationFeedbackRecorded]` — a NEW SignalType variant that W4-A pre-declares for downstream W4-B/C consumption. Per wave plan §line 1018, the SignalType variant requires L0 approval — this packet is the approval request.
+- **Schema version:** 1
+
+### §3.2 Input
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRecommendationFeedbackInput {
+    pub schema_version: u32, // pinned to 1 per A14 schema-version-cliff policy
+    pub claim_id: ClaimId,
+    pub decision: RecommendationFeedbackDecision, // existing enum from contracts.rs
+    pub context: RecommendationFeedbackContext,   // existing struct (surface + invocation_id)
+}
+```
+
+`RecommendationFeedbackDecision` and `RecommendationFeedbackContext` already exist in `src-tauri/src/services/recommendations/contracts.rs` (W1-A landed them). No new types required.
+
+### §3.3 Output
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRecommendationFeedbackResponse {
+    pub schema_version: u32,
+    pub claim_id: ClaimId,
+    pub feedback_state: FeedbackState,         // always Decided(<variant>) after success
+    pub conversion_state: ConversionState,     // updated if Convert variant
+    pub downstream_effect: DownstreamEffect,   // see below — explains what happened
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum DownstreamEffect {
+    ClaimFeedbackRecorded { action: FeedbackAction, feedback_id: String },
+    SurfacingCooldownBumped { subject_kind: String, subject_id: String, action_signature: String, new_cooldown_until: DateTime<Utc> },
+    BothApplied { action: FeedbackAction, feedback_id: String, new_cooldown_until: DateTime<Utc> },
+    NoMutation { reason: String }, // e.g., already-decided idempotent reject
+}
+```
+
+`DownstreamEffect` exposes which path the mapping took — useful for the surface to render a confirmation chip ("Action recorded" vs "Cooldown extended") and for tests to verify the mapping deterministically.
+
+### §3.4 Service-side flow
+
+`services::recommendations::feedback::record_recommendation_feedback`:
+
+1. Load the `RecommendationClaim` by `claim_id`. Reject if not found (`ClaimError::UnknownClaimId`) or if not a recommendation claim (`ClaimError::UnsupportedClaimType`).
+2. Check `feedback_state`. If already `Decided`, return `DownstreamEffect::NoMutation { reason: "already_decided" }` and the existing state. Idempotent semantics.
+3. Match on `decision` variant per §1 mapping table; dispatch to either:
+   - `record_claim_feedback(...)` with the mapped `FeedbackAction` and constructed `ClaimFeedbackInput`
+   - `services::recommendations::surfacing::bump_cooldown(...)` with the subject + action_signature
+   - Both (for the `Dismiss { Other }` and `Convert { ClaimCorrection }` variants)
+4. Update the `RecommendationClaim` row's `feedback_state` and (if applicable) `conversion_state` columns atomically within the transaction.
+5. Emit `RecommendationFeedbackRecorded` signal.
+6. Return `SubmitRecommendationFeedbackResponse` with the relevant `DownstreamEffect`.
+
+All within `with_claim_transaction` so the claim_feedback insert + recommendation_claim update + cooldown bump are atomic per claim.
+
+---
+
+## §4 Acceptance criteria
+
+1. **Ability ships and is registered.** `submit_recommendation_feedback` in `tools/dailyos-abilities.json` (regen); `AbilityRegistry` exposes to `[User, SurfaceClient]`. `cargo test recommendations::submit_recommendation_feedback` passes.
+2. **Mapping is deterministic.** Parametric test enumerates all 10 mapping rows in §1; asserts the documented `DownstreamEffect` shape for each.
+3. **Idempotent.** Re-submitting feedback for an already-`Decided` claim returns `NoMutation` and does not mutate `claim_feedback` or surfacing state.
+4. **Atomicity.** The recommendation_claim feedback_state column + the underlying action (claim_feedback row, cooldown bump, or both) are all in one transaction; partial mutations are not observable.
+5. **No new tables.** Migrations diff is empty. Uses existing `claim_feedback` and surfacing state.
+6. **No new ADR-0123 variants.** Maps to the existing 10 variants only. If reviewer panel finds any variant needs a new ADR-0123 mapping, L0 amendment first.
+7. **Privacy.** `Dismiss { reason: Other(BoundedNote) }` enforces the 200-char cap at the API boundary (already enforced by `BoundedNote::try_from` in contracts.rs). The note is stored in `claim_feedback.payload_json`, never in surfacing rows.
+8. **Signal contract.** `RecommendationFeedbackRecorded` SignalType variant declared in `signals/policy_registry.rs` (W0-style shared infrastructure file); downstream W4-B/C will reference it from this declaration.
+9. **W3-A integration ready.** When `dailyos_suggested_next_steps_feedback_enabled` flips to true (post W4-A merge), the W3-A view.js handler POSTs to the WP REST bridge that invokes this ability with `Actor::SurfaceClient`. W4-A does not flip the filter; that's a one-line UI follow-up.
+10. **Cycle hygiene.** `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean.
+
+---
+
+## §5 Registry channel enumeration
+
+Per W3-A's A8 pattern (channels enumerated before merge):
+
+1. **Ability registry** — auto via `#[ability(...)]` macro; tested via `tools/dailyos-abilities.json` diff.
+2. **Surface scope registry** — new `write.recommendations` scope; verify file path at L1 grep (likely `abilities-runtime/src/abilities/registry.rs`).
+3. **WP REST endpoint allowlist** — the new ability must be admitted by `wp/dailyos/includes/transport/class-dailyos-runtime-client.php`'s allowlist (if explicit) or pass through (if dynamic per scope). Verify at L1.
+4. **`tools/dailyos-abilities.json`** — regen + commit.
+5. **`signals/policy_registry.rs`** — pre-declare `RecommendationFeedbackRecorded` SignalType.
+6. **Per-Actor dry-run test** — assert `[User, SurfaceClient]` admit; `[System, Agent, Admin, McpClient]` deny with `Capability` error.
+
+---
+
+## §6 Test plan
+
+### Rust unit
+
+- Mapping table parametric: each `RecommendationFeedbackDecision` variant produces the documented `DownstreamEffect` (10 rows)
+- Idempotent re-submission returns `NoMutation`
+- `Dismiss { Other }` with note >200 chars rejected at contract level (already enforced by `BoundedNote`)
+- Unknown `claim_id` returns `ClaimError::UnknownClaimId`
+- Non-recommendation claim_id returns `ClaimError::UnsupportedClaimType`
+- Per-Actor allowlist test ([User, SurfaceClient] admit; rest deny)
+
+### Integration (`cargo test --test` recommendations)
+
+- Full Pending → Decided cycle: seed claim, submit Accept, verify `claim_feedback` row + claim's `feedback_state` updated atomically
+- Cooldown-only path: submit `NotUseful`, verify no `claim_feedback` row; cooldown bumped in surfacing state
+- Both-paths: submit `Convert { ClaimCorrection }`, verify `claim_feedback` `MarkOutdated` row + corrected claim proposal exists
+- Signal emission: assert `RecommendationFeedbackRecorded` signal fired with correct claim_id + decision variant
+
+### Substrate-side smoke (deferred to W3-A integration when UI flips)
+
+- WP block view.js → REST endpoint → ability → service path → claim_feedback / surfacing — full vertical test. Deferred per UI Surface Deferral.
+
+---
+
+## §7 CI gate inputs (L1 deliverables per memory rule)
+
+| Artifact | Notes |
+|---|---|
+| `tools/dailyos-abilities.json` regen | Deterministic per W3-A precedent |
+| `signals/policy_registry.rs` `RecommendationFeedbackRecorded` variant | Shared infra file; commit alongside |
+| `services::recommendations::feedback` doc comments | Document the mapping table inline so future readers don't have to find this packet |
+| L2-status in commit messages | `passed` per memory rule |
+
+---
+
+## §8 Migration disposition
+
+**No new migrations.** Empty migrations diff. v273 stays available for W4-B/W4-C if they need storage.
+
+---
+
+## §9 Cross-wave coordination
+
+- **W3-A (merged):** W3-A's WP block has affordance markup gated by `dailyos_suggested_next_steps_feedback_enabled` filter (default false). Post W4-A merge, a one-line follow-up flips this filter. That follow-up is NOT W4-A scope per the UI Surface Deferral — it depends on WP surface readiness.
+- **DOS-802 (parked):** Tauri carve-out follows the same pattern when it unblocks.
+- **W4-B (DOS-316 deviation):** consumes feedback signal as Novelty factor input. W4-B's L0 reads from `RecommendationFeedbackRecorded` signal declared here.
+- **W4-C (DOS-317 engagement):** distinct from feedback (engagement is implicit observation; feedback is explicit click). W4-C imports the same `EngagementSignal` types from W1-A contracts but does not call into W4-A's service.
+- **W5 eval (DOS-338):** the eval harness tests "feedback updates ranking on next cycle" — depends on W4-A's signal + W1-B's salience consumer.
+
+---
+
+## §10 Out of scope (restatement)
+
+- WP block UI changes
+- Tauri React UI (DOS-802 parked)
+- New tables, migrations, or ADR-0123 variants
+- Engagement telemetry (W4-C)
+- Deviation detection (W4-B)
+- Salience re-compute timing (W1-B owns)
+- Cross-surface dedup of recommendations (W3-B parked)
+
+---
+
+## §11 K-in citations (preliminary; `ce-learnings-researcher` confirms in parallel)
+
+- ADR-0123 (Typed Claim Feedback Semantics) — the 10-variant enum W4-A maps onto
+- ADR-0102 (Abilities as Runtime Contract) — ability registration pattern
+- ADR-0105 (Provenance as First-Class Output) — feedback writes carry provenance
+- `services::claims::record_claim_feedback` (claims.rs:7128) — existing write path
+- `services::recommendations::contracts` — `RecommendationFeedbackDecision`, `RecommendationFeedbackContext`, `BoundedNote` already landed in W1-A
+- `abilities-runtime::abilities::feedback` — existing `FeedbackAction` enum + claim-feedback ability (for the bridge keys)
+- `services::recommendations::surfacing` — W2-A's cooldown state API (consume from this lane)
+- `docs/solutions/security-issues/prompt-channel-sensitivity-class-sweep-2026-05-18.md` — class-sweep test pattern (less critical here than W3-A but applicable)
+
+K-in needs to confirm: no prior `submit_recommendation_feedback` solution exists; no parallel feedback-mapping memory documents alternative variant→action mappings.
+
+---
+
+## §12 Open questions (L0 panel decides)
+
+1. **`Dismiss { Other(BoundedNote) }` mapping.** Proposed: cooldown bump + note logged to `claim_feedback.payload_json`. Alternative: treat as MarkOutdated with note. Which is the better default?
+2. **`NotUseful` vs `TooNoisy` distinction.** Both are cooldown-only. Should TooNoisy bump the cooldown MORE aggressively (e.g., extend the whole subject's cooldown across action_signatures), or just bump the same as NotUseful? Per DOS-332 AC's "TooNoisy updates surfacing thresholds/cooldowns" — sounds like broader-than-NotUseful.
+3. **Convert → ClaimCorrection mapping.** Currently MarkOutdated on the original + new claim proposal. Should the new corrected claim be auto-committed or stay in `propose` state per ADR-0123? Default: propose, per ADR-0123 §5.
+4. **`RecommendationFeedbackRecorded` SignalType payload.** What fields does the signal carry? Minimal: `{ claim_id, decision_variant, downstream_effect_kind }`. Should also include `subject` for downstream filtering?
+5. **WP REST endpoint shape.** The block needs a WP REST endpoint to POST feedback. Does it use existing dailyos-runtime-client transport with `Actor::SurfaceClient`, or a dedicated `/v1/surface/submit-feedback` endpoint? Default: reuse the runtime client invoke path (write abilities go through the same path; scope policy enforces).
+
+---
+
+## §13 Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Mapping table is wrong (a variant punishes source when it shouldn't) | HIGH | Reviewer panel hits this hardest; parametric test asserts each variant's downstream_effect_kind matches the documented contract |
+| Atomicity bug — claim_feedback row written but recommendation_claim feedback_state not updated | HIGH | Single transaction wrap via `with_claim_transaction`; integration test asserts both observe same state |
+| Idempotent re-submission accidentally double-writes | MED | Explicit feedback_state check at step 2 of service flow; test asserts re-submission returns NoMutation |
+| `BoundedNote` 200-char enforcement bypassed | LOW | Already enforced at `BoundedNote::try_from` construction; can't bypass without unsafe code |
+| New `write.recommendations` scope isn't registered in WP allowlist → block can't call ability | MED | A8 channel enumeration covers this; L1 grep before merge |
+| `Convert { Action }` writes both `ConfirmCurrent` AND an open-loop attachment — what if the open-loop service fails? | MED | Wrap both in the same transaction; if open-loop create fails, rollback the feedback too |
+| `RecommendationFeedbackRecorded` signal fires before downstream consumers (W4-B/C) exist | LOW | Signal type declared but unused for one wave; no harm |
+
+---
+
+## §14 Definition of Done
+
+Per CLAUDE.md DoD section:
+
+1. All 5 `RecommendationFeedbackDecision` variants (10 mapping rows including Dismiss reasons) implemented per §1 table
+2. End-to-end flow tested: ability invocation → service path → claim_feedback / surfacing state → signal emission
+3. No stubs or TODOs
+4. `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean
+5. L2-status declared in commit messages
+6. No L4 evidence required (no UI surface in this lane)
+7. K-out: any class-pattern findings from L2 filed via `/ce-compound mode:headless` at retro close

--- a/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
@@ -433,10 +433,10 @@ No `ce-design-lens-reviewer` — substrate-only. No `ce-security-lens-reviewer` 
 | `Dismiss { reason: NotRelevant }` | `NotRelevantHere` | No trust delta | 14-day cooldown via `feedback_suppression_days` |
 | `Dismiss { reason: AlreadyKnew }` | `NotRelevantHere` | No trust delta | 14-day cooldown |
 | `Dismiss { reason: WrongSubject }` | `WrongSubject` | -0.3 subject_evidence on linker; source untouched | Tombstones the claim on the asserted subject (per-subject) |
-| `Dismiss { reason: Other(BoundedNote) }` | `NotRelevantHere` with `note` field populated | No trust delta; note captured in ADR-0123 typed `note: Option<String>` column | 14-day cooldown |
+| `Dismiss { reason: Other(BoundedNote) }` | `NotRelevantHere` with `note` encoded in `payload_json` | No trust delta; note encoded as `{"invocation_id": ..., "note": "..."}` in `payload_json` (per B15 — `claim_feedback` has no typed `note` column; validator extended to admit optional `note` key) | 14-day cooldown |
 | `NotUseful { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown |
 | `TooNoisy { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown (same as NotUseful at substrate level; intensity is UX framing, not substrate distinction) |
-| `Convert { at, into: Action(action_id) }` | `ConfirmCurrent` | +α on source / agent | None. **Open-loop attachment is a separate at-least-once call** (`services::actions::attach_from_recommendation` or equivalent); not transactional with the feedback write because attachment may invoke external side effects (calendar / message scheduling). If attachment fails, the feedback row stays (truth-feedback is authoritative); attachment retries via existing action retry infrastructure. |
+| `Convert { at, into: Action(action_id) }` | `ConfirmCurrent` | +α on source / agent | None. **Pure state update** (per B16): `conversion_state` set to `ConvertedToAction { action_id }` via `json_set` on `metadata_json`. The `action_id` references an already-existing action the caller created/holds; W4-A does NOT create the action and does NOT attach. No external service call. If the caller submits a bogus `action_id`, the conversion_state points at a non-existent action (acceptable — see AC#14). |
 | `Convert { at, into: ClaimCorrection(claim_id) }` | `NeedsNuance` with `corrected_text` payload referencing the corrected claim_id | Refinement path per ADR-0123 §149 row #7 | Cooldown on original subject |
 | `Convert { at, into: ReviewQueue(queue_item_id) }` | None (no claim_feedback row) | No trust delta | None — DOS-336 review queue routes independently |
 
@@ -600,6 +600,7 @@ All steps 4–7 are within `with_claim_transaction` (SQLite serializable isolati
 11. **W3-A filter-flip is L4-gated, not auto-merged.** Per B12: the `dailyos_suggested_next_steps_feedback_enabled` filter flip from `false` to `true` is a separate L4-gated change requiring hands-on QA of the full WP block → REST → ability → record_claim_feedback → surfacing read pickup vertical. The flip does NOT ship with W4-A merge.
 12. **First Maintenance ability under `recommendations/`.** Per B4 + feas #8: existing `dailyos-abilities.json` inventory has Read/Transform/Maintenance categories; transport admits Maintenance without changes. L1 confirms regen handles it as passthrough.
 13. **Cycle hygiene.** `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean.
+14. **Caller responsibility for Convert{into:*} ID references** — per B16 + cycle-3 adversarial NEEDS_REVISION on phantom-id: W4-A does NOT validate that `action_id` / `claim_id` / `queue_item_id` references exist before writing `conversion_state` via json_set. The caller (a surface or test seeder) is responsible for supplying IDs of real entities. If the conversion target is later deleted or never existed, the recommendation's `conversion_state` points at a phantom — acceptable today since: (a) the substrate doesn't enforce referential integrity on JSON-encoded refs anywhere else, (b) surfaces render conversion confirmation eagerly so phantom refs are caller-bug not substrate-bug, (c) downstream consumers (W4-B/C analytics) can detect dangling refs at read time if needed. If future surface evolution requires substrate-side validation, it's an additive ability change.
 
 ---
 
@@ -671,7 +672,7 @@ Per W3-A's A8 pattern (channels enumerated before merge):
 
 - **W3-A (merged):** W3-A's WP block has affordance markup gated by `dailyos_suggested_next_steps_feedback_enabled` filter (default false). Post W4-A merge, a one-line follow-up flips this filter. That follow-up is NOT W4-A scope per the UI Surface Deferral — it depends on WP surface readiness.
 - **DOS-802 (parked):** Tauri carve-out follows the same pattern when it unblocks.
-- **W4-B (DOS-316 deviation):** consumes feedback signal as Novelty factor input. W4-B's L0 reads from `RecommendationFeedbackRecorded` signal declared here.
+- **W4-B (DOS-316 deviation):** consumes feedback signal as Novelty factor input. W4-B's L0 reads from the existing `claim_feedback_recorded` signal (`claims.rs:9112-9136`), filtering recommendation-specific events via JOIN against `intelligence_claims` on `claim_type = 'recommendation'`.
 - **W4-C (DOS-317 engagement):** distinct from feedback (engagement is implicit observation; feedback is explicit click). W4-C imports the same `EngagementSignal` types from W1-A contracts but does not call into W4-A's service.
 - **W5 eval (DOS-338):** the eval harness tests "feedback updates ranking on next cycle" — depends on W4-A's signal + W1-B's salience consumer.
 
@@ -706,16 +707,17 @@ K-in needs to confirm: no prior `submit_recommendation_feedback` solution exists
 
 ## §12 Open questions
 
-**All cycle-0 open questions resolved by B10.** Remaining open items are L1-resolvable, not L0-blocking:
+**All cycle-0/1/2 open questions resolved by B10 + B14-B21.** No remaining L0-blocking questions.
 
-1. **`validate_feedback_payload` admits `{ note: "..." }` for `NotRelevantHere`?** L1 reads `claims.rs:5525+` (the `validate_feedback_payload` body). If admitted: proceed. If not admitted: either (a) extend the validator allowlist for `NotRelevantHere` + `note` key, or (b) re-map `Dismiss{Other}` to `SurfaceInappropriate` if THAT action admits a note. Decision made at L1 against the live validator; not blocking L0.
-2. **`services::actions::attach_from_recommendation`** — the exact function name + signature for the open-loop attachment in `Convert{Action}` step 6. L1 grep confirms the existing function; if no such function exists, L1 either authors one (small scope, matches existing action service patterns) or routes through whatever the current attachment path is. Not blocking L0.
+Cycle 3 confirmed:
+- `validate_feedback_action_metadata` for `NotRelevantHere` requires `invocation_id` only (per §15 row); L1 adds optional `note` key admission (3-line addition at `claims.rs:5560`).
+- `attach_from_recommendation` does NOT exist and is NOT needed — per B16, Convert{Action} is pure state update on `conversion_state` via json_set; no external service call.
 
 **Resolved at cycle 1:**
-- Q1 (cycle 0) `Dismiss { Other }` → `NotRelevantHere` with typed `note` column (B1)
+- Q1 (cycle 0) `Dismiss { Other }` → `NotRelevantHere` with `note` encoded in `payload_json` (B1 + B15)
 - Q2 (cycle 0) `NotUseful` vs `TooNoisy` → same `SurfaceInappropriate` (B1)
 - Q3 (cycle 0) `Convert { ClaimCorrection }` → `NeedsNuance` (B1)
-- Q4 (cycle 0) Signal payload → consume existing `claim_feedback_recorded` (B3)
+- Q4 (cycle 0) Signal payload → consume existing `claim_feedback_recorded` (B3 + B18)
 - Q5 (cycle 0) WP REST endpoint → existing transport admits all categories (B9)
 
 ---
@@ -724,13 +726,13 @@ K-in needs to confirm: no prior `submit_recommendation_feedback` solution exists
 
 | Risk | Severity | Mitigation |
 |---|---|---|
-| Mapping table is wrong (a variant punishes source when it shouldn't) | HIGH | Reviewer panel hits this hardest; parametric test asserts each variant's downstream_effect_kind matches the documented contract |
+| Mapping table is wrong (a variant punishes source when it shouldn't) | HIGH | Parametric test asserts each variant's `(FeedbackAction, EffectKind)` pair matches §1 + ADR-0123 citations |
 | Atomicity bug — claim_feedback row written but recommendation_claim feedback_state not updated | HIGH | Single transaction wrap via `with_claim_transaction`; integration test asserts both observe same state |
-| Idempotent re-submission accidentally double-writes | MED | Explicit feedback_state check at step 2 of service flow; test asserts re-submission returns NoMutation |
-| `BoundedNote` 200-char enforcement bypassed | LOW | Already enforced at `BoundedNote::try_from` construction; can't bypass without unsafe code |
-| New `write.recommendations` scope isn't registered in WP allowlist → block can't call ability | MED | A8 channel enumeration covers this; L1 grep before merge |
-| `Convert { Action }` writes both `ConfirmCurrent` AND an open-loop attachment — what if the open-loop service fails? | MED | Wrap both in the same transaction; if open-loop create fails, rollback the feedback too |
-| `RecommendationFeedbackRecorded` signal fires before downstream consumers (W4-B/C) exist | LOW | Signal type declared but unused for one wave; no harm |
+| Idempotent re-submission silently fails to short-circuit (predicate bug) | HIGH | Cycle 3 B14 fixed the `LIKE '%"pending"%'` to `= 'pending'` (empirically verified). Test asserts predicate matches Pending state shape from `contracts.rs:103-106`. |
+| `BoundedNote` 200-char enforcement bypassed | LOW | Already enforced at `BoundedNote::try_from` construction (`contracts.rs:148`); validator extension imposes server-side cap on `note` value (B15) |
+| `submit.recommendations.feedback` scope not registered in WP allowlist → block can't call ability | LOW | Transport at `class-dailyos-runtime-client.php:85` is category-agnostic (verified B9); scope is allowlist-runtime-registered per `SurfaceScope::new` (verified §15) |
+| Convert{Action(action_id)} accepts phantom action_id | LOW | Explicit per AC#14 — caller responsibility; W4-A does not validate action existence. If validation needed later, additive ability change |
+| Convert{ClaimCorrection(claim_id)} accepts phantom claim_id | LOW | Same as above — `corrected_text` payload references claim_id; W4-A trusts the caller-supplied reference |
 
 ---
 
@@ -742,7 +744,7 @@ Per CLAUDE.md DoD section:
 2. End-to-end flow tested: ability invocation → `record_claim_feedback` → `claim_feedback` row written → `claim_feedback_recorded` signal fires automatically → `latest_feedback_suppression` returns the row on next read
 3. No stubs or TODOs
 4. `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean
-5. L2-status declared in commit messages
+5. **L2-status declared in commit messages** — enforced by `.githooks/commit-msg` per CLAUDE.md; this is process hygiene every PR observes, not a W4-A-specific artifact (per cycle 2 scope TRIM moved out of §7 CI gate table). Still binding as a project rule.
 6. **No L4 evidence required for the W4-A merge itself** (no UI surface introduced by this lane). However: the `dailyos_suggested_next_steps_feedback_enabled` filter flip in the W3-A WP block is an **L4-gated change**, shipped separately from W4-A merge, gated by hands-on QA of the WP block → REST → ability → record_claim_feedback → claim_feedback row → surfacing read pickup vertical (B12).
 7. **Privacy non-leak documented.** `EffectKind` carries no subject identity beyond what the caller already knows about its own claim (B12).
 8. **Auth overhaul note.** Per the 2026-05-21 auth overhaul memory, ADR-0111 §193 nonce requirement for write events is being stripped for local same-user contexts. W4-A does NOT add nonce machinery; relies on the post-overhaul actor-allowlist model. L1 verifies the current state via a transport-layer grep (B12).

--- a/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
@@ -19,6 +19,163 @@ related:
 
 # v1.4.6 W4-A — Recommendation feedback loop (DOS-332)
 
+## Cycle 1 amendments (2026-05-27) — 4-reviewer panel resolutions
+
+Cycle 0 panel: adversarial BLOCKED (3 BLOCKED + 5 NEEDS_REVISION + 2 NIT); feasibility CYCLE_2 (1 BLOCKED + 5 NEEDS_REVISION); scope-guardian CONDITIONAL APPROVE (1 BLOCKED + 3 TRIMs); K-in NO REINVENTION (but with substrate-side answers that resolve most BLOCKED items by pointing at what exists).
+
+**The class pattern across reviewers:** the cycle-0 packet was authored without enough grounding in the actual substrate. It invented APIs (`bump_cooldown`), missed ADR-0123 variants (`NotRelevantHere`, `NeedsNuance`, `SurfaceInappropriate`), and proposed a new signal where one already exists. Cycle 1 reframes the packet around primitives that actually exist — verified against code at:
+
+- `src-tauri/src/services/recommendations/surfacing.rs:33` (`SURFACING_DECISION_SIGNAL` is a string const, not an enum variant)
+- `src-tauri/src/services/recommendations/surfacing.rs:120,136` (`feedback_suppression_days: i64` default 14; cooldown is read-derived)
+- `src-tauri/src/services/recommendations/surfacing.rs:724` (`latest_feedback_suppression` reads `claim_feedback` rows)
+- `src-tauri/src/services/claims.rs:5488-5527` (`validate_feedback_actor` admits ONLY `User`; SurfaceClient/Agent/System all rejected by `actor_class_for_actor`)
+- `src-tauri/src/services/claims.rs:9127` (`claim_feedback_recorded` signal already emits from `record_claim_feedback`)
+- `src-tauri/abilities-runtime/src/abilities/feedback.rs:39` (`FeedbackAction` enum has all 10 ADR-0123 variants including `NotRelevantHere`, `NeedsNuance`, `SurfaceInappropriate`)
+- `src-tauri/src/migrations/269_recommendation_claim_metadata_indexes.sql:9-18` (`feedback_state` lives in `intelligence_claims.metadata_json` as JSON — indexed via `json_extract`, NOT a column)
+
+### B1. The mapping table reframed — every variant writes via `record_claim_feedback` (supersedes §1)
+
+The cycle-0 mapping was wrong on three rows and confused on three more. Cycle 1 uses ADR-0123's existing variant catalog faithfully. **Every `RecommendationFeedbackDecision` variant writes to `claim_feedback` with the appropriate `FeedbackAction`.** Cooldown emerges automatically from the read side (`latest_feedback_suppression`); there is no separate cooldown table, no separate cooldown writer.
+
+| `RecommendationFeedbackDecision` | `FeedbackAction` | Truth/Trust effect | Surfacing effect | Rationale |
+|---|---|---|---|---|
+| `Accept { at }` | `ConfirmCurrent` | +α on source / agent | None | Standard reinforcement (ADR-0123 §149 row #1) |
+| `Dismiss { reason: NotRelevant }` | `NotRelevantHere` | No trust delta | 14-day cooldown via `feedback_suppression_days` | "True but not relevant here" — ADR-0123 §149 explicitly for this case. Resolves adv F2. |
+| `Dismiss { reason: AlreadyKnew }` | `NotRelevantHere` | No trust delta | 14-day cooldown | Not disputing truth, just not useful surfacing. Same as NotRelevant. |
+| `Dismiss { reason: WrongSubject }` | `WrongSubject` | -0.3 subject_evidence on linker; source untouched | Tombstones the claim on the asserted subject (per-subject) | Direct ADR-0123 mapping |
+| `Dismiss { reason: Other(BoundedNote) }` | `NotRelevantHere` with `note` field populated | No trust delta; note captured | 14-day cooldown | Conservative default — user provided free text but not a structured judgment; treat as "not relevant" + log the note via ADR-0123's typed `note: Option<String>` column (NOT `payload_json`). Resolves adv F3. |
+| `NotUseful { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown + flags for review | ADR-0123 §149 overflow set — "this surface placement is wrong"; ranking-only |
+| `TooNoisy { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown (same as NotUseful at substrate level; intensity is a UX framing, not a substrate distinction) | Per K-in: K-in could not find a §149 variant that distinguishes "too noisy" from "surface inappropriate." Both map to the same FeedbackAction. Cooldown bump is uniform; future cross-claim aggregation (ADR-0123 §207 deferred to v1.5.0+) handles "user often marks X as noisy" learning. |
+| `Convert { at, into: Action(action_id) }` | `ConfirmCurrent` | +α on source / agent | None | Reinforcement + open-loop attachment. Open-loop attachment is a SEPARATE service call (`services::actions::attach_from_recommendation` or equivalent); not transactional with the claim_feedback write because attachment may invoke external side effects (calendar / message scheduling). **Cycle 1 explicit:** the ability returns success after `claim_feedback` write; open-loop attachment is at-least-once via a follow-up service call within the same ability body. If attachment fails, the feedback row stays (truth-feedback is authoritative); the attachment is retried via existing action retry infrastructure. Resolves adv F4. |
+| `Convert { at, into: ClaimCorrection(claim_id) }` | `NeedsNuance` with `corrected_text` payload | Refinement path per ADR-0123 §149 row #7 | Cooldown on original subject | ADR-0123 `NeedsNuance` is **specifically named** for user-authored corrections via text-overlap heuristic. K-in cited ADR-0123 §154 structured-only rules as routing structured corrections elsewhere — but §154 covers structured corrections IN the feedback API. Our `ClaimCorrection(claim_id)` references an EXISTING claim that already went through propose/commit. So the original recommendation's correctness is refined; `NeedsNuance` with the corrected claim_id as evidence is the cleanest mapping. Resolves adv F8. |
+| `Convert { at, into: ReviewQueue(queue_item_id) }` | None (no claim_feedback row) | No trust delta | No cooldown | DOS-336 review queue routes independently; this variant emits the queue item id only. W4-A doesn't write claim_feedback here. |
+
+**Q1/Q2/Q3 from cycle-0 §12 are RESOLVED by this table** (per scope-guardian TRIM):
+- Q1: `Dismiss { Other }` → `NotRelevantHere` with typed `note`
+- Q2: `NotUseful` vs `TooNoisy` cooldown magnitude → same at substrate; UX distinction is surface-side
+- Q3: `Convert { ClaimCorrection }` → `NeedsNuance` (substrate keeps the original claim refining-path semantic)
+
+### B2. Cooldown is read-derived — drop the `bump_cooldown` API (supersedes §1, §3.4, §11)
+
+Cooldown is NOT a separate write API. `services::recommendations::surfacing::latest_feedback_suppression` reads `claim_feedback` rows within the policy's `feedback_suppression_days` window (default 14) and surfaces them through `feedback_suppressed_recently: bool` in the surfacing state. **A feedback write IS the cooldown bump.**
+
+This deletes the `bump_cooldown` references throughout cycle-0 §1 / §3.4 / §11. The W4-A scope shrinks: no cross-lane coordination with W2-A, no scope creep into surfacing.rs, no parallel cooldown table. Resolves adv F1 + feas #2.
+
+### B3. Signal: reuse `claim_feedback_recorded`, do not declare new (supersedes §3.1, §3.4 step 5, §4 AC #8)
+
+`record_claim_feedback` already emits the `claim_feedback_recorded` signal (string const at `services::claims:9127`). All recommendation feedback paths flow through `record_claim_feedback`, so this signal fires automatically for W4-A writes.
+
+The cycle-0 packet's new `RecommendationFeedbackRecorded` SignalType variant is **dropped**. Resolves scope F4 (W0 ownership concern — by dropping the new variant, W0 ownership of `signals/policy_registry.rs` is preserved) and feas #6.
+
+If W4-B (deviation) or W4-C (engagement) need finer-grained discrimination, they consume `claim_feedback_recorded` with payload filtering — the existing signal carries `feedback_id`, `claim_id`, `feedback_type` (which is the `FeedbackAction`). For the `NeedsNuance` and overflow-set variants, downstream lanes can filter by `feedback_type`. No new signal needed.
+
+### B4. Category is `Maintenance`, not `Write` (supersedes §3.1)
+
+Per ADR-0102 §82, ability categories are call-graph-derived (Read / Transform / Publish / Maintenance), not author-declared. `submit_recommendation_feedback` mutates internal state through `services::claims::record_claim_feedback` (which itself is the canonical maintenance path for `intelligence_claims` mutations). The ability is **Maintenance**.
+
+ADR-0103 maintenance-ability constraints apply: `may_publish = false`, `client_side_executable = false`, no MCP exposure for maintenance abilities by default (`mcp_exposure = None`). Updated:
+
+- **`category`:** `Maintenance` (not `Write`)
+- **`required_scopes`:** `["maintenance.recommendations.feedback"]` (replaces the cycle-0 `write.recommendations` since maintenance scopes follow a different naming convention; verify at L1 grep against existing maintenance scope strings)
+- **`mutates`:** `["intelligence_claims", "claim_feedback"]` declared at the macro
+
+This is the **first Maintenance ability under `recommendations/`** (cycle-0 was framed as the first Write; that framing was wrong). Inventory pattern: existing Maintenance abilities elsewhere in the codebase establish the pattern; W4-A follows.
+
+### B5. Actor normalization — SurfaceClient → "user" at the ability boundary (supersedes §3.1, §3.4)
+
+`validate_feedback_actor` (`services::claims:5507`) admits only `User` (`"user"` or `"human"` strings via `actor_class_for_actor`). SurfaceClient string `"surface_client"` is unmapped and would hard-fail with `InvalidFeedback`.
+
+**Resolution:** the ability normalizes `ctx.actor()` to `"user"` before calling `record_claim_feedback`. The actor-class check inside `record_claim_feedback` is for the CONTENT of the feedback (it IS a user-class feedback regardless of which surface posted it). The original Actor identity (`SurfaceClient { instance, scopes }`) is preserved in `RecommendationFeedbackContext` (existing field) and in the ability's provenance envelope, so the audit trail records the surface that posted.
+
+This is a 2-line normalization at the ability body, not an extension of `actor_class_for_actor`. Resolves feas #1.
+
+### B6. `feedback_state` mutation is JSON-patch, not column UPDATE (supersedes §3.4 step 4)
+
+`RecommendationClaim.feedback_state` lives in `intelligence_claims.metadata_json` as a JSON field, indexed via `json_extract(metadata_json, '$.recommendation.feedbackState…')` per migration `269_recommendation_claim_metadata_indexes.sql`. The mutation path uses SQLite's `json_set`:
+
+```sql
+UPDATE intelligence_claims
+SET metadata_json = json_set(metadata_json, '$.recommendation.feedbackState', ?, '$.recommendation.conversionState', ?)
+WHERE id = ?
+  AND json_extract(metadata_json, '$.recommendation.feedbackState') LIKE '%"pending"%'
+```
+
+The `WHERE … LIKE '%"pending"%'` clause is the **atomic compare-and-set** for idempotency (resolves adv F6): if the row's feedback_state is already non-Pending, the UPDATE affects 0 rows, the ability returns `EffectKind::NoMutation`. SQLite's single-writer guarantee (per feas #4) prevents the read-then-write race. The packet cites SQLite single-writer rather than implying row-level locking.
+
+### B7. Output type trim — `EffectKind` replaces `DownstreamEffect` (supersedes §3.3)
+
+Per scope-guardian TRIM: the cycle-0 `DownstreamEffect` enum carried inner fields (`feedback_id`, `new_cooldown_until`, etc.) for a confirmation-chip use case in a surface that's parked. Trim to a leaner discriminator:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum EffectKind {
+    ClaimFeedbackRecorded,
+    NoMutation,
+}
+```
+
+`NoMutation` is the idempotent-reject case (already-decided per B6). When a surface ships and wants confirmation-chip metadata, that ability evolution is additive (add `feedback_id` field; bump schema_version).
+
+The cycle-0 `BothApplied` and `SurfacingCooldownBumped` variants are gone because B2 eliminated the separate cooldown path. Every successful write produces `ClaimFeedbackRecorded`; cooldown is read-side.
+
+`Convert { Action }` still attaches the open-loop; its success/failure does NOT show up in `EffectKind` — instead, the response carries an `Option<ActionAttachment>` field for the surface to render. Failure of the open-loop attach does not roll back the feedback (per B1 Convert row + adv F4).
+
+### B8. Output wrapped in `AbilityOutput<T>` for provenance (supersedes §3.3)
+
+Per K-in (ADR-0105 §8 "lives-once" invariant), the response shape is:
+
+```rust
+pub type SubmitRecommendationFeedbackOutput = AbilityOutput<SubmitRecommendationFeedbackResponse>;
+```
+
+Provenance envelope lives once on the `AbilityOutput`; the response struct itself carries no envelope copy. Standard `ProvenanceBuilder` pattern used by all v1.4.6 abilities.
+
+### B9. WP REST Write-path verified (resolves feas #8 + adv F5)
+
+Per feas grep: `wp/dailyos/includes/transport/class-dailyos-runtime-client.php:85` exposes `invoke_ability(name, payload, scope_set)` category-agnostic. No category-specific branching in the transport. This is the **first Maintenance ability** to traverse it (cycle-0 mis-framed as Write), but the transport admits all categories. No new transport work.
+
+L1 verification step: confirm `tools/dailyos-abilities.json` regen handles `Maintenance` category as passthrough (per feas #9 — existing inventory has Read/Transform/Maintenance categories already, so this is exercised).
+
+### B10. Cycle 0 §12 open questions — all resolved
+
+- Q1 (`Dismiss { Other }` mapping) → B1 row: `NotRelevantHere` with typed `note`
+- Q2 (NotUseful vs TooNoisy) → B1 rows: same FeedbackAction (`SurfaceInappropriate`); UX distinction is surface-side
+- Q3 (Convert { ClaimCorrection } target) → B1 row: `NeedsNuance` with corrected_text payload
+- Q4 (Signal payload shape) → B3: dropped new signal; consume existing `claim_feedback_recorded`
+- Q5 (WP REST endpoint shape) → B9: existing transport admits all categories
+
+### B11. CI gate inputs add per-Actor dry-run row (supersedes §7)
+
+Per scope-guardian TRIM: per-Actor dry-run test enumerated in §5 channel #6 and §6 unit tests but missing from §7 CI gate table. Added:
+
+| Artifact | Notes |
+|---|---|
+| Per-Actor dry-run test | `[User, SurfaceClient]` admit; `[System, Agent, Admin, McpClient]` deny with `Capability` error. Lives in `abilities-runtime/src/abilities/recommendations/mod.rs::tests`. CI-enforced gate, not advisory. |
+
+### B12. DoD additions (supersedes §14)
+
+Three additions per adv F9 + F10:
+
+- **L4 filter-flip gate.** The W3-A WP block's `dailyos_suggested_next_steps_feedback_enabled` filter flip from `false` to `true` is **NOT** an automatic post-merge step. It is an L4-gated change requiring hands-on QA of the full WP block → REST → ability → `record_claim_feedback` → claim_feedback row → surfacing.rs read pickup vertical. The flip ships separately from W4-A merge, gated by L4 evidence + DOS-298 / DOS-333 readiness.
+- **Privacy non-leak documented.** `EffectKind::ClaimFeedbackRecorded` carries no subject identity; surface that submitted the feedback already knows its own claim's subject. No new privacy surface introduced. Documented in §3.3.
+- **Auth overhaul note.** ADR-0111 §193 nonce requirement for write events is currently being stripped for local same-user contexts per the 2026-05-21 auth overhaul (per memory). W4-A does NOT add nonce machinery; it relies on the post-overhaul actor-allowlist model. If the overhaul lands differently than expected, W4-A's transport gate at L1 grep adds nonce verification.
+
+### B13. Scope shrinks net
+
+After cycle 1: NO new tables, NO new SignalType variants, NO new cooldown API, NO new scope (just a maintenance-scope rename), NO new column (json_set on metadata_json). The ability + service-function fill (`feedback.rs`) is the entire scope.
+
+This is appropriately smaller than W3-A. Per scope-guardian: "If W4-A's packet bloats toward W3-A scale, that's a signal." Cycle 1 trims it back to substrate-extension.
+
+### Cycle 1 status
+
+- B1–B12 amendments apply; B13 trim confirmed
+- Original §1, §3.1, §3.3, §3.4, §4, §7, §12, §14 sections are SUPERSEDED inline by cycle 1 (the inline-sweep pattern from W3-A's cycle 3); a future cycle-2 reviewer reading any single section should see consistent state without needing to cross-reference cycle 1 amendments
+
+**Ready for cycle 2 panel re-dispatch.** Recommended subset: adversarial (verify F1/F2/F3/F8 closed); feasibility (verify B6 json_set + B5 actor normalization + B9 transport); scope-guardian (verify B3/B4 dropped scope; B11 added test row). Skip K-in (no scope changes need re-validation).
+
+---
+
 ## §0 Frame
 
 W4-A is **substrate-only**. Per the UI Surface Deferral Amendment (2026-05-27), v1.4.6 continues with backend wiring while WP and Tauri surfaces wait for production readiness + redesign respectively. W4-A delivers the feedback ability + service path so that *when* a surface ships its affordance, the producer is ready.
@@ -50,26 +207,34 @@ No `ce-design-lens-reviewer` — substrate-only. No `ce-security-lens-reviewer` 
 
 ---
 
-## §1 The mapping (proposed; reviewer-challengeable)
+## §1 The mapping (locked at cycle 1; see B1)
 
-Five `RecommendationFeedbackDecision` variants → ADR-0123 actions OR surfacing-state writes. **This is the load-bearing design decision of W4-A.**
+**Every `RecommendationFeedbackDecision` variant writes to `claim_feedback` via `record_claim_feedback` with the appropriate ADR-0123 `FeedbackAction`.** Cooldown emerges automatically from the read side (`services::recommendations::surfacing::latest_feedback_suppression`); there is no separate cooldown table or writer.
 
-| `RecommendationFeedbackDecision` | Maps to | Rationale |
-|---|---|---|
-| `Accept { at }` | `FeedbackAction::ConfirmCurrent` via `record_claim_feedback` | User confirms the recommendation is valid; reinforces source + agent reliability. Salience UserFit factor weights up on next compute. |
-| `Dismiss { at, reason: NotRelevant }` | `FeedbackAction::WrongSubject` via `record_claim_feedback` | Per ADR-0123 §5: WrongSubject tombstones the claim on the asserted subject; source not punished. Matches "not relevant to this entity." |
-| `Dismiss { at, reason: AlreadyKnew }` | Surfacing cooldown only (no `claim_feedback` write) | User isn't disputing the recommendation's truth — just doesn't need it surfaced. Bumps the cooldown on `(subject, action_signature)` per W2-A's surfacing policy. Does NOT downweight source or claim. |
-| `Dismiss { at, reason: WrongSubject }` | `FeedbackAction::WrongSubject` via `record_claim_feedback` | Direct mapping; linker reliability hit, source untouched. |
-| `Dismiss { at, reason: Other(BoundedNote) }` | Surfacing cooldown only + note logged to `claim_feedback` payload | Reason unknown; safest interpretation is "don't surface again on this subject" without truth-judgment. The note is captured for future analysis but doesn't drive any automatic semantic action. |
-| `NotUseful { at }` | Surfacing cooldown only (no `claim_feedback` write) | Per DOS-332 AC: "Dismissed and not-useful recommendations reduce salience without necessarily reducing source trust." Treated as ranking-only signal — surfacing cooldown extends, UserFit downweights via W1-B salience re-compute. |
-| `TooNoisy { at }` | Surfacing cooldown only (no `claim_feedback` write) | Per DOS-332 AC: "Too-noisy feedback updates surfacing thresholds/cooldowns rather than treating the claim as false." Extends cooldown more aggressively than NotUseful; possibly flags the entire subject's surfacing tier (subject becomes more conservative). |
-| `Convert { at, into: Action(action_id) }` | `FeedbackAction::ConfirmCurrent` + open-loop attachment | Conversion is the strongest positive signal. The recommendation becomes an action (existing open-loop infrastructure); ConfirmCurrent reinforces the source. |
-| `Convert { at, into: ClaimCorrection(claim_id) }` | `FeedbackAction::MarkOutdated` on the original + new claim proposal | The user is saying "the recommendation was based on outdated info; here's the corrected claim." MarkOutdated demotes the trigger claim; the corrected claim_id is the new ground truth. |
-| `Convert { at, into: ReviewQueue(queue_item_id) }` | No `claim_feedback` write; existing review-queue routing applies | Per DOS-336 (review queue) the existing claim-review-queue lifecycle handles this. W4-A only emits the queue-item id — review queue owns the conversion semantics. |
+| `RecommendationFeedbackDecision` | `FeedbackAction` | Truth/Trust effect | Surfacing effect (read-derived) |
+|---|---|---|---|
+| `Accept { at }` | `ConfirmCurrent` | +α on source / agent | None |
+| `Dismiss { reason: NotRelevant }` | `NotRelevantHere` | No trust delta | 14-day cooldown via `feedback_suppression_days` |
+| `Dismiss { reason: AlreadyKnew }` | `NotRelevantHere` | No trust delta | 14-day cooldown |
+| `Dismiss { reason: WrongSubject }` | `WrongSubject` | -0.3 subject_evidence on linker; source untouched | Tombstones the claim on the asserted subject (per-subject) |
+| `Dismiss { reason: Other(BoundedNote) }` | `NotRelevantHere` with `note` field populated | No trust delta; note captured in ADR-0123 typed `note: Option<String>` column | 14-day cooldown |
+| `NotUseful { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown |
+| `TooNoisy { at }` | `SurfaceInappropriate` | No trust delta | 14-day cooldown (same as NotUseful at substrate level; intensity is UX framing, not substrate distinction) |
+| `Convert { at, into: Action(action_id) }` | `ConfirmCurrent` | +α on source / agent | None. **Open-loop attachment is a separate at-least-once call** (`services::actions::attach_from_recommendation` or equivalent); not transactional with the feedback write because attachment may invoke external side effects (calendar / message scheduling). If attachment fails, the feedback row stays (truth-feedback is authoritative); attachment retries via existing action retry infrastructure. |
+| `Convert { at, into: ClaimCorrection(claim_id) }` | `NeedsNuance` with `corrected_text` payload referencing the corrected claim_id | Refinement path per ADR-0123 §149 row #7 | Cooldown on original subject |
+| `Convert { at, into: ReviewQueue(queue_item_id) }` | None (no claim_feedback row) | No trust delta | None — DOS-336 review queue routes independently |
 
-**Cooldown-only writes go through W2-A's surfacing-policy service**, not through a new path. W4-A imports the cooldown API from `services::recommendations::surfacing` (which W2-A owns) and calls it with `(subject, action_signature, reason, decided_at)`.
+**Rationale citations:**
 
-**Updated `FeedbackState` after the call:** every variant transitions `Pending → Decided(<the variant>)` on the `RecommendationClaim`. The claim's `feedback_state` column updates atomically with the underlying action (whether that's a `claim_feedback` insert, a cooldown bump, or both).
+- `NotRelevantHere` (ADR-0123 §149) is the explicit variant for "true but not relevant here — no trust delta." Used for `Dismiss{NotRelevant|AlreadyKnew|Other}`.
+- `SurfaceInappropriate` (ADR-0123 §149 overflow set) covers "this surface placement is wrong — ranking-only." Used for `NotUseful` and `TooNoisy`.
+- `WrongSubject` (ADR-0123 §1) tombstones at the asserted subject; linker takes the -0.3 hit; source untouched. Used only for explicit `Dismiss{WrongSubject}`.
+- `NeedsNuance` (ADR-0123 §149 row #7) is specifically named for user-authored corrections via text-overlap heuristic. Used for `Convert{ClaimCorrection}`.
+- `ConfirmCurrent` (ADR-0123 §149 row #1) is standard reinforcement. Used for `Accept` and `Convert{Action}`.
+
+**Cooldown:** `surfacing.rs::latest_feedback_suppression` reads `claim_feedback` rows within `feedback_suppression_days` (default 14, per `SurfacingPolicy` at `surfacing.rs:120,136`). Every feedback write IS the cooldown bump; no separate writer needed.
+
+**FeedbackState transition:** every successful variant transitions `Pending → Decided(<the variant>)` on the `RecommendationClaim`'s `metadata_json` JSON field via `json_set` (NOT a column UPDATE — the field is indexed via `json_extract` per migration `269_recommendation_claim_metadata_indexes.sql`). The mutation is wrapped in an atomic compare-and-set: `UPDATE … WHERE json_extract(metadata_json, '$.recommendation.feedbackState') LIKE '%"pending"%'`. SQLite single-writer guarantees the race-free path (see B6).
 
 ---
 
@@ -114,13 +279,15 @@ Wave plan §line 1015-1020:
 ### §3.1 Identity
 
 - **Name:** `submit_recommendation_feedback`
-- **Category:** `Write`
-- **Allowed actors:** `[User, SurfaceClient]` — the user OR a surface acting on the user's explicit click. NOT `System` (no automatic feedback), NOT `Agent` / `Admin`, NOT `McpClient`.
-- **`required_scopes`:** `["write.recommendations"]` (NEW scope; needs to be registered in the surface scope policy — see §5 channel enumeration)
-- **`may_publish`:** false (writes don't publish to other surfaces; downstream effects are async via salience re-compute and surfacing-state mutation)
-- **`mcp_exposure`:** `None`
-- **`composes`:** `[claim_receipt]` (reads the receipt to verify the claim is in `Pending` feedback state before mutating; rejects double-feedback)
-- **`signal_policy.emits_on_output_change`:** `[RecommendationFeedbackRecorded]` — a NEW SignalType variant that W4-A pre-declares for downstream W4-B/C consumption. Per wave plan §line 1018, the SignalType variant requires L0 approval — this packet is the approval request.
+- **Category:** `Maintenance` — per ADR-0102 §82 the category is call-graph-derived. Mutates internal state through `services::claims::record_claim_feedback` (canonical maintenance path for `intelligence_claims` mutations). ADR-0103 maintenance-ability constraints apply.
+- **Allowed actors:** `[User, SurfaceClient]` — the user OR a surface acting on the user's explicit click. NOT `System` (no automatic feedback), NOT `Agent` / `Admin`, NOT `McpClient`. Note: per B5, the ability **normalizes `ctx.actor()` to `"user"`** before calling `record_claim_feedback` because `validate_feedback_actor` (`claims.rs:5507`) admits only `User`. The original SurfaceClient identity is preserved in the provenance envelope.
+- **`required_scopes`:** `["maintenance.recommendations.feedback"]` (maintenance naming convention; verify at L1 grep against existing maintenance scope strings)
+- **`may_publish`:** false (per ADR-0103 maintenance default)
+- **`mcp_exposure`:** `None` (per ADR-0103 maintenance default)
+- **`client_side_executable`:** false (per ADR-0103)
+- **`mutates`:** `["intelligence_claims", "claim_feedback"]` declared at the `#[ability(...)]` macro
+- **`composes`:** `[]` (does NOT compose `claim_receipt` — idempotent compare-and-set on `feedback_state` happens in the UPDATE itself, no separate read needed)
+- **`signal_policy.emits_on_output_change`:** `[]` — the existing `claim_feedback_recorded` signal fires automatically from `record_claim_feedback` (`claims.rs:9127`); W4-A does not declare a new signal (B3).
 - **Schema version:** 1
 
 ### §3.2 Input
@@ -140,60 +307,95 @@ pub struct SubmitRecommendationFeedbackInput {
 
 ### §3.3 Output
 
+The ability returns `AbilityOutput<SubmitRecommendationFeedbackResponse>` per ADR-0105 §8 "lives-once" invariant. The provenance envelope rides on the wrapper; the inner response carries no envelope copy.
+
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitRecommendationFeedbackResponse {
     pub schema_version: u32,
     pub claim_id: ClaimId,
-    pub feedback_state: FeedbackState,         // always Decided(<variant>) after success
-    pub conversion_state: ConversionState,     // updated if Convert variant
-    pub downstream_effect: DownstreamEffect,   // see below — explains what happened
+    pub feedback_state: FeedbackState,                // always Decided(<variant>) after success; Pending on NoMutation
+    pub conversion_state: ConversionState,             // updated if Convert variant
+    pub effect_kind: EffectKind,
+    pub action_attachment: Option<ActionAttachment>,   // only Some(...) for Convert{Action}; carries the open-loop action_id
     pub recorded_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum EffectKind {
+    ClaimFeedbackRecorded,
+    NoMutation, // idempotent reject — claim's feedback_state was already non-Pending at write time
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
-pub enum DownstreamEffect {
-    ClaimFeedbackRecorded { action: FeedbackAction, feedback_id: String },
-    SurfacingCooldownBumped { subject_kind: String, subject_id: String, action_signature: String, new_cooldown_until: DateTime<Utc> },
-    BothApplied { action: FeedbackAction, feedback_id: String, new_cooldown_until: DateTime<Utc> },
-    NoMutation { reason: String }, // e.g., already-decided idempotent reject
+#[serde(rename_all = "camelCase")]
+pub struct ActionAttachment {
+    pub action_id: String,
+    pub attached_at: DateTime<Utc>,
+    pub attach_status: AttachStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum AttachStatus {
+    /// Open-loop attached successfully within this ability call
+    Attached,
+    /// Feedback recorded; open-loop attach queued for at-least-once retry (per B1 Convert{Action} row)
+    Queued,
 }
 ```
 
-`DownstreamEffect` exposes which path the mapping took — useful for the surface to render a confirmation chip ("Action recorded" vs "Cooldown extended") and for tests to verify the mapping deterministically.
+**Privacy note:** `EffectKind` carries no subject identity. The caller (the surface that posted the feedback) already knows its own claim's subject and decision. No new privacy surface introduced (resolves adv F10).
+
+**Why `EffectKind` not the full `DownstreamEffect` from cycle 0:** per scope-guardian TRIM (B7) — the cycle-0 enum carried fields (`feedback_id`, `new_cooldown_until`, `action_signature`, etc.) for a confirmation-chip surface that's parked. When a surface lights up and needs confirmation metadata, schema-version bump adds fields additively.
 
 ### §3.4 Service-side flow
 
 `services::recommendations::feedback::record_recommendation_feedback`:
 
-1. Load the `RecommendationClaim` by `claim_id`. Reject if not found (`ClaimError::UnknownClaimId`) or if not a recommendation claim (`ClaimError::UnsupportedClaimType`).
-2. Check `feedback_state`. If already `Decided`, return `DownstreamEffect::NoMutation { reason: "already_decided" }` and the existing state. Idempotent semantics.
-3. Match on `decision` variant per §1 mapping table; dispatch to either:
-   - `record_claim_feedback(...)` with the mapped `FeedbackAction` and constructed `ClaimFeedbackInput`
-   - `services::recommendations::surfacing::bump_cooldown(...)` with the subject + action_signature
-   - Both (for the `Dismiss { Other }` and `Convert { ClaimCorrection }` variants)
-4. Update the `RecommendationClaim` row's `feedback_state` and (if applicable) `conversion_state` columns atomically within the transaction.
-5. Emit `RecommendationFeedbackRecorded` signal.
-6. Return `SubmitRecommendationFeedbackResponse` with the relevant `DownstreamEffect`.
+1. **Resolve claim.** Load the `RecommendationClaim` by `claim_id` via `load_claim_by_id`. Reject with `ClaimError::UnknownClaimId` if not found, or `ClaimError::UnsupportedClaimType` if not a recommendation claim.
+2. **Normalize actor.** `ctx.actor()` resolves to either `Actor::User` or `Actor::SurfaceClient { ... }`. The downstream call to `record_claim_feedback` requires the `actor` string to map to `ClaimActorClass::User` via `actor_class_for_actor` (`claims.rs:5488-5504`) — which admits only `"user"` or `"human"`. The ability normalizes by passing `"user"` regardless of which actor variant invoked. The original Actor identity (with `SurfaceClient.instance` / `SurfaceClient.scopes` if applicable) is captured in the provenance envelope at the ability boundary, so audit trail is complete.
+3. **Map `decision` variant per §1 table.** Constructs a `ClaimFeedbackInput` with the mapped `FeedbackAction` and an appropriate `note` (for `Dismiss{Other(BoundedNote)}`) or `payload_json` (for `Convert{ClaimCorrection}` carrying `corrected_text` per ADR-0123 §149 row #7).
+4. **Idempotent compare-and-set on `feedback_state`.** SQLite atomic UPDATE within `with_claim_transaction`:
+   ```sql
+   UPDATE intelligence_claims
+   SET metadata_json = json_set(metadata_json,
+       '$.recommendation.feedbackState', ?,
+       '$.recommendation.conversionState', ?)
+   WHERE id = ?
+     AND json_extract(metadata_json, '$.recommendation.feedbackState') LIKE '%"pending"%'
+   ```
+   If `rows_affected == 0`, return `Ok(EffectKind::NoMutation)` with the existing state — the claim was already decided. SQLite single-writer prevents the read-then-write race (per feas #4); the WHERE-clause check is the atomic guard. **Resolves adv F6.**
+5. **Call `record_claim_feedback`.** With the constructed `ClaimFeedbackInput` and the normalized `"user"` actor string. This:
+   - Inserts the `claim_feedback` row (UUID generated internally per `claims.rs:7156`)
+   - Validates the payload per `validate_feedback_payload` (L1 verifies the `note` + `corrected_text` keys are admitted by the validator for the `NotRelevantHere` / `NeedsNuance` / `SurfaceInappropriate` actions; if not, L1 amendment to the validator's allowlist)
+   - Transitions verification_state per ADR-0123 dispatch table
+   - Emits `claim_feedback_recorded` signal automatically (no W4-A action needed — per B3)
+6. **Convert{Action} side effect.** If the decision is `Convert{Action(action_id)}`, AFTER the feedback row is inserted, invoke `services::actions::attach_from_recommendation(action_id, recommendation_claim_id)` (or the existing analog — L1 grep confirms the function name). If attachment fails, the feedback row stays; the response's `action_attachment.attach_status = Queued` signals at-least-once retry. **Resolves adv F4 atomicity-honesty.**
+7. **Convert{ReviewQueue} side effect.** If the decision is `Convert{ReviewQueue(queue_item_id)}`, skip the `record_claim_feedback` call entirely (per §1 table); just update `conversion_state` via `json_set` on `metadata_json` and return. DOS-336's review-queue lifecycle owns the conversion semantics.
+8. **Return `AbilityOutput<SubmitRecommendationFeedbackResponse>`.** Wrap in provenance via `ProvenanceBuilder` per ADR-0105.
 
-All within `with_claim_transaction` so the claim_feedback insert + recommendation_claim update + cooldown bump are atomic per claim.
+All steps 4–7 are within `with_claim_transaction` (which provides SQL transaction boundaries via SQLite's serializable isolation). External side effects (action attachment in step 6) cannot be rolled back — that's the at-least-once contract documented in `AttachStatus::Queued`.
 
 ---
 
 ## §4 Acceptance criteria
 
-1. **Ability ships and is registered.** `submit_recommendation_feedback` in `tools/dailyos-abilities.json` (regen); `AbilityRegistry` exposes to `[User, SurfaceClient]`. `cargo test recommendations::submit_recommendation_feedback` passes.
-2. **Mapping is deterministic.** Parametric test enumerates all 10 mapping rows in §1; asserts the documented `DownstreamEffect` shape for each.
-3. **Idempotent.** Re-submitting feedback for an already-`Decided` claim returns `NoMutation` and does not mutate `claim_feedback` or surfacing state.
-4. **Atomicity.** The recommendation_claim feedback_state column + the underlying action (claim_feedback row, cooldown bump, or both) are all in one transaction; partial mutations are not observable.
-5. **No new tables.** Migrations diff is empty. Uses existing `claim_feedback` and surfacing state.
-6. **No new ADR-0123 variants.** Maps to the existing 10 variants only. If reviewer panel finds any variant needs a new ADR-0123 mapping, L0 amendment first.
-7. **Privacy.** `Dismiss { reason: Other(BoundedNote) }` enforces the 200-char cap at the API boundary (already enforced by `BoundedNote::try_from` in contracts.rs). The note is stored in `claim_feedback.payload_json`, never in surfacing rows.
-8. **Signal contract.** `RecommendationFeedbackRecorded` SignalType variant declared in `signals/policy_registry.rs` (W0-style shared infrastructure file); downstream W4-B/C will reference it from this declaration.
-9. **W3-A integration ready.** When `dailyos_suggested_next_steps_feedback_enabled` flips to true (post W4-A merge), the W3-A view.js handler POSTs to the WP REST bridge that invokes this ability with `Actor::SurfaceClient`. W4-A does not flip the filter; that's a one-line UI follow-up.
-10. **Cycle hygiene.** `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean.
+1. **Ability ships and is registered.** `submit_recommendation_feedback` in `tools/dailyos-abilities.json` (regen); `AbilityRegistry` exposes to `[User, SurfaceClient]` with `category = Maintenance`. `cargo test recommendations::submit_recommendation_feedback` passes.
+2. **Mapping is deterministic.** Parametric test enumerates all 10 mapping rows in §1; asserts the documented `(FeedbackAction, EffectKind)` pair for each. Each row's claim_feedback row inspection confirms the typed `note` or `payload_json` shape.
+3. **Idempotent.** Re-submitting feedback for an already-`Decided` claim returns `EffectKind::NoMutation` and does NOT mutate `claim_feedback` (the atomic compare-and-set UPDATE affects 0 rows; service short-circuits per §3.4 step 4).
+4. **Atomicity via SQLite single-writer.** The `metadata_json` json_set UPDATE + the `record_claim_feedback` INSERT are within `with_claim_transaction`. SQLite's serializable isolation prevents partial observation. External side effects (Convert{Action} attachment) are explicitly at-least-once per `AttachStatus::Queued`.
+5. **No new tables.** Migrations diff is empty. Uses existing `claim_feedback` rows; cooldown is read-derived from `latest_feedback_suppression` (per B2).
+6. **No new ADR-0123 variants.** Maps to the existing 10 `FeedbackAction` variants from `abilities-runtime/src/abilities/feedback.rs:39`.
+7. **Privacy.** `Dismiss { reason: Other(BoundedNote) }` enforces 200-char cap via `BoundedNote::try_from`. The note is stored in `claim_feedback`'s typed `note: Option<String>` column per ADR-0123 §2 (NOT `payload_json` — resolves adv F3). L1 verifies `validate_feedback_payload` admits the `note` key for `NotRelevantHere`; if not, L1 extends the validator.
+8. **Signal: reuse `claim_feedback_recorded`.** The existing signal fires automatically from `record_claim_feedback` (`claims.rs:9127`). W4-A does NOT declare a new SignalType. Downstream W4-B/C consume the existing signal and filter by `feedback_type` (per B3).
+9. **Actor normalization at the ability boundary.** Per B5: `ctx.actor()` is normalized to `"user"` before calling `record_claim_feedback` so `validate_feedback_actor` admits. Original Actor identity preserved in the provenance envelope.
+10. **`feedback_state` is JSON, not a column.** Mutation via `json_set` on `metadata_json` (per migration `269_recommendation_claim_metadata_indexes.sql`). Per B6.
+11. **W3-A filter-flip is L4-gated, not auto-merged.** Per B12: the `dailyos_suggested_next_steps_feedback_enabled` filter flip from `false` to `true` is a separate L4-gated change requiring hands-on QA of the full WP block → REST → ability → record_claim_feedback → surfacing read pickup vertical. The flip does NOT ship with W4-A merge.
+12. **First Maintenance ability under `recommendations/`.** Per B4 + feas #8: existing `dailyos-abilities.json` inventory has Read/Transform/Maintenance categories; the Maintenance category for recommendations is new but the transport admits it without changes. L1 confirms regen handles it as passthrough.
+13. **Cycle hygiene.** `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean.
 
 ---
 
@@ -238,10 +440,15 @@ Per W3-A's A8 pattern (channels enumerated before merge):
 
 | Artifact | Notes |
 |---|---|
-| `tools/dailyos-abilities.json` regen | Deterministic per W3-A precedent |
-| `signals/policy_registry.rs` `RecommendationFeedbackRecorded` variant | Shared infra file; commit alongside |
-| `services::recommendations::feedback` doc comments | Document the mapping table inline so future readers don't have to find this packet |
+| `tools/dailyos-abilities.json` regen | Deterministic per W3-A precedent; first Maintenance ability under `recommendations/` |
+| `services::recommendations::feedback` doc comments | Document the §1 mapping table inline so future readers don't need to find this packet |
+| Per-Actor dry-run test | Asserts `[User, SurfaceClient]` admit; `[System, Agent, Admin, McpClient]` deny with `Capability` error. Lives in `abilities-runtime/src/abilities/recommendations/mod.rs::tests`. CI-enforced gate. |
+| Parametric mapping test | All 10 mapping rows from §1; asserts `(FeedbackAction, EffectKind, note/payload_json shape)` per row. |
+| Idempotent compare-and-set test | Re-submit feedback for an already-Decided claim → `EffectKind::NoMutation`; zero new `claim_feedback` rows. |
+| `validate_feedback_payload` admits `note` for `NotRelevantHere` | L1 either confirms via grep + test, or extends the validator allowlist for the new key + action pair |
 | L2-status in commit messages | `passed` per memory rule |
+
+**No new `signals/policy_registry.rs` row** — per B3, W4-A consumes the existing `claim_feedback_recorded` signal (`claims.rs:9127`); no new SignalType variant declared. W0 ownership preserved.
 
 ---
 
@@ -288,13 +495,19 @@ K-in needs to confirm: no prior `submit_recommendation_feedback` solution exists
 
 ---
 
-## §12 Open questions (L0 panel decides)
+## §12 Open questions
 
-1. **`Dismiss { Other(BoundedNote) }` mapping.** Proposed: cooldown bump + note logged to `claim_feedback.payload_json`. Alternative: treat as MarkOutdated with note. Which is the better default?
-2. **`NotUseful` vs `TooNoisy` distinction.** Both are cooldown-only. Should TooNoisy bump the cooldown MORE aggressively (e.g., extend the whole subject's cooldown across action_signatures), or just bump the same as NotUseful? Per DOS-332 AC's "TooNoisy updates surfacing thresholds/cooldowns" — sounds like broader-than-NotUseful.
-3. **Convert → ClaimCorrection mapping.** Currently MarkOutdated on the original + new claim proposal. Should the new corrected claim be auto-committed or stay in `propose` state per ADR-0123? Default: propose, per ADR-0123 §5.
-4. **`RecommendationFeedbackRecorded` SignalType payload.** What fields does the signal carry? Minimal: `{ claim_id, decision_variant, downstream_effect_kind }`. Should also include `subject` for downstream filtering?
-5. **WP REST endpoint shape.** The block needs a WP REST endpoint to POST feedback. Does it use existing dailyos-runtime-client transport with `Actor::SurfaceClient`, or a dedicated `/v1/surface/submit-feedback` endpoint? Default: reuse the runtime client invoke path (write abilities go through the same path; scope policy enforces).
+**All cycle-0 open questions resolved by B10.** Remaining open items are L1-resolvable, not L0-blocking:
+
+1. **`validate_feedback_payload` admits `{ note: "..." }` for `NotRelevantHere`?** L1 reads `claims.rs:5525+` (the `validate_feedback_payload` body). If admitted: proceed. If not admitted: either (a) extend the validator allowlist for `NotRelevantHere` + `note` key, or (b) re-map `Dismiss{Other}` to `SurfaceInappropriate` if THAT action admits a note. Decision made at L1 against the live validator; not blocking L0.
+2. **`services::actions::attach_from_recommendation`** — the exact function name + signature for the open-loop attachment in `Convert{Action}` step 6. L1 grep confirms the existing function; if no such function exists, L1 either authors one (small scope, matches existing action service patterns) or routes through whatever the current attachment path is. Not blocking L0.
+
+**Resolved at cycle 1:**
+- Q1 (cycle 0) `Dismiss { Other }` → `NotRelevantHere` with typed `note` column (B1)
+- Q2 (cycle 0) `NotUseful` vs `TooNoisy` → same `SurfaceInappropriate` (B1)
+- Q3 (cycle 0) `Convert { ClaimCorrection }` → `NeedsNuance` (B1)
+- Q4 (cycle 0) Signal payload → consume existing `claim_feedback_recorded` (B3)
+- Q5 (cycle 0) WP REST endpoint → existing transport admits all categories (B9)
 
 ---
 
@@ -317,9 +530,11 @@ K-in needs to confirm: no prior `submit_recommendation_feedback` solution exists
 Per CLAUDE.md DoD section:
 
 1. All 5 `RecommendationFeedbackDecision` variants (10 mapping rows including Dismiss reasons) implemented per §1 table
-2. End-to-end flow tested: ability invocation → service path → claim_feedback / surfacing state → signal emission
+2. End-to-end flow tested: ability invocation → `record_claim_feedback` → `claim_feedback` row written → `claim_feedback_recorded` signal fires automatically → `latest_feedback_suppression` returns the row on next read
 3. No stubs or TODOs
 4. `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean
 5. L2-status declared in commit messages
-6. No L4 evidence required (no UI surface in this lane)
-7. K-out: any class-pattern findings from L2 filed via `/ce-compound mode:headless` at retro close
+6. **No L4 evidence required for the W4-A merge itself** (no UI surface introduced by this lane). However: the `dailyos_suggested_next_steps_feedback_enabled` filter flip in the W3-A WP block is an **L4-gated change**, shipped separately from W4-A merge, gated by hands-on QA of the WP block → REST → ability → record_claim_feedback → claim_feedback row → surfacing read pickup vertical (B12).
+7. **Privacy non-leak documented.** `EffectKind` carries no subject identity beyond what the caller already knows about its own claim (B12).
+8. **Auth overhaul note.** Per the 2026-05-21 auth overhaul memory, ADR-0111 §193 nonce requirement for write events is being stripped for local same-user contexts. W4-A does NOT add nonce machinery; relies on the post-overhaul actor-allowlist model. L1 verifies the current state via a transport-layer grep (B12).
+9. K-out: any class-pattern findings from L2 filed via `/ce-compound mode:headless` at retro close.

--- a/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
+++ b/.docs/plans/v1.4.6-w4a-recommendation-feedback/lane-a-l0.md
@@ -172,7 +172,223 @@ This is appropriately smaller than W3-A. Per scope-guardian: "If W4-A's packet b
 - B1–B12 amendments apply; B13 trim confirmed
 - Original §1, §3.1, §3.3, §3.4, §4, §7, §12, §14 sections are SUPERSEDED inline by cycle 1 (the inline-sweep pattern from W3-A's cycle 3); a future cycle-2 reviewer reading any single section should see consistent state without needing to cross-reference cycle 1 amendments
 
-**Ready for cycle 2 panel re-dispatch.** Recommended subset: adversarial (verify F1/F2/F3/F8 closed); feasibility (verify B6 json_set + B5 actor normalization + B9 transport); scope-guardian (verify B3/B4 dropped scope; B11 added test row). Skip K-in (no scope changes need re-validation).
+---
+
+## Cycle 2 amendments (2026-05-27 late) — substrate grounding pass
+
+Cycle-2 panel verdict: adversarial BLOCKED (5 new findings); feasibility CYCLE_3 (3 defects); scope-guardian CYCLE_3 (1 scope decision + stale text cleanup).
+
+**The class pattern recurred:** cycle 1 dropped the cycle-0 `bump_cooldown` hallucination but introduced new hallucinations of the same class (typed `note` column that doesn't exist; `LIKE '%"pending"%'` predicate that doesn't actually match; `attach_from_recommendation` retry infra that doesn't exist). Per adversarial reviewer's own recommendation: "the packet author needs to do a single grounding pass against the live schema, the FeedbackState serde shape, and the actions service module, then re-emit a packet whose every 'X already exists' claim is line-cited."
+
+This amendment block does that grounding pass. **Every claim below is file:line-cited and verified against the current `dev` HEAD (`2a6ec716`).**
+
+### B14. Compare-and-set predicate fixed (supersedes B6 + §3.4 step 4)
+
+`LIKE '%"pending"%'` was empirically broken in `sqlite3 :memory:` testing. Reason: `json_extract` strips JSON quotes from primitive string values; the LIKE pattern searches for embedded quotes that never appear in the extracted text.
+
+**Verified empirically:**
+
+```
+sqlite> SELECT json_extract(json('{"recommendation":{"feedbackState":"pending"}}'),
+                            '$.recommendation.feedbackState');
+pending                              -- bare text, no quotes
+sqlite> SELECT json_extract(...) LIKE '%"pending"%';
+0                                    -- DOES NOT MATCH
+sqlite> SELECT json_extract(...) = 'pending';
+1                                    -- correct match
+```
+
+**Corrected predicate** (replaces B6's UPDATE):
+
+```sql
+UPDATE intelligence_claims
+SET metadata_json = json_set(metadata_json,
+    '$.recommendation.feedbackState', json(?),
+    '$.recommendation.conversionState', json(?))
+WHERE id = ?
+  AND json_extract(metadata_json, '$.recommendation.feedbackState') = 'pending'
+```
+
+Note: `json_set` requires explicit `json(?)` wrapping when the bound parameter is itself a JSON value (e.g., the Decided object). For the Pending → Decided transition, the new feedbackState is `{"decided": {...}}` (object), so `json(?)` parses the parameter as JSON. SQLite `json_extract` continues to return the unquoted primitive string `"pending"` for the prior state, allowing the `= 'pending'` compare-and-set to succeed only when the row is in Pending state.
+
+**FeedbackState serde shape verified** at `src-tauri/src/services/recommendations/contracts.rs:103-106`:
+
+```rust
+#[derive(...)]
+#[serde(rename_all = "camelCase")]
+pub enum FeedbackState {
+    Pending,                                          // → bare JSON string "pending"
+    Decided(RecommendationFeedbackDecision),          // → {"decided": {...}}
+}
+```
+
+No `#[serde(tag = ...)]` → external tagging default. Pending serializes to the JSON string `"pending"`; Decided serializes to an object with the `decided` key.
+
+The packet's atomic compare-and-set is structurally sound; only the predicate was broken. Cycle 3 fixes it.
+
+### B15. `note` storage — encode in payload_json with validator extension (supersedes B1 row #5 + §4 AC#7 + §12 Q1)
+
+**Grounded against schema:** `claim_feedback` table at `src-tauri/src/migrations/245_dos_484_feedback_merge_intent.sql` has columns:
+
+```
+id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
+```
+
+**There is no `note` column.** `ClaimFeedbackInput` at `src-tauri/src/services/claims.rs:230-236` has fields:
+
+```rust
+pub struct ClaimFeedbackInput {
+    pub claim_id: String,
+    pub action: FeedbackAction,
+    pub actor: String,
+    pub actor_id: Option<String>,
+    pub payload_json: Option<String>,
+}
+```
+
+**There is no `note: Option<String>` field.** ADR-0123 §2 describes an intended typed shape, but it is not present in the live substrate. The cycle-1 packet's "typed `note: Option<String>` column" claim is wrong.
+
+**Correction.** The note encodes into `payload_json` as a JSON key alongside the action-required key:
+
+```json
+{ "invocation_id": "<surface_invocation_id>", "note": "<up to 200 chars>" }
+```
+
+**Validator extension required.** `validate_feedback_action_metadata` at `claims.rs:5560-5570` is action-keyed:
+
+```rust
+match action {
+    FeedbackAction::WrongSource       => require_payload_string(action, payload, "source_ref"),
+    FeedbackAction::NeedsNuance       => require_payload_string(action, payload, "corrected_text"),
+    FeedbackAction::SurfaceInappropriate => require_payload_string(action, payload, "surface"),
+    FeedbackAction::NotRelevantHere   => require_payload_string(action, payload, "invocation_id"),
+    FeedbackAction::MergeIntent       => require_payload_object(action, payload, "merge_target"),
+    _ => Ok(()),
+}
+```
+
+L1 extends this for `NotRelevantHere` to admit an OPTIONAL `note` key (size-validated to 200 chars at the writer, matching `BoundedNote::MAX_CHARS` from `contracts.rs:148`). The validator change is a 3-line addition: keep the required `invocation_id` check, add an optional `note` length check.
+
+This is a **net-new validator-allowlist line, not a schema change.** §4 AC#5 "no new migrations" holds; §4 AC#11 "first Maintenance ability under recommendations/" is unaffected. New CI gate input row in §7: "Validator extension: `NotRelevantHere` admits optional `note` key with 200-char cap."
+
+§4 AC#7 cycle-1 text superseded: "The note is encoded in `payload_json.note` per B15. The 200-char cap is enforced at the API boundary by `BoundedNote::try_from`; the validator extension at `claims.rs:5560` enforces it server-side after JSON deserialization."
+
+### B16. Convert{Action} simplifies — pure state update, no external side effect (supersedes B1 Convert{Action} row + §3.3 ActionAttachment / AttachStatus + §3.4 step 6)
+
+**Grounded against actions service.** Greppy survey of `src-tauri/src/services/`:
+
+- `sync_action_open_loop_claim` exists at `src-tauri/src/services/action_claims.rs` — takes an existing `DbAction`, syncs its open-loop claim shape. Does not link an arbitrary action to a recommendation.
+- `commitment_bridge.rs` handles commitments → action linkage. Not recommendation-specific.
+- `attach_from_recommendation` does NOT exist. The cycle-1 packet's "existing action retry infrastructure" claim is a hallucination.
+
+**Key insight from `ConversionState` enum** (`contracts.rs`):
+
+```rust
+pub enum ConversionState {
+    NotConverted,
+    ConvertedToAction { action_id: String },          // existing action_id
+    ConvertedToClaimCorrection { claim_id: ClaimId }, // existing claim_id
+    ConvertedToReviewQueue { queue_item_id: String }, // existing queue_item_id
+}
+```
+
+Every Convert variant carries an ID of an **already-existing** entity. The user has the action / claim / queue item in hand BEFORE submitting feedback. The recommendation just records "I was converted to that thing." This is pure state mutation on the recommendation's `metadata_json`. **No external service call. No attachment. No retry infrastructure.**
+
+**Convert{Action(action_id)} flow simplifies:**
+
+1. `record_claim_feedback(... ConfirmCurrent ...)` — reinforce source/agent
+2. `json_set` on `metadata_json` sets `recommendation.conversionState = {kind: "convertedToAction", actionId: <action_id>}`
+3. Done. No `ActionAttachment` type, no `AttachStatus::Queued`, no retry.
+
+**Output simplifies (supersedes §3.3):**
+
+```rust
+pub struct SubmitRecommendationFeedbackResponse {
+    pub schema_version: u32,
+    pub claim_id: ClaimId,
+    pub feedback_state: FeedbackState,
+    pub conversion_state: ConversionState,
+    pub effect_kind: EffectKind,
+    pub recorded_at: DateTime<Utc>,
+}
+
+pub enum EffectKind {
+    ClaimFeedbackRecorded,
+    NoMutation,
+}
+```
+
+`ActionAttachment` and `AttachStatus` types from cycle 1 are **dropped**. The conversion_state field on the response already carries the action_id when relevant; no separate envelope needed.
+
+**Resolves the cycle-1 atomicity-honesty concern** (adv F4): there is no external side effect, so there is no honesty problem to disclose. The cycle-1 framing was solving a non-problem.
+
+### B17. `actor_id` populated with SurfaceClient instance (supersedes B5 audit-trail gap)
+
+Per adversarial cycle 2 new attack surface: when normalized to `"user"`, the `claim_feedback.actor` column loses SurfaceClient identity. **Resolution: populate `actor_id`.**
+
+Verified at `claims.rs:230-236`: `ClaimFeedbackInput` has `actor_id: Option<String>`. Setting this to the SurfaceClient instance string (e.g., `"surface:wp-block-suggested-next-steps-{uuid}"`) preserves audit-trail identity in the DB row alongside the normalized `actor: "user"`.
+
+For `Actor::User` direct invocations, `actor_id` is `None`. For `Actor::SurfaceClient { instance, .. }`, `actor_id = Some(instance.to_string())`.
+
+**Verified against actor_class_for_actor** at `claims.rs:5488`: the function splits on `[:, /, @]` so `actor: "user"` admits regardless of `actor_id` value — the audit identity is captured without breaking validation.
+
+### B18. Signal payload corrected (supersedes B3 description in cycle 1)
+
+**Grounded against signal emission** at `claims.rs:9112-9136`:
+
+```rust
+let payload = serde_json::json!({
+    "action": write.outcome.action.as_str(),
+    "claim_id": &write.outcome.claim_id,
+    "verification_state_before": &write.verification_state_before,
+    "verification_state_after": &write.verification_state_after,
+}).to_string();
+```
+
+Cycle 1's claim that the signal carries `feedback_id, claim_id, feedback_type` is wrong. The actual payload is `{action, claim_id, verification_state_before, verification_state_after}`.
+
+**Discriminator surface for downstream W4-B/W4-C:**
+
+- `action` is the FeedbackAction string (e.g., `"not_relevant_here"`, `"surface_inappropriate"`, `"needs_nuance"`, `"confirm_current"`, `"wrong_subject"`)
+- `claim_id` is the recommendation's claim_id
+
+W4-B / W4-C consumers filter recommendation-feedback events by joining on `claim_id` against `intelligence_claims` to confirm `claim_type = 'recommendation'`. They cannot filter from signal payload alone without the join. **This is a known cost, not a defect** — the signal is a notification, not a self-contained record.
+
+§4 AC#8 superseded: "Signal payload is `{action, claim_id, verification_state_before, verification_state_after}` per the existing `claim_feedback_recorded` emission at `claims.rs:9114`. Downstream W4-B/C consumers filter via JOIN against `intelligence_claims` on `claim_type = 'recommendation'`."
+
+### B19. Scope name follows existing convention (supersedes B4 scope naming)
+
+Per feasibility cycle 2: existing scope strings in `registry.rs:2759, 2845` follow `verb.noun` (e.g., `read.account_overview`, `submit.feedback`). The cycle-1 `maintenance.recommendations.feedback` has no precedent — grep returned zero `maintenance.*` scopes.
+
+**Corrected:** `submit.recommendations.feedback` (matches existing `submit.feedback` convention; verb prefix; noun-namespace).
+
+§3.1 `required_scopes` superseded: `["submit.recommendations.feedback"]`.
+
+ADR-0103 maintenance-ability constraints still apply via category, not scope namespace.
+
+### B20. Stale-text cleanup (sweep of cycle-1 in-document references to dropped primitives)
+
+Cycle 2 scope-guardian flagged stale references to dropped concepts (B3 SignalType, B7 ActionAttachment, B16 retry infra). Cleanup applied inline:
+
+- **§5 channel #5** — was: "`signals/policy_registry.rs` `RecommendationFeedbackRecorded` variant." Updated: "No new SignalType variant; consume existing `claim_feedback_recorded` per B3 + B18."
+- **§6 integration test bullets** — references to `MarkOutdated` (was cycle-0 mapping for Convert{ClaimCorrection}) replaced with `NeedsNuance` per B1; references to declaring a new signal dropped.
+- **§9 cross-wave coordination** — sentence "W4-B's L0 reads from `RecommendationFeedbackRecorded` signal declared here" replaced with "W4-B's L0 reads from the existing `claim_feedback_recorded` signal (filtering via JOIN on `claim_type = 'recommendation'`)."
+- **§13 risk register** — last row "Signal type declared but unused" dropped entirely (no signal declared).
+- **§7 CI gate inputs** — L2-status row dropped (per scope cycle 2: commit hygiene, not artifact deliverable).
+
+### B21. Verified-against-codebase appendix (new §15)
+
+Per adversarial cycle 2: "the packet must include a 'verified-against-codebase' appendix with file:line citations for every 'X already exists' claim." Added as §15.
+
+### Cycle 3 status
+
+- B14–B21 amendments apply; cycle 2 hallucinations resolved with citations
+- B16 simplifies the Convert{Action} path — drops `ActionAttachment` / `AttachStatus` types entirely
+- B17 closes the SurfaceClient audit-trail gap via `actor_id` field (no schema change)
+- B19 aligns scope naming with codebase convention
+- B20 sweeps stale references
+
+**Ready for cycle 3 panel re-dispatch.** Recommended subset: adversarial only (verify the LIKE-fix + note-storage + Convert simplification all close their cycle-2 findings). Feasibility + scope-guardian skipped — their cycle-2 findings are addressed by B14–B19 with citations they can verify by spot-check.
 
 ---
 
@@ -280,8 +496,8 @@ Wave plan §line 1015-1020:
 
 - **Name:** `submit_recommendation_feedback`
 - **Category:** `Maintenance` — per ADR-0102 §82 the category is call-graph-derived. Mutates internal state through `services::claims::record_claim_feedback` (canonical maintenance path for `intelligence_claims` mutations). ADR-0103 maintenance-ability constraints apply.
-- **Allowed actors:** `[User, SurfaceClient]` — the user OR a surface acting on the user's explicit click. NOT `System` (no automatic feedback), NOT `Agent` / `Admin`, NOT `McpClient`. Note: per B5, the ability **normalizes `ctx.actor()` to `"user"`** before calling `record_claim_feedback` because `validate_feedback_actor` (`claims.rs:5507`) admits only `User`. The original SurfaceClient identity is preserved in the provenance envelope.
-- **`required_scopes`:** `["maintenance.recommendations.feedback"]` (maintenance naming convention; verify at L1 grep against existing maintenance scope strings)
+- **Allowed actors:** `[User, SurfaceClient]` — the user OR a surface acting on the user's explicit click. NOT `System` (no automatic feedback), NOT `Agent` / `Admin`, NOT `McpClient`. Per B5 + B17, the ability **normalizes `ClaimFeedbackInput.actor = "user"`** (so `validate_feedback_actor` at `claims.rs:5507` admits) AND **populates `actor_id` with the SurfaceClient instance string** (when caller is `Actor::SurfaceClient { instance, .. }`) so the audit trail in `claim_feedback.actor_id` (per migration 245 schema) preserves identity. For `Actor::User` direct invocations, `actor_id` is `None`.
+- **`required_scopes`:** `["submit.recommendations.feedback"]` (per B19 — matches existing `submit.feedback` convention at `registry.rs:2759, 2845`; `maintenance.*` prefix from cycle 1 has no codebase precedent)
 - **`may_publish`:** false (per ADR-0103 maintenance default)
 - **`mcp_exposure`:** `None` (per ADR-0103 maintenance default)
 - **`client_side_executable`:** false (per ADR-0103)
@@ -315,10 +531,9 @@ The ability returns `AbilityOutput<SubmitRecommendationFeedbackResponse>` per AD
 pub struct SubmitRecommendationFeedbackResponse {
     pub schema_version: u32,
     pub claim_id: ClaimId,
-    pub feedback_state: FeedbackState,                // always Decided(<variant>) after success; Pending on NoMutation
-    pub conversion_state: ConversionState,             // updated if Convert variant
+    pub feedback_state: FeedbackState,           // always Decided(<variant>) after success; Pending on NoMutation
+    pub conversion_state: ConversionState,        // updated if Convert variant; carries the action_id / claim_id / queue_item_id inline
     pub effect_kind: EffectKind,
-    pub action_attachment: Option<ActionAttachment>,   // only Some(...) for Convert{Action}; carries the open-loop action_id
     pub recorded_at: DateTime<Utc>,
 }
 
@@ -326,26 +541,11 @@ pub struct SubmitRecommendationFeedbackResponse {
 #[serde(rename_all = "camelCase")]
 pub enum EffectKind {
     ClaimFeedbackRecorded,
-    NoMutation, // idempotent reject — claim's feedback_state was already non-Pending at write time
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ActionAttachment {
-    pub action_id: String,
-    pub attached_at: DateTime<Utc>,
-    pub attach_status: AttachStatus,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub enum AttachStatus {
-    /// Open-loop attached successfully within this ability call
-    Attached,
-    /// Feedback recorded; open-loop attach queued for at-least-once retry (per B1 Convert{Action} row)
-    Queued,
+    NoMutation, // idempotent reject — claim's feedback_state was already non-Pending at compare-and-set time
 }
 ```
+
+Per B16: cycle 1's `ActionAttachment` + `AttachStatus` types are **dropped**. The existing `ConversionState` enum already carries `ConvertedToAction { action_id }` / `ConvertedToClaimCorrection { claim_id }` / `ConvertedToReviewQueue { queue_item_id }` inline — no separate attachment envelope needed. No external service call, no retry infrastructure required; the Convert variants record the user-supplied IDs of already-existing entities.
 
 **Privacy note:** `EffectKind` carries no subject identity. The caller (the surface that posted the feedback) already knows its own claim's subject and decision. No new privacy surface introduced (resolves adv F10).
 
@@ -363,38 +563,42 @@ pub enum AttachStatus {
    UPDATE intelligence_claims
    SET metadata_json = json_set(metadata_json,
        '$.recommendation.feedbackState', ?,
-       '$.recommendation.conversionState', ?)
+       '$.recommendation.conversionState', json(?))
    WHERE id = ?
-     AND json_extract(metadata_json, '$.recommendation.feedbackState') LIKE '%"pending"%'
+     AND json_extract(metadata_json, '$.recommendation.feedbackState') = 'pending'
    ```
-   If `rows_affected == 0`, return `Ok(EffectKind::NoMutation)` with the existing state — the claim was already decided. SQLite single-writer prevents the read-then-write race (per feas #4); the WHERE-clause check is the atomic guard. **Resolves adv F6.**
-5. **Call `record_claim_feedback`.** With the constructed `ClaimFeedbackInput` and the normalized `"user"` actor string. This:
-   - Inserts the `claim_feedback` row (UUID generated internally per `claims.rs:7156`)
-   - Validates the payload per `validate_feedback_payload` (L1 verifies the `note` + `corrected_text` keys are admitted by the validator for the `NotRelevantHere` / `NeedsNuance` / `SurfaceInappropriate` actions; if not, L1 amendment to the validator's allowlist)
-   - Transitions verification_state per ADR-0123 dispatch table
-   - Emits `claim_feedback_recorded` signal automatically (no W4-A action needed — per B3)
-6. **Convert{Action} side effect.** If the decision is `Convert{Action(action_id)}`, AFTER the feedback row is inserted, invoke `services::actions::attach_from_recommendation(action_id, recommendation_claim_id)` (or the existing analog — L1 grep confirms the function name). If attachment fails, the feedback row stays; the response's `action_attachment.attach_status = Queued` signals at-least-once retry. **Resolves adv F4 atomicity-honesty.**
-7. **Convert{ReviewQueue} side effect.** If the decision is `Convert{ReviewQueue(queue_item_id)}`, skip the `record_claim_feedback` call entirely (per §1 table); just update `conversion_state` via `json_set` on `metadata_json` and return. DOS-336's review-queue lifecycle owns the conversion semantics.
+   Predicate is `= 'pending'` (NOT `LIKE '%"pending"%'` — per B14, `json_extract` strips JSON quotes from primitive strings; LIKE-with-quotes would never match). If `rows_affected == 0`, return `Ok(EffectKind::NoMutation)` with the existing state — the claim was already decided. SQLite single-writer prevents the read-then-write race (per feas #4); the WHERE-clause `=` check is the atomic guard. **Resolves adv F6 + cycle-2 dissent.**
+5. **Call `record_claim_feedback`.** With the constructed `ClaimFeedbackInput`:
+   - `actor = "user"` (normalized per B5)
+   - `actor_id = Some(<surface_instance_string>)` for `Actor::SurfaceClient { instance, .. }` invocations; `None` for direct `Actor::User`. Per B17 — preserves audit identity in `claim_feedback.actor_id` column (verified in migration 245 schema).
+   - `payload_json` per the action's validator requirement at `claims.rs:5560-5570`:
+     - `NotRelevantHere` → `{"invocation_id": "<context.invocation_id>", "note": "<optional BoundedNote, ≤200 chars>"}`. The `note` key is OPTIONAL; L1 extends `validate_feedback_action_metadata` for `NotRelevantHere` to admit it (per B15).
+     - `NeedsNuance` → `{"corrected_text": "<reference to corrected claim_id>"}` (uses the corrected claim_id reference; L1 confirms text-vs-id semantics).
+     - `SurfaceInappropriate` → `{"surface": "<context.surface>"}`.
+     - `WrongSubject`, `ConfirmCurrent` → no required payload keys (per validator).
+   This inserts the `claim_feedback` row (UUID generated per `claims.rs:7156`), transitions verification_state per ADR-0123 dispatch, and emits the `claim_feedback_recorded` signal automatically.
+6. **Convert variants — pure state update on conversion_state.** Per B16: no external service call. The `ConversionState` enum variants (`ConvertedToAction { action_id }`, `ConvertedToClaimCorrection { claim_id }`, `ConvertedToReviewQueue { queue_item_id }`) carry user-supplied IDs of already-existing entities. The step-4 UPDATE already sets `recommendation.conversionState` via `json_set`; no follow-up call needed.
+7. **Convert{ReviewQueue} skips record_claim_feedback.** Per §1 row 10: ReviewQueue conversion routes through DOS-336's review queue lifecycle independently; W4-A's ability skips step 5 (no `record_claim_feedback` call), executes only step 4 (the `json_set` UPDATE setting `conversionState`), then returns.
 8. **Return `AbilityOutput<SubmitRecommendationFeedbackResponse>`.** Wrap in provenance via `ProvenanceBuilder` per ADR-0105.
 
-All steps 4–7 are within `with_claim_transaction` (which provides SQL transaction boundaries via SQLite's serializable isolation). External side effects (action attachment in step 6) cannot be rolled back — that's the at-least-once contract documented in `AttachStatus::Queued`.
+All steps 4–7 are within `with_claim_transaction` (SQLite serializable isolation). **There are no external side effects to roll back** — per B16, Convert variants record IDs of pre-existing entities, not creation calls.
 
 ---
 
 ## §4 Acceptance criteria
 
-1. **Ability ships and is registered.** `submit_recommendation_feedback` in `tools/dailyos-abilities.json` (regen); `AbilityRegistry` exposes to `[User, SurfaceClient]` with `category = Maintenance`. `cargo test recommendations::submit_recommendation_feedback` passes.
-2. **Mapping is deterministic.** Parametric test enumerates all 10 mapping rows in §1; asserts the documented `(FeedbackAction, EffectKind)` pair for each. Each row's claim_feedback row inspection confirms the typed `note` or `payload_json` shape.
-3. **Idempotent.** Re-submitting feedback for an already-`Decided` claim returns `EffectKind::NoMutation` and does NOT mutate `claim_feedback` (the atomic compare-and-set UPDATE affects 0 rows; service short-circuits per §3.4 step 4).
-4. **Atomicity via SQLite single-writer.** The `metadata_json` json_set UPDATE + the `record_claim_feedback` INSERT are within `with_claim_transaction`. SQLite's serializable isolation prevents partial observation. External side effects (Convert{Action} attachment) are explicitly at-least-once per `AttachStatus::Queued`.
-5. **No new tables.** Migrations diff is empty. Uses existing `claim_feedback` rows; cooldown is read-derived from `latest_feedback_suppression` (per B2).
-6. **No new ADR-0123 variants.** Maps to the existing 10 `FeedbackAction` variants from `abilities-runtime/src/abilities/feedback.rs:39`.
-7. **Privacy.** `Dismiss { reason: Other(BoundedNote) }` enforces 200-char cap via `BoundedNote::try_from`. The note is stored in `claim_feedback`'s typed `note: Option<String>` column per ADR-0123 §2 (NOT `payload_json` — resolves adv F3). L1 verifies `validate_feedback_payload` admits the `note` key for `NotRelevantHere`; if not, L1 extends the validator.
-8. **Signal: reuse `claim_feedback_recorded`.** The existing signal fires automatically from `record_claim_feedback` (`claims.rs:9127`). W4-A does NOT declare a new SignalType. Downstream W4-B/C consume the existing signal and filter by `feedback_type` (per B3).
-9. **Actor normalization at the ability boundary.** Per B5: `ctx.actor()` is normalized to `"user"` before calling `record_claim_feedback` so `validate_feedback_actor` admits. Original Actor identity preserved in the provenance envelope.
-10. **`feedback_state` is JSON, not a column.** Mutation via `json_set` on `metadata_json` (per migration `269_recommendation_claim_metadata_indexes.sql`). Per B6.
+1. **Ability ships and is registered.** `submit_recommendation_feedback` in `tools/dailyos-abilities.json` (regen); `AbilityRegistry` exposes to `[User, SurfaceClient]` with `category = Maintenance`. Required scope `submit.recommendations.feedback` (per B19; matches existing `submit.feedback` convention at `registry.rs:2759, 2845`). `cargo test recommendations::submit_recommendation_feedback` passes.
+2. **Mapping is deterministic.** Parametric test enumerates all 10 mapping rows in §1; asserts the documented `(FeedbackAction, EffectKind)` pair for each. Each row's `claim_feedback` row inspection confirms the `payload_json` keys match the validator requirement per `claims.rs:5560-5570`.
+3. **Idempotent compare-and-set.** Re-submitting feedback for an already-`Decided` claim returns `EffectKind::NoMutation` and does NOT mutate `claim_feedback`. Per B14: predicate is `json_extract(...) = 'pending'` (verified empirically). Test asserts: pre-Decided claim → UPDATE affects 0 rows → service returns NoMutation without calling `record_claim_feedback`.
+4. **Atomicity via SQLite single-writer.** The `metadata_json` json_set UPDATE + the `record_claim_feedback` INSERT are within `with_claim_transaction`. SQLite's serializable isolation prevents partial observation. **No external side effects** — per B16, Convert variants record IDs of pre-existing entities; no creation calls, no retry infra needed.
+5. **No new tables.** Migrations diff is empty. Uses existing `claim_feedback` rows; cooldown is read-derived from `latest_feedback_suppression` at `surfacing.rs:724` (per B2).
+6. **No new ADR-0123 variants.** Maps to the existing 10 `FeedbackAction` variants at `abilities-runtime/src/abilities/feedback.rs:39`.
+7. **Note encoded in `payload_json`, not a typed column.** Per B15: `claim_feedback` table has no `note` column (verified migration 245); `ClaimFeedbackInput` has no `note` field (verified `claims.rs:230-236`). `Dismiss { reason: Other(BoundedNote) }` encodes the note in `payload_json` as `{"invocation_id": "<...>", "note": "<≤200 chars>"}`. L1 extends `validate_feedback_action_metadata` for `NotRelevantHere` to admit the optional `note` key (3-line addition at `claims.rs:5560`).
+8. **Signal: reuse `claim_feedback_recorded`.** The existing signal fires automatically from `record_claim_feedback` (`claims.rs:9112-9136`). W4-A does NOT declare a new SignalType. Actual signal payload per B18: `{action, claim_id, verification_state_before, verification_state_after}`. Downstream W4-B/C consume this signal and JOIN against `intelligence_claims` to filter by `claim_type = 'recommendation'`.
+9. **Actor normalization + `actor_id` populated.** Per B5 + B17: ability passes `actor = "user"` (so `validate_feedback_actor` at `claims.rs:5507` admits) AND `actor_id = Some(<surface_instance>)` for SurfaceClient invocations. Preserves SurfaceClient audit identity in `claim_feedback.actor_id` column (verified migration 245 schema).
+10. **`feedback_state` is JSON, not a column.** Mutation via `json_set` on `metadata_json` (per migration 269). Predicate per B14: `json_extract(...) = 'pending'`.
 11. **W3-A filter-flip is L4-gated, not auto-merged.** Per B12: the `dailyos_suggested_next_steps_feedback_enabled` filter flip from `false` to `true` is a separate L4-gated change requiring hands-on QA of the full WP block → REST → ability → record_claim_feedback → surfacing read pickup vertical. The flip does NOT ship with W4-A merge.
-12. **First Maintenance ability under `recommendations/`.** Per B4 + feas #8: existing `dailyos-abilities.json` inventory has Read/Transform/Maintenance categories; the Maintenance category for recommendations is new but the transport admits it without changes. L1 confirms regen handles it as passthrough.
+12. **First Maintenance ability under `recommendations/`.** Per B4 + feas #8: existing `dailyos-abilities.json` inventory has Read/Transform/Maintenance categories; transport admits Maintenance without changes. L1 confirms regen handles it as passthrough.
 13. **Cycle hygiene.** `cargo clippy -- -D warnings && cargo test --lib && pnpm tsc --noEmit` clean.
 
 ---
@@ -404,11 +608,12 @@ All steps 4–7 are within `with_claim_transaction` (which provides SQL transact
 Per W3-A's A8 pattern (channels enumerated before merge):
 
 1. **Ability registry** — auto via `#[ability(...)]` macro; tested via `tools/dailyos-abilities.json` diff.
-2. **Surface scope registry** — new `write.recommendations` scope; verify file path at L1 grep (likely `abilities-runtime/src/abilities/registry.rs`).
-3. **WP REST endpoint allowlist** — the new ability must be admitted by `wp/dailyos/includes/transport/class-dailyos-runtime-client.php`'s allowlist (if explicit) or pass through (if dynamic per scope). Verify at L1.
+2. **Surface scope registry** — new `submit.recommendations.feedback` scope per B19 (matches existing `submit.feedback` convention). File path at L1 grep is likely `abilities-runtime/src/abilities/registry.rs` (existing scope strings at `registry.rs:2759, 2845`).
+3. **WP REST endpoint allowlist** — `wp/dailyos/includes/transport/class-dailyos-runtime-client.php` transport is category-agnostic per feas #8 cycle 0. No allowlist change needed for the new Maintenance category.
 4. **`tools/dailyos-abilities.json`** — regen + commit.
-5. **`signals/policy_registry.rs`** — pre-declare `RecommendationFeedbackRecorded` SignalType.
+5. **No new `signals/policy_registry.rs` row.** Per B3 + B20: W4-A consumes the existing `claim_feedback_recorded` signal at `claims.rs:9112`; no new SignalType variant. W0 ownership preserved.
 6. **Per-Actor dry-run test** — assert `[User, SurfaceClient]` admit; `[System, Agent, Admin, McpClient]` deny with `Capability` error.
+7. **`validate_feedback_action_metadata` extension** — L1 adds optional `note` key admission for `NotRelevantHere` at `claims.rs:5560-5570`. 3-line addition; preserves required `invocation_id` check.
 
 ---
 
@@ -416,23 +621,25 @@ Per W3-A's A8 pattern (channels enumerated before merge):
 
 ### Rust unit
 
-- Mapping table parametric: each `RecommendationFeedbackDecision` variant produces the documented `DownstreamEffect` (10 rows)
-- Idempotent re-submission returns `NoMutation`
-- `Dismiss { Other }` with note >200 chars rejected at contract level (already enforced by `BoundedNote`)
+- Mapping table parametric: each `RecommendationFeedbackDecision` variant produces the documented `(FeedbackAction, EffectKind)` pair (10 rows)
+- Idempotent compare-and-set: pre-Decided claim returns `NoMutation`; predicate `json_extract(...) = 'pending'` verified to match Pending shape via fixture (per B14)
+- `Dismiss { Other }` with note >200 chars rejected at contract level (already enforced by `BoundedNote::try_from`)
 - Unknown `claim_id` returns `ClaimError::UnknownClaimId`
 - Non-recommendation claim_id returns `ClaimError::UnsupportedClaimType`
 - Per-Actor allowlist test ([User, SurfaceClient] admit; rest deny)
+- `actor_id` populated correctly: User direct → None; SurfaceClient → Some(instance) (per B17)
 
 ### Integration (`cargo test --test` recommendations)
 
-- Full Pending → Decided cycle: seed claim, submit Accept, verify `claim_feedback` row + claim's `feedback_state` updated atomically
-- Cooldown-only path: submit `NotUseful`, verify no `claim_feedback` row; cooldown bumped in surfacing state
-- Both-paths: submit `Convert { ClaimCorrection }`, verify `claim_feedback` `MarkOutdated` row + corrected claim proposal exists
-- Signal emission: assert `RecommendationFeedbackRecorded` signal fired with correct claim_id + decision variant
+- Full Pending → Decided cycle: seed claim, submit Accept, verify `claim_feedback` row + claim's `metadata_json.recommendation.feedbackState` updated atomically to `{"decided": {"kind": "accept", "at": "..."}}`
+- NotUseful path: submit `NotUseful`, verify `claim_feedback` row with `feedback_type = 'surface_inappropriate'` AND `latest_feedback_suppression` returns the row on subsequent surfacing.rs read (cooldown emergent — per B2)
+- Convert{ClaimCorrection} path: submit decision, verify `claim_feedback` row with `feedback_type = 'needs_nuance'` + `payload_json` containing `corrected_text` (per B1 row + ADR-0123 §149 row #7); verify `conversion_state` updated to `convertedToClaimCorrection` via json_set
+- Convert{Action} path: submit decision with action_id, verify `claim_feedback` row with `feedback_type = 'confirm_current'` + `conversion_state` updated to `convertedToAction { action_id }` via json_set; **NO** external service call (per B16)
+- Signal emission: assert `claim_feedback_recorded` signal payload matches `{action, claim_id, verification_state_before, verification_state_after}` per `claims.rs:9112-9136` (per B18)
 
 ### Substrate-side smoke (deferred to W3-A integration when UI flips)
 
-- WP block view.js → REST endpoint → ability → service path → claim_feedback / surfacing — full vertical test. Deferred per UI Surface Deferral.
+- WP block view.js → REST endpoint → ability → service path → claim_feedback → surfacing.rs read pickup — full vertical test. Deferred per UI Surface Deferral; gated by L4 per AC#11.
 
 ---
 
@@ -443,12 +650,14 @@ Per W3-A's A8 pattern (channels enumerated before merge):
 | `tools/dailyos-abilities.json` regen | Deterministic per W3-A precedent; first Maintenance ability under `recommendations/` |
 | `services::recommendations::feedback` doc comments | Document the §1 mapping table inline so future readers don't need to find this packet |
 | Per-Actor dry-run test | Asserts `[User, SurfaceClient]` admit; `[System, Agent, Admin, McpClient]` deny with `Capability` error. Lives in `abilities-runtime/src/abilities/recommendations/mod.rs::tests`. CI-enforced gate. |
-| Parametric mapping test | All 10 mapping rows from §1; asserts `(FeedbackAction, EffectKind, note/payload_json shape)` per row. |
-| Idempotent compare-and-set test | Re-submit feedback for an already-Decided claim → `EffectKind::NoMutation`; zero new `claim_feedback` rows. |
-| `validate_feedback_payload` admits `note` for `NotRelevantHere` | L1 either confirms via grep + test, or extends the validator allowlist for the new key + action pair |
-| L2-status in commit messages | `passed` per memory rule |
+| Parametric mapping test | All 10 mapping rows from §1; asserts `(FeedbackAction, EffectKind)` pair per row + `payload_json` shape per `validate_feedback_action_metadata` requirements at `claims.rs:5560-5570`. |
+| Idempotent compare-and-set test | Re-submit feedback for an already-Decided claim → `EffectKind::NoMutation`; zero new `claim_feedback` rows. Tests both predicate halves: pre-Pending claim succeeds, pre-Decided claim short-circuits. |
+| `validate_feedback_action_metadata` extension | L1 adds optional `note` key admission for `NotRelevantHere` at `claims.rs:5560-5570` (3-line addition; preserves required `invocation_id` check). |
+| `actor_id` populated correctly | Test: `Actor::User` direct → `actor_id = None`; `Actor::SurfaceClient { instance, .. }` → `actor_id = Some(instance_string)`. Per B17. |
 
-**No new `signals/policy_registry.rs` row** — per B3, W4-A consumes the existing `claim_feedback_recorded` signal (`claims.rs:9127`); no new SignalType variant declared. W0 ownership preserved.
+**No new `signals/policy_registry.rs` row** — per B3 + B18, W4-A consumes the existing `claim_feedback_recorded` signal at `claims.rs:9112-9136`; no new SignalType variant declared. W0 ownership preserved.
+
+**No `L2-status` row** — per cycle 2 scope-guardian TRIM: L2-status in commit messages is process hygiene enforced by the `.githooks/commit-msg` hook, not a W4-A deliverable artifact. Covered by CLAUDE.md, not by this packet.
 
 ---
 
@@ -538,3 +747,37 @@ Per CLAUDE.md DoD section:
 7. **Privacy non-leak documented.** `EffectKind` carries no subject identity beyond what the caller already knows about its own claim (B12).
 8. **Auth overhaul note.** Per the 2026-05-21 auth overhaul memory, ADR-0111 §193 nonce requirement for write events is being stripped for local same-user contexts. W4-A does NOT add nonce machinery; relies on the post-overhaul actor-allowlist model. L1 verifies the current state via a transport-layer grep (B12).
 9. K-out: any class-pattern findings from L2 filed via `/ce-compound mode:headless` at retro close.
+
+---
+
+## §15 Verified-against-codebase appendix (cycle 3 grounding pass)
+
+Per adversarial cycle-2 recommendation. Every "X already exists" claim in this packet has been grep-verified against `public/dev@2a6ec716`. Citations below.
+
+| Claim | File:Line | Verified shape |
+|---|---|---|
+| `claim_feedback` table schema | `src-tauri/src/migrations/245_dos_484_feedback_merge_intent.sql:25-45` | Columns: `id, claim_id, feedback_type (CHECK IN 10 ADR-0123 variants), actor, actor_id, payload_json, submitted_at, applied_at`. **No `note` column.** |
+| `ClaimFeedbackInput` struct | `src-tauri/src/services/claims.rs:230-236` | Fields: `claim_id, action, actor, actor_id, payload_json`. **No `note` field.** |
+| `validate_feedback_action_metadata` | `src-tauri/src/services/claims.rs:5560-5570` | Per-action required keys: WrongSource→`source_ref`; NeedsNuance→`corrected_text`; SurfaceInappropriate→`surface`; NotRelevantHere→`invocation_id`; MergeIntent→`merge_target`; rest unrestricted. L1 extends NotRelevantHere to admit optional `note` (B15). |
+| `validate_feedback_actor` | `src-tauri/src/services/claims.rs:5507-5527` | Admits only `ClaimActorClass::User`; rejects all others. Normalization required (B5). |
+| `actor_class_for_actor` | `src-tauri/src/services/claims.rs:5488-5504` | Maps `"user"\|"human"` → User. Splits on `[:/@]` so `"user:surface-id"` also admits (allowing audit-rich actor strings if desired). |
+| `record_claim_feedback` | `src-tauri/src/services/claims.rs:7128-7170` | Wraps in `with_claim_transaction` + `MutationGuard`; generates UUID feedback_id at line 7156; returns `ClaimFeedbackOutcome`. |
+| `claim_feedback_recorded` signal emission | `src-tauri/src/services/claims.rs:9112-9136` | Payload: `{action, claim_id, verification_state_before, verification_state_after}`. **No `feedback_id` in emitted payload.** |
+| `FeedbackAction` enum (10 ADR-0123 variants) | `src-tauri/abilities-runtime/src/abilities/feedback.rs:39` | All 10 variants present: `ConfirmCurrent, MarkOutdated, MarkFalse, WrongSubject, WrongSource, CannotVerify, NeedsNuance, SurfaceInappropriate, NotRelevantHere, MergeIntent`. |
+| `FeedbackState` serde shape | `src-tauri/src/services/recommendations/contracts.rs:103-106` | External tagging default (no `#[serde(tag = ...)]`): `Pending` → bare JSON string `"pending"`; `Decided(x)` → `{"decided": x}`. |
+| `feedback_state` storage in `metadata_json` | `src-tauri/src/migrations/269_recommendation_claim_metadata_indexes.sql:9-18` | Indexed via `json_extract(metadata_json, '$.recommendation.feedbackState')`. Not a column. |
+| `json_extract` behavior on primitive strings | SQLite empirical test (`sqlite3 :memory:`) | Returns the UNQUOTED text value. `json_extract(...) = 'pending'` matches; `json_extract(...) LIKE '%"pending"%'` does NOT match. |
+| `surfacing.rs` cooldown read | `src-tauri/src/services/recommendations/surfacing.rs:724` (`latest_feedback_suppression`); policy at `:120, 136` (`feedback_suppression_days: 14`) | Cooldown derived from `claim_feedback` rows within `feedback_suppression_days` window. No bump_cooldown writer needed (B2). |
+| `SURFACING_DECISION_SIGNAL` declaration pattern | `src-tauri/src/services/recommendations/surfacing.rs:33` | `pub const X: &str = "..."` — stringly-typed module constant. Not a centralized SignalType enum. |
+| `ConversionState` enum | `src-tauri/src/services/recommendations/contracts.rs` (existing W1-A type) | Variants carry IDs of pre-existing entities: `ConvertedToAction { action_id }`, `ConvertedToClaimCorrection { claim_id }`, `ConvertedToReviewQueue { queue_item_id }`. **No external attachment call required** (B16). |
+| `sync_action_open_loop_claim` | `src-tauri/src/services/action_claims.rs` | Takes `&DbAction` (existing); syncs open-loop claim shape. Not a recommendation attachment function. **`attach_from_recommendation` does NOT exist** — Convert{Action} doesn't need it (B16). |
+| Existing scope-name convention | `src-tauri/abilities-runtime/src/abilities/registry.rs:2759, 2845` | `verb.noun` (e.g., `read.account_overview`, `submit.feedback`). No `maintenance.*` prefix exists. W4-A uses `submit.recommendations.feedback` (B19). |
+| WP REST transport | `wp/dailyos/includes/transport/class-dailyos-runtime-client.php:85` | `invoke_ability(name, payload, scope_set)` is category-agnostic. Maintenance category traverses without changes (B9). |
+
+**Hallucinations dropped at cycle 3** (each replaced by its grounded primitive in the table above):
+- `bump_cooldown` API — read-derived per surfacing.rs:724 instead
+- Typed `note: Option<String>` column on claim_feedback — encoded in `payload_json` instead
+- `attach_from_recommendation` retry infrastructure — `ConversionState` already carries the action_id; no attachment needed
+- New `RecommendationFeedbackRecorded` SignalType variant — reuse existing `claim_feedback_recorded` per claims.rs:9112
+- `LIKE '%"pending"%'` predicate — replaced with `= 'pending'` (empirically verified)
+- `maintenance.recommendations.feedback` scope name — replaced with `submit.recommendations.feedback` matching codebase convention

--- a/.docs/plans/v1.4.6-waves.md
+++ b/.docs/plans/v1.4.6-waves.md
@@ -10,6 +10,25 @@ The original v1.4.6 L0 plan reserved **v260-v279**. Current `dev` now registers 
 
 This amendment moves the active v1.4.6 block to **v269-v288**. Historical cycle notes below may still mention the original v260-v279 block as cycle history; all active assignments are in §"Migration slot assignments".
 
+## UI Surface Deferral Amendment (2026-05-27)
+
+W3-A landed at PR #406 (merge commit `39b4abc4`) — the `dailyos/suggested-next-steps` block + `list_suggested_next_steps` ability + reference HTML shipped clean. Substrate side of the recommendations layer is now complete through W3.
+
+**The remaining UI-facing v1.4.6 work is paused.** Rationale:
+
+1. The WordPress surface is not production-ready or close to it. W3-B (DOS-333) cross-surface block embedding sits on a foundation that needs more time to mature before integration delivers user-visible value.
+2. The Tauri app is mid-refresh — surface redesigns are coming for nearly every page, with downstream changes expected in pty prompts and likely the DB schema. Wiring the Tauri carve-out (DOS-802) into the current surfaces would be paving over a soon-to-be-replaced layout.
+3. The recommendations substrate is producer-side and works regardless of which UI eventually consumes it. ADR-0123 V1.1's 10 typed feedback variants and the existing ability contracts are mature enough that redesign-era changes will mostly be additive fields, not breaking shape changes.
+
+**Parked tickets (this amendment):**
+
+- **DOS-333 — W3-B cross-surface recommendation rendering** — parked pending WP surface readiness. Substrate ready (W3-A block exists). Resume when WP composition layer is production-grade.
+- **DOS-802 — Tauri React rendering carve-out (W5 release-prep)** — parked pending Tauri surface redesign + schema landing. Substrate ready (same ability). Resume when redesigned surfaces lock their composition.
+
+**Active v1.4.6 sequence:** continue substrate-only wiring — W4-A (feedback) → W4-B (deviation) → W4-C (engagement) → W5 (eval). All substrate-only, no UI dependencies. When the redesign settles, the producers are ready for whatever consumes them.
+
+The W3 merge gate (line 973) is satisfied by W3-A alone for this amendment; W3-B closes as parked rather than completed for the v1.4.6 release. This is a sequencing change, not a scope cut — both tickets stay in v1.4.6 project, just outside this release cycle.
+
 ## Engineering Ladder + Producer Reconciliation Amendment (2026-05-26)
 
 This plan now uses the current Engineering Ladder adopted 2026-05-18 and revised 2026-05-23. The old "Review ladder" language from earlier v1.4.x packets is superseded wherever it conflicts with `.docs/plans/engineering-ladder.md` / `.docs/plans/engineering-ladder.html`.

--- a/src-tauri/abilities-macro/src/lib.rs
+++ b/src-tauri/abilities-macro/src/lib.rs
@@ -167,7 +167,13 @@ fn expand_ability(args: AbilityArgs, item_fn: ItemFn) -> syn::Result<proc_macro2
         .iter()
         .map(ComposeArg::registry_expr)
         .collect();
-    let mutates_exprs: Vec<_> = detected.iter().map(|path| quote! { #path }).collect();
+    let mut mutates = args.mutates.clone();
+    for path in detected {
+        if !mutates.contains(&path) {
+            mutates.push(path);
+        }
+    }
+    let mutates_exprs: Vec<_> = mutates.iter().map(|path| quote! { #path }).collect();
     let signal_exprs = args
         .signal_policy
         .emits_on_output_change
@@ -749,6 +755,7 @@ struct AbilityArgs {
     requires_confirmation: bool,
     may_publish: bool,
     composes: Vec<ComposeArg>,
+    mutates: Vec<String>,
     experimental: bool,
     registered_at: Option<String>,
     signal_policy: SignalPolicyArg,
@@ -782,6 +789,7 @@ impl Parse for AbilityArgs {
         let mut requires_confirmation = None;
         let mut may_publish = None;
         let mut composes = Vec::new();
+        let mut mutates = Vec::new();
         let mut experimental = false;
         let mut registered_at = None;
         let mut signal_policy = SignalPolicyArg::default();
@@ -808,6 +816,7 @@ impl Parse for AbilityArgs {
                 }
                 "may_publish" => may_publish = Some(input.parse::<LitBool>()?.value),
                 "composes" => composes = parse_composes_array(input)?,
+                "mutates" => mutates = parse_string_or_ident_array(input)?,
                 "experimental" => experimental = input.parse::<LitBool>()?.value,
                 "registered_at" => registered_at = Some(input.parse::<LitStr>()?.value()),
                 "signal_policy" => signal_policy = parse_signal_policy(input)?,
@@ -847,6 +856,7 @@ impl Parse for AbilityArgs {
             may_publish: may_publish
                 .ok_or_else(|| input.error("missing required #[ability] may_publish"))?,
             composes,
+            mutates,
             experimental,
             registered_at,
             signal_policy,
@@ -1064,6 +1074,19 @@ fn parse_string_array(input: ParseStream<'_>) -> syn::Result<Vec<String>> {
     let mut values = Vec::new();
     while !content.is_empty() {
         values.push(content.parse::<LitStr>()?.value());
+        if content.peek(Token![,]) {
+            content.parse::<Token![,]>()?;
+        }
+    }
+    Ok(values)
+}
+
+fn parse_string_or_ident_array(input: ParseStream<'_>) -> syn::Result<Vec<String>> {
+    let content;
+    bracketed!(content in input);
+    let mut values = Vec::new();
+    while !content.is_empty() {
+        values.push(parse_string_or_ident(&content)?);
         if content.peek(Token![,]) {
             content.parse::<Token![,]>()?;
         }

--- a/src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/recommendations/contracts.rs
@@ -8,6 +8,7 @@ use crate::abilities::claim_receipt::{ClaimReceiptSnapshot, ClaimReceiptSurfaceC
 use crate::abilities::provenance::SubjectRef;
 use crate::abilities::registry::ActorKind;
 use crate::abilities::trust::types::TrustBand;
+use crate::sensitivity::RenderSurface;
 
 pub const SCORE_SALIENCE_ABILITY_NAME: &str = "score_salience";
 pub const SCORE_SALIENCE_SCHEMA_VERSION: u32 = 1;
@@ -15,6 +16,9 @@ pub const SCORE_SALIENCE_SCOPE: &str = "read.recommendations";
 pub const LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME: &str = "list_suggested_next_steps";
 pub const LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION: u16 = 1;
 pub const LIST_SUGGESTED_NEXT_STEPS_SCOPE: &str = SCORE_SALIENCE_SCOPE;
+pub const SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME: &str = "submit_recommendation_feedback";
+pub const SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION: u32 = 1;
+pub const SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE: &str = "submit.recommendations.feedback";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
@@ -199,6 +203,13 @@ pub enum BoundedNoteError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct RecommendationFeedbackContext {
+    pub surface: RenderSurface,
+    pub invocation_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub enum ConversionTarget {
     Action(String),
     ClaimCorrection(ClaimId),
@@ -216,6 +227,34 @@ pub enum ConversionState {
     ConvertedToAction { action_id: String },
     ConvertedToClaimCorrection { claim_id: ClaimId },
     ConvertedToReviewQueue { queue_item_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRecommendationFeedbackInput {
+    pub schema_version: u32,
+    pub claim_id: ClaimId,
+    pub decision: RecommendationFeedbackDecision,
+    pub context: RecommendationFeedbackContext,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitRecommendationFeedbackResponse {
+    pub schema_version: u32,
+    pub claim_id: ClaimId,
+    pub feedback_state: FeedbackState,
+    pub conversion_state: ConversionState,
+    pub effect_kind: EffectKind,
+    #[schemars(with = "String")]
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum EffectKind {
+    ClaimFeedbackRecorded,
+    NoMutation,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -332,4 +371,23 @@ pub enum SuggestedNextStepsReadError {
     ClaimNotVisible(String),
     #[error("{0}")]
     ReadFailed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SubmitRecommendationFeedbackError {
+    #[error("unsupported schema_version `{0}` for submit_recommendation_feedback")]
+    UnsupportedSchemaVersion(u32),
+    #[error("unknown claim_id: {0}")]
+    UnknownClaimId(String),
+    #[error("claim `{claim_id}` has unsupported claim_type `{claim_type}`")]
+    UnsupportedClaimType {
+        claim_id: String,
+        claim_type: String,
+    },
+    #[error("invalid recommendation feedback: {0}")]
+    InvalidFeedback(String),
+    #[error("recommendation feedback mutation blocked: {0}")]
+    MutationBlocked(String),
+    #[error("recommendation feedback write failed: {0}")]
+    WriteFailed(String),
 }

--- a/src-tauri/abilities-runtime/src/abilities/recommendations/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/recommendations/mod.rs
@@ -3,14 +3,17 @@
 pub mod contracts;
 
 pub use contracts::{
-    BoundedNote, ClaimId, ConversionState, ConversionTarget, DismissReason, FactorRationale,
-    FeedbackState, ListSuggestedNextStepsInput, ListSuggestedNextStepsResponse, PrimaryFactorBand,
-    RecommendationFeedbackDecision, RecommendedActionView, SalienceFactor, SalienceFactorKind,
-    SaliencePersistence, SalienceReadError, SalienceScore, ScoreSalienceInput,
-    ScoreSalienceReadRequest, ScoreSalienceResponse, SuggestedNextStepItem,
-    SuggestedNextStepsReadError, LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME,
-    LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION, LIST_SUGGESTED_NEXT_STEPS_SCOPE,
-    SCORE_SALIENCE_ABILITY_NAME, SCORE_SALIENCE_SCHEMA_VERSION, SCORE_SALIENCE_SCOPE,
+    BoundedNote, ClaimId, ConversionState, ConversionTarget, DismissReason, EffectKind,
+    FactorRationale, FeedbackState, ListSuggestedNextStepsInput, ListSuggestedNextStepsResponse,
+    PrimaryFactorBand, RecommendationFeedbackContext, RecommendationFeedbackDecision,
+    RecommendedActionView, SalienceFactor, SalienceFactorKind, SaliencePersistence,
+    SalienceReadError, SalienceScore, ScoreSalienceInput, ScoreSalienceReadRequest,
+    ScoreSalienceResponse, SubmitRecommendationFeedbackError, SubmitRecommendationFeedbackInput,
+    SubmitRecommendationFeedbackResponse, SuggestedNextStepItem, SuggestedNextStepsReadError,
+    LIST_SUGGESTED_NEXT_STEPS_ABILITY_NAME, LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
+    LIST_SUGGESTED_NEXT_STEPS_SCOPE, SCORE_SALIENCE_ABILITY_NAME, SCORE_SALIENCE_SCHEMA_VERSION,
+    SCORE_SALIENCE_SCOPE, SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME,
+    SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION, SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE,
 };
 
 use dailyos_abilities_macro::ability;
@@ -91,6 +94,42 @@ pub async fn list_suggested_next_steps(
     finalize_list_suggested_next_steps_output(ctx, schema_version, subject, response)
 }
 
+#[ability(
+    name = "submit_recommendation_feedback",
+    category = Maintenance,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [User, SurfaceClient],
+    allowed_modes = [Live],
+    requires_confirmation = false,
+    may_publish = false,
+    required_scopes = ["submit.recommendations.feedback"],
+    mcp_exposure = None,
+    client_side_executable = false,
+    mutates = [intelligence_claims, claim_feedback],
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn submit_recommendation_feedback(
+    ctx: &AbilityContext<'_>,
+    input: SubmitRecommendationFeedbackInput,
+) -> AbilityResult<SubmitRecommendationFeedbackResponse> {
+    validate_submit_recommendation_feedback_schema_version(input.schema_version)?;
+    ctx.services()
+        .check_mutation_allowed()
+        .map_err(service_error)?;
+
+    let schema_version = input.schema_version;
+    let response = ctx
+        .services()
+        .submit_recommendation_feedback(input, ctx.actor.clone())
+        .await
+        .map_err(submit_feedback_error)?;
+
+    finalize_submit_recommendation_feedback_output(ctx, schema_version, response)
+}
+
 fn validate_schema_version(schema_version: u32) -> Result<(), AbilityError> {
     if schema_version == SCORE_SALIENCE_SCHEMA_VERSION {
         Ok(())
@@ -119,6 +158,21 @@ fn validate_list_suggested_next_steps_schema_version(
     }
 }
 
+fn validate_submit_recommendation_feedback_schema_version(
+    schema_version: u32,
+) -> Result<(), AbilityError> {
+    if schema_version == SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!(
+                "unsupported schema_version `{schema_version}` for `{SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME}`"
+            ),
+        })
+    }
+}
+
 fn read_error(error: SalienceReadError) -> AbilityError {
     match error {
         SalienceReadError::UnsupportedSchemaVersion(schema_version) => AbilityError {
@@ -135,6 +189,42 @@ fn read_error(error: SalienceReadError) -> AbilityError {
         SalienceReadError::ReadFailed(message) => AbilityError {
             kind: AbilityErrorKind::HardError(message.clone()),
             message: format!("salience_read_failed: {message}"),
+        },
+    }
+}
+
+fn submit_feedback_error(error: SubmitRecommendationFeedbackError) -> AbilityError {
+    match error {
+        SubmitRecommendationFeedbackError::UnsupportedSchemaVersion(schema_version) => {
+            AbilityError {
+                kind: AbilityErrorKind::Validation,
+                message: format!(
+                    "unsupported schema_version `{schema_version}` for `{SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME}`"
+                ),
+            }
+        }
+        SubmitRecommendationFeedbackError::UnknownClaimId(claim_id) => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("claim_not_found: {claim_id}"),
+        },
+        SubmitRecommendationFeedbackError::UnsupportedClaimType {
+            claim_id,
+            claim_type,
+        } => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("unsupported_claim_type: {claim_id}:{claim_type}"),
+        },
+        SubmitRecommendationFeedbackError::InvalidFeedback(message) => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("invalid_recommendation_feedback: {message}"),
+        },
+        SubmitRecommendationFeedbackError::MutationBlocked(message) => AbilityError {
+            kind: AbilityErrorKind::Capability,
+            message,
+        },
+        SubmitRecommendationFeedbackError::WriteFailed(message) => AbilityError {
+            kind: AbilityErrorKind::HardError(message.clone()),
+            message: format!("recommendation_feedback_write_failed: {message}"),
         },
     }
 }
@@ -197,6 +287,26 @@ fn finalize_list_suggested_next_steps_output(
     builder.finalize(response).map_err(provenance_error)
 }
 
+fn finalize_submit_recommendation_feedback_output(
+    ctx: &AbilityContext<'_>,
+    schema_version: u32,
+    response: SubmitRecommendationFeedbackResponse,
+) -> AbilityResult<SubmitRecommendationFeedbackResponse> {
+    let mut builder = ProvenanceBuilder::new(submit_recommendation_feedback_provenance_config(
+        ctx,
+        schema_version,
+    ));
+    let subject_attribution = SubjectAttribution::direct_confident(SubjectRef::Global);
+    builder.set_subject(subject_attribution.clone());
+    builder
+        .attribute_subtree(
+            FieldPath::root(),
+            FieldAttribution::constant(subject_attribution),
+        )
+        .map_err(provenance_error)?;
+    builder.finalize(response).map_err(provenance_error)
+}
+
 fn provenance_config(ctx: &AbilityContext<'_>, schema_version: u32) -> ProvenanceBuilderConfig {
     let mut config =
         ProvenanceBuilderConfig::new(SCORE_SALIENCE_ABILITY_NAME, ctx.services().clock.now());
@@ -205,6 +315,22 @@ fn provenance_config(ctx: &AbilityContext<'_>, schema_version: u32) -> Provenanc
     config.actor = provenance_actor(&ctx.actor);
     config.mode = AbilityExecutionMode::from(ctx.mode());
     config.category = AbilityCategory::Read;
+    config
+}
+
+fn submit_recommendation_feedback_provenance_config(
+    ctx: &AbilityContext<'_>,
+    schema_version: u32,
+) -> ProvenanceBuilderConfig {
+    let mut config = ProvenanceBuilderConfig::new(
+        SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME,
+        ctx.services().clock.now(),
+    );
+    config.ability_version = AbilityVersion::new(1, 0);
+    config.ability_schema_version = SchemaVersion(schema_version);
+    config.actor = provenance_actor(&ctx.actor);
+    config.mode = AbilityExecutionMode::from(ctx.mode());
+    config.category = AbilityCategory::Maintenance;
     config
 }
 
@@ -256,6 +382,13 @@ fn provenance_error(error: impl std::fmt::Display) -> AbilityError {
     }
 }
 
+fn service_error(error: impl std::fmt::Display) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Capability,
+        message: error.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,8 +407,10 @@ mod tests {
     use crate::intelligence::provider::ReplayProvider;
     use crate::sensitivity::ClaimDismissalSurface;
     use crate::services::context::{
-        ExternalClients, FixedClock, SalienceReadFuture, SalienceReadHandle, SeedableRng,
-        ServiceContext, SuggestedNextStepsReadFuture, SuggestedNextStepsReadHandle,
+        ExternalClients, FixedClock, RecommendationFeedbackWriteFuture,
+        RecommendationFeedbackWriteHandle, RecommendationFeedbackWriteRequest, SalienceReadFuture,
+        SalienceReadHandle, SeedableRng, ServiceContext, SuggestedNextStepsReadFuture,
+        SuggestedNextStepsReadHandle,
     };
 
     #[derive(Default)]
@@ -326,6 +461,21 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct CapturingRecommendationFeedbackWriter {
+        requests: Mutex<Vec<RecommendationFeedbackWriteRequest>>,
+    }
+
+    impl RecommendationFeedbackWriteHandle for CapturingRecommendationFeedbackWriter {
+        fn submit_recommendation_feedback<'a>(
+            &'a self,
+            request: RecommendationFeedbackWriteRequest,
+        ) -> RecommendationFeedbackWriteFuture<'a> {
+            self.requests.lock().expect("requests lock").push(request);
+            Box::pin(async { Ok(submit_recommendation_feedback_response_fixture()) })
+        }
+    }
+
     #[test]
     fn descriptor_is_user_system_read_only_and_hidden_from_clients() {
         let registry = AbilityRegistry::global_checked().expect("registry builds");
@@ -358,7 +508,7 @@ mod tests {
     #[test]
     fn registry_does_not_admit_surface_or_mcp_actors() {
         let registry = AbilityRegistry::global_checked().expect("registry builds");
-        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(SCORE_SALIENCE_SCOPE)]);
+        set_recommendation_scope_allowlist_for_tests();
         let surface_scopes =
             ScopeSet::new([SurfaceScope::new(SCORE_SALIENCE_SCOPE)]).expect("surface scope set");
         assert!(registry
@@ -407,9 +557,49 @@ mod tests {
         assert!(descriptor.mutates.is_empty());
     }
 
+    #[test]
+    fn submit_recommendation_feedback_descriptor_is_maintenance_and_surface_scoped() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let descriptor = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME)
+            .expect("submit_recommendation_feedback ability is registered");
+
+        assert_eq!(descriptor.category, AbilityCategory::Maintenance);
+        assert!(descriptor.policy.allowed_actors.contains(&ActorKind::User));
+        assert!(descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::SurfaceClient));
+        assert!(!descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::System));
+        assert!(!descriptor.policy.allowed_actors.contains(&ActorKind::Agent));
+        assert!(!descriptor.policy.allowed_actors.contains(&ActorKind::Admin));
+        assert!(!descriptor
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::McpClient));
+        assert_eq!(
+            descriptor.policy.required_scopes,
+            &[SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE]
+        );
+        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::None);
+        assert!(!descriptor.policy.may_publish);
+        assert!(!descriptor.policy.client_side_executable);
+        assert_eq!(
+            descriptor.mutates,
+            &["intelligence_claims", "claim_feedback"]
+        );
+        assert!(descriptor.composes.is_empty());
+        assert!(descriptor.signal_policy.emits_on_output_change.is_empty());
+        assert!(!descriptor.signal_policy.coalesce);
+    }
+
     #[tokio::test]
     async fn list_suggested_next_steps_per_actor_dry_run_matches_allowlist() {
-        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]);
+        set_recommendation_scope_allowlist_for_tests();
         let reader = Arc::new(CapturingSuggestedNextStepsReader::default());
 
         for actor in [Actor::User, Actor::System, surface_actor()] {
@@ -433,8 +623,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn submit_recommendation_feedback_per_actor_dry_run_matches_allowlist() {
+        set_recommendation_scope_allowlist_for_tests();
+        let writer = Arc::new(CapturingRecommendationFeedbackWriter::default());
+
+        for actor in [Actor::User, submit_surface_actor()] {
+            invoke_submit_recommendation_feedback(writer.clone(), actor)
+                .await
+                .expect("allowed actor succeeds");
+        }
+
+        for actor in [Actor::System, Actor::Agent, Actor::Admin, mcp_actor()] {
+            let error = invoke_submit_recommendation_feedback(writer.clone(), actor)
+                .await
+                .expect_err("disallowed actor is denied");
+            assert_eq!(error.kind, AbilityErrorKind::Capability);
+        }
+
+        let requests = writer.requests.lock().expect("requests lock");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].actor.kind(), ActorKind::User);
+        assert_eq!(requests[1].actor.kind(), ActorKind::SurfaceClient);
+    }
+
+    #[tokio::test]
     async fn list_suggested_next_steps_forwards_subject_filter_placeholder() {
-        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]);
+        set_recommendation_scope_allowlist_for_tests();
         let reader = Arc::new(CapturingSuggestedNextStepsReader::default());
         invoke_list_suggested_next_steps_with_payload(
             reader.clone(),
@@ -545,7 +759,7 @@ mod tests {
 
     #[tokio::test]
     async fn surface_actor_is_denied_before_reader() {
-        ScopeSet::set_allowlist_for_tests([SurfaceScope::new(SCORE_SALIENCE_SCOPE)]);
+        set_recommendation_scope_allowlist_for_tests();
         let scopes = ScopeSet::new([SurfaceScope::new(SCORE_SALIENCE_SCOPE)]).expect("scope set");
         let reader = Arc::new(CapturingSalienceReader::default());
         let err = invoke(
@@ -643,9 +857,63 @@ mod tests {
             .await
     }
 
+    async fn invoke_submit_recommendation_feedback<W>(
+        writer: Arc<W>,
+        actor: Actor,
+    ) -> Result<serde_json::Value, AbilityError>
+    where
+        W: RecommendationFeedbackWriteHandle + 'static,
+    {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(7);
+        let external = ExternalClients::default();
+        let services = ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("test")
+            .with_recommendation_feedback_writer(writer);
+        let provider = ReplayProvider::new(std::collections::HashMap::new());
+        let ctx = crate::abilities::AbilityContext::new(
+            &services,
+            &provider,
+            &NOOP_ABILITY_TRACER,
+            actor,
+            None,
+            ClaimDismissalSurface::Eval,
+        );
+        registry
+            .invoke_by_name_json(
+                &ctx,
+                SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME,
+                json!({
+                    "schemaVersion": SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION,
+                    "claimId": "claim-feedback-1",
+                    "decision": {
+                        "kind": "accept",
+                        "at": "2026-05-26T12:00:00Z"
+                    },
+                    "context": {
+                        "surface": "tauri_entity_detail",
+                        "invocationId": "invocation-1"
+                    }
+                }),
+            )
+            .await
+    }
+
     fn surface_actor() -> Actor {
+        set_recommendation_scope_allowlist_for_tests();
         let scopes =
             ScopeSet::new([SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE)]).expect("scope set");
+        Actor::SurfaceClient {
+            instance: SurfaceClientId::new("surface-1"),
+            scopes,
+        }
+    }
+
+    fn submit_surface_actor() -> Actor {
+        set_recommendation_scope_allowlist_for_tests();
+        let scopes = ScopeSet::new([SurfaceScope::new(SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE)])
+            .expect("scope set");
         Actor::SurfaceClient {
             instance: SurfaceClientId::new("surface-1"),
             scopes,
@@ -657,6 +925,31 @@ mod tests {
             client_id: McpClientId::new("client-1"),
             conversation_handle: Some(OpaqueConversationHandle::new("conv-1")),
         }
+    }
+
+    fn set_recommendation_scope_allowlist_for_tests() {
+        // `ScopeSet::set_allowlist_for_tests` is a global static; tests run
+        // in parallel and ANY test setting the allowlist races with others.
+        // The defensive pattern (matching `registry.rs` `scope_set` helper):
+        // include every production scope used anywhere in the codebase so
+        // the global overwrite doesn't break tests in unrelated modules.
+        // If a future test needs to verify scope-rejection-of-an-allowlisted-scope,
+        // it should `clear_allowlist_for_tests()` and `set_allowlist_for_tests`
+        // with a tight subset within the test body.
+        ScopeSet::set_allowlist_for_tests([
+            SurfaceScope::new(SCORE_SALIENCE_SCOPE),
+            SurfaceScope::new(LIST_SUGGESTED_NEXT_STEPS_SCOPE),
+            SurfaceScope::new(SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE),
+            SurfaceScope::new("read.account_overview"),
+            SurfaceScope::new("read.composition"),
+            SurfaceScope::new("read.entity_names"),
+            SurfaceScope::new("read.markdown_preview"),
+            SurfaceScope::new("read.workspace_graph"),
+            SurfaceScope::new("read.workspace_sources"),
+            SurfaceScope::new("submit.feedback"),
+            SurfaceScope::new("write.entity_intake"),
+            SurfaceScope::new("write.feedback"),
+        ]);
     }
 
     fn response_fixture() -> ScoreSalienceResponse {
@@ -684,6 +977,18 @@ mod tests {
             schema_version: LIST_SUGGESTED_NEXT_STEPS_SCHEMA_VERSION,
             items: Vec::new(),
             generated_at: Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap(),
+        }
+    }
+
+    fn submit_recommendation_feedback_response_fixture() -> SubmitRecommendationFeedbackResponse {
+        let at = Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0).unwrap();
+        SubmitRecommendationFeedbackResponse {
+            schema_version: SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION,
+            claim_id: ClaimId("claim-feedback-1".to_string()),
+            feedback_state: FeedbackState::Decided(RecommendationFeedbackDecision::Accept { at }),
+            conversion_state: ConversionState::NotConverted,
+            effect_kind: EffectKind::ClaimFeedbackRecorded,
+            recorded_at: at,
         }
     }
 }

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -47,9 +47,11 @@ pub use crate::abilities::markdown_preview::contracts::{
 };
 pub use crate::abilities::recommendations::contracts::{
     ListSuggestedNextStepsInput, ListSuggestedNextStepsResponse, SalienceReadError,
-    ScoreSalienceReadRequest, ScoreSalienceResponse, SuggestedNextStepsReadError,
+    ScoreSalienceReadRequest, ScoreSalienceResponse, SubmitRecommendationFeedbackError,
+    SubmitRecommendationFeedbackInput, SubmitRecommendationFeedbackResponse,
+    SuggestedNextStepsReadError,
 };
-use crate::abilities::registry::ActorKind;
+use crate::abilities::registry::{Actor, ActorKind};
 pub use crate::abilities::source_management_ledger::contracts::{
     SourceManagementActionReceipt, SourceManagementActionRequest,
     SourceManagementLedgerReadRequest, SourceManagementLedgerResponse,
@@ -871,6 +873,7 @@ pub struct ServiceContext<'a> {
     source_management_ledger_reader: Option<Arc<dyn SourceManagementLedgerReadHandle>>,
     salience_reader: Option<Arc<dyn SalienceReadHandle>>,
     suggested_next_steps_reader: Option<Arc<dyn SuggestedNextStepsReadHandle>>,
+    recommendation_feedback_writer: Option<Arc<dyn RecommendationFeedbackWriteHandle>>,
     source_management_action_handler: Option<Arc<dyn SourceManagementActionHandle>>,
     workspace_intake: Option<Arc<dyn WorkspaceIntakeService>>,
 }
@@ -1270,6 +1273,34 @@ pub trait SuggestedNextStepsReadHandle: Send + Sync {
         input: ListSuggestedNextStepsInput,
         actor: ActorKind,
     ) -> SuggestedNextStepsReadFuture<'a>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecommendationFeedbackWriteRequest {
+    pub input: SubmitRecommendationFeedbackInput,
+    pub actor: Actor,
+    pub mode: ExecutionMode,
+    pub recorded_at: DateTime<Utc>,
+    pub ability_id: Option<String>,
+}
+
+pub type RecommendationFeedbackWriteFuture<'a> = Pin<
+    Box<
+        dyn Future<
+                Output = Result<
+                    SubmitRecommendationFeedbackResponse,
+                    SubmitRecommendationFeedbackError,
+                >,
+            > + Send
+            + 'a,
+    >,
+>;
+
+pub trait RecommendationFeedbackWriteHandle: Send + Sync {
+    fn submit_recommendation_feedback<'a>(
+        &'a self,
+        request: RecommendationFeedbackWriteRequest,
+    ) -> RecommendationFeedbackWriteFuture<'a>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -1997,6 +2028,7 @@ impl<'a> ServiceContext<'a> {
             source_management_ledger_reader: None,
             salience_reader: None,
             suggested_next_steps_reader: None,
+            recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -2037,6 +2069,7 @@ impl<'a> ServiceContext<'a> {
             source_management_ledger_reader: None,
             salience_reader: None,
             suggested_next_steps_reader: None,
+            recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -2088,6 +2121,7 @@ impl<'a> ServiceContext<'a> {
             source_management_ledger_reader: None,
             salience_reader: None,
             suggested_next_steps_reader: None,
+            recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
         }
@@ -2246,6 +2280,14 @@ impl<'a> ServiceContext<'a> {
         reader: Arc<dyn SuggestedNextStepsReadHandle>,
     ) -> Self {
         self.suggested_next_steps_reader = Some(reader);
+        self
+    }
+
+    pub fn with_recommendation_feedback_writer(
+        mut self,
+        writer: Arc<dyn RecommendationFeedbackWriteHandle>,
+    ) -> Self {
+        self.recommendation_feedback_writer = Some(writer);
         self
     }
 
@@ -2555,6 +2597,28 @@ impl<'a> ServiceContext<'a> {
         };
 
         reader.list_suggested_next_steps(input, actor).await
+    }
+
+    pub async fn submit_recommendation_feedback(
+        &self,
+        input: SubmitRecommendationFeedbackInput,
+        actor: Actor,
+    ) -> Result<SubmitRecommendationFeedbackResponse, SubmitRecommendationFeedbackError> {
+        let Some(writer) = &self.recommendation_feedback_writer else {
+            return Err(SubmitRecommendationFeedbackError::WriteFailed(
+                self.missing_reader_error("recommendation_feedback_write"),
+            ));
+        };
+
+        writer
+            .submit_recommendation_feedback(RecommendationFeedbackWriteRequest {
+                input,
+                actor,
+                mode: self.mode,
+                recorded_at: self.clock.now(),
+                ability_id: self.ability_id.map(str::to_string),
+            })
+            .await
     }
 
     pub async fn apply_source_management_action(

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -299,6 +299,11 @@ pub enum ClaimError {
     UnknownClaimType(String),
     #[error("unknown claim_id: {0}")]
     UnknownClaimId(String),
+    #[error("claim {claim_id} has unsupported claim_type {claim_type}")]
+    UnsupportedClaimType {
+        claim_id: String,
+        claim_type: String,
+    },
     #[error("claim not found: {0}")]
     ClaimNotFound(String),
     #[error("stale claim version for {claim_id}: expected {expected}, current {current}")]
@@ -3358,7 +3363,7 @@ where
     Ok(serde_json::from_value(serde_json::Value::String(value))?)
 }
 
-fn with_claim_transaction<T>(
+pub(crate) fn with_claim_transaction<T>(
     db: &ActionDb,
     f: impl FnOnce(&ActionDb) -> Result<T, ClaimError>,
 ) -> Result<T, ClaimError> {
@@ -5561,13 +5566,44 @@ fn validate_feedback_action_metadata(
         FeedbackAction::WrongSource => require_payload_string(action, payload, "source_ref"),
         FeedbackAction::NeedsNuance => require_payload_string(action, payload, "corrected_text"),
         FeedbackAction::SurfaceInappropriate => require_payload_string(action, payload, "surface"),
-        FeedbackAction::NotRelevantHere => require_payload_string(action, payload, "invocation_id"),
+        FeedbackAction::NotRelevantHere => {
+            require_payload_string(action, payload, "invocation_id")?;
+            validate_optional_payload_string_chars(action, payload, "note", 200)
+        }
         // MergeIntent (ADR-0123 V1.1) requires merge_target as a JSON-encoded
         // SubjectRef. The receipt-side validator already deep-decodes the
         // SubjectRef shape (`services::claim_receipt::feedback`); here the
         // writer enforces presence + non-empty.
         FeedbackAction::MergeIntent => require_payload_object(action, payload, "merge_target"),
         _ => Ok(()),
+    }
+}
+
+fn validate_optional_payload_string_chars(
+    action: FeedbackAction,
+    payload: &serde_json::Value,
+    key: &str,
+    max_chars: usize,
+) -> Result<(), ClaimError> {
+    let Some(value) = payload.get(key) else {
+        return Ok(());
+    };
+    let Some(value) = value.as_str() else {
+        return Err(ClaimError::InvalidFeedback(format!(
+            "{} feedback requires payload_json.{} to be a string when present",
+            action.as_str(),
+            key
+        )));
+    };
+    let actual = value.chars().count();
+    if actual <= max_chars {
+        Ok(())
+    } else {
+        Err(ClaimError::InvalidFeedback(format!(
+            "{} feedback payload_json.{} is {actual} characters; maximum is {max_chars}",
+            action.as_str(),
+            key
+        )))
     }
 }
 

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -58,6 +58,7 @@ pub struct LiveWorkspaceGraphReader;
 pub struct LiveSourceManagementLedgerReader;
 pub struct LiveSalienceReader;
 pub struct LiveSuggestedNextStepsReader;
+pub struct LiveRecommendationFeedbackWriter;
 pub struct LiveSourceManagementActionHandler {
     signal_engine: Option<Arc<crate::signals::propagation::PropagationEngine>>,
 }
@@ -94,6 +95,7 @@ pub fn attach_live_workspace_readers_with_signal_engine(
         .with_source_management_ledger_reader(Arc::new(LiveSourceManagementLedgerReader))
         .with_salience_reader(Arc::new(LiveSalienceReader))
         .with_suggested_next_steps_reader(Arc::new(LiveSuggestedNextStepsReader))
+        .with_recommendation_feedback_writer(Arc::new(LiveRecommendationFeedbackWriter))
         .with_source_management_action_handler(Arc::new(LiveSourceManagementActionHandler {
             signal_engine: signal_engine.clone(),
         }))
@@ -406,6 +408,83 @@ impl SuggestedNextStepsReadHandle for LiveSuggestedNextStepsReader {
                 runtime_salience::SuggestedNextStepsReadError::ReadFailed(error.to_string())
             })
         })
+    }
+}
+
+impl RecommendationFeedbackWriteHandle for LiveRecommendationFeedbackWriter {
+    fn submit_recommendation_feedback<'a>(
+        &'a self,
+        request: RecommendationFeedbackWriteRequest,
+    ) -> RecommendationFeedbackWriteFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                if request.mode != ExecutionMode::Live {
+                    return Err(
+                        runtime_salience::SubmitRecommendationFeedbackError::MutationBlocked(
+                            format!("write blocked by execution mode: {:?}", request.mode),
+                        ),
+                    );
+                }
+
+                let db = crate::db::ActionDb::open(Arc::new(crate::db::LocalKeychain::new()))
+                    .map_err(|error| {
+                        runtime_salience::SubmitRecommendationFeedbackError::WriteFailed(format!(
+                            "Database unavailable: {error}"
+                        ))
+                    })?;
+                let clock = FixedClock::new(request.recorded_at);
+                let rng = SeedableRng::new(7);
+                let external = ExternalClients::default();
+                let service_actor = "user";
+                let mut service_ctx =
+                    ServiceContext::new_live(&clock, &rng, &external).with_actor(service_actor);
+                if let Some(ability_id) = request.ability_id.as_deref() {
+                    service_ctx = service_ctx.with_ability_id(ability_id);
+                }
+
+                crate::services::recommendations::feedback::record_recommendation_feedback(
+                    &service_ctx,
+                    &db,
+                    request.input.claim_id,
+                    request.input.decision,
+                    request.input.context,
+                    &request.actor,
+                )
+                .map_err(recommendation_feedback_error_to_runtime)
+            })
+            .await
+            .map_err(|error| {
+                runtime_salience::SubmitRecommendationFeedbackError::WriteFailed(format!(
+                    "recommendation feedback write task failed: {error}"
+                ))
+            })?
+        })
+    }
+}
+
+fn recommendation_feedback_error_to_runtime(
+    error: crate::services::claims::ClaimError,
+) -> runtime_salience::SubmitRecommendationFeedbackError {
+    match error {
+        crate::services::claims::ClaimError::UnknownClaimId(claim_id) => {
+            runtime_salience::SubmitRecommendationFeedbackError::UnknownClaimId(claim_id)
+        }
+        crate::services::claims::ClaimError::UnsupportedClaimType {
+            claim_id,
+            claim_type,
+        } => runtime_salience::SubmitRecommendationFeedbackError::UnsupportedClaimType {
+            claim_id,
+            claim_type,
+        },
+        crate::services::claims::ClaimError::InvalidFeedback(message) => {
+            runtime_salience::SubmitRecommendationFeedbackError::InvalidFeedback(message)
+        }
+        crate::services::claims::ClaimError::Mode(message) => {
+            runtime_salience::SubmitRecommendationFeedbackError::MutationBlocked(message)
+        }
+        error => {
+            runtime_salience::SubmitRecommendationFeedbackError::WriteFailed(error.to_string())
+        }
     }
 }
 

--- a/src-tauri/src/services/recommendations/feedback.rs
+++ b/src-tauri/src/services/recommendations/feedback.rs
@@ -2,6 +2,951 @@
 //!
 //! Wires user feedback (accepted / dismissed / not-useful /
 //! too-noisy / converted) on a `Recommendation` claim into the
-//! salience-factor weight table, adjusting future ranking on the
-//! same fixture entity. Extends the existing semantic feedback
-//! substrate; does not introduce a parallel feedback path.
+//! existing ADR-0123 claim feedback substrate and recommendation
+//! metadata state. Does not introduce a parallel feedback path.
+
+use abilities_runtime::abilities::recommendations::contracts as runtime;
+use abilities_runtime::abilities::registry::Actor;
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+
+use crate::abilities::claims::ClaimType;
+use crate::abilities::feedback::FeedbackAction;
+use crate::db::ActionDb;
+use crate::services::claims::{
+    load_claim_by_id, record_claim_feedback, with_claim_transaction, ClaimError, ClaimFeedbackInput,
+};
+use crate::services::context::ServiceContext;
+use crate::services::recommendations::contracts as app;
+
+/// Record a user's decision on a recommendation claim.
+///
+/// Mapping is intentionally the locked v1.4.6 W4-A table: recommendation
+/// decisions reuse ADR-0123 `claim_feedback` actions, while conversion IDs are
+/// stored only in `metadata_json.recommendation.conversionState`.
+pub fn record_recommendation_feedback(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    claim_id: runtime::ClaimId,
+    decision: runtime::RecommendationFeedbackDecision,
+    context: runtime::RecommendationFeedbackContext,
+    actor: &Actor,
+) -> Result<runtime::SubmitRecommendationFeedbackResponse, ClaimError> {
+    ctx.check_mutation_allowed()
+        .map_err(|error| ClaimError::Mode(error.to_string()))?;
+
+    let recorded_at = ctx.clock.now();
+    let mapping = map_feedback_decision(&decision, &context)?;
+    let decided_state = runtime::FeedbackState::Decided(decision.clone());
+    let app_decided_state = app::FeedbackState::Decided(runtime_decision_to_app(&decision)?);
+    let app_conversion_state = runtime_conversion_state_to_app(&mapping.conversion_state);
+    let feedback_state_json = serde_json::to_string(&app_decided_state)?;
+    let conversion_state_json = serde_json::to_string(&app_conversion_state)?;
+
+    with_claim_transaction(db, |tx| {
+        let claim = load_claim_by_id(tx.conn_ref(), &claim_id.0)?
+            .ok_or_else(|| ClaimError::UnknownClaimId(claim_id.0.clone()))?;
+        if claim.claim_type != ClaimType::Recommendation.as_str() {
+            return Err(ClaimError::UnsupportedClaimType {
+                claim_id: claim_id.0.clone(),
+                claim_type: claim.claim_type,
+            });
+        }
+
+        parse_recommendation_metadata(claim.metadata_json.as_deref())?;
+
+        let rows_affected = tx.conn_ref().execute(
+            "UPDATE intelligence_claims
+             SET metadata_json = json_set(metadata_json,
+                 '$.recommendation.feedbackState', json(?1),
+                 '$.recommendation.conversionState', json(?2))
+             WHERE id = ?3
+               AND json_extract(metadata_json, '$.recommendation.feedbackState') = 'pending'",
+            params![&feedback_state_json, &conversion_state_json, &claim_id.0],
+        )?;
+
+        if rows_affected == 0 {
+            return no_mutation_response(tx, &claim_id, recorded_at);
+        }
+
+        if let Some(action) = mapping.action {
+            record_claim_feedback(
+                ctx,
+                tx,
+                ClaimFeedbackInput {
+                    claim_id: claim_id.0.clone(),
+                    action,
+                    actor: "user".to_string(),
+                    actor_id: actor_id_for_feedback(actor),
+                    payload_json: mapping.payload_json,
+                },
+            )?;
+        }
+
+        Ok(runtime::SubmitRecommendationFeedbackResponse {
+            schema_version: runtime::SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION,
+            claim_id,
+            feedback_state: decided_state,
+            conversion_state: mapping.conversion_state,
+            effect_kind: runtime::EffectKind::ClaimFeedbackRecorded,
+            recorded_at,
+        })
+    })
+}
+
+struct FeedbackMapping {
+    action: Option<FeedbackAction>,
+    payload_json: Option<String>,
+    conversion_state: runtime::ConversionState,
+}
+
+fn map_feedback_decision(
+    decision: &runtime::RecommendationFeedbackDecision,
+    context: &runtime::RecommendationFeedbackContext,
+) -> Result<FeedbackMapping, ClaimError> {
+    let conversion_state = conversion_state_for_decision(decision);
+    let (action, payload_json) = match decision {
+        runtime::RecommendationFeedbackDecision::Accept { .. } => {
+            (Some(FeedbackAction::ConfirmCurrent), empty_payload())
+        }
+        runtime::RecommendationFeedbackDecision::Dismiss { reason, .. } => match reason {
+            runtime::DismissReason::NotRelevant | runtime::DismissReason::AlreadyKnew => (
+                Some(FeedbackAction::NotRelevantHere),
+                Some(not_relevant_payload(context, None)),
+            ),
+            runtime::DismissReason::WrongSubject => {
+                (Some(FeedbackAction::WrongSubject), empty_payload())
+            }
+            runtime::DismissReason::Other(note) => (
+                Some(FeedbackAction::NotRelevantHere),
+                Some(not_relevant_payload(context, Some(note.as_str()))),
+            ),
+        },
+        runtime::RecommendationFeedbackDecision::NotUseful { .. }
+        | runtime::RecommendationFeedbackDecision::TooNoisy { .. } => (
+            Some(FeedbackAction::SurfaceInappropriate),
+            Some(
+                serde_json::json!({ "surface": render_surface_name(context.surface)? }).to_string(),
+            ),
+        ),
+        runtime::RecommendationFeedbackDecision::Convert { into, .. } => match into {
+            runtime::ConversionTarget::Action(_) => {
+                (Some(FeedbackAction::ConfirmCurrent), empty_payload())
+            }
+            runtime::ConversionTarget::ClaimCorrection(claim_id) => (
+                Some(FeedbackAction::NeedsNuance),
+                Some(serde_json::json!({ "corrected_text": &claim_id.0 }).to_string()),
+            ),
+            runtime::ConversionTarget::ReviewQueue(_) => (None, None),
+        },
+    };
+
+    Ok(FeedbackMapping {
+        action,
+        payload_json,
+        conversion_state,
+    })
+}
+
+fn empty_payload() -> Option<String> {
+    Some(serde_json::json!({}).to_string())
+}
+
+fn not_relevant_payload(
+    context: &runtime::RecommendationFeedbackContext,
+    note: Option<&str>,
+) -> String {
+    let mut payload = serde_json::json!({
+        "invocation_id": &context.invocation_id,
+    });
+    if let Some(note) = note {
+        payload["note"] = serde_json::Value::String(note.to_string());
+    }
+    payload.to_string()
+}
+
+fn render_surface_name(
+    surface: abilities_runtime::sensitivity::RenderSurface,
+) -> Result<String, ClaimError> {
+    let value = serde_json::to_value(surface)?;
+    value.as_str().map(str::to_string).ok_or_else(|| {
+        ClaimError::InvalidFeedback("surface did not serialize as a string".to_string())
+    })
+}
+
+fn conversion_state_for_decision(
+    decision: &runtime::RecommendationFeedbackDecision,
+) -> runtime::ConversionState {
+    match decision {
+        runtime::RecommendationFeedbackDecision::Convert { into, .. } => match into {
+            runtime::ConversionTarget::Action(action_id) => {
+                runtime::ConversionState::ConvertedToAction {
+                    action_id: action_id.clone(),
+                }
+            }
+            runtime::ConversionTarget::ClaimCorrection(claim_id) => {
+                runtime::ConversionState::ConvertedToClaimCorrection {
+                    claim_id: claim_id.clone(),
+                }
+            }
+            runtime::ConversionTarget::ReviewQueue(queue_item_id) => {
+                runtime::ConversionState::ConvertedToReviewQueue {
+                    queue_item_id: queue_item_id.clone(),
+                }
+            }
+        },
+        _ => runtime::ConversionState::NotConverted,
+    }
+}
+
+fn actor_id_for_feedback(actor: &Actor) -> Option<String> {
+    match actor {
+        Actor::SurfaceClient { instance, .. } => Some(instance.to_string()),
+        _ => None,
+    }
+}
+
+fn no_mutation_response(
+    tx: &ActionDb,
+    claim_id: &runtime::ClaimId,
+    recorded_at: DateTime<Utc>,
+) -> Result<runtime::SubmitRecommendationFeedbackResponse, ClaimError> {
+    let claim = load_claim_by_id(tx.conn_ref(), &claim_id.0)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(claim_id.0.clone()))?;
+    let metadata = parse_recommendation_metadata(claim.metadata_json.as_deref())?;
+    Ok(runtime::SubmitRecommendationFeedbackResponse {
+        schema_version: runtime::SUBMIT_RECOMMENDATION_FEEDBACK_SCHEMA_VERSION,
+        claim_id: claim_id.clone(),
+        feedback_state: app_feedback_state_to_runtime(metadata.feedback_state)?,
+        conversion_state: app_conversion_state_to_runtime(metadata.conversion_state),
+        effect_kind: runtime::EffectKind::NoMutation,
+        recorded_at,
+    })
+}
+
+fn parse_recommendation_metadata(
+    metadata_json: Option<&str>,
+) -> Result<app::RecommendationMetadataPayload, ClaimError> {
+    let raw = metadata_json
+        .map(str::trim)
+        .filter(|metadata| !metadata.is_empty())
+        .ok_or_else(|| {
+            ClaimError::InvalidFeedback("recommendation claim missing metadata_json".to_string())
+        })?;
+    let envelope: app::RecommendationMetadataEnvelope =
+        serde_json::from_str(raw).map_err(|error| {
+            ClaimError::InvalidFeedback(format!(
+                "recommendation metadata_json did not match schema: {error}"
+            ))
+        })?;
+    Ok(envelope.recommendation)
+}
+
+fn runtime_decision_to_app(
+    decision: &runtime::RecommendationFeedbackDecision,
+) -> Result<app::RecommendationFeedbackDecision, ClaimError> {
+    Ok(match decision {
+        runtime::RecommendationFeedbackDecision::Accept { at } => {
+            app::RecommendationFeedbackDecision::Accept { at: *at }
+        }
+        runtime::RecommendationFeedbackDecision::Dismiss { at, reason } => {
+            app::RecommendationFeedbackDecision::Dismiss {
+                at: *at,
+                reason: runtime_dismiss_reason_to_app(reason)?,
+            }
+        }
+        runtime::RecommendationFeedbackDecision::NotUseful { at } => {
+            app::RecommendationFeedbackDecision::NotUseful { at: *at }
+        }
+        runtime::RecommendationFeedbackDecision::TooNoisy { at } => {
+            app::RecommendationFeedbackDecision::TooNoisy { at: *at }
+        }
+        runtime::RecommendationFeedbackDecision::Convert { at, into } => {
+            app::RecommendationFeedbackDecision::Convert {
+                at: *at,
+                into: runtime_conversion_target_to_app(into),
+            }
+        }
+    })
+}
+
+fn runtime_dismiss_reason_to_app(
+    reason: &runtime::DismissReason,
+) -> Result<app::DismissReason, ClaimError> {
+    Ok(match reason {
+        runtime::DismissReason::NotRelevant => app::DismissReason::NotRelevant,
+        runtime::DismissReason::AlreadyKnew => app::DismissReason::AlreadyKnew,
+        runtime::DismissReason::WrongSubject => app::DismissReason::WrongSubject,
+        runtime::DismissReason::Other(note) => app::DismissReason::Other(
+            app::BoundedNote::try_from(note.as_str().to_string())
+                .map_err(|error| ClaimError::InvalidFeedback(error.to_string()))?,
+        ),
+    })
+}
+
+fn runtime_conversion_target_to_app(target: &runtime::ConversionTarget) -> app::ConversionTarget {
+    match target {
+        runtime::ConversionTarget::Action(action_id) => {
+            app::ConversionTarget::Action(action_id.clone())
+        }
+        runtime::ConversionTarget::ClaimCorrection(claim_id) => {
+            app::ConversionTarget::ClaimCorrection(app::ClaimId(claim_id.0.clone()))
+        }
+        runtime::ConversionTarget::ReviewQueue(queue_item_id) => {
+            app::ConversionTarget::ReviewQueue(queue_item_id.clone())
+        }
+    }
+}
+
+fn runtime_conversion_state_to_app(state: &runtime::ConversionState) -> app::ConversionState {
+    match state {
+        runtime::ConversionState::NotConverted => app::ConversionState::NotConverted,
+        runtime::ConversionState::ConvertedToAction { action_id } => {
+            app::ConversionState::ConvertedToAction {
+                action_id: action_id.clone(),
+            }
+        }
+        runtime::ConversionState::ConvertedToClaimCorrection { claim_id } => {
+            app::ConversionState::ConvertedToClaimCorrection {
+                claim_id: app::ClaimId(claim_id.0.clone()),
+            }
+        }
+        runtime::ConversionState::ConvertedToReviewQueue { queue_item_id } => {
+            app::ConversionState::ConvertedToReviewQueue {
+                queue_item_id: queue_item_id.clone(),
+            }
+        }
+    }
+}
+
+fn app_feedback_state_to_runtime(
+    state: app::FeedbackState,
+) -> Result<runtime::FeedbackState, ClaimError> {
+    Ok(match state {
+        app::FeedbackState::Pending => runtime::FeedbackState::Pending,
+        app::FeedbackState::Decided(decision) => {
+            runtime::FeedbackState::Decided(app_decision_to_runtime(decision)?)
+        }
+    })
+}
+
+fn app_decision_to_runtime(
+    decision: app::RecommendationFeedbackDecision,
+) -> Result<runtime::RecommendationFeedbackDecision, ClaimError> {
+    Ok(match decision {
+        app::RecommendationFeedbackDecision::Accept { at } => {
+            runtime::RecommendationFeedbackDecision::Accept { at }
+        }
+        app::RecommendationFeedbackDecision::Dismiss { at, reason } => {
+            runtime::RecommendationFeedbackDecision::Dismiss {
+                at,
+                reason: app_dismiss_reason_to_runtime(reason)?,
+            }
+        }
+        app::RecommendationFeedbackDecision::NotUseful { at } => {
+            runtime::RecommendationFeedbackDecision::NotUseful { at }
+        }
+        app::RecommendationFeedbackDecision::TooNoisy { at } => {
+            runtime::RecommendationFeedbackDecision::TooNoisy { at }
+        }
+        app::RecommendationFeedbackDecision::Convert { at, into } => {
+            runtime::RecommendationFeedbackDecision::Convert {
+                at,
+                into: app_conversion_target_to_runtime(into),
+            }
+        }
+    })
+}
+
+fn app_dismiss_reason_to_runtime(
+    reason: app::DismissReason,
+) -> Result<runtime::DismissReason, ClaimError> {
+    Ok(match reason {
+        app::DismissReason::NotRelevant => runtime::DismissReason::NotRelevant,
+        app::DismissReason::AlreadyKnew => runtime::DismissReason::AlreadyKnew,
+        app::DismissReason::WrongSubject => runtime::DismissReason::WrongSubject,
+        app::DismissReason::Other(note) => runtime::DismissReason::Other(
+            runtime::BoundedNote::try_from(note.as_str().to_string())
+                .map_err(|error| ClaimError::InvalidFeedback(error.to_string()))?,
+        ),
+    })
+}
+
+fn app_conversion_target_to_runtime(target: app::ConversionTarget) -> runtime::ConversionTarget {
+    match target {
+        app::ConversionTarget::Action(action_id) => runtime::ConversionTarget::Action(action_id),
+        app::ConversionTarget::ClaimCorrection(claim_id) => {
+            runtime::ConversionTarget::ClaimCorrection(runtime::ClaimId(claim_id.0))
+        }
+        app::ConversionTarget::ReviewQueue(queue_item_id) => {
+            runtime::ConversionTarget::ReviewQueue(queue_item_id)
+        }
+    }
+}
+
+fn app_conversion_state_to_runtime(state: app::ConversionState) -> runtime::ConversionState {
+    match state {
+        app::ConversionState::NotConverted => runtime::ConversionState::NotConverted,
+        app::ConversionState::ConvertedToAction { action_id } => {
+            runtime::ConversionState::ConvertedToAction { action_id }
+        }
+        app::ConversionState::ConvertedToClaimCorrection { claim_id } => {
+            runtime::ConversionState::ConvertedToClaimCorrection {
+                claim_id: runtime::ClaimId(claim_id.0),
+            }
+        }
+        app::ConversionState::ConvertedToReviewQueue { queue_item_id } => {
+            runtime::ConversionState::ConvertedToReviewQueue { queue_item_id }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use abilities_runtime::abilities::provenance::SubjectRef;
+    use abilities_runtime::abilities::registry::{ScopeSet, SurfaceClientId, SurfaceScope};
+    use abilities_runtime::sensitivity::RenderSurface;
+    use chrono::TimeZone;
+    use serde_json::json;
+
+    use crate::db::ActionDb;
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
+    use crate::services::recommendations::recommendation::metadata_envelope;
+
+    #[test]
+    fn recommendation_feedback_mapping_enumerates_all_locked_rows() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        for case in mapping_cases() {
+            let claim_id = format!("claim-{}", case.name);
+            seed_recommendation_claim(&db, &claim_id, app::FeedbackState::Pending);
+
+            let response = record_recommendation_feedback(
+                &ctx,
+                &db,
+                runtime::ClaimId(claim_id.clone()),
+                case.decision.clone(),
+                feedback_context(),
+                &Actor::User,
+            )
+            .expect("feedback write succeeds");
+
+            assert_eq!(
+                response.effect_kind,
+                runtime::EffectKind::ClaimFeedbackRecorded,
+                "{}",
+                case.name
+            );
+            assert_eq!(response.conversion_state, case.expected_conversion);
+
+            let rows = claim_feedback_rows(&db, &claim_id);
+            match case.expected_action {
+                Some(action) => {
+                    assert_eq!(rows.len(), 1, "{}", case.name);
+                    assert_eq!(rows[0].feedback_type, action.as_str(), "{}", case.name);
+                    let payload = rows[0]
+                        .payload_json
+                        .as_deref()
+                        .map(|raw| serde_json::from_str::<serde_json::Value>(raw).unwrap())
+                        .unwrap_or(serde_json::Value::Null);
+                    assert_eq!(payload, case.expected_payload, "{}", case.name);
+                }
+                None => assert!(rows.is_empty(), "{}", case.name),
+            }
+
+            let metadata = recommendation_metadata_value(&db, &claim_id);
+            assert_ne!(
+                metadata["recommendation"]["feedbackState"],
+                serde_json::Value::String("pending".to_string()),
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                metadata["recommendation"]["conversionState"],
+                serde_json::to_value(&case.expected_conversion).unwrap(),
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn recommendation_feedback_is_idempotent_after_decision() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        seed_recommendation_claim(&db, "claim-idempotent", app::FeedbackState::Pending);
+
+        let decision = runtime::RecommendationFeedbackDecision::Accept { at: at() };
+        let first = record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-idempotent".to_string()),
+            decision.clone(),
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect("first feedback succeeds");
+        assert_eq!(
+            first.effect_kind,
+            runtime::EffectKind::ClaimFeedbackRecorded
+        );
+
+        let second = record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-idempotent".to_string()),
+            decision,
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect("second feedback is idempotent");
+
+        assert_eq!(second.effect_kind, runtime::EffectKind::NoMutation);
+        assert_eq!(claim_feedback_rows(&db, "claim-idempotent").len(), 1);
+    }
+
+    #[test]
+    fn recommendation_feedback_populates_actor_id_only_for_surface_client() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        seed_recommendation_claim(&db, "claim-user-actor", app::FeedbackState::Pending);
+        seed_recommendation_claim(&db, "claim-surface-actor", app::FeedbackState::Pending);
+
+        record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-user-actor".to_string()),
+            runtime::RecommendationFeedbackDecision::Accept { at: at() },
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect("user feedback succeeds");
+        record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-surface-actor".to_string()),
+            runtime::RecommendationFeedbackDecision::Accept { at: at() },
+            feedback_context(),
+            &surface_actor(),
+        )
+        .expect("surface feedback succeeds");
+
+        let user_rows = claim_feedback_rows(&db, "claim-user-actor");
+        let surface_rows = claim_feedback_rows(&db, "claim-surface-actor");
+        assert_eq!(user_rows[0].actor, "user");
+        assert_eq!(user_rows[0].actor_id, None);
+        assert_eq!(surface_rows[0].actor, "user");
+        assert_eq!(surface_rows[0].actor_id.as_deref(), Some("surface-1"));
+    }
+
+    #[test]
+    fn recommendation_feedback_rejects_unknown_claim_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+
+        let error = record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("missing-claim".to_string()),
+            runtime::RecommendationFeedbackDecision::Accept { at: at() },
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect_err("unknown claim rejected");
+
+        assert!(matches!(error, ClaimError::UnknownClaimId(id) if id == "missing-claim"));
+    }
+
+    #[test]
+    fn recommendation_feedback_rejects_non_recommendation_claim_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        seed_claim_row(&db, "claim-risk", "risk", None);
+
+        let error = record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-risk".to_string()),
+            runtime::RecommendationFeedbackDecision::Accept { at: at() },
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect_err("non-recommendation claim rejected");
+
+        assert!(matches!(
+            error,
+            ClaimError::UnsupportedClaimType {
+                claim_id,
+                claim_type,
+            } if claim_id == "claim-risk" && claim_type == "risk"
+        ));
+    }
+
+    #[test]
+    fn recommendation_feedback_reuses_claim_feedback_recorded_signal() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        seed_recommendation_claim(&db, "claim-signal", app::FeedbackState::Pending);
+
+        record_recommendation_feedback(
+            &ctx,
+            &db,
+            runtime::ClaimId("claim-signal".to_string()),
+            runtime::RecommendationFeedbackDecision::Accept { at: at() },
+            feedback_context(),
+            &Actor::User,
+        )
+        .expect("feedback succeeds");
+
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+        let payload = first_signal_value(&db, "claim_feedback_recorded");
+        let payload_json: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(payload_json["action"], "confirm_current");
+        assert_eq!(payload_json["claim_id"], "claim-signal");
+        assert_eq!(payload_json["verification_state_before"], "active");
+        assert_eq!(payload_json["verification_state_after"], "active");
+    }
+
+    struct MappingCase {
+        name: &'static str,
+        decision: runtime::RecommendationFeedbackDecision,
+        expected_action: Option<FeedbackAction>,
+        expected_payload: serde_json::Value,
+        expected_conversion: runtime::ConversionState,
+    }
+
+    fn mapping_cases() -> Vec<MappingCase> {
+        vec![
+            MappingCase {
+                name: "accept",
+                decision: runtime::RecommendationFeedbackDecision::Accept { at: at() },
+                expected_action: Some(FeedbackAction::ConfirmCurrent),
+                expected_payload: json!({}),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "dismiss-not-relevant",
+                decision: runtime::RecommendationFeedbackDecision::Dismiss {
+                    at: at(),
+                    reason: runtime::DismissReason::NotRelevant,
+                },
+                expected_action: Some(FeedbackAction::NotRelevantHere),
+                expected_payload: json!({ "invocation_id": "invocation-1" }),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "dismiss-already-knew",
+                decision: runtime::RecommendationFeedbackDecision::Dismiss {
+                    at: at(),
+                    reason: runtime::DismissReason::AlreadyKnew,
+                },
+                expected_action: Some(FeedbackAction::NotRelevantHere),
+                expected_payload: json!({ "invocation_id": "invocation-1" }),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "dismiss-wrong-subject",
+                decision: runtime::RecommendationFeedbackDecision::Dismiss {
+                    at: at(),
+                    reason: runtime::DismissReason::WrongSubject,
+                },
+                expected_action: Some(FeedbackAction::WrongSubject),
+                expected_payload: json!({}),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "dismiss-other-note",
+                decision: runtime::RecommendationFeedbackDecision::Dismiss {
+                    at: at(),
+                    reason: runtime::DismissReason::Other(
+                        runtime::BoundedNote::try_from("handled elsewhere".to_string()).unwrap(),
+                    ),
+                },
+                expected_action: Some(FeedbackAction::NotRelevantHere),
+                expected_payload: json!({
+                    "invocation_id": "invocation-1",
+                    "note": "handled elsewhere"
+                }),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "not-useful",
+                decision: runtime::RecommendationFeedbackDecision::NotUseful { at: at() },
+                expected_action: Some(FeedbackAction::SurfaceInappropriate),
+                expected_payload: json!({ "surface": "tauri_entity_detail" }),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "too-noisy",
+                decision: runtime::RecommendationFeedbackDecision::TooNoisy { at: at() },
+                expected_action: Some(FeedbackAction::SurfaceInappropriate),
+                expected_payload: json!({ "surface": "tauri_entity_detail" }),
+                expected_conversion: runtime::ConversionState::NotConverted,
+            },
+            MappingCase {
+                name: "convert-action",
+                decision: runtime::RecommendationFeedbackDecision::Convert {
+                    at: at(),
+                    into: runtime::ConversionTarget::Action("action-1".to_string()),
+                },
+                expected_action: Some(FeedbackAction::ConfirmCurrent),
+                expected_payload: json!({}),
+                expected_conversion: runtime::ConversionState::ConvertedToAction {
+                    action_id: "action-1".to_string(),
+                },
+            },
+            MappingCase {
+                name: "convert-claim-correction",
+                decision: runtime::RecommendationFeedbackDecision::Convert {
+                    at: at(),
+                    into: runtime::ConversionTarget::ClaimCorrection(runtime::ClaimId(
+                        "claim-correction-1".to_string(),
+                    )),
+                },
+                expected_action: Some(FeedbackAction::NeedsNuance),
+                expected_payload: json!({ "corrected_text": "claim-correction-1" }),
+                expected_conversion: runtime::ConversionState::ConvertedToClaimCorrection {
+                    claim_id: runtime::ClaimId("claim-correction-1".to_string()),
+                },
+            },
+            MappingCase {
+                name: "convert-review-queue",
+                decision: runtime::RecommendationFeedbackDecision::Convert {
+                    at: at(),
+                    into: runtime::ConversionTarget::ReviewQueue("queue-item-1".to_string()),
+                },
+                expected_action: None,
+                expected_payload: serde_json::Value::Null,
+                expected_conversion: runtime::ConversionState::ConvertedToReviewQueue {
+                    queue_item_id: "queue-item-1".to_string(),
+                },
+            },
+        ]
+    }
+
+    #[derive(Debug)]
+    struct FeedbackRow {
+        feedback_type: String,
+        actor: String,
+        actor_id: Option<String>,
+        payload_json: Option<String>,
+    }
+
+    fn claim_feedback_rows(db: &ActionDb, claim_id: &str) -> Vec<FeedbackRow> {
+        let mut stmt = db
+            .conn_ref()
+            .prepare(
+                "SELECT feedback_type, actor, actor_id, payload_json
+                 FROM claim_feedback
+                 WHERE claim_id = ?1
+                 ORDER BY rowid",
+            )
+            .expect("prepare feedback rows query");
+        stmt.query_map(params![claim_id], |row| {
+            Ok(FeedbackRow {
+                feedback_type: row.get(0)?,
+                actor: row.get(1)?,
+                actor_id: row.get(2)?,
+                payload_json: row.get(3)?,
+            })
+        })
+        .expect("query feedback rows")
+        .map(|row| row.expect("read feedback row"))
+        .collect()
+    }
+
+    fn recommendation_metadata_value(db: &ActionDb, claim_id: &str) -> serde_json::Value {
+        let raw: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT metadata_json FROM intelligence_claims WHERE id = ?1",
+                params![claim_id],
+                |row| row.get(0),
+            )
+            .expect("read recommendation metadata");
+        serde_json::from_str(&raw).expect("metadata json")
+    }
+
+    fn signal_count(db: &ActionDb, signal_type: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM signal_events WHERE signal_type = ?1",
+                params![signal_type],
+                |row| row.get(0),
+            )
+            .expect("count signals")
+    }
+
+    fn first_signal_value(db: &ActionDb, signal_type: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT value FROM signal_events WHERE signal_type = ?1 ORDER BY rowid LIMIT 1",
+                params![signal_type],
+                |row| row.get(0),
+            )
+            .expect("read signal value")
+    }
+
+    fn seed_recommendation_claim(
+        db: &ActionDb,
+        claim_id: &str,
+        feedback_state: app::FeedbackState,
+    ) {
+        let metadata = recommendation_metadata(claim_id, feedback_state);
+        seed_claim_row(
+            db,
+            claim_id,
+            ClaimType::Recommendation.as_str(),
+            Some(serde_json::to_string(&metadata).expect("metadata serializes")),
+        );
+    }
+
+    fn seed_claim_row(
+        db: &ActionDb,
+        claim_id: &str,
+        claim_type: &str,
+        metadata_json: Option<String>,
+    ) {
+        let now = at().to_rfc3339();
+        db.conn_ref()
+            .execute(
+                "INSERT INTO intelligence_claims /* dos7-allowed: recommendation feedback unit test seed */ (
+                    id, subject_ref, claim_type, field_path, topic_key, text, dedup_key,
+                    item_hash, actor, data_source, source_ref, source_asof, observed_at,
+                    created_at, provenance_json, metadata_json, claim_state, surfacing_state,
+                    demotion_reason, reactivated_at, retraction_reason, expires_at,
+                    superseded_by, trust_score, trust_computed_at, trust_version, thread_id,
+                    temporal_scope, sensitivity, verification_state, verification_reason,
+                    needs_user_decision_at, claim_version, canonical_status,
+                    non_semantic_mergeable
+                ) VALUES (
+                    ?1, ?2, ?3, 'recommendation.reviewClaim', ?1,
+                    'Review the account before the next customer conversation.',
+                    ?4, ?5, 'agent:test', 'recommendation', 'run:test', ?6, ?6,
+                    ?6, '{\"sources\":[]}', ?7, 'active', 'active',
+                    NULL, NULL, NULL, NULL, NULL, 0.82, ?6, 1, NULL, 'state',
+                    'internal', 'active', NULL, NULL, 1, 'live', 0
+                )",
+                params![
+                    claim_id,
+                    r#"{"kind":"account","id":"acct-1"}"#,
+                    claim_type,
+                    format!("dedup-{claim_id}"),
+                    format!("hash-{claim_id}"),
+                    now,
+                    metadata_json,
+                ],
+            )
+            .expect("seed claim row");
+    }
+
+    fn recommendation_metadata(
+        claim_id: &str,
+        feedback_state: app::FeedbackState,
+    ) -> app::RecommendationMetadataEnvelope {
+        let draft = app::RecommendationDraft {
+            subject: SubjectRef::Account("acct-1".to_string()),
+            recommended_action: app::RecommendedAction::ReviewClaim {
+                claim_id: app::ClaimId("claim-source-1".to_string()),
+                reason: "verify before next customer conversation".to_string(),
+            },
+            evidence: vec![app::EvidenceRef {
+                source: format!("claim:{claim_id}"),
+                chunk: None,
+            }],
+            provenance_json: r#"{"sources":[]}"#.to_string(),
+            source_ref: Some("run:test".to_string()),
+            source_asof: Some(at()),
+            observed_at: at(),
+            text: "Review the account before the next customer conversation.".to_string(),
+            salience: app::SalienceScore {
+                total: 0.91,
+                factors: vec![app::SalienceFactor {
+                    kind: app::SalienceFactorKind::Urgency,
+                    value: Some(0.91),
+                    weight: 0.15,
+                    rationale: app::FactorRationale::Urgency {
+                        deadline: Some(at()),
+                        decay_factor: 0.91,
+                    },
+                }],
+            },
+        };
+        let mut envelope = metadata_envelope(&draft);
+        envelope.recommendation.feedback_state = feedback_state;
+        envelope.recommendation.conversion_state = app::ConversionState::NotConverted;
+        envelope
+    }
+
+    fn feedback_context() -> runtime::RecommendationFeedbackContext {
+        runtime::RecommendationFeedbackContext {
+            surface: RenderSurface::TauriEntityDetail,
+            invocation_id: "invocation-1".to_string(),
+        }
+    }
+
+    fn surface_actor() -> Actor {
+        // Include the production scopes used by other modules' tests so this
+        // global-allowlist write doesn't pollute interleaved test runs.
+        // See `recommendations/mod.rs::set_recommendation_scope_allowlist_for_tests`
+        // rationale (cross-test-pollution rule).
+        ScopeSet::set_allowlist_for_tests([
+            SurfaceScope::new(runtime::SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE),
+            SurfaceScope::new("read.account_overview"),
+            SurfaceScope::new("read.composition"),
+            SurfaceScope::new("read.entity_names"),
+            SurfaceScope::new("read.markdown_preview"),
+            SurfaceScope::new("read.recommendations"),
+            SurfaceScope::new("read.workspace_graph"),
+            SurfaceScope::new("read.workspace_sources"),
+            SurfaceScope::new("submit.feedback"),
+            SurfaceScope::new("write.entity_intake"),
+            SurfaceScope::new("write.feedback"),
+        ]);
+        let scopes = ScopeSet::new([SurfaceScope::new(
+            runtime::SUBMIT_RECOMMENDATION_FEEDBACK_SCOPE,
+        )])
+        .expect("scope set");
+        Actor::SurfaceClient {
+            instance: SurfaceClientId::new("surface-1"),
+            scopes,
+        }
+    }
+
+    fn test_db() -> ActionDb {
+        ActionDb::from_connection_for_tests(crate::migrations::migrated_in_memory_for_tests())
+    }
+
+    fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
+        (
+            FixedClock::new(at()),
+            SeedableRng::new(7),
+            ExternalClients::default(),
+        )
+    }
+
+    fn live_ctx<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external)
+            .with_actor("user")
+            .with_ability_id(runtime::SUBMIT_RECOMMENDATION_FEEDBACK_ABILITY_NAME)
+    }
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 26, 12, 0, 0)
+            .single()
+            .unwrap()
+    }
+}

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -442,6 +442,27 @@
       }
     },
     {
+      "name": "submit_recommendation_feedback",
+      "description": "",
+      "category": "maintenance",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "submit.recommendations.feedback"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "side_effect",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "workspace_graph",
       "description": "",
       "category": "read",


### PR DESCRIPTION
## Summary

W4-A of v1.4.6 — Salience & Recommendations. Substrate-only lane per the UI Surface Deferral amendment (2026-05-27); no UI work.

Fills the `services/recommendations/feedback.rs` placeholder with the `submit_recommendation_feedback` ability + service wrapper. Every `RecommendationFeedbackDecision` variant writes to `claim_feedback` via the existing `record_claim_feedback` substrate. Cooldown emerges automatically from `latest_feedback_suppression` (per `SurfacingPolicy.feedback_suppression_days = 14`). **No new tables, no new SignalType variants, no new cooldown API.**

Closes W4-A of v1.4.6 (DOS-332). Unblocks W4-B (DOS-316 deviation) + W4-C (DOS-317 engagement) once W4-A merges.

## Mapping table (locked at L0 §1, 10 rows)

| `RecommendationFeedbackDecision` | `FeedbackAction` | Audit + ranking effect |
|---|---|---|
| `Accept` | `ConfirmCurrent` | +α on source / agent |
| `Dismiss{NotRelevant\|AlreadyKnew}` | `NotRelevantHere` | 14-day cooldown via `feedback_suppression_days` |
| `Dismiss{WrongSubject}` | `WrongSubject` | -0.3 subject_evidence on linker; source untouched |
| `Dismiss{Other(BoundedNote)}` | `NotRelevantHere` + note in payload_json | Cooldown; note captured via validator extension |
| `NotUseful` / `TooNoisy` | `SurfaceInappropriate` | Cooldown |
| `Convert{Action}` | `ConfirmCurrent` + state update | Reinforce + conversion_state ConvertedToAction |
| `Convert{ClaimCorrection}` | `NeedsNuance` + corrected_text payload | Refinement path per ADR-0123 §149 row #7 |
| `Convert{ReviewQueue}` | None | state update only; DOS-336 review queue routes |

## Critical invariants verified (per §15 verified-against-codebase appendix)

1. Mapping table per §1 — all 10 variants implemented; parametric test asserts each
2. Compare-and-set predicate is `= 'pending'` (NOT `LIKE`) — empirically verified SQLite semantics
3. `note` encoded in `payload_json` — no typed column; validator extension at `claims.rs:5569-5572`
4. No new SignalType — reuses existing `claim_feedback_recorded`
5. Category is **Maintenance** per ADR-0102 §82
6. `actor_id` populated with SurfaceClient instance to preserve audit identity
7. Transaction atomicity via reentrant `with_claim_transaction`
8. No new tables / migrations
9. Convert{Action} is pure state update — no external service calls, no retry infra
10. Actor normalization: `record_claim_feedback` called with `actor = "user"`

## L0 cycle history

- Cycle 0: 4-reviewer panel — 3 BLOCKED + multiple findings
- Cycle 1: B1-B13 amendments (reframe around existing primitives)
- Cycle 2: 3-reviewer subset — found new hallucination class (cycle 1 introduced new BLOCKED)
- Cycle 3: B14-B21 grounding pass + §15 verified-against-codebase appendix (18 file:line citations); APPROVE-with-tightening
- Cycle 3 tightening: stale text sweep + AC#14 (phantom-id acceptance)

## L2 cycle: unanimous APPROVE

- **l2-bounded-reviewer**: zero BLOCK + zero maintenance findings; all 5 Linear ACs + 10 critical invariants verified
- **ce-security-reviewer**: 1 path-α (DOS-809) + 3 testing-gap residuals (DOS-810); all 10 adversarial constructions clean
- **ce-reliability-reviewer**: zero findings; transaction reentrancy + idempotency + error propagation all verified

## L4 — N/A for W4-A merge

Substrate-only lane. The W3-A `dailyos_suggested_next_steps_feedback_enabled` filter flip in the WP block is a **separate L4-gated change** (per AC#11), shipped post-W4-A when WP surface readiness allows.

## Path-α maintenance tickets filed (Codebase Maintenance project)

- DOS-809 Convert{ReviewQueue} audit completeness
- DOS-810 Server-side validator-bypass tests for note

## §4 Security

security_auditor_invoked: true

**Exemption ID:** _none_ (auditor ran)

**Exemption rationale:** N/A — L2 dispatched `ce-security-reviewer` against the W4-A diff (actor allowlist + scope + privacy + adversarial constructions). Returned APPROVE; all 10 enumerated concerns verified clean. Full review captured in DOS-332 L2 comment.

## Test plan

- [ ] CI green: cargo clippy, cargo test --lib, pnpm tsc --noEmit
- [ ] CI green: PHPUnit, WP Plugin Check, lint+grep-gates, block-kit integration fixtures, L2 / config-fence, L2 / validate-pr-template
- [ ] Linear DOS-332 closes when merged
- [ ] After merge: start W4-B (DOS-316 deviation) on a fresh `dev`-based worktree; W4-C (DOS-317 engagement) parallel-eligible per cycle 2 stage 4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)