### PR TITLE
intelligence/glean: harden JSON ingestion + parser diagnostics

### DIFF
--- a/.docs/plans/glean-ingestion-hardening-2026-05-28.md
+++ b/.docs/plans/glean-ingestion-hardening-2026-05-28.md
@@ -1,0 +1,132 @@
+# Glean Ingestion Hardening — Phase 1 Spec (2026-05-28)
+
+Status: Spec — pending L0 plan review
+Scope tier: Standard, low-risk. Single PR, ~530 LOC across 4 files.
+Branch: continues uncommitted work on `codex/glean-output-contract-fix`
+Threat topology: local-to-local, single-user, encrypted local DB
+Related prior work: `.docs/plans/glean-finalization-shared-producer-l0-2026-05-23.md` (different problem — queue/manual producer asymmetry — but adjacent code path)
+
+## Problem
+
+Glean dimension responses fail at the JSON ingestion step more often than not. The user-visible symptom is partial enrichment — strategic, engagement, or commercial dimensions go stale because their refresh attempts failed silently or surfaced misleading errors.
+
+Investigation (summarized at the top of this session) identified three concrete defects in the current ingestion pipeline:
+
+1. **Shape drift.** Glean emits JSON that drifts from the app's `IntelligenceJson` schema in two specific ways:
+   - Scalar fields wrapped as objects: e.g. `"trend": {"direction": "stable", "rationale": "..."}` where the schema expects `"trend": "stable"`. Seen repeatedly on `engagement_signals` and `commercial_financial` dimensions.
+   - Multiline strings inside string fields produce `Invalid JSON: control character ... while parsing a string`.
+   - Snake_case or typo'd field names that don't match the camelCase contract.
+2. **Diagnostic masking.** `try_parse_json_response` at `src-tauri/src/intelligence/prompts.rs:3373` returns `None` on real serde validation failures. The caller falls through to the legacy pipe-delimited parser, which surfaces `No INTELLIGENCE block or JSON found in response`. The real serde error is logged at `warn` level but never reaches the user-facing per-dimension error string.
+3. **Lost forensic state.** `glean_provider.rs:310-321` writes only the first parallel dimension's response to a fixed path `dailyos-glean-response.txt`. When dimensions 2-6 fail, the response that caused the failure is unrecoverable after the run.
+
+The investigation report's recommendation is a small, targeted patch. An in-flight uncommitted patch on `codex/glean-output-contract-fix` already implements the shape-drift tolerance layer (495 lines: key normalizer, `stringish_value` coercion, defaulted required fields with empty-text filtering, custom `deserialize_recommended_actions`). It does **not** address defects 2 or 3.
+
+This spec lands the in-flight patch plus the two missing diagnostic fixes as one standalone PR, then defers architectural decisions to data collected from real Glean traffic after the patch ships.
+
+## Out of scope (explicit)
+
+- **PTY-Claude repair shim.** Considered. Deferred until we have data on what the lenient parser leaves uncaught.
+- **Producer/consumer rearchitecture.** Considered (Glean as evidence emitter, deterministic step shapes to `IntelligenceJson`). Deferred for the same reason.
+- **Tightening the prompt contract further** than the +4 lines already in the in-flight patch. Same reason.
+- **Reducing `prompts.rs` file size** (currently 5209 lines). Real signal but different problem.
+- **Queue-vs-manual producer asymmetry** addressed in `.docs/plans/glean-finalization-shared-producer-l0-2026-05-23.md`. Adjacent code; different defect.
+
+## Architecture
+
+Pipeline unchanged at the high level:
+
+```
+Glean response → extract_json → validate → normalize → deserialize → IntelligenceJson
+                                                                  ↘ on failure: real error logged + surfaced
+no JSON found ────────────────────────────────────────────────────→ pipe-delimited fallback (legitimate path)
+```
+
+The change is **distinguishing two failure modes** that currently collapse into one:
+- "No JSON object in the response" — fall through to the pipe parser is the legitimate path.
+- "JSON object extracted but failed validation/deserialization" — fall through is misleading. We want the real serde error to surface directly.
+
+## Components
+
+### 1. Lenient parser layer — already in `codex/glean-output-contract-fix` (~495 LOC)
+
+Lands as-is. Touches `src-tauri/src/intelligence/{prompts.rs, dimension_prompts.rs, glean_prompts.rs, io.rs}`. Specifically:
+
+- `normalize_ai_response_value` recursively rewrites snake_case/typo keys to canonical camelCase (e.g. `renewaloutlook` → `agreementOutlook`, `meetingcadenceassessment` → `meetingCadence`).
+- `stringish_value` extracts string-bearing inner fields from objects when the schema expects scalars (e.g. `{"direction": "stable", ...}` → `"stable"`).
+- `#[serde(default)]` added to previously-required `text` / `name` / `statement` / `description` fields, paired with `.filter(|x| !x.text.trim().is_empty())` so a missing field drops the item instead of the whole array.
+- `deserialize_recommended_actions` custom deserializer accepts strings or objects, normalizes to `RecommendedAction`.
+- Three one-line "use exact camelCase" reminders in the prompt builders.
+- Inline test `test_parse_json_response_accepts_glean_case_and_shape_drift` exercising a Glean-shaped drift blob.
+
+### 2. Error propagation — new (~25 LOC)
+
+In `src-tauri/src/intelligence/prompts.rs`:
+
+- Change `try_parse_json_response` return type from `Option<IntelligenceJson>` to `Result<Option<IntelligenceJson>, String>`.
+  - `Ok(Some(intel))` — success.
+  - `Ok(None)` — no JSON object found in the response at all (no `{` candidate, no fenced block). Caller falls through to the pipe parser as today.
+  - `Err(msg)` — JSON object extracted but `validate_intelligence_response` or `serde_json::from_value` rejected it. Caller returns the error directly; pipe parser is **not** invoked.
+- In `parse_intelligence_response` at line 3216, update the call site to match the new three-state return.
+- Error message format: `<stage>: <serde_error>` where `<stage>` is one of `validation` or `deserialize`. The existing per-dimension channel wrapper at `glean_provider.rs:346` already prepends `parse failed:`, so the user-visible string is e.g. `parse failed: deserialize: missing field 'text' at line 42 column 3`.
+
+### 3. Per-dimension debug capture — new (~10 LOC)
+
+In `src-tauri/src/intelligence/glean_provider.rs:310-321`:
+
+- Drop the `if is_first` guard.
+- Filename pattern: `dailyos-glean-{dim_name}-{utc_millis}.txt` in `std::env::temp_dir()`.
+- Always-on. Local /tmp, user's own data, threat topology is local-to-local.
+- No retention policy in this PR — `/tmp` is OS-managed.
+
+## Data flow change
+
+Only one branch is new. When `extract_json_from_response` returns `Some(json_str)` but downstream validation or deserialization fails after normalization, the dimension's error string flows back through the existing `mpsc::channel` in `glean_provider.rs` as:
+
+```
+parse failed: deserialize: missing field `text` at line 42 column 3
+```
+
+instead of:
+
+```
+parse failed: No INTELLIGENCE block or JSON found in response
+```
+
+The on-disk debug capture at `/tmp/dailyos-glean-{dim_name}-{ts}.txt` then lets us inspect the exact response that triggered the failure.
+
+## Error handling
+
+No new error types. No new error surfaces. The existing per-dimension `Err(String)` channel in `glean_provider.rs:340-347` is the surface; the change is that the strings flowing through it are now diagnostic instead of misleading.
+
+## Testing
+
+- Keep the existing `test_parse_json_response_accepts_glean_case_and_shape_drift` test from the in-flight patch.
+- Add one failure-path test: `test_parse_json_response_propagates_schema_error`. Feeds a JSON blob with a structural error the normalizer cannot resolve (e.g. `"risks": "not an array"`). Assert the returned error string contains the serde wording (e.g. "expected sequence", "expected array") and does **not** contain "No INTELLIGENCE block".
+- Add one extraction-failure test: `test_parse_json_response_returns_none_when_no_json_present`. Feeds a response with no `{` candidate; asserts `Ok(None)` so the caller's fall-through to the pipe parser still triggers.
+- No automated test for per-dim debug capture. Manual verification: run `pnpm dev`, trigger an account refresh that exercises Glean enrichment, confirm `/tmp/dailyos-glean-*` contains one file per dimension.
+
+## Acceptance criteria
+
+1. `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit` passes.
+2. Existing `test_parse_json_response_accepts_glean_case_and_shape_drift` still passes (no regression on lenient-parser coverage).
+3. New `test_parse_json_response_propagates_schema_error` proves the misleading-error path is fixed.
+4. Manual verification: a Glean refresh writes one debug file per dimension to `/tmp/dailyos-glean-*`.
+5. PR title contains no PII per `.claude/pii-blocklist.txt`. Commit message includes `L2-status: passed`.
+
+## Phase 2 trigger — explicit, not a deferral
+
+After this PR ships, run real Glean refreshes for ~1 week. Categorize per-dimension failures from `/tmp/dailyos-glean-*` and the real serde error strings. Three possible outcomes drive the next decision:
+
+- **<5% failure rate, varied shapes.** Done. No Phase 2.
+- **5-20% failure rate, clustered shapes.** Tighten prompt contract or add targeted normalizers in a follow-up PR. Still no Phase 2.
+- **>20% failure rate, or persistent unrecoverable shapes.** That's the evidence that justifies revisiting the PTY-Claude repair shim OR the producer/consumer rearchitecture. File as a new L0 plan packet with the failure data attached.
+
+## Intelligence Loop check
+
+This PR does not add new tables, schema columns, claim fields, or user-visible intelligence surfaces. The 5-question check does not apply at the substrate level. The PR hardens the parser path that already feeds existing claim writes; provenance, trust scoring, signal emission, runtime consumption, and feedback are unchanged.
+
+## Risks
+
+- **Normalizer false positives.** The recursive key normalizer could rewrite a legitimately distinct field name to a canonical one and silently coerce wrong data. Mitigation: the in-flight patch's normalizer only rewrites a fixed allowlist (`renewaloutlook`, `meetingcadenceassessment`, `commitments`, etc.). Generic `_` / `-` / space splitting is gated on a separate match arm and only camelCases — it doesn't rename.
+- **`stringish_value` data loss.** When Glean returns `{"direction": "stable", "rationale": "..."}` and we extract `"stable"`, the rationale is lost. Mitigation: this is acceptable for v1.4.x — rationale is not part of the consuming schema for those fields. If Phase 2 widens the schema to hold the rationale, the deserializer changes accordingly.
+- **Always-on debug capture writes.** Six dim files per refresh per entity. `/tmp` is OS-managed but this is non-zero disk usage. Acceptable for the duration of the data-collection window; revisit if Phase 2 lands.

