### PR TITLE
chore(pr-template): remove inline literal that trips validator ambiguity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,7 @@
 
 <!-- If false, cite the exemption ID and rationale. -->
 
-**Exemption ID** (if `security_auditor_invoked: false`): `EXEMPT-DOC-ONLY` | `EXEMPT-TEST-FIXTURE` | `EXEMPT-RENAME-NON-SENSITIVE` | `EXEMPT-STYLE` | _none_
+**Exemption ID** (when the field above is set false): `EXEMPT-DOC-ONLY` | `EXEMPT-TEST-FIXTURE` | `EXEMPT-RENAME-NON-SENSITIVE` | `EXEMPT-STYLE` | _none_
 
 **Exemption rationale**:
 


### PR DESCRIPTION
## Linear ticket

n/a — discovered while shipping PR #412. Authors who set the §4 Security field to true and leave the template's exemption-ID guidance line intact trip the validator's "ambiguous" branch because it sees two distinct values.

## Summary

One-line prose fix to `.github/pull_request_template.md` removing an inline literal that's bait for the PR-template validator. No validator behavior change.

## What changed

- `.github/pull_request_template.md` line 49: rewrite the exemption-ID guidance to refer to the field without re-citing it with a literal value. Old text: `(if [field]: false)`. New text: `(when the field above is set false)`.

## Test plan

- [x] No code changes — docs-only.
- [x] Diff reviewed: one line.
- [ ] **Manual verification post-merge:** open a fresh PR using the template, set the §4 field to true, do not modify the exemption-ID line, confirm validator passes.

## Definition of Done

- [x] Pure prose change to the PR template; no behavioral or schema impact.
- [x] Tests pass: n/a — no code.

## §4 Security

security_auditor_invoked: true

**Exemption ID** (when the security field above is set false): _none — security reviewer invoked_

**Exemption rationale**: n/a — path-prefix override fires (`.github/pull_request_template.md` is in the security-auditor `when_changed` list under "Workflow / governance"). `ce-security-reviewer` ran on the diff. Verdict: APPROVE. Findings: none. The change preserves all security guidance and enables no bypass — the validator behavior is unchanged; the template just no longer baits authors into ambiguous matches.

Path-prefix checklist:

- [ ] Touches src-tauri/src/services/, abilities/, bridges/, commands/, or intelligence/?
- [ ] Modifies .sql migrations or migrations.rs?
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template?
- [ ] Modifies sensitivity, render_policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs or skill definitions?
- [ ] Adds a new trust boundary?
- [ ] Defines a privileged action?
- [ ] Adds or modifies .github/workflows/* with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency?

## Follow-ups

- None. Optional future hardening: extend `.github/scripts/validate-pr-template.py` to skip matches inside inline backticks, so future template prose drift can't reintroduce this trap. Out of scope here.

## Notes for review

Discovered while shipping PR #412 (Glean ingestion hardening). After adding the security field set to true on that PR's body, the validator failed with "multiple distinct values" because the template's exemption-ID guidance line counted as a second match. This PR fixes the template; PR #412 worked around it by rewriting the literal in its own body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

