### PR TITLE
fix(briefing): skip non-customer-facing meetings in advisories (DOS-816)

### DIFF
--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
@@ -39,8 +39,8 @@ use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
 };
 use crate::services::context::{
-    DailyReadinessContextSnapshot, DailyReadinessMeetingSnapshot, MeetingPrepStatusReadError,
-    MeetingPrepStatusSnapshot,
+    is_customer_facing, DailyReadinessContextSnapshot, DailyReadinessMeetingSnapshot,
+    MeetingPrepStatusReadError, MeetingPrepStatusSnapshot,
 };
 use crate::types::{ClaimSensitivity, ClaimState};
 
@@ -125,22 +125,42 @@ pub async fn build_daily_briefing(
             .await
         {
             Ok(snapshot) => {
-                if prep_status_is_needs_preparation(&snapshot.status) {
+                // Only customer-facing meeting types drive the "needs prep"
+                // advisory. Internal syncs / 1:1s / team meetings legitimately
+                // have no prep doc; counting them inflates the strip and
+                // recreates the DOS-771 phantom-row shape one level up.
+                if prep_status_is_needs_preparation(&snapshot.status)
+                    && is_customer_facing(&meeting.meeting_type)
+                {
                     needs_prep_meeting_ids.push(snapshot.meeting_id.clone());
                 }
                 prep_snapshots.insert(meeting.id.clone(), snapshot);
             }
             Err(MeetingPrepStatusReadError::MeetingNotFound(_)) => {
                 // Meeting in readiness context but not in prep table → treat
-                // as NeedsPreparation; do NOT enqueue (AC-507.3).
-                needs_prep_meeting_ids.push(meeting.id.clone());
+                // as NeedsPreparation; do NOT enqueue (AC-507.3). Same
+                // customer-facing gate as the Ok branch.
+                if is_customer_facing(&meeting.meeting_type) {
+                    needs_prep_meeting_ids.push(meeting.id.clone());
+                }
             }
             Err(MeetingPrepStatusReadError::ReadFailed(message)) => {
                 prep_read_failures.push(message);
-                needs_prep_meeting_ids.push(meeting.id.clone());
+                if is_customer_facing(&meeting.meeting_type) {
+                    needs_prep_meeting_ids.push(meeting.id.clone());
+                }
             }
         }
     }
+
+    // Set of meeting IDs that are NOT customer-facing — passed to
+    // derive_advisories so its unlinked-meetings filter can skip internal
+    // / team-sync / 1:1 rows that legitimately have no customer entity.
+    let non_customer_meeting_ids: std::collections::HashSet<String> = meetings
+        .iter()
+        .filter(|m| !is_customer_facing(&m.meeting_type))
+        .map(|m| m.id.clone())
+        .collect();
 
     // ---- compose: meeting brief refs --------------------------------------
     let current_meeting = current_meeting_seed
@@ -222,6 +242,7 @@ pub async fn build_daily_briefing(
     let advisories = derive_advisories(
         &readiness,
         &expanded_meeting_refs,
+        &non_customer_meeting_ids,
         &prep_read_failures,
         &envelope_failures,
     );
@@ -671,6 +692,7 @@ fn ambiguity_pair_placeholder(a: &str, b: &str, reason: &str) -> AmbiguityPair {
 fn derive_advisories(
     readiness: &DailyReadinessContextSnapshot,
     meetings: &[MeetingBriefRef],
+    non_customer_meeting_ids: &std::collections::HashSet<String>,
     prep_read_failures: &[String],
     envelope_failures: &[String],
 ) -> Vec<BriefingAdvisory> {
@@ -678,6 +700,9 @@ fn derive_advisories(
     let unlinked = meetings
         .iter()
         .filter(|m| m.linked_entity_id.is_none())
+        // Internal / team-sync / 1:1 meetings have no customer entity by
+        // design — they shouldn't trip the "link N meetings" advisory.
+        .filter(|m| !non_customer_meeting_ids.contains(&m.meeting_id))
         .map(|m| m.meeting_id.clone())
         .collect::<Vec<_>>();
     if !unlinked.is_empty() {
@@ -1052,6 +1077,7 @@ mod state_matrix_fixtures {
             starts_at,
             ends_at: None,
             workspace_scope: "local".to_string(),
+            meeting_type: "customer".to_string(),
         }
     }
 
@@ -1066,6 +1092,7 @@ mod state_matrix_fixtures {
             starts_at: Some(starts_at.to_string()),
             ends_at: ends_at.map(str::to_string),
             workspace_scope: "local".to_string(),
+            meeting_type: "customer".to_string(),
         }
     }
 
@@ -1432,5 +1459,125 @@ mod state_matrix_fixtures {
         assert_eq!(parse_entity_kind("person"), Some(EntityKind::Person));
         assert!(parse_entity_kind("meeting").is_none());
         assert!(parse_entity_kind("").is_none());
+    }
+
+    /// DOS-816 regression: internal / team-sync / 1:1 meetings must NOT trip
+    /// the "Link N meetings" unlinked-meetings advisory. Customer-facing rows
+    /// continue to advisory normally.
+    #[test]
+    fn derive_advisories_skips_non_customer_facing_meetings() {
+        let readiness = DailyReadinessContextSnapshot {
+            workspace_scope: "local".to_string(),
+            date: "2026-05-28".to_string(),
+            meetings: Vec::new(),
+            tracked_subjects: Vec::new(),
+            overnight_changes: Vec::new(),
+            risk_shifts: Vec::new(),
+            open_loops: Vec::new(),
+            coverage_warnings: Vec::new(),
+        };
+        let meetings = vec![
+            // 4 internal, 1 customer — none has linked_entity_id
+            meeting_brief_unlinked("m-internal-1"),
+            meeting_brief_unlinked("m-internal-2"),
+            meeting_brief_unlinked("m-internal-3"),
+            meeting_brief_unlinked("m-internal-4"),
+            meeting_brief_unlinked("m-customer-1"),
+        ];
+        let non_customer: std::collections::HashSet<String> = [
+            "m-internal-1",
+            "m-internal-2",
+            "m-internal-3",
+            "m-internal-4",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let advisories = derive_advisories(&readiness, &meetings, &non_customer, &[], &[]);
+
+        // Only the customer meeting should appear in the unlinked advisory.
+        // Pre-fix this would have produced "Link 5 meetings" — DOS-816 shape.
+        let unlinked_ids: Vec<&str> = advisories
+            .iter()
+            .find_map(|a| match a {
+                BriefingAdvisory::UnlinkedMeetings { meeting_ids } => {
+                    Some(meeting_ids.iter().map(String::as_str).collect())
+                }
+                _ => None,
+            })
+            .expect("UnlinkedMeetings advisory present");
+        assert_eq!(unlinked_ids, vec!["m-customer-1"]);
+    }
+
+    /// DOS-816 regression: when every meeting is internal, no
+    /// UnlinkedMeetings advisory should fire at all.
+    #[test]
+    fn derive_advisories_emits_no_unlinked_advisory_when_all_internal() {
+        let readiness = DailyReadinessContextSnapshot {
+            workspace_scope: "local".to_string(),
+            date: "2026-05-28".to_string(),
+            meetings: Vec::new(),
+            tracked_subjects: Vec::new(),
+            overnight_changes: Vec::new(),
+            risk_shifts: Vec::new(),
+            open_loops: Vec::new(),
+            coverage_warnings: Vec::new(),
+        };
+        let meetings = vec![
+            meeting_brief_unlinked("m-internal-1"),
+            meeting_brief_unlinked("m-internal-2"),
+        ];
+        let non_customer: std::collections::HashSet<String> =
+            ["m-internal-1", "m-internal-2"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+
+        let advisories = derive_advisories(&readiness, &meetings, &non_customer, &[], &[]);
+
+        let has_unlinked = advisories
+            .iter()
+            .any(|a| matches!(a, BriefingAdvisory::UnlinkedMeetings { .. }));
+        assert!(
+            !has_unlinked,
+            "internal-only day must not emit UnlinkedMeetings advisory; got {:?}",
+            advisories
+        );
+    }
+
+    fn meeting_brief_unlinked(id: &str) -> MeetingBriefRef {
+        MeetingBriefRef {
+            meeting_id: id.to_string(),
+            title: Some(id.to_string()),
+            starts_at: Some("2026-05-28T10:00:00Z".to_string()),
+            ends_at: Some("2026-05-28T10:30:00Z".to_string()),
+            linked_entity_type: None,
+            linked_entity_id: None,
+            prep_status: "prep_needed".to_string(),
+            blocking_reason: None,
+            stale_reason: None,
+            last_prepared_at: None,
+        }
+    }
+
+    #[test]
+    fn is_customer_facing_recognizes_canonical_set() {
+        for ty in ["customer", "qbr", "partnership", "external"] {
+            assert!(is_customer_facing(ty), "{ty} should be customer-facing");
+        }
+        for ty in [
+            "internal",
+            "team_sync",
+            "one_on_one",
+            "all_hands",
+            "training",
+            "personal",
+        ] {
+            assert!(
+                !is_customer_facing(ty),
+                "{ty} should not be customer-facing"
+            );
+        }
     }
 }

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
@@ -128,7 +128,8 @@ pub async fn build_daily_briefing(
                 // Only customer-facing meeting types drive the "needs prep"
                 // advisory. Internal syncs / 1:1s / team meetings legitimately
                 // have no prep doc; counting them inflates the strip and
-                // recreates the DOS-771 phantom-row shape one level up.
+                // recreates the phantom-row shape one level up from the
+                // projection-layer filter.
                 if prep_status_is_needs_preparation(&snapshot.status)
                     && is_customer_facing(&meeting.meeting_type)
                 {
@@ -1461,8 +1462,8 @@ mod state_matrix_fixtures {
         assert!(parse_entity_kind("").is_none());
     }
 
-    /// DOS-816 regression: internal / team-sync / 1:1 meetings must NOT trip
-    /// the "Link N meetings" unlinked-meetings advisory. Customer-facing rows
+    /// Regression: internal / team-sync / 1:1 meetings must NOT trip the
+    /// "Link N meetings" unlinked-meetings advisory. Customer-facing rows
     /// continue to advisory normally.
     #[test]
     fn derive_advisories_skips_non_customer_facing_meetings() {
@@ -1497,7 +1498,7 @@ mod state_matrix_fixtures {
         let advisories = derive_advisories(&readiness, &meetings, &non_customer, &[], &[]);
 
         // Only the customer meeting should appear in the unlinked advisory.
-        // Pre-fix this would have produced "Link 5 meetings" — DOS-816 shape.
+        // Pre-fix this would have produced "Link 5 meetings" — the bug shape.
         let unlinked_ids: Vec<&str> = advisories
             .iter()
             .find_map(|a| match a {
@@ -1510,8 +1511,8 @@ mod state_matrix_fixtures {
         assert_eq!(unlinked_ids, vec!["m-customer-1"]);
     }
 
-    /// DOS-816 regression: when every meeting is internal, no
-    /// UnlinkedMeetings advisory should fire at all.
+    /// Regression: when every meeting is internal, no UnlinkedMeetings
+    /// advisory should fire at all.
     #[test]
     fn derive_advisories_emits_no_unlinked_advisory_when_all_internal() {
         let readiness = DailyReadinessContextSnapshot {

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -1617,6 +1617,11 @@ pub struct DailyReadinessMeetingSnapshot {
     pub starts_at: Option<String>,
     pub ends_at: Option<String>,
     pub workspace_scope: String,
+    /// Lower-snake_case meeting_type discriminant (`customer`, `qbr`,
+    /// `partnership`, `external`, `internal`, `team_sync`, `one_on_one`,
+    /// `all_hands`, `training`). Consumers gate advisory-class logic on
+    /// `is_customer_facing` — surface display still iterates every row.
+    pub meeting_type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1700,6 +1705,18 @@ pub enum MeetingsViewIntent {
     Briefing,
     Schedule,
     AllRows,
+}
+
+/// Customer-facing meeting types — the ones that warrant prep documents and
+/// customer/account entity attribution. Internal team meetings stay in the
+/// schedule but should not drive `needs_prep` / `unlinked_meetings`
+/// advisories. Pure-function, no allocation; callers pass the snapshot's
+/// `meeting_type` discriminant directly.
+pub fn is_customer_facing(meeting_type: &str) -> bool {
+    matches!(
+        meeting_type,
+        "customer" | "qbr" | "partnership" | "external"
+    )
 }
 
 /// Narrow read handle for daily-readiness seed assembly. Ability code receives

--- a/src-tauri/src/services/meetings_view.rs
+++ b/src-tauri/src/services/meetings_view.rs
@@ -35,7 +35,7 @@ use crate::helpers::today_meeting_filter_for_date;
 // wrap it in a newtype with a phantom intent tag so the projection invariant
 // is compile-time.
 pub use abilities_runtime::services::context::{
-    DailyReadinessMeetingSnapshot as SurfaceMeeting, MeetingsViewIntent,
+    is_customer_facing, DailyReadinessMeetingSnapshot as SurfaceMeeting, MeetingsViewIntent,
 };
 
 /// Surface-relevant meetings for one local day, filtered to the rows the
@@ -64,29 +64,28 @@ pub fn read_surface_meetings(
     let rows = stmt
         .query_map(rusqlite::params![window.utc_start, window.utc_end], |row| {
             let meeting_type: String = row.get(4)?;
-            Ok((
-                SurfaceMeeting {
-                    id: row.get(0)?,
-                    title: row.get(1)?,
-                    starts_at: row.get(2)?,
-                    ends_at: row.get(3)?,
-                    workspace_scope: workspace_scope.to_string(),
-                },
+            Ok(SurfaceMeeting {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                starts_at: row.get(2)?,
+                ends_at: row.get(3)?,
+                workspace_scope: workspace_scope.to_string(),
                 meeting_type,
-            ))
+            })
         })
         .map_err(|error| error.to_string())?;
 
     let mut out = Vec::new();
     for row in rows {
-        let (meeting, meeting_type) = row.map_err(|error| error.to_string())?;
-        if !intent_includes(intent, &meeting_type) {
+        let meeting = row.map_err(|error| error.to_string())?;
+        if !intent_includes(intent, &meeting.meeting_type) {
             continue;
         }
         out.push(meeting);
     }
     Ok(out)
 }
+
 
 fn intent_includes(intent: MeetingsViewIntent, meeting_type: &str) -> bool {
     match intent {

--- a/src-tauri/tests/w5_a_get_daily_readiness_test.rs
+++ b/src-tauri/tests/w5_a_get_daily_readiness_test.rs
@@ -684,6 +684,7 @@ fn meeting(workspace_scope: &str, id: &str, title: &str) -> DailyReadinessMeetin
         starts_at: Some("2026-05-14T14:00:00Z".to_string()),
         ends_at: Some("2026-05-14T14:30:00Z".to_string()),
         workspace_scope: workspace_scope.to_string(),
+        meeting_type: "customer".to_string(),
     }
 }
 


### PR DESCRIPTION
## Linear ticket

[DOS-816](https://linear.app/a8c/issue/DOS-816) — sibling of [DOS-771](https://linear.app/a8c/issue/DOS-771). Parent wave: [DOS-773](https://linear.app/a8c/issue/DOS-773).

## Summary

Internal meetings (team_sync / one_on_one / all_hands / training / internal) were counted by the briefing producer's `needs_prep` and `unlinked_meetings` advisories. Lane A's projection correctly let them through for schedule display, but the producer treated all surface-relevant rows as advisory-worthy. James observed "5 BRIEFINGS NEED PREP" + "Link 2 meetings" on a day with 4 internal + 1 other meeting — the bug class one level up from DOS-771.

The fix gates the two advisory loops on `is_customer_facing(meeting_type)`. Customer-facing = customer / qbr / partnership / external. Internal types stay in the schedule but no longer trip advisories.

## What changed

- `DailyReadinessMeetingSnapshot` (in `abilities-runtime/services/context.rs`) gains `meeting_type: String`. Populated by `read_surface_meetings` from the existing SELECT column index 4.
- New `is_customer_facing(meeting_type)` helper next to `MeetingsViewIntent` in the same module. `services::meetings_view` re-exports it for symmetry with `MeetingsViewIntent`.
- Producer's `needs_prep_meeting_ids` loop (`producer.rs:118-180`): each push gated on `is_customer_facing(&meeting.meeting_type)` across all 3 outcome branches (Ok / `MeetingNotFound` / `ReadFailed`). AC-507.3 no-enqueue contract preserved.
- Producer pre-computes `non_customer_meeting_ids: HashSet<String>` and threads it into `derive_advisories`, which filters the unlinked list to customer-facing rows only. `MeetingBriefRef`'s wire shape unchanged — the filter happens via side-data.

## Test plan

- [x] `cargo clippy -- -D warnings` clean (no new warnings in diff'd files)
- [x] `cargo test -p abilities-runtime --lib` — 20/20 producer tests pass including 3 new regression tests
- [x] `cargo test --lib services::meetings_view` — 3/3 (Lane A meetings_view tests still green)
- [x] `cargo test --lib personal_blocks_excluded` — 1/1 (Lane A regression still green)
- [x] `cargo test --test w5_a_get_daily_readiness_test` — 6/6
- [x] `pnpm tsc --noEmit` clean
- [x] L2 unanimous APPROVE — l2-bounded-reviewer (AC-scoped); no maintenance findings filed because none surfaced from this diff
- [ ] L4: James verifies on a 4-internal-1-customer day → strip shows accurate advisory counts (0 needs_prep, customer-only unlinked if any)

## Definition of Done

- [x] AC-1 — `DailyReadinessMeetingSnapshot.meeting_type` shipped + populated
- [x] AC-2 — `needs_prep_meeting_ids` loop skips non-customer-facing
- [x] AC-3 — `derive_advisories` unlinked filter skips non-customer-facing
- [x] AC-4 — Regression tests (3 new) pass
- [x] AC-5 — clippy + cargo test + tsc clean
- [ ] AC-6 — L4 live verification (pending merge)

## §4 Security

`security_auditor_invoked: true`

**Exemption ID**: _none_

**Exemption rationale**: _n/a_

- [x] Touches `src-tauri/src/services/` + `abilities-runtime/services/`?
- [ ] Modifies `.sql` migrations / `migrations.rs` / `migrations/`?
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs, tool registry, or skill definitions?
- [ ] Adds a new trust boundary?
- [ ] Defines a privileged action?
- [ ] Adds or modifies `.github/workflows/*`?
- [ ] Adds a new dependency?

Read-side filter on already-projected data; no new auth/scope surface. Local-to-local single-user threat topology. L2-bounded reviewer surfaced no security concerns.

## Notes for review

- The filter is the same conceptual cut as Lane A's `meeting_type = 'personal'` exclusion, just at the advisory layer rather than the projection layer. Three questions the producer was conflating:
  1. Is this meeting on my calendar today? → all non-personal/non-cancelled/non-all-day (Lane A is correct)
  2. Does this meeting need a prep doc? → customer-facing only (this PR)
  3. Does this meeting need entity linkage to make sense? → customer-facing only (this PR)
- `MeetingBriefRef` wire shape intentionally unchanged. The producer carries the customer-facing classification via a `HashSet<String>` side-channel into `derive_advisories`. Avoids a JSON-contract change on the briefing output.
- Customer-facing canonical set pinned by `is_customer_facing_recognizes_canonical_set` test: `customer | qbr | partnership | external` IN; `internal | team_sync | one_on_one | all_hands | training | personal` OUT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)