--- a/src-tauri/src/intelligence/dimension_prompts.rs
+++ b/src-tauri/src/intelligence/dimension_prompts.rs
@@ -936,6 +936,9 @@ ACCOUNT TRUTH rules:\n\
 
 const PROMPT_QUALITY_RULES: &str = "\
 ## Quality Rules\n\n\
+- Use the exact camelCase field names shown in the schema. Do not use snake_case, title case, renamed fields, or extra wrapper objects.\n\
+- Values shown as \"a|b|c\" are plain strings. Do not expand string fields into objects like {\"direction\":\"stable\",\"rationale\":\"...\"}.\n\
+- Arrays shown as strings must contain strings only. Arrays shown as objects must contain objects with the exact object fields shown.\n\
 - Prefer empty arrays or null over unsupported claims.\n\
 - If evidence is stale or timing is unknown, say so in the relevant unknowns or narrative field instead of sounding current.\n\
 - Do not write generic summaries. Every sentence should add a concrete source-grounded fact, risk, opportunity, or unknown.\n\

--- a/src-tauri/src/intelligence/glean_prompts.rs
+++ b/src-tauri/src/intelligence/glean_prompts.rs
@@ -224,6 +224,7 @@ fn build_json_schema(entity_type: &str) -> String {
     // Quality guidance
     schema.push_str("IMPORTANT:\n");
     schema.push_str("- Return ONLY valid JSON. No markdown, no commentary before or after.\n");
+    schema.push_str("- Use the exact camelCase field names and value types shown above. Do not use snake_case, renamed fields, or object values where the schema shows strings.\n");
     schema.push_str("- For risks: RED urgency = champion departure, competitor eval, budget cut. YELLOW = usage decline, reorg. Use \"critical\"/\"watch\"/\"low\".\n");
     schema.push_str("- For wins: only extract verifiable outcomes, not vague sentiment. \"Customer seems happy\" is NOT a win.\n");
     schema.push_str("- For valueDelivered: must include a number (dollars, percentages, time saved). Reject vague usage statements.\n");

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -232,15 +232,12 @@ impl GleanIntelligenceProvider {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<(String, Result<IntelligenceJson, String>)>(
             prompts.len().max(1),
         );
-        let mut wrote_debug_file = false;
 
         for (dim_name, prompt) in prompts {
             let ep = endpoint.clone();
             let eid = entity_id_owned.clone();
             let etype = entity_type_owned.clone();
             let ename = entity_name_owned.clone();
-            let is_first = !wrote_debug_file;
-            wrote_debug_file = true;
             let sender = tx.clone();
 
             tokio::spawn(async move {
@@ -307,14 +304,24 @@ impl GleanIntelligenceProvider {
                     response_text.len()
                 );
 
-                // Write debug file for the first dimension only
-                if is_first {
-                    let debug_path = std::env::temp_dir().join("dailyos-glean-response.txt");
+                // Always capture every dimension's response. Single-file
+                // capture lost dimensions 2-6 when the first one happened to
+                // succeed; per-dim filenames preserve forensic state across
+                // parallel failures.
+                {
+                    let ts = chrono::Utc::now().timestamp_millis();
+                    let debug_path = std::env::temp_dir()
+                        .join(format!("dailyos-glean-{}-{}.txt", dim_name, ts));
                     if let Err(e) = std::fs::write(&debug_path, &response_text) {
-                        log::warn!("[I574] Failed to write debug response: {}", e);
+                        log::warn!(
+                            "[I574] Failed to write debug response for {}: {}",
+                            dim_name,
+                            e
+                        );
                     } else {
                         log::info!(
-                            "[I574] Glean dimension response written to {}",
+                            "[I574] Glean dimension {} response written to {}",
+                            dim_name,
                             debug_path.display()
                         );
                     }

--- a/src-tauri/src/intelligence/io.rs
+++ b/src-tauri/src/intelligence/io.rs
@@ -63,6 +63,66 @@ fn default_recommended_priority() -> i32 {
     3
 }
 
+fn deserialize_optional_stringish<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(stringish_value))
+}
+
+fn deserialize_stringish_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().map(stringish_vec).unwrap_or_default())
+}
+
+fn deserialize_stringish_default<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value.as_ref().and_then(stringish_value).unwrap_or_default())
+}
+
+fn stringish_vec(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::Array(values) => values.iter().filter_map(stringish_value).collect(),
+        other => stringish_value(other).into_iter().collect(),
+    }
+}
+
+fn stringish_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Object(obj) => [
+            "direction",
+            "text",
+            "title",
+            "action",
+            "description",
+            "summary",
+            "rationale",
+            "value",
+        ]
+        .iter()
+        .filter_map(|key| obj.get(*key))
+        .find_map(stringish_value),
+        _ => None,
+    }
+}
+
 /// Tombstone for user-dismissed intelligence items.
 /// Prevents enrichment from re-creating items the user explicitly removed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -236,7 +296,11 @@ pub struct AccountHealth {
     pub divergence: Option<HealthDivergence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub narrative: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub recommended_actions: Vec<String>,
 }
 
@@ -259,11 +323,21 @@ pub struct HealthTrendTag {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HealthTrend {
-    #[serde(default = "default_health_trend_direction")]
+    #[serde(
+        default = "default_health_trend_direction",
+        deserialize_with = "deserialize_stringish_default"
+    )]
     pub direction: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_stringish",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub rationale: Option<String>,
-    #[serde(default = "default_timeframe")]
+    #[serde(
+        default = "default_timeframe",
+        deserialize_with = "deserialize_stringish_default"
+    )]
     pub timeframe: String,
     #[serde(default)]
     pub confidence: f64,
@@ -304,9 +378,16 @@ pub struct DimensionScore {
     pub score: f64,
     #[serde(default)]
     pub weight: f64,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub evidence: Vec<String>,
-    #[serde(default = "default_dimension_trend")]
+    #[serde(
+        default = "default_dimension_trend",
+        deserialize_with = "deserialize_stringish_default"
+    )]
     pub trend: String,
 }
 
@@ -646,13 +727,19 @@ pub struct CadenceAssessment {
     /// Meetings per month (30d rolling average).
     pub meetings_per_month: Option<f64>,
     /// Trend: "increasing" | "stable" | "declining" | "erratic"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub trend: Option<String>,
     /// Days since last meeting.
     pub days_since_last: Option<u32>,
     /// Assessment: "healthy" | "adequate" | "sparse" | "cold"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub assessment: Option<String>,
     /// Evidence strings for transparency.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub evidence: Vec<String>,
 }
 
@@ -661,13 +748,20 @@ pub struct CadenceAssessment {
 #[serde(rename_all = "camelCase")]
 pub struct ResponsivenessAssessment {
     /// Trend in reply cadence: "improving" | "stable" | "slowing" | "gone_quiet"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub trend: Option<String>,
     /// Volume trend: "increasing" | "stable" | "decreasing"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub volume_trend: Option<String>,
     /// Assessment: "responsive" | "normal" | "slow" | "unresponsive"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub assessment: Option<String>,
     /// Evidence strings.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub evidence: Vec<String>,
 }
 
@@ -749,24 +843,43 @@ pub struct ExpansionSignal {
 #[serde(rename_all = "camelCase")]
 pub struct AgreementOutlook {
     /// high | moderate | low — AI-assessed confidence in successful renewal.
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub confidence: Option<String>,
     /// Specific risk factors for THIS renewal.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub risk_factors: Vec<String>,
     /// Is there upsell/expansion potential tied to the renewal conversation?
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub expansion_potential: Option<String>,
     /// One-paragraph editorial read on the renewal — rendered as a
     /// pull-quote below the outlook grid. Distinct from `expansion_potential`.
     /// The AI emits this from the commercial_financial dimension prompt.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_stringish",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub renewal_narrative: Option<String>,
     /// When to start the renewal conversation.
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub recommended_start: Option<String>,
     /// What strengthens our position.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub negotiation_leverage: Vec<String>,
     /// What weakens our position.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub negotiation_risk: Vec<String>,
     /// Peer-cohort renewal benchmark for the Outlook panel's
     /// Benchmark cell. Optional — the cell collapses to the 2-col layout
@@ -823,12 +936,15 @@ pub struct SupportHealth {
     /// Tickets with severity P1/P2.
     pub critical_tickets: Option<u32>,
     /// Average resolution time (hours or days).
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub avg_resolution_time: Option<String>,
     /// Trend: "improving" | "stable" | "degrading"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub trend: Option<String>,
     /// CSAT score if available (0-100).
     pub csat: Option<f64>,
     /// Source: "glean_zendesk" | "glean_intercom" | etc.
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub source: Option<String>,
 }
 
@@ -839,13 +955,20 @@ pub struct AdoptionSignals {
     /// Active users / licensed users ratio (0.0-1.0).
     pub adoption_rate: Option<f64>,
     /// Trend: "growing" | "stable" | "declining"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub trend: Option<String>,
     /// Key features adopted or not adopted.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringish_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub feature_adoption: Vec<String>,
     /// Last login or usage date (ISO).
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub last_active: Option<String>,
     /// Source: "glean" | "product_data"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub source: Option<String>,
 }
 
@@ -858,10 +981,13 @@ pub struct SatisfactionData {
     /// CSAT score (0-100).
     pub csat: Option<f64>,
     /// Survey date (ISO).
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub survey_date: Option<String>,
     /// Verbatim feedback if available.
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub verbatim: Option<String>,
     /// Source: "glean" | "survey_tool"
+    #[serde(default, deserialize_with = "deserialize_optional_stringish")]
     pub source: Option<String>,
 }
 

--- a/src-tauri/src/intelligence/prompts.rs
+++ b/src-tauri/src/intelligence/prompts.rs
@@ -2265,6 +2265,7 @@ fn build_intelligence_prompt_inner(
     prompt.push_str(&format!(
         "Return ONLY a JSON object — no other text before or after.\n\
          The JSON must conform exactly to this schema:\n\n\
+         Use the exact camelCase field names and value types shown below. Do not use snake_case, renamed fields, or object values where the schema shows strings.\n\n\
          ```json\n\
          {{\n\
            \"executiveAssessment\": \"2-4 paragraphs separated by \\\\n\\\\n. \
@@ -2631,7 +2632,7 @@ struct AiIntelResponse {
     #[serde(default)]
     success_plan_signals: Option<crate::types::SuccessPlanSignals>,
     /// AI-recommended actions from intelligence enrichment.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_recommended_actions")]
     recommended_actions: Vec<super::io::RecommendedAction>,
 }
 
@@ -2700,6 +2701,7 @@ struct AiSuccessMetric {
 struct AiOpenCommitment {
     #[serde(default)]
     commitment_id: Option<String>,
+    #[serde(default)]
     description: String,
     #[serde(default)]
     owner: Option<String>,
@@ -2799,6 +2801,7 @@ struct AiPortfolioHotspot {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AiRisk {
+    #[serde(default)]
     text: String,
     #[serde(default)]
     source: Option<String>,
@@ -2822,6 +2825,7 @@ struct AiRisk {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AiWin {
+    #[serde(default)]
     text: String,
     #[serde(default)]
     source: Option<String>,
@@ -2847,6 +2851,7 @@ struct AiCurrentState {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AiStakeholder {
+    #[serde(default)]
     name: String,
     #[serde(default)]
     role: Option<String>,
@@ -2873,6 +2878,7 @@ struct AiStakeholder {
 struct AiValue {
     #[serde(default)]
     date: Option<String>,
+    #[serde(default)]
     statement: String,
     #[serde(default)]
     source: Option<String>,
@@ -2923,6 +2929,100 @@ where
             }
         }),
     )
+}
+
+fn deserialize_recommended_actions<'de, D>(
+    deserializer: D,
+) -> Result<Vec<super::io::RecommendedAction>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(value
+        .as_ref()
+        .map(parse_recommended_actions_value)
+        .unwrap_or_default())
+}
+
+fn parse_recommended_actions_value(value: &serde_json::Value) -> Vec<super::io::RecommendedAction> {
+    value
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(parse_recommended_action_value)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_recommended_action_value(
+    value: &serde_json::Value,
+) -> Option<super::io::RecommendedAction> {
+    if let Ok(action) = serde_json::from_value::<super::io::RecommendedAction>(value.clone()) {
+        if !action.title.trim().is_empty() {
+            return Some(action);
+        }
+    }
+
+    if let Some(title) = stringish_value(value) {
+        return Some(super::io::RecommendedAction {
+            title,
+            rationale: "Recommended from current intelligence signals.".to_string(),
+            priority: 3,
+            suggested_due: None,
+        });
+    }
+
+    let obj = value.as_object()?;
+    let title = first_stringish_field(obj, &["title", "action", "text", "description"])?;
+    let rationale = first_stringish_field(obj, &["rationale", "why", "evidence", "context"])
+        .unwrap_or_else(|| "Recommended from current intelligence signals.".to_string());
+    let priority = obj
+        .get("priority")
+        .and_then(|value| {
+            value
+                .as_i64()
+                .and_then(|n| i32::try_from(n).ok())
+                .or_else(|| value.as_str().and_then(|s| s.trim().parse::<i32>().ok()))
+        })
+        .unwrap_or(3);
+    let suggested_due = first_stringish_field(obj, &["suggestedDue", "suggested_due", "dueDate"]);
+
+    Some(super::io::RecommendedAction {
+        title,
+        rationale,
+        priority,
+        suggested_due,
+    })
+}
+
+fn first_stringish_field(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| obj.get(*key))
+        .find_map(stringish_value)
+}
+
+fn stringish_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Object(obj) => {
+            first_stringish_field(obj, &["text", "title", "action", "description", "summary"])
+        }
+        _ => None,
+    }
 }
 
 fn deserialize_optional_product_classification<'de, D>(
@@ -3120,26 +3220,39 @@ pub fn parse_intelligence_response(
     source_file_count: usize,
     manifest: Vec<SourceManifestEntry>,
 ) -> Result<IntelligenceJson, String> {
-    // Try JSON first (includes validation + anomaly detection)
-    let mut intel = if let Some(parsed) = try_parse_json_response(
+    // Try JSON first (includes validation + anomaly detection).
+    //
+    // Three outcomes:
+    // - Ok(Some(intel))  → JSON path succeeded.
+    // - Err(msg)         → JSON was found but failed validation or
+    //                      deserialization. Propagate the real error so the
+    //                      per-dimension failure message names the actual
+    //                      cause instead of falling through to the pipe parser
+    //                      and emitting a misleading "No INTELLIGENCE block"
+    //                      message.
+    // - Ok(None)         → No JSON object in the response at all. Legitimate
+    //                      fall-through to the pipe-delimited parser.
+    let mut intel = match try_parse_json_response(
         response,
         entity_id,
         entity_type,
         source_file_count,
         &manifest,
     ) {
-        parsed
-    } else {
-        // Fall back to pipe-delimited format (backwards compat).
-        // Run anomaly detection on the raw response even for non-JSON.
-        crate::intelligence::validation::check_anomalies_public(response);
-        parse_pipe_delimited_response(
-            response,
-            entity_id,
-            entity_type,
-            source_file_count,
-            manifest,
-        )?
+        Ok(Some(parsed)) => parsed,
+        Err(msg) => return Err(msg),
+        Ok(None) => {
+            // Fall back to pipe-delimited format (backwards compat).
+            // Run anomaly detection on the raw response even for non-JSON.
+            crate::intelligence::validation::check_anomalies_public(response);
+            parse_pipe_delimited_response(
+                response,
+                entity_id,
+                entity_type,
+                source_file_count,
+                manifest,
+            )?
+        }
     };
 
     // Cap array sizes to prevent oversized output
@@ -3325,23 +3438,21 @@ fn extract_balanced_json_object(candidate: &str) -> Option<&str> {
     None
 }
 
-fn response_refreshed_fields(json_str: &str) -> Vec<String> {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) else {
-        return Vec::new();
-    };
+fn response_refreshed_fields(value: &serde_json::Value) -> Vec<String> {
     let Some(object) = value.as_object() else {
         return Vec::new();
     };
 
     object
         .keys()
-        .filter_map(|key| canonical_response_field_name(key))
+        .filter_map(|key| refreshed_field_root(key))
         .map(ToOwned::to_owned)
         .collect()
 }
 
-fn canonical_response_field_name(field: &str) -> Option<&'static str> {
-    match field {
+fn refreshed_field_root(field: &str) -> Option<&'static str> {
+    let canonical = response_key_for_deserialization(field);
+    match canonical.as_str() {
         "executiveAssessment" => Some("executiveAssessment"),
         "pullQuote" => Some("pullQuote"),
         "health" | "healthScore" | "healthTrend" => Some("health"),
@@ -3358,27 +3469,123 @@ fn canonical_response_field_name(field: &str) -> Option<&'static str> {
         "blockers" => Some("blockers"),
         "contractContext" => Some("contractContext"),
         "expansionSignals" => Some("expansionSignals"),
-        "agreementOutlook" | "renewalOutlook" | "renewal_outlook" => Some("agreementOutlook"),
+        "agreementOutlook" => Some("agreementOutlook"),
         "valueDelivered" => Some("valueDelivered"),
         "successMetrics" => Some("successMetrics"),
         "openCommitments" => Some("openCommitments"),
         "stakeholderInsights" => Some("stakeholderInsights"),
         "companyContext" => Some("companyContext"),
         "gongCallSummaries" => Some("gongCallSummaries"),
+        "coverageAssessment" => Some("coverageAssessment"),
+        "relationshipDepth" => Some("relationshipDepth"),
+        "meetingCadence" => Some("meetingCadence"),
+        "emailResponsiveness" => Some("emailResponsiveness"),
+        "productClassification" => Some("productClassification"),
+        "supportHealth" => Some("supportHealth"),
+        "productAdoption" => Some("productAdoption"),
+        "npsCsat" => Some("npsCsat"),
+        "sourceAttribution" => Some("sourceAttribution"),
+        "successPlanSignals" => Some("successPlanSignals"),
+        "nextMeetingReadiness" => Some("nextMeetingReadiness"),
         _ => None,
     }
 }
 
-/// Try to parse the response as JSON format. Returns None if it fails.
+fn normalize_ai_response_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut normalized = serde_json::Map::with_capacity(map.len());
+            for (key, value) in map {
+                let normalized_key = response_key_for_deserialization(&key);
+                normalized.insert(normalized_key, normalize_ai_response_value(value));
+            }
+            serde_json::Value::Object(normalized)
+        }
+        serde_json::Value::Array(values) => serde_json::Value::Array(
+            values
+                .into_iter()
+                .map(normalize_ai_response_value)
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn response_key_for_deserialization(field: &str) -> String {
+    let normalized = field
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect::<String>();
+
+    match normalized.as_str() {
+        "renewaloutlook" => "agreementOutlook".to_string(),
+        "meetingcadenceassessment" => "meetingCadence".to_string(),
+        "orgchartchanges" | "rolechanges" => "organizationalChanges".to_string(),
+        "commitments" => "openCommitments".to_string(),
+        "criticalissues" => "criticalTickets".to_string(),
+        "recenttrend" => "trend".to_string(),
+        "threat" => "threatLevel".to_string(),
+        "signal" => "opportunity".to_string(),
+        "oldstatus" => "from".to_string(),
+        "newstatus" => "to".to_string(),
+        "personname" => "person".to_string(),
+        "ownedby" => "ownedBy".to_string(),
+        _ if field.contains('_') || field.contains('-') || field.contains(' ') => {
+            lower_camel_key(field)
+        }
+        _ => lower_initial(field),
+    }
+}
+
+fn lower_camel_key(field: &str) -> String {
+    let mut parts = field
+        .split(|ch: char| ch == '_' || ch == '-' || ch.is_ascii_whitespace())
+        .filter(|part| !part.is_empty());
+    let Some(first) = parts.next() else {
+        return String::new();
+    };
+    let mut out = first.to_ascii_lowercase();
+    for part in parts {
+        let mut chars = part.chars();
+        if let Some(first_char) = chars.next() {
+            out.push(first_char.to_ascii_uppercase());
+            out.push_str(&chars.as_str().to_ascii_lowercase());
+        }
+    }
+    out
+}
+
+fn lower_initial(field: &str) -> String {
+    let mut chars = field.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let mut out = first.to_ascii_lowercase().to_string();
+    out.push_str(chars.as_str());
+    out
+}
+
+/// Try to parse the response as JSON format.
+///
+/// Returns:
+/// - `Ok(Some(intel))` when extraction, validation, and deserialization all succeed.
+/// - `Ok(None)` when no JSON object is found in the response. Caller should
+///   legitimately fall through to the pipe-delimited parser.
+/// - `Err(msg)` when a JSON object IS extracted but fails validation or
+///   deserialization. Caller should propagate the error directly — falling
+///   through to the pipe parser would mask the real cause with a misleading
+///   "No INTELLIGENCE block or JSON found" message.
 fn try_parse_json_response(
     response: &str,
     entity_id: &str,
     entity_type: &str,
     source_file_count: usize,
     manifest: &[SourceManifestEntry],
-) -> Option<IntelligenceJson> {
-    let json_str = extract_json_from_response(response)?;
-    let refreshed_fields = response_refreshed_fields(json_str);
+) -> Result<Option<IntelligenceJson>, String> {
+    let Some(json_str) = extract_json_from_response(response) else {
+        return Ok(None);
+    };
 
     // Validate structure and run anomaly detection before deserialization
     if let Err(e) = super::validation::validate_intelligence_response(json_str) {
@@ -3387,10 +3594,24 @@ fn try_parse_json_response(
             entity_id,
             e
         );
-        return None;
+        return Err(format!("validation: {}", e));
     }
 
-    let ai_resp: AiIntelResponse = match serde_json::from_str(json_str) {
+    let response_value: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(value) => value,
+        Err(e) => {
+            log::warn!(
+                "Intelligence response JSON parse failed for {}: {}",
+                entity_id,
+                e
+            );
+            return Err(format!("deserialize: {}", e));
+        }
+    };
+    let refreshed_fields = response_refreshed_fields(&response_value);
+    let normalized_response = normalize_ai_response_value(response_value);
+
+    let ai_resp: AiIntelResponse = match serde_json::from_value(normalized_response) {
         Ok(parsed) => parsed,
         Err(e) => {
             log::warn!(
@@ -3398,7 +3619,7 @@ fn try_parse_json_response(
                 entity_id,
                 e
             );
-            return None;
+            return Err(format!("deserialize: {}", e));
         }
     };
 
@@ -3445,7 +3666,7 @@ fn try_parse_json_response(
         portfolio_narrative: p.portfolio_narrative,
     });
 
-    Some(IntelligenceJson {
+    Ok(Some(IntelligenceJson {
         executive_assessment_render_policy: None,
         version: 1,
         entity_id: entity_id.to_string(),
@@ -3459,6 +3680,7 @@ fn try_parse_json_response(
         risks: ai_resp
             .risks
             .into_iter()
+            .filter(|r| !r.text.trim().is_empty())
             .map(|r| IntelRisk {
                 render_policy: None,
                 claim_id: None,
@@ -3475,6 +3697,7 @@ fn try_parse_json_response(
         recent_wins: ai_resp
             .recent_wins
             .into_iter()
+            .filter(|w| !w.text.trim().is_empty())
             .map(|w| IntelWin {
                 render_policy: None,
                 claim_id: None,
@@ -3489,6 +3712,7 @@ fn try_parse_json_response(
         stakeholder_insights: ai_resp
             .stakeholder_insights
             .into_iter()
+            .filter(|s| !s.name.trim().is_empty())
             .map(|s| StakeholderInsight {
                 render_policy: None,
                 claim_id: None,
@@ -3509,6 +3733,7 @@ fn try_parse_json_response(
         value_delivered: ai_resp
             .value_delivered
             .into_iter()
+            .filter(|v| !v.statement.trim().is_empty())
             .map(|v| ValueItem {
                 render_policy: None,
                 claim_id: None,
@@ -3561,6 +3786,7 @@ fn try_parse_json_response(
         open_commitments: ai_resp.open_commitments.map(|commits| {
             commits
                 .into_iter()
+                .filter(|c| !c.description.trim().is_empty())
                 .map(|c| super::io::OpenCommitment {
                     commitment_id: c.commitment_id,
                     description: c.description,
@@ -3608,7 +3834,7 @@ fn try_parse_json_response(
         domains: Vec::new(),
         dismissed_items: Vec::new(),
         recommended_actions: ai_resp.recommended_actions,
-    })
+    }))
 }
 
 /// Parse legacy pipe-delimited format (backwards compatibility).
@@ -4490,6 +4716,190 @@ Some trailing text"#;
     }
 
     #[test]
+    fn test_parse_json_response_accepts_glean_case_and_shape_drift() {
+        let response = r#"{
+  "executive_assessment": "Brief.",
+  "meeting_cadence": {
+    "meetings_per_month": 1.5,
+    "trend": {"direction": "stable", "rationale": "regular calls"},
+    "days_since_last": 7,
+    "assessment": {"summary": "adequate"},
+    "evidence": [{"text": "weekly customer call"}]
+  },
+  "email_responsiveness": {
+    "trend": {"direction": "slowing"},
+    "volume_trend": "decreasing",
+    "assessment": "slow",
+    "evidence": [{"summary": "reply gaps increased"}]
+  },
+  "product_adoption": {
+    "adoption_rate": 0.42,
+    "trend": "stable",
+    "feature_adoption": [{"title": "workflow automation active"}],
+    "last_active": "2026-05-20"
+  },
+  "support_health": {
+    "open_tickets": 2,
+    "critical_tickets": 1,
+    "trend": {"direction": "degrading"},
+    "csat": 82.0
+  },
+  "nps_csat": {
+    "nps": 10,
+    "survey_date": "2026-05-01",
+    "verbatim": {"text": "service is improving"}
+  }
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("Glean field-name and simple shape drift should still parse");
+
+        assert_eq!(intel.executive_assessment.as_deref(), Some("Brief."));
+        assert_eq!(
+            intel.meeting_cadence.as_ref().unwrap().trend.as_deref(),
+            Some("stable")
+        );
+        assert_eq!(
+            intel
+                .email_responsiveness
+                .as_ref()
+                .unwrap()
+                .evidence
+                .first()
+                .map(String::as_str),
+            Some("reply gaps increased")
+        );
+        assert_eq!(
+            intel
+                .product_adoption
+                .as_ref()
+                .unwrap()
+                .feature_adoption
+                .first()
+                .map(String::as_str),
+            Some("workflow automation active")
+        );
+        assert_eq!(
+            intel.support_health.as_ref().unwrap().trend.as_deref(),
+            Some("degrading")
+        );
+        assert_eq!(
+            intel.nps_csat.as_ref().unwrap().verbatim.as_deref(),
+            Some("service is improving")
+        );
+        assert!(intel
+            .refreshed_fields
+            .contains(&"meetingCadence".to_string()));
+        assert!(intel
+            .refreshed_fields
+            .contains(&"productAdoption".to_string()));
+    }
+
+    #[test]
+    fn test_parse_json_response_propagates_schema_error() {
+        // JSON IS extractable (balanced `{...}`) but `risks` is a string
+        // where the schema expects an array. The lenient normalizer cannot
+        // resolve this, so deserialization fails. We must surface the real
+        // serde error, NOT collapse to the legacy pipe-parser's misleading
+        // "No INTELLIGENCE block or JSON found" message.
+        let response = r#"{"executiveAssessment":"Brief.","risks":"not an array"}"#;
+        let err = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect_err("malformed risks should propagate a real schema error");
+
+        assert!(
+            err.contains("deserialize") || err.contains("expected") || err.contains("sequence"),
+            "error should name the real cause, got: {}",
+            err
+        );
+        assert!(
+            !err.contains("No INTELLIGENCE block"),
+            "error must not collapse to the legacy fall-through message, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_parse_json_response_returns_none_when_no_json_present() {
+        // No `{` candidate in the response. The JSON path returns Ok(None)
+        // and the caller falls through to the pipe-delimited parser
+        // (which will then fail on its own terms, but legitimately).
+        let response = "raw prose with no json object at all";
+        let result = parse_intelligence_response(response, "account-1", "account", 1, vec![]);
+
+        // We don't care whether the pipe parser succeeds or fails here —
+        // only that we reached it. If we'd short-circuited with our new
+        // Err path, the error message would name a JSON stage (validation
+        // or deserialize). Any error message here should come from the
+        // pipe parser, not our JSON propagation.
+        if let Err(err) = result {
+            assert!(
+                !err.starts_with("validation:") && !err.starts_with("deserialize:"),
+                "no-JSON case must NOT surface a JSON-stage error; got: {}",
+                err
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_json_response_tolerates_action_string_and_object_shapes() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "health": {
+    "narrative": "Health needs attention.",
+    "recommendedActions": [
+      {"title": "Schedule renewal review", "rationale": "commercial timing is close"}
+    ]
+  },
+  "recommended_actions": ["Prepare stakeholder map"]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("Glean action shape drift should not reject the response");
+
+        assert_eq!(
+            intel
+                .health
+                .as_ref()
+                .unwrap()
+                .recommended_actions
+                .first()
+                .map(String::as_str),
+            Some("Schedule renewal review")
+        );
+        assert_eq!(intel.recommended_actions.len(), 1);
+        assert_eq!(
+            intel.recommended_actions[0].title,
+            "Prepare stakeholder map"
+        );
+        assert!(!intel.recommended_actions[0].rationale.is_empty());
+        assert!(intel
+            .refreshed_fields
+            .contains(&"recommendedActions".to_string()));
+    }
+
+    #[test]
+    fn test_parse_json_response_drops_blank_items_from_unrequested_arrays() {
+        let response = r#"{
+  "executiveAssessment": "Brief.",
+  "risks": [{"headline": "Risk without body"}],
+  "recentWins": [{"impact": "high"}],
+  "stakeholderInsights": [{"role": "VP Operations"}],
+  "valueDelivered": [{"source": "Glean"}],
+  "openCommitments": [{"owner": "us"}]
+}"#;
+
+        let intel = parse_intelligence_response(response, "account-1", "account", 1, vec![])
+            .expect("missing optional item text should not reject unrelated fields");
+
+        assert_eq!(intel.executive_assessment.as_deref(), Some("Brief."));
+        assert!(intel.risks.is_empty());
+        assert!(intel.recent_wins.is_empty());
+        assert!(intel.stakeholder_insights.is_empty());
+        assert!(intel.value_delivered.is_empty());
+        assert!(intel.open_commitments.unwrap().is_empty());
+    }
+
+    #[test]
     fn test_parse_json_response_raw_no_fence() {
         let response = r#"{"executiveAssessment": "Brief.", "risks": [{"text": "One risk", "urgency": "low"}]}"#;
 
@@ -4980,20 +5390,18 @@ mod eval_tests {
     fn eval_parse_malformed_response_graceful_handling() {
         let response = include_str!("fixtures/enrichment_response_malformed.json");
         // The malformed response has risks as a string instead of array.
-        // serde_json will fail to deserialize AiIntelResponse, so try_parse_json_response
-        // returns None, and it falls through to pipe-delimited parsing which also fails.
-        // Either way, the function should not panic.
+        // serde_json fails to deserialize AiIntelResponse, so
+        // try_parse_json_response now returns Err with the real serde
+        // message. parse_intelligence_response propagates that error and
+        // does NOT fall through to the pipe parser. The key assertion is:
+        // no panic, and graceful degradation if we somehow got Ok.
         let result = parse_intelligence_response(response, "bad-1", "account", 0, Vec::new());
-        // Malformed JSON with wrong types should either produce an error or degrade gracefully.
-        // The key assertion is: no panic.
         if let Ok(intel) = &result {
-            // If it somehow parsed (unlikely), verify it degraded gracefully
             assert!(
                 intel.risks.len() <= 1,
                 "Malformed risks should not produce valid entries"
             );
         }
-        // Either way, we got here without panicking — success
     }
 
     #[test]


### PR DESCRIPTION
## Linear ticket

n/a — spec-driven PR (no originating Linear issue). Spec lives at `.docs/plans/glean-ingestion-hardening-2026-05-28.md` in this PR. Path-α maintenance findings tracked separately: **DOS-817** (bound /tmp debug capture lifetime and size), **DOS-818** (de-duplicate `stringish_value` helper).

## Summary

Phase 1 of a deliberately bounded two-phase plan to fix Glean dimension parsing failures. Three changes that ship together; Phase 2 (PTY-repair shim vs producer/consumer rearchitecture) is explicitly deferred until ~1 week of real Glean traffic against the hardened parser tells us what shapes still fail.

## What changed

- **Lenient parsing layer** (`io.rs`, `prompts.rs`). Recursive key normalizer (snake_case / typos → canonical camelCase via fixed allowlist) and `stringish_value` coercion (objects-where-scalars-expected → scalar via known string-bearing inner keys). Previously-required `text`/`name`/`statement`/`description` fields defaulted with empty-text filtering so a missing field drops the item, not the whole array. Custom `deserialize_recommended_actions` accepting strings or objects. One-line "use exact camelCase" reminders in three prompt builders.
- **Error propagation** (`prompts.rs`). `try_parse_json_response` signature changes from `Option<IntelligenceJson>` to `Result<Option<IntelligenceJson>, String>`. The three states distinguish "no JSON at all" (`Ok(None)`, legitimate fall-through to pipe parser) from "JSON extracted but validation/deserialization failed" (`Err`, propagated directly). Per-dimension errors now name the real serde cause instead of collapsing to the misleading legacy `No INTELLIGENCE block or JSON found in response` message.
- **Per-dimension debug capture** (`glean_provider.rs`). Writes one file per dimension per refresh to `/tmp/dailyos-glean-{dim}-{ts}.txt` instead of overwriting a single fixed path with dimension #1. Forensic state preserved across parallel failures so the Phase 2 data collection actually produces signal.
- **Spec** (`.docs/plans/glean-ingestion-hardening-2026-05-28.md`).

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib intelligence::` passes (376 tests, 0 fail)
- [x] `pnpm tsc --noEmit` clean
- [x] Three target parser tests verified by name:
  - `test_parse_json_response_accepts_glean_case_and_shape_drift` (existing, lenient layer coverage)
  - `test_parse_json_response_propagates_schema_error` (new — proves misleading-error path is fixed)
  - `test_parse_json_response_returns_none_when_no_json_present` (new — proves legitimate fall-through still triggers)
- [ ] **Manual post-merge:** trigger an account Glean refresh and confirm `/tmp/dailyos-glean-*` contains one file per dimension (not just dimension #1).

## Definition of Done

- [x] Acceptance criteria from the spec are validated with real test runs (not stubs)
- [x] End-to-end flow works — parser path feeds existing claim writes; no new tables/columns/surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced — Phase 2 is explicitly out of scope with a documented trigger and decision criteria
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field is set false above): _none — security reviewer invoked_

**Exemption rationale**: n/a — `ce-security-reviewer` ran on the diff before push. Verdict: APPROVE.

Path-prefix checklist answers:

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`? — YES (`intelligence/`)
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

Only the first checkbox applies (touches `intelligence/`). `ce-security-reviewer` confirmed:

1. **Lenient parser cannot inject privileged fields.** `AiIntelResponse` and its leaves declare no `actor_id`, `sensitivity`, `render_policy`, or other privileged fields. Serde silently drops unknown keys (no `flatten`). Server-controlled fields (`render_policy: None`, `claim_id: None`, `version: 1`, `entity_id` from caller) are stamped post-parse regardless of LLM input.
2. **`stringish_value` object-drop** only invoked for fields declared `String`/`Option<String>`/`Vec<String>`. Dropped sibling keys would not have been deserialized anyway since the target struct doesn't declare them.
3. **Post-filter timing** — `.filter(|x| !x.text.trim().is_empty())` runs inside `try_parse_json_response` before any consumer sees the result. No privileged-action codepath sits between deserialize and filter.
4. **Error string propagation** — serde errors flow only to `log::warn` (file-local). The `failed_dims` collection at `glean_provider.rs:442` discards the error message and pushes only `dim_name`. Emitted `enrichment-glean-degraded` events and audit logs carry dimension names only, not serde error strings. No new UI exposure of source JSON snippets.
5. **No new trust boundary, MCP/tool surface, auth gate, or sensitivity tier.**

## Follow-ups

- DOS-817 — bound /tmp debug capture lifetime and size (env-gate + retention)
- DOS-818 — de-duplicate `stringish_value` helper between `prompts.rs` and `io.rs`
- Phase 2 decision after ~1 week of real Glean traffic (criteria in spec §Phase 2 trigger)

## Notes for review

L2 bounded review (codex via `l2-bounded-reviewer` agent) ran against the spec's acceptance criteria before push. Verdict: APPROVE. No BLOCK findings. Two MAINTENANCE findings filed separately to unblock per path-α policy (DOS-817, DOS-818). `L2-status: passed` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
