### PR TITLE
feat(db): DB-mode isolation safety core — fail-closed default + structural prod-open deny (DOS-821 / 820-A)

### DIFF
--- a/.docs/plans/v1.4.9-replica-db-l0-plan.html
+++ b/.docs/plans/v1.4.9-replica-db-l0-plan.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>DB Mode Isolation (DOS-820) · DailyOS L0 Plan</title>
+  <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/AtmosphereLayer.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/styles/MagazinePageLayout.module.css">
+  <link rel="stylesheet" href="../design/reference/_shared/chrome.css">
+  <link rel="stylesheet" href="plans.css">
+  <style>
+    /* TODO(ds): needs pattern — verdict banner for L0/review outcomes */
+    .verdict-banner {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-md);
+      align-items: center;
+      margin: var(--space-lg) 0;
+      padding: var(--space-md) var(--space-lg);
+      background: var(--color-paper-warm-white);
+      border: 1px solid var(--color-rule-heavy);
+      border-left: 4px solid var(--color-garden-sage);
+      border-radius: 6px;
+      font-family: var(--font-sans);
+      font-size: 13px;
+      color: var(--color-text-secondary);
+    }
+    .verdict-banner strong { color: var(--color-text-primary); }
+    .verdict-pill {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 3px 8px;
+      border-radius: 3px;
+      background: var(--color-garden-sage);
+      color: #fff;
+    }
+
+    /* TODO(ds): needs pattern — blocker / finding table */
+    .l0-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: var(--space-lg) 0;
+      font-family: var(--font-sans);
+      font-size: 13px;
+      background: var(--color-paper-warm-white);
+      border: 1px solid var(--color-rule-heavy);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .l0-table th {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--color-text-tertiary);
+      padding: var(--space-md) var(--space-lg);
+      text-align: left;
+      background: var(--color-paper-linen);
+      border-bottom: 1px solid var(--color-rule-heavy);
+      vertical-align: top;
+    }
+    .l0-table td {
+      padding: var(--space-md) var(--space-lg);
+      border-bottom: 1px solid var(--color-rule-light);
+      vertical-align: top;
+      line-height: 1.5;
+      color: var(--color-text-secondary);
+    }
+    .l0-table tbody tr:last-child td { border-bottom: none; }
+    .l0-table td:first-child {
+      font-family: var(--font-mono);
+      font-weight: 700;
+      color: var(--color-text-primary);
+      white-space: nowrap;
+    }
+    .l0-table td code, .l0-table th code {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      background: rgba(0, 0, 0, 0.04);
+      padding: 1px 4px;
+      border-radius: 2px;
+    }
+    .l0-table tr[data-sev="blocker"] td:first-child { border-left: 3px solid var(--color-spice-terracotta); padding-left: calc(var(--space-lg) - 3px); }
+    .l0-table tr[data-sev="sharpen"] td:first-child { border-left: 3px solid var(--color-spice-saffron); padding-left: calc(var(--space-lg) - 3px); }
+
+    /* TODO(ds): needs pattern — per-mode policy matrix (Live/Replica/Mock columns) */
+    .mode-matrix { width: 100%; border-collapse: collapse; margin: var(--space-lg) 0; font-family: var(--font-sans); font-size: 12.5px; background: var(--color-paper-warm-white); border: 1px solid var(--color-rule-heavy); border-radius: 6px; overflow: hidden; }
+    .mode-matrix th, .mode-matrix td { padding: var(--space-sm) var(--space-md); text-align: left; border-bottom: 1px solid var(--color-rule-light); vertical-align: top; line-height: 1.45; }
+    .mode-matrix thead th { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-text-tertiary); background: var(--color-paper-linen); border-bottom: 1px solid var(--color-rule-heavy); }
+    .mode-matrix tbody th { font-family: var(--font-mono); font-size: 11px; font-weight: 700; color: var(--color-text-primary); background: var(--color-paper-warm-white); white-space: nowrap; }
+    .mode-matrix col.col-live { background: rgba(0,0,0,0.015); }
+    .mode-matrix col.col-replica { background: var(--color-spice-saffron); }
+    .mode-matrix th.h-replica { color: var(--color-spice-terracotta); }
+    .mode-matrix code { font-family: var(--font-mono); font-size: 10.5px; background: rgba(0,0,0,0.04); padding: 1px 3px; border-radius: 2px; }
+
+    /* TODO(ds): needs pattern — decision cards row */
+    .decisions { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--space-md); margin: var(--space-lg) 0; }
+    .decision-card { padding: var(--space-lg); background: var(--color-paper-warm-white); border: 1px solid var(--color-rule-heavy); border-radius: 6px; border-top: 3px solid var(--color-spice-saffron); }
+    .decision-card .d-id { font-family: var(--font-mono); font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-spice-terracotta); margin: 0 0 var(--space-xs); }
+    .decision-card .d-q { font-family: var(--font-sans); font-size: 13.5px; font-weight: 600; color: var(--color-text-primary); margin: 0 0 var(--space-sm); line-height: 1.4; }
+    .decision-card .d-rec { font-family: var(--font-sans); font-size: 12.5px; color: var(--color-text-secondary); line-height: 1.5; }
+    .decision-card .d-rec strong { color: var(--color-text-primary); }
+
+    /* TODO(ds): needs pattern — split chips (820-A/B/C) */
+    .split-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--space-md); margin: var(--space-lg) 0; }
+    .split-card { padding: var(--space-lg); background: var(--color-paper-warm-white); border: 1px solid var(--color-rule-heavy); border-radius: 6px; }
+    .split-card .s-id { font-family: var(--font-mono); font-size: 12px; font-weight: 700; color: var(--color-text-primary); margin: 0 0 var(--space-xs); }
+    .split-card .s-body { font-family: var(--font-sans); font-size: 12.5px; color: var(--color-text-secondary); line-height: 1.5; }
+    .split-card[data-core="true"] { border-left: 3px solid var(--color-garden-sage); }
+
+    .anchor-line { font-family: var(--font-mono); font-size: 11px; line-height: 1.8; color: var(--color-text-tertiary); }
+    .anchor-line code { color: var(--color-text-secondary); }
+  </style>
+</head>
+<body
+  data-tint="eucalyptus"
+  data-active-page="planning">
+<div class="MagazinePageLayout_magazinePage">
+<main class="MagazinePageLayout_pageContainer">
+<div class="plans-shell">
+
+<!-- TOPNAV -->
+<nav class="plans-topnav" aria-label="Planning surface">
+  <a class="plans-mark" href="index.html">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 433 407" width="16" height="16" aria-hidden="true">
+      <path d="M159 407 161 292 57 355 0 259 102 204 0 148 57 52 161 115 159 0H273L271 115L375 52L433 148L331 204L433 259L375 355L271 292L273 407Z" fill="currentColor"/>
+    </svg>
+    DailyOS · Planning
+  </a>
+  <div class="plans-topnav-links">
+    <a href="engineering-ladder.html">Engineering Ladder</a>
+    <a href="db-throughput-architecture.html">Throughput Architecture</a>
+    <a href="v1.4.9-replica-db-l0-plan.html" data-active="true">Replica-DB L0 (DOS-820)</a>
+    <a href="AUTHORING.md">Authoring Ruleset</a>
+  </div>
+</nav>
+
+<!-- COVER -->
+<section class="plans-cover">
+  <p class="plans-eyebrow">DailyOS · v1.4.9 W1 · Substrate Reset</p>
+  <h1 class="plans-title">The dev workflow must be structurally incapable of touching the production database.</h1>
+  <p class="plans-kicker">An L0 plan for DB-mode isolation — Live / Replica / Mock — so a rebuild-and-<code>pkill</code> loop can never again corrupt the real personal-intelligence DB.</p>
+  <p class="plans-lede">
+    The 2026-05-28 corruption was not a substrate flaw. It was a <strong>dev-workflow artifact</strong> &mdash;
+    <code>tasks/lessons.md:5</code>: <em>&ldquo;Do not edit Rust backend files while <code>pnpm tauri dev</code> is writing
+    to the production SQLCipher DB; hot-restarts terminate WAL writers &rarr; btree corruption.&rdquo;</em> All three root
+    causes are patched (PR #416). The durable fix is structural isolation: production runs untouched; the dev loop runs
+    against a <strong>production replica</strong> (real content &mdash; Glean connectors only work on real account names) or a
+    <strong>mock</strong> fixture set. This unblocks the safe nuke + fresh-install and lets DailyOS run in production daily
+    without corruption or migration fear.
+  </p>
+  <div class="plans-meta">
+    <span>Issue DOS-820 · v1.4.9 W1</span>
+    <span>L0-hardened 2026-05-29 · 4-reviewer panel, unanimous</span>
+    <span>Reinforces ADR-0135 / ADR-0128 · orthogonal to ADR-0104</span>
+    <span>Tier 1 · HTML-first</span>
+  </div>
+</section>
+
+<!-- VERDICT -->
+<div class="verdict-banner">
+  <span class="verdict-pill">L0 · Approve (hardened)</span>
+  <span><strong>codex</strong> + <strong>ce-feasibility</strong> + <strong>ce-security-lens</strong> + <strong>ce-learnings</strong> (K-in) — unanimous. Initial &ldquo;extend the <code>DEV_DB_MODE</code> bool&rdquo; framing rejected by all four; three convergent blockers, now designed against. No reinvented substrate.</span>
+</div>
+
+<!-- SECTION 1 — root cause -->
+<section class="plans-section" aria-labelledby="sec-cause">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Why this exists</p>
+    <h2 id="sec-cause" class="plans-section-title">The hazard is the developer loop, not the user.</h2>
+    <p class="plans-section-lede">
+      A real user never <code>pkill</code>s a hot WAL writer. The developer does &mdash; on every kill-to-apply-a-fix
+      rebuild &mdash; and today that loop runs against the same <code>~/.dailyos/dailyos.db</code> that holds the real
+      personal-intelligence graph. Isolate the loop from production and the corruption class cannot recur.
+    </p>
+  </header>
+</section>
+
+<!-- SECTION 2 — L0 blockers -->
+<section class="plans-section" aria-labelledby="sec-blockers">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">What the panel caught</p>
+    <h2 id="sec-blockers" class="plans-section-title">Three convergent blockers killed the &ldquo;small flag&rdquo; framing.</h2>
+  </header>
+  <table class="l0-table">
+    <thead><tr><th>Blocker</th><th>Why the naïve flag fails</th><th>Design response</th></tr></thead>
+    <tbody>
+      <tr data-sev="blocker">
+        <td>B1 · Not process-wide enough</td>
+        <td><code>dailyos-mcp</code> + maintenance bins are separate processes with their own <code>main()</code>; none set the mode &rarr; default &rarr; prod. MCP launched by Claude/Cursor with no env opens prod and writes audit/recovery state.</td>
+        <td>DB mode is an <strong>immutable library bootstrap contract used by every binary</strong> (app, MCP, doctor, maintenance, tests). Set once, <code>Acquire/Release</code>, before any thread or open.</td>
+      </tr>
+      <tr data-sev="blocker">
+        <td>B2 · Default-Live isn't a boundary</td>
+        <td><code>beforeDevCommand</code> starts Vite, not the backend; IDE runs, <code>cargo tauri dev</code>, <code>cargo run</code>, doctor all skip it. Default-Live means any no-env launch hits prod.</td>
+        <td><strong>Fail-closed:</strong> non-release builds default <strong>non-Live</strong>; Live requires explicit <code>--live</code> / <code>DAILYOS_DB_MODE=live</code>. A no-env dev process can never fall through to prod.</td>
+      </tr>
+      <tr data-sev="blocker">
+        <td>B3 · <code>db_path()</code> guard too narrow</td>
+        <td>Misses explicit-path opens (<code>open_at</code>), backup/restore/refresh, and — worst — devtools <em>forces Live</em> on invariant mismatch (exact wrong failure mode). Key cache is path-blind, so the path layer is the only barrier.</td>
+        <td><strong>Structural prod-open deny at <code>open_resolved_path()</code></strong> — the one chokepoint every open passes, before key fetch or file touch. Assert: <code>mode != Live &amp;&amp; path == prod</code> &rarr; hard error.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- SECTION 3 — policy matrix -->
+<section class="plans-section" aria-labelledby="sec-matrix">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">The hardened design</p>
+    <h2 id="sec-matrix" class="plans-section-title">Three modes, each a full policy &mdash; not three labels on one path.</h2>
+    <p class="plans-section-lede">
+      Reviewers flagged that a mode mixes data source, workspace, config, migrations, external services, and clone
+      direction. Each axis is specified, and ~8 mode-blind <code>~/.dailyos</code> sites (incl. the hardcoded Google
+      OAuth token) must route through the mode-aware resolver.
+    </p>
+  </header>
+  <table class="mode-matrix">
+    <colgroup><col /><col class="col-live" /><col class="col-replica" /><col /></colgroup>
+    <thead><tr><th>Axis</th><th>Live</th><th class="h-replica">Replica (primary dev)</th><th>Mock</th></tr></thead>
+    <tbody>
+      <tr><th>DB</th><td><code>~/.dailyos/dailyos.db</code></td><td><code>dailyos-replica.db</code></td><td><code>dailyos-dev.db</code></td></tr>
+      <tr><th>Workspace</th><td><code>~/Documents/DailyOS</code></td><td><code>~/.dailyos/replica-workspace/</code> (dotfolder — out of iCloud/Spotlight)</td><td><code>~/.dailyos/dev-workspace/</code></td></tr>
+      <tr><th>Config</th><td><code>config.json</code></td><td><code>config-replica.json</code></td><td><code>config-dev.json</code></td></tr>
+      <tr><th>Google / OAuth token</th><td>prod <code>.dailyos/google/</code></td><td>replica-scoped</td><td>mock / none</td></tr>
+      <tr><th>Audit · enrichment · integrations</th><td>prod</td><td>replica-scoped</td><td>mock</td></tr>
+      <tr><th>Migrations</th><td>run</td><td>run — <strong>migration test bed</strong> (validate before prod)</td><td>run</td></tr>
+      <tr><th>External services</th><td>live</td><td>live (real Glean/API — note cost)</td><td>replayed / none</td></tr>
+      <tr><th>Clone</th><td>—</td><td>source = prod (read-only) → dest = replica</td><td>fixtures</td></tr>
+    </tbody>
+  </table>
+  <p class="plans-section-lede">
+    Plus: <strong>guard the prod-destroyers</strong> (<code>start_fresh_database</code>, <code>restore_database_from_backup</code>)
+    with command-level path assertions so a mistakenly-Live session can't nuke prod; <code>replica-refresh</code> clones via
+    <code>run_chunked_backup</code> (SQLite backup API, key applied to destination) with the app closed / WAL-checkpointed for a
+    point-in-time-consistent replica; replace devtools&rsquo; &ldquo;force-Live on mismatch&rdquo; with fail-closed.
+  </p>
+</section>
+
+<!-- SECTION 4 — scope split -->
+<section class="plans-section" aria-labelledby="sec-split">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Scope — revised</p>
+    <h2 id="sec-split" class="plans-section-title">This is isolation substrate, not flag plumbing. Split it.</h2>
+  </header>
+  <div class="split-row">
+    <div class="split-card" data-core="true">
+      <p class="s-id">820-A · safety core</p>
+      <p class="s-body">Mode bootstrap contract (every binary) + fail-closed default + structural deny at <code>open_resolved_path()</code>. <strong>Lands first; alone makes prod safe</strong> and unblocks the fresh-install.</p>
+    </div>
+    <div class="split-card">
+      <p class="s-id">820-B · resolver</p>
+      <p class="s-body">Per-mode workspace/config resolver + the ~8 subdir sites (Google token, audit, enrichment, integrations) + devtools fail-closed fix.</p>
+    </div>
+    <div class="split-card">
+      <p class="s-id">820-C · clone</p>
+      <p class="s-body"><code>replica-refresh</code> (DB + workspace, read-only source, checkpointed) + destructive-command guards.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECTION 5 — decisions -->
+<section class="plans-section" aria-labelledby="sec-decisions">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Open — James's calls</p>
+    <h2 id="sec-decisions" class="plans-section-title">Three decisions before implementation.</h2>
+  </header>
+  <div class="decisions">
+    <div class="decision-card">
+      <p class="d-id">D2 · dev default mode</p>
+      <p class="d-q">Which non-Live mode does <code>pnpm tauri dev</code> land in?</p>
+      <p class="d-rec"><strong>Rec: Replica</strong> (real content; Glean works; closest to reality), with <code>--mock</code> opt-in for surface-state testing.</p>
+    </div>
+    <div class="decision-card">
+      <p class="d-id">D3 · workspace isolation</p>
+      <p class="d-q">How is the replica workspace isolated?</p>
+      <p class="d-rec"><strong>Rec: full copy to <code>~/.dailyos/replica-workspace/</code></strong> (dotfolder — isolates dev writes AND fixes the iCloud/Spotlight exposure). Cost: disk + clone time.</p>
+    </div>
+    <div class="decision-card">
+      <p class="d-id">D5 · governance</p>
+      <p class="d-q">SQLCipher-drop sequencing?</p>
+      <p class="d-rec"><strong>Rec: decouple</strong> — dropping at-rest encryption is a standing ADR-0092 decision and needs its own <strong>ADR amendment</strong>, not part of this ticket.</p>
+    </div>
+  </div>
+</section>
+
+<!-- SECTION 6 — acceptance + verification anchors -->
+<section class="plans-section" aria-labelledby="sec-accept">
+  <header class="plans-section-header">
+    <p class="plans-section-eyebrow">Done means</p>
+    <h2 id="sec-accept" class="plans-section-title">The regression that defines done: prod DB byte-identical across a dev <code>pkill</code>.</h2>
+    <p class="plans-section-lede">
+      Mode set at bootstrap in every binary, no silent default, non-release fail-closed to non-Live. Structural deny proven
+      from a spawned thread AND a separate process. All workspace/config/Google-token/audit sites resolve per mode (CI-gated).
+      <code>start_fresh_database</code> + <code>restore</code> refuse prod from non-Live. <code>pnpm tauri dev</code> + a
+      <code>pkill</code> leaves <code>dailyos.db</code> mtime unchanged. <code>replica-refresh</code> produces a consistent
+      replica from a read-only prod source. DoD gates: <code>cargo clippy -- -D warnings &amp;&amp; cargo test &amp;&amp; pnpm tsc --noEmit</code>.
+    </p>
+  </header>
+  <p class="anchor-line">
+    Verified anchors (Read, 2026-05-29): <code>db/core.rs:638-647</code> (db_path), <code>:24-28</code>/<code>:75-82</code> (DEV_DB_MODE, Relaxed), <code>:423-426</code> (open_resolved_path — deny site), <code>:651-668</code> (checkpoint-before-copy) · <code>key_provider.rs:24-25</code>, <code>:51-87</code> (path-blind CACHED_KEY) · <code>db_backup.rs:252-297</code> (run_chunked_backup, private), <code>:358</code>/<code>:496-506</code> (restore) · <code>devtools/mod.rs:69-83</code> (assert_dev_db_connection), <code>:248-253</code> · <code>state.rs:1885-1893</code> (config_path), <code>:2152</code> (hardcoded google token) · <code>projects_data.rs:277</code> (start_fresh_database) · <code>audit_log.rs:655</code>, <code>enrichment.rs:275</code>, <code>integrations.rs:1024</code>, <code>lib.rs:461-464</code> · <code>abilities-runtime/&hellip;/context.rs:81-93</code> (ExecutionMode — orthogonal).
+  </p>
+</section>
+
+<!-- FINIS -->
+<div class="finis">
+  <div class="finis-mark">DB · MODE · ISOLATION</div>
+  <div class="finis-date">v1.4.9-replica-db-l0-plan &middot; DOS-820 &middot; 2026-05-29</div>
+  <div class="finis-caption">Production is sacred. The dev loop gets a replica. The path layer is the only wall — so build it where every open must pass.</div>
+</div>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/.docs/plans/v1.4.9-replica-db-l0-plan.md
+++ b/.docs/plans/v1.4.9-replica-db-l0-plan.md
@@ -1,0 +1,10 @@
+# L0 Plan — DB Mode isolation (DOS-820)
+
+**This is a Tier 1 (HTML-first) plan. The canonical version is [`v1.4.9-replica-db-l0-plan.html`](v1.4.9-replica-db-l0-plan.html).**
+
+Layout carries information here (the per-mode policy matrix, the blocker table, the decision cards), so per `.docs/plans/AUTHORING.md` it's authored HTML-first against the shared design system. This stub exists only so links to the `.md` path resolve.
+
+- **Issue:** [DOS-820](https://linear.app/a8c/issue/DOS-820) · v1.4.9 W1
+- **L0 verdict (2026-05-29):** APPROVE hardened — unanimous 4-reviewer panel (codex + ce-feasibility + ce-security-lens + ce-learnings K-in). Verdict recorded as a comment on DOS-820.
+- **Open decisions:** D2 (dev default = Replica vs Mock), D3 (replica workspace → `~/.dailyos/` dotfolder copy), D5 (SQLCipher-drop decoupled to its own ADR-0092 amendment).
+- **Recommended split:** 820-A (bootstrap contract + fail-closed + structural deny — safety core), 820-B (per-mode resolver + subdir audit), 820-C (replica-refresh clone + destructive-command guards).

--- a/.docs/research/2026-05-25-dailyos-work-record.html
+++ b/.docs/research/2026-05-25-dailyos-work-record.html
@@ -515,13 +515,12 @@
 
     <!-- 1. COVER ============================================ -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite demo-cover">
-      <p class="d-eyebrow">DailyOS &middot; Demo Day &middot; May 25, 2026</p>
+      <p class="d-eyebrow">DailyOS &middot; RSM Final Update</p>
       <h1 class="d-headline">
-        If we want trustworthy output, the system itself has to be trustworthy.
+        Can we codify trust?
       </h1>
       <p class="d-lede d-lede--wide">
-        Radical Speed Month was us trying to define trust in code.
-        Here&rsquo;s what that took.
+        AI at work relies on solving this one thing.
       </p>
     </section>
 
@@ -536,7 +535,7 @@
         arrives confident and complete, with no way to tell what&rsquo;s grounded,
         what&rsquo;s stale, what&rsquo;s a guess, or what got pulled from where.
       </p>
-      <p class="d-lede d-lede--narrow">
+      <p class="d-lede d-lede--wide">
         So you double-check everything by hand. Which is the work the AI was supposed to remove.
       </p>
       <p class="d-meta" style="margin-top: 24px;">
@@ -547,41 +546,20 @@
 
     <!-- 3. THE TRUST QUESTION ================================ -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgLinen">
-      <p class="d-eyebrow">The question that ate the month</p>
+      <p class="d-eyebrow">The Trust Question</p>
       <h2 class="d-headline">
         Can you define trust in code?
       </h2>
       <p class="d-lede">
-        AI is happy to give you an answer. Most of the time we don&rsquo;t trust the answer.
-        The model isn&rsquo;t usually wrong. The system around the model has no way to tell
-        us what it&rsquo;s sure of, what&rsquo;s stale, what&rsquo;s a guess, and what to
-        leave out.
+        Trust isn&rsquo;t really a fact. It&rsquo;s a feeling you arrive at with instincts
+        you don't always reason your way to. I wanted to explore whether that 'gut feeling' was something we could build around.
       </p>
       <p class="d-lede d-lede--narrow">
-        If trust is the bottleneck, then trust is what we have to build.
+        Can we make AI trustworthy?
       </p>
     </section>
 
-    <!-- 4. THE BET — WISER, NOT JUST SMARTER ================ -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgEucalyptus">
-      <p class="d-eyebrow">The bet</p>
-      <h2 class="d-headline d-headline--med">
-        Not just smarter. Wiser.
-      </h2>
-      <p class="d-lede d-lede--wide">
-        Karpathy ships a wiki his AI maintains. Garry Tan ships a brain his AI reads
-        before every reply. Kieran Klaassen&rsquo;s compound engineering pattern is in
-        every new agent skill ecosystem. They&rsquo;re all chasing the same thing.
-        Better recall, faster retrieval, longer compounding loops. Personal AI is
-        getting smart.
-      </p>
-      <p class="d-lede d-lede--wide">
-        We think the harder problem is making it wiser.
-        Memory and judgment. That&rsquo;s what wiser looks like.
-      </p>
-    </section>
-
-    <!-- 5. MICRO-EXPRESSIONS (DIAGRAM A) ===================== -->
+    <!-- 4. MICRO-EXPRESSIONS (DIAGRAM A) ===================== -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite">
       <p class="d-eyebrow">How humans decide trust</p>
       <h2 class="d-headline d-headline--sm" style="margin-bottom: 16px;">
@@ -627,6 +605,24 @@
           </p>
         </div>
       </div>
+    </section>
+
+    <!-- 5. THE BLIND SPOT ==================================== -->
+    <section class="monthly-wrapped_slide monthly-wrapped_bgEucalyptus">
+      <p class="d-eyebrow">The blind spot</p>
+      <h2 class="d-headline d-headline--med">
+        Smart isn&rsquo;t the same as trustworthy.
+      </h2>
+      <p class="d-lede d-lede--wide">
+        Karpathy ships a wiki his AI maintains. Garry Tan ships a brain his AI reads
+        before every reply. Kieran Klaassen&rsquo;s compound engineering pattern is in
+        every new agent skill ecosystem. They&rsquo;re all chasing the same thing.
+        Better recall, faster retrieval, longer compounding loops. Personal AI is
+        getting smart.
+      </p>
+      <p class="d-lede d-lede--narrow">
+        How does smart memory know what matters?
+      </p>
     </section>
 
     <!-- 6. WHAT AI IS MISSING (DIAGRAM B) ==================== -->

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Enforce DOS-589 dispatcher module boundaries
         run: ./scripts/check_version_dispatcher_boundaries.sh
 
+      - name: Enforce DB open guard allowlist
+        run: bash src-tauri/scripts/check_db_open_guard_allowlist.sh
+
       - name: Enforce ability surface drift guard
         run: |
           bash src-tauri/scripts/check_ability_surface_drift.sh

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -98,6 +98,9 @@ run_step "service-layer boundary" ./scripts/check_service_layer_boundary.sh
 # 4. must_use on DB mutation methods
 run_step "db mutator must_use" ./scripts/check_db_mutator_must_use.sh
 
+# 4a. file-backed DB opens stay behind guarded chokepoints
+run_step "db open guard allowlist" bash src-tauri/scripts/check_db_open_guard_allowlist.sh
+
 # 4b. stakeholder graph writer signal helper
 run_step "stakeholder writer signal helper" ./scripts/check_stakeholder_writer_emits_signal.sh
 

--- a/src-tauri/scripts/check_db_open_guard_allowlist.sh
+++ b/src-tauri/scripts/check_db_open_guard_allowlist.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# DB open guard lint.
+#
+# Direct rusqlite opens of file-backed databases must stay behind the known DB
+# chokepoints, where DbMode's production-path guard can run before key fetch or
+# file open. New file-backed Connection::open/open_with_flags call sites outside
+# this allowlist must either move behind ActionDb/DbService or carry a per-line
+# `db-open-guard-allowed:` rationale.
+
+set -euo pipefail
+
+if [[ -d "src-tauri" ]]; then
+  roots=("src-tauri/src")
+else
+  roots=("src")
+fi
+
+allowed_path_regex='(^|/)db/core\.rs:|(^|/)db_service\.rs:|(^|/)db/key_provider\.rs:|(^|/)db/encryption\.rs:|(^|/)db_backup\.rs:|(^|/)migrations\.rs:|(^|/)harness/runner\.rs:|(^|/)services/claims_backfill\.rs:'
+pattern='(rusqlite::)?Connection::open(_with_flags)?[[:space:]]*\('
+
+matches="$(
+  grep -rEn --include='*.rs' "$pattern" "${roots[@]}" 2>/dev/null \
+    | grep -v 'open_in_memory' \
+    | grep -vE ':\s*(//|//!|///|\*)' \
+    | grep -Ev "$allowed_path_regex" \
+    | grep -v 'db-open-guard-allowed:' \
+    || true
+)"
+
+if [[ -n "$matches" ]]; then
+  echo "Direct file-backed SQLite opens outside the DB open guard allowlist are forbidden." >&2
+  echo "Route through ActionDb/DbService guarded helpers, or add a narrow allowlist rationale." >&2
+  echo >&2
+  echo "Allowed chokepoint/exception files:" >&2
+  echo "  - src-tauri/src/db/core.rs" >&2
+  echo "  - src-tauri/src/db_service.rs" >&2
+  echo "  - src-tauri/src/db/key_provider.rs" >&2
+  echo "  - src-tauri/src/db/encryption.rs" >&2
+  echo "  - src-tauri/src/db_backup.rs" >&2
+  echo "  - src-tauri/src/migrations.rs" >&2
+  echo "  - src-tauri/src/harness/runner.rs" >&2
+  echo "  - src-tauri/src/services/claims_backfill.rs" >&2
+  echo >&2
+  echo "$matches" >&2
+  exit 1
+fi
+
+echo "DB open guard allowlist clean."

--- a/src-tauri/src/bin/generate_canonicalization_corpus.rs
+++ b/src-tauri/src/bin/generate_canonicalization_corpus.rs
@@ -38,6 +38,8 @@ const CROSS_WORKSPACE_COUNT: usize = 10;
 const LEGACY_UNMIGRATED_COUNT: usize = 10;
 
 fn main() {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     let root = repo_relative(CORPUS_ROOT);
     purge_generated_pairs(&root);
 

--- a/src-tauri/src/bin/reconcile_post_migration.rs
+++ b/src-tauri/src/bin/reconcile_post_migration.rs
@@ -21,6 +21,8 @@ use std::process::ExitCode;
 const RECONCILE_SQL_PATH: &str = "scripts/reconcile_ghost_resurrection.sql";
 
 fn main() -> ExitCode {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .format_timestamp_millis()
         .init();

--- a/src-tauri/src/bin/reconcile_post_migration.rs
+++ b/src-tauri/src/bin/reconcile_post_migration.rs
@@ -5,8 +5,8 @@
 //! findings.
 //!
 //! Usage:
-//!   reconcile_post_migration              — read-only reconcile; report findings.
-//!   reconcile_post_migration --repair     — apply repair (re-tombstone via commit_claim).
+//!   reconcile_post_migration --live              — read-only reconcile; report findings.
+//!   reconcile_post_migration --live --repair     — apply repair (re-tombstone via commit_claim).
 //!
 //! ## Status (W1 ship)
 //!
@@ -26,6 +26,16 @@ fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .format_timestamp_millis()
         .init();
+
+    let resolved_mode = dailyos_lib::db::db_mode();
+    log::info!("Resolved DbMode: {resolved_mode:?}");
+    if resolved_mode != dailyos_lib::db::DbMode::Live || !explicit_live_db_mode_requested() {
+        log::error!(
+            "Refusing to run maintenance against an implicit or non-Live DB mode. \
+             Pass --live or set DAILYOS_DB_MODE=live to run against the production DB."
+        );
+        return ExitCode::from(2);
+    }
 
     let args: Vec<String> = std::env::args().collect();
     let repair_mode = args.iter().any(|a| a == "--repair");
@@ -166,6 +176,11 @@ fn locate_reconcile_sql() -> PathBuf {
         return PathBuf::from(p);
     }
     cwd_relative
+}
+
+fn explicit_live_db_mode_requested() -> bool {
+    std::env::args().any(|arg| arg == "--live")
+        || std::env::var("DAILYOS_DB_MODE").is_ok_and(|value| value.trim() == "live")
 }
 
 #[derive(Debug)]

--- a/src-tauri/src/bin/release_gate.rs
+++ b/src-tauri/src/bin/release_gate.rs
@@ -1,6 +1,8 @@
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     match dailyos_lib::release_gate::run_from_args(std::env::args_os()) {
         Ok(outcome) => {
             println!("{}", outcome.summary_markdown.trim_end());

--- a/src-tauri/src/bin/repair_entity_linking.rs
+++ b/src-tauri/src/bin/repair_entity_linking.rs
@@ -3,6 +3,8 @@ use std::process::ExitCode;
 use dailyos_lib::services::entity_linking::repair::{apply_repair, build_report, RepairOptions};
 
 fn main() -> ExitCode {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .format_timestamp_millis()
         .init();

--- a/src-tauri/src/bin/repair_entity_linking.rs
+++ b/src-tauri/src/bin/repair_entity_linking.rs
@@ -9,6 +9,16 @@ fn main() -> ExitCode {
         .format_timestamp_millis()
         .init();
 
+    let resolved_mode = dailyos_lib::db::db_mode();
+    log::info!("Resolved DbMode: {resolved_mode:?}");
+    if resolved_mode != dailyos_lib::db::DbMode::Live || !explicit_live_db_mode_requested() {
+        eprintln!(
+            "refusing to run maintenance against an implicit or non-Live DB mode; \
+             pass --live or set DAILYOS_DB_MODE=live"
+        );
+        return ExitCode::from(2);
+    }
+
     let args: Vec<String> = std::env::args().skip(1).collect();
     let apply = args.iter().any(|arg| arg == "--apply");
     let opts = match parse_options(&args) {
@@ -65,6 +75,9 @@ fn parse_options(args: &[String]) -> Result<RepairOptions, String> {
             "--dry-run" => {
                 i += 1;
             }
+            "--live" => {
+                i += 1;
+            }
             "--min-batch" => {
                 i += 1;
                 let Some(value) = args.get(i) else {
@@ -98,6 +111,11 @@ fn parse_options(args: &[String]) -> Result<RepairOptions, String> {
 
 fn print_usage() {
     eprintln!(
-        "usage: repair_entity_linking [--dry-run] [--apply] [--min-batch N] [--min-coattendees N]"
+        "usage: repair_entity_linking --live [--dry-run] [--apply] [--min-batch N] [--min-coattendees N]"
     );
+}
+
+fn explicit_live_db_mode_requested() -> bool {
+    std::env::args().any(|arg| arg == "--live")
+        || std::env::var("DAILYOS_DB_MODE").is_ok_and(|value| value.trim() == "live")
 }

--- a/src-tauri/src/bin/workspace_backfill.rs
+++ b/src-tauri/src/bin/workspace_backfill.rs
@@ -13,6 +13,8 @@ struct Args {
 }
 
 fn main() {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     let args = Args::parse();
     match run(args) {
         Ok(exit_code) => std::process::exit(exit_code),

--- a/src-tauri/src/bin/workspace_backfill.rs
+++ b/src-tauri/src/bin/workspace_backfill.rs
@@ -3,6 +3,8 @@ use clap::{ArgAction, Parser};
 #[derive(Debug, Parser)]
 struct Args {
     #[arg(long, action = ArgAction::SetTrue)]
+    live: bool,
+    #[arg(long, action = ArgAction::SetTrue)]
     apply: bool,
     #[arg(long)]
     workspace_root: Option<std::path::PathBuf>,
@@ -16,6 +18,16 @@ fn main() {
     dailyos_lib::db::resolve_and_set_db_mode_from_process();
 
     let args = Args::parse();
+    let resolved_mode = dailyos_lib::db::db_mode();
+    eprintln!("Resolved DbMode: {resolved_mode:?}");
+    if resolved_mode != dailyos_lib::db::DbMode::Live || !explicit_live_db_mode_requested(args.live)
+    {
+        eprintln!(
+            "refusing to run maintenance against an implicit or non-Live DB mode; \
+             pass --live or set DAILYOS_DB_MODE=live"
+        );
+        std::process::exit(2);
+    }
     match run(args) {
         Ok(exit_code) => std::process::exit(exit_code),
         Err(error) => {
@@ -23,6 +35,10 @@ fn main() {
             std::process::exit(3);
         }
     }
+}
+
+fn explicit_live_db_mode_requested(live_arg: bool) -> bool {
+    live_arg || std::env::var("DAILYOS_DB_MODE").is_ok_and(|value| value.trim() == "live")
 }
 
 fn run(args: Args) -> Result<i32, String> {

--- a/src-tauri/src/bin/workspace_graph_audit.rs
+++ b/src-tauri/src/bin/workspace_graph_audit.rs
@@ -13,6 +13,8 @@ struct Args {
 }
 
 fn main() {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     let args = Args::parse();
     match run(args) {
         Ok(exit_code) => std::process::exit(exit_code),

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 // Dev DB isolation
 // ---------------------------------------------------------------------------
 
-/// Process-wide DB-mode selector (DOS-821 / 820-A). Steers `ActionDb::db_path()`
+/// Process-wide DB-mode selector. Steers `ActionDb::db_path()`
 /// between the production DB and isolated dev files, and — via the structural
 /// guard below — forbids opening the production DB in any non-Live mode.
 ///
@@ -181,7 +181,7 @@ fn prod_db_paths() -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
-/// Structural prod-open deny (DOS-821 / 820-A). Called at every connection-open
+/// Structural prod-open deny. Called at every connection-open
 /// chokepoint with the resolved path BEFORE the key is fetched or the file is
 /// opened. The encryption key cache is path-blind, so the path layer is the only
 /// barrier — it must be enforced here, not merely in `db_path()`.
@@ -486,7 +486,7 @@ impl ActionDb {
         path: &Path,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<(Connection, EncryptionKey), DbError> {
-        // DOS-821: structural prod-open deny — before key fetch or file open.
+        // structural prod-open deny — before key fetch or file open.
         guard_path_for_mode(path)?;
 
         // Ensure parent directory exists
@@ -633,7 +633,7 @@ impl ActionDb {
         path: &Path,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<(Connection, EncryptionKey), DbError> {
-        // DOS-821: structural prod-open deny — before key fetch or file open.
+        // structural prod-open deny — before key fetch or file open.
         guard_path_for_mode(path)?;
 
         if let Some(parent) = path.parent() {
@@ -682,7 +682,7 @@ impl ActionDb {
         path: PathBuf,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<Self, DbError> {
-        // DOS-821: structural prod-open deny — covers the svc.open_fresh_serialized
+        // structural prod-open deny — covers the svc.open_fresh_serialized
         // branch, which does not route through prepare_encrypted_connection.
         guard_path_for_mode(&path)?;
         let rotation_lock = crate::db::key_provider::rotation_lock_read();
@@ -830,7 +830,7 @@ impl ActionDb {
         let home = dirs::home_dir().ok_or(DbError::HomeDirNotFound)?;
         let dailyos_dir = home.join(".dailyos");
 
-        // DB-mode isolation (DOS-821): non-Live modes resolve to isolated files
+        // DB-mode isolation: non-Live modes resolve to isolated files
         // and never to the production DB.
         match db_mode() {
             DbMode::Replica => return Ok(dailyos_dir.join("dailyos-replica.db")),

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -61,6 +61,24 @@ impl DbMode {
             _ => None,
         }
     }
+
+    fn from_process_arg(arg: &str) -> Option<Self> {
+        match arg {
+            "--live" => Some(DbMode::Live),
+            "--replica" => Some(DbMode::Replica),
+            "--mock" => Some(DbMode::Mock),
+            _ => None,
+        }
+    }
+
+    fn from_env_value(value: &str) -> Option<Self> {
+        match value.trim() {
+            "live" => Some(DbMode::Live),
+            "replica" => Some(DbMode::Replica),
+            "mock" => Some(DbMode::Mock),
+            _ => None,
+        }
+    }
 }
 static WRITE_TRANSACTION_GATE: parking_lot::Mutex<()> = parking_lot::const_mutex(());
 static WRITE_TRANSACTION_HOLDER: parking_lot::Mutex<Option<WriteTransactionHolder>> =
@@ -110,6 +128,24 @@ fn write_transaction_holder_summary() -> String {
 /// thread spawn or `ActionDb::open()`. Changing it after the first open is a bug.
 pub fn set_db_mode(mode: DbMode) {
     DB_MODE.store(mode.as_u8(), Ordering::Release);
+}
+
+/// Resolve DB mode from process inputs and set it when explicitly provided.
+///
+/// CLI flags (`--live`, `--replica`, `--mock`) take precedence over
+/// `DAILYOS_DB_MODE=live|replica|mock`. If neither is present, leave DB_MODE
+/// unset so `db_mode()` keeps its fail-closed default.
+pub fn resolve_and_set_db_mode_from_process() {
+    if let Some(mode) = std::env::args().find_map(|arg| DbMode::from_process_arg(&arg)) {
+        set_db_mode(mode);
+        return;
+    }
+
+    if let Ok(value) = std::env::var("DAILYOS_DB_MODE") {
+        if let Some(mode) = DbMode::from_env_value(&value) {
+            set_db_mode(mode);
+        }
+    }
 }
 
 /// Resolve the active DB mode. **Fail-closed default when unset:** non-release
@@ -1006,6 +1042,79 @@ pub mod test_utils {
             .execute_batch("PRAGMA foreign_keys = OFF;")
             .expect("disable FK for tests");
         db
+    }
+}
+
+#[cfg(test)]
+mod db_mode_tests {
+    use super::*;
+
+    static DB_MODE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct ResetDbMode;
+
+    impl Drop for ResetDbMode {
+        fn drop(&mut self) {
+            set_db_mode(DbMode::Live);
+        }
+    }
+
+    fn production_db_path() -> PathBuf {
+        dirs::home_dir()
+            .expect("home dir")
+            .join(".dailyos")
+            .join("dailyos.db")
+    }
+
+    fn assert_prod_open_denied(mode: DbMode) {
+        set_db_mode(mode);
+        let err = guard_path_for_mode(&production_db_path())
+            .expect_err("non-Live mode must deny production DB path");
+        assert!(
+            matches!(err, DbError::ProdOpenDenied { .. }),
+            "expected ProdOpenDenied, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn replica_mode_refuses_production_db_path() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+
+        assert_prod_open_denied(DbMode::Replica);
+    }
+
+    #[test]
+    fn mock_mode_refuses_production_db_path() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+
+        assert_prod_open_denied(DbMode::Mock);
+    }
+
+    #[test]
+    fn live_mode_allows_production_db_path() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+
+        set_db_mode(DbMode::Live);
+
+        guard_path_for_mode(&production_db_path())
+            .expect("Live mode must allow production DB path");
+    }
+
+    #[test]
+    fn unrelated_temp_path_is_allowed_in_every_mode() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let unrelated_path = temp.path().join("dailyos.db");
+
+        for mode in [DbMode::Live, DbMode::Replica, DbMode::Mock] {
+            set_db_mode(mode);
+            guard_path_for_mode(&unrelated_path)
+                .unwrap_or_else(|err| panic!("{mode:?} should allow unrelated temp path: {err}"));
+        }
     }
 }
 

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -7,7 +7,7 @@
 //! filesystem at natural synchronization points (archive, dashboard regeneration).
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 use super::types::*;
@@ -21,11 +21,47 @@ use sha2::{Digest, Sha256};
 // Dev DB isolation
 // ---------------------------------------------------------------------------
 
-/// Process-wide flag steering `ActionDb::db_path()` between live and dev files.
-/// Background threads (executor, intel_queue, watcher, hygiene) all call
-/// `ActionDb::open()` independently — the static flag means they automatically
-/// pick up the right path without plumbing config through every thread.
-static DEV_DB_MODE: AtomicBool = AtomicBool::new(false);
+/// Process-wide DB-mode selector (DOS-821 / 820-A). Steers `ActionDb::db_path()`
+/// between the production DB and isolated dev files, and — via the structural
+/// guard below — forbids opening the production DB in any non-Live mode.
+///
+/// Background threads (executor, intel_queue, watcher, hygiene) and separate
+/// binaries (MCP, doctor, maintenance) all call `ActionDb::open()` independently;
+/// the process-wide value means each picks up the right path without plumbing.
+/// Set ONCE at process bootstrap, before any thread spawn or open. `0` = unset
+/// (resolves to the fail-closed default in `db_mode()`).
+static DB_MODE: AtomicU8 = AtomicU8::new(0);
+
+/// Which database a process operates against. Process-wide, set once at bootstrap.
+/// Orthogonal to ADR-0104 `ExecutionMode` (request-scoped mutation-gating) — this
+/// is process-wide path-selection. Do not merge the two.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum DbMode {
+    /// Production. `~/.dailyos/dailyos.db`. The ONLY mode allowed to open prod.
+    Live,
+    /// Production replica with real content. `~/.dailyos/dailyos-replica.db`.
+    Replica,
+    /// Fixtures / surface-state testing. `~/.dailyos/dailyos-dev.db`.
+    Mock,
+}
+
+impl DbMode {
+    fn as_u8(self) -> u8 {
+        match self {
+            DbMode::Live => 1,
+            DbMode::Replica => 2,
+            DbMode::Mock => 3,
+        }
+    }
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            1 => Some(DbMode::Live),
+            2 => Some(DbMode::Replica),
+            3 => Some(DbMode::Mock),
+            _ => None,
+        }
+    }
+}
 static WRITE_TRANSACTION_GATE: parking_lot::Mutex<()> = parking_lot::const_mutex(());
 static WRITE_TRANSACTION_HOLDER: parking_lot::Mutex<Option<WriteTransactionHolder>> =
     parking_lot::const_mutex(None);
@@ -70,15 +106,63 @@ fn write_transaction_holder_summary() -> String {
         .unwrap_or_else(|| "unknown holder".to_string())
 }
 
-/// Activate dev-mode DB isolation. All subsequent `ActionDb::open()` calls
-/// will target `~/.dailyos/dailyos-dev.db` instead of `dailyos.db`.
-pub fn set_dev_db_mode(enabled: bool) {
-    DEV_DB_MODE.store(enabled, Ordering::Relaxed);
+/// Set the process-wide DB mode. Must be called once at bootstrap, before any
+/// thread spawn or `ActionDb::open()`. Changing it after the first open is a bug.
+pub fn set_db_mode(mode: DbMode) {
+    DB_MODE.store(mode.as_u8(), Ordering::Release);
 }
 
-/// Check whether dev-mode DB isolation is active.
+/// Resolve the active DB mode. **Fail-closed default when unset:** non-release
+/// (`debug_assertions`) builds default to `Replica`, release builds to `Live`.
+/// A no-env dev process can therefore never fall through to the production DB.
+pub fn db_mode() -> DbMode {
+    match DbMode::from_u8(DB_MODE.load(Ordering::Acquire)) {
+        Some(mode) => mode,
+        None if cfg!(debug_assertions) => DbMode::Replica,
+        None => DbMode::Live,
+    }
+}
+
+/// Legacy shim: "dev mode" == `Mock` (fixture DB). Preserved for callers not yet
+/// migrated to `db_mode()` (820-B migrates them). Returns `false` in Replica/Live.
 pub fn is_dev_db_mode() -> bool {
-    DEV_DB_MODE.load(Ordering::Relaxed)
+    db_mode() == DbMode::Mock
+}
+
+/// Legacy shim. `true` → `Mock`, `false` → `Live`.
+pub fn set_dev_db_mode(enabled: bool) {
+    set_db_mode(if enabled { DbMode::Mock } else { DbMode::Live });
+}
+
+/// The production database file paths (live + legacy). These may be opened ONLY
+/// when `db_mode() == Live`; the guard below enforces it.
+fn prod_db_paths() -> Vec<PathBuf> {
+    dirs::home_dir()
+        .map(|home| {
+            let dir = home.join(".dailyos");
+            vec![dir.join("dailyos.db"), dir.join("actions.db")]
+        })
+        .unwrap_or_default()
+}
+
+/// Structural prod-open deny (DOS-821 / 820-A). Called at every connection-open
+/// chokepoint with the resolved path BEFORE the key is fetched or the file is
+/// opened. The encryption key cache is path-blind, so the path layer is the only
+/// barrier — it must be enforced here, not merely in `db_path()`.
+fn guard_path_for_mode(path: &Path) -> Result<(), DbError> {
+    let mode = db_mode();
+    if mode == DbMode::Live {
+        return Ok(());
+    }
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let target = canon(path);
+    if prod_db_paths().iter().any(|p| canon(p) == target) {
+        return Err(DbError::ProdOpenDenied {
+            mode: format!("{mode:?}"),
+            path: path.display().to_string(),
+        });
+    }
+    Ok(())
 }
 
 #[repr(transparent)]
@@ -306,6 +390,9 @@ impl ActionDb {
         path: &Path,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<(Connection, EncryptionKey), DbError> {
+        // DOS-821: structural prod-open deny — before key fetch or file open.
+        guard_path_for_mode(path)?;
+
         // Ensure parent directory exists
         if let Some(parent) = path.parent() {
             if !parent.exists() {
@@ -450,6 +537,9 @@ impl ActionDb {
         path: &Path,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<(Connection, EncryptionKey), DbError> {
+        // DOS-821: structural prod-open deny — before key fetch or file open.
+        guard_path_for_mode(path)?;
+
         if let Some(parent) = path.parent() {
             if !parent.exists() {
                 std::fs::create_dir_all(parent).map_err(DbError::CreateDir)?;
@@ -496,6 +586,9 @@ impl ActionDb {
         path: PathBuf,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<Self, DbError> {
+        // DOS-821: structural prod-open deny — covers the svc.open_fresh_serialized
+        // branch, which does not route through prepare_encrypted_connection.
+        guard_path_for_mode(&path)?;
         let rotation_lock = crate::db::key_provider::rotation_lock_read();
         if let Some(svc) = crate::db_service::try_global() {
             let user = UserIdentity::local(path.clone());
@@ -639,9 +732,12 @@ impl ActionDb {
         let home = dirs::home_dir().ok_or(DbError::HomeDirNotFound)?;
         let dailyos_dir = home.join(".dailyos");
 
-        // Dev-mode: isolated DB, no migration needed
-        if is_dev_db_mode() {
-            return Ok(dailyos_dir.join("dailyos-dev.db"));
+        // DB-mode isolation (DOS-821): non-Live modes resolve to isolated files
+        // and never to the production DB.
+        match db_mode() {
+            DbMode::Replica => return Ok(dailyos_dir.join("dailyos-replica.db")),
+            DbMode::Mock => return Ok(dailyos_dir.join("dailyos-dev.db")),
+            DbMode::Live => {}
         }
 
         let new_path = dailyos_dir.join("dailyos.db");

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -6,7 +6,7 @@
 //! SQLite is not disposable — important state lives here and is written back to the
 //! filesystem at natural synchronization points (archive, dashboard regeneration).
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -185,20 +185,80 @@ fn prod_db_paths() -> Vec<PathBuf> {
 /// chokepoint with the resolved path BEFORE the key is fetched or the file is
 /// opened. The encryption key cache is path-blind, so the path layer is the only
 /// barrier — it must be enforced here, not merely in `db_path()`.
-fn guard_path_for_mode(path: &Path) -> Result<(), DbError> {
+pub(crate) fn guard_path_for_mode(path: &Path) -> Result<(), DbError> {
     let mode = db_mode();
     if mode == DbMode::Live {
         return Ok(());
     }
-    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
-    let target = canon(path);
-    if prod_db_paths().iter().any(|p| canon(p) == target) {
+    let target_candidates = guarded_path_candidates(path);
+    if prod_db_paths().iter().any(|prod_path| {
+        let prod_candidates = guarded_path_candidates(prod_path);
+        target_candidates.iter().any(|target| {
+            prod_candidates
+                .iter()
+                .any(|prod| guarded_paths_equal(target, prod))
+        })
+    }) {
         return Err(DbError::ProdOpenDenied {
             mode: format!("{mode:?}"),
             path: path.display().to_string(),
         });
     }
     Ok(())
+}
+
+fn guarded_path_candidates(path: &Path) -> Vec<PathBuf> {
+    let mut candidates = vec![lexically_normalized_path(path)];
+    if let Ok(canonicalized) = path.canonicalize() {
+        let canonicalized = lexically_normalized_path(&canonicalized);
+        if !candidates
+            .iter()
+            .any(|candidate| guarded_paths_equal(candidate, &canonicalized))
+        {
+            candidates.push(canonicalized);
+        }
+    }
+    candidates
+}
+
+fn lexically_normalized_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let can_pop = matches!(
+                    normalized.components().next_back(),
+                    Some(Component::Normal(_))
+                );
+                if can_pop {
+                    normalized.pop();
+                } else if !normalized.has_root() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn guarded_paths_equal(left: &Path, right: &Path) -> bool {
+    left.as_os_str()
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&right.as_os_str().to_string_lossy())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn guarded_paths_equal(left: &Path, right: &Path) -> bool {
+    left == right
 }
 
 #[repr(transparent)]
@@ -702,6 +762,8 @@ impl ActionDb {
         path: &std::path::Path,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<Self, DbError> {
+        guard_path_for_mode(path)?;
+
         let user = UserIdentity::local(path.to_path_buf());
         let encryption_key = key_provider.get_or_create_key(&user).map_err(|e| {
             if e.starts_with("KEY_MISSING:") {
@@ -1051,6 +1113,28 @@ mod db_mode_tests {
 
     static DB_MODE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    struct EnvVarGuard {
+        name: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &Path) -> Self {
+            let original = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
     struct ResetDbMode;
 
     impl Drop for ResetDbMode {
@@ -1066,6 +1150,14 @@ mod db_mode_tests {
             .join("dailyos.db")
     }
 
+    fn production_db_path_with_redundant_dot_segment() -> PathBuf {
+        dirs::home_dir()
+            .expect("home dir")
+            .join(".dailyos")
+            .join(".")
+            .join("dailyos.db")
+    }
+
     fn assert_prod_open_denied(mode: DbMode) {
         set_db_mode(mode);
         let err = guard_path_for_mode(&production_db_path())
@@ -1074,6 +1166,26 @@ mod db_mode_tests {
             matches!(err, DbError::ProdOpenDenied { .. }),
             "expected ProdOpenDenied, got {err:?}"
         );
+    }
+
+    fn assert_readonly_prod_open_denied(path: &Path, mode: DbMode) {
+        set_db_mode(mode);
+        match ActionDb::open_readonly_at(path, Arc::new(FixtureDbKeyProvider::new())) {
+            Err(DbError::ProdOpenDenied { .. }) => {}
+            Err(err) => panic!("expected ProdOpenDenied, got {err:?}"),
+            Ok(_) => panic!("non-Live mode must deny production DB read path"),
+        }
+    }
+
+    fn create_encrypted_prod_db(path: &Path) {
+        std::fs::create_dir_all(path.parent().expect("prod db parent"))
+            .expect("create prod db parent");
+        let provider = FixtureDbKeyProvider::new();
+        let conn = Connection::open(path).expect("create encrypted prod db");
+        conn.execute_batch(&provider.key.to_pragma())
+            .expect("apply fixture key");
+        conn.execute_batch("CREATE TABLE readonly_smoke (id INTEGER PRIMARY KEY);")
+            .expect("create smoke table");
     }
 
     #[test]
@@ -1115,6 +1227,52 @@ mod db_mode_tests {
             guard_path_for_mode(&unrelated_path)
                 .unwrap_or_else(|err| panic!("{mode:?} should allow unrelated temp path: {err}"));
         }
+    }
+
+    #[test]
+    fn open_readonly_at_refuses_prod_path_in_replica_and_mock_when_absent() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", temp_home.path());
+        let prod_path = production_db_path();
+        assert!(
+            !prod_path.exists(),
+            "test requires the temp production DB file to be absent"
+        );
+
+        assert_readonly_prod_open_denied(&prod_path, DbMode::Replica);
+        assert_readonly_prod_open_denied(&prod_path, DbMode::Mock);
+    }
+
+    #[test]
+    fn open_readonly_at_refuses_prod_path_with_redundant_dot_segment_when_absent() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", temp_home.path());
+        let prod_path = production_db_path();
+        let redundant_path = production_db_path_with_redundant_dot_segment();
+        assert!(
+            !prod_path.exists(),
+            "test requires the temp production DB file to be absent"
+        );
+
+        assert_readonly_prod_open_denied(&redundant_path, DbMode::Replica);
+    }
+
+    #[test]
+    fn open_readonly_at_allows_prod_path_in_live() {
+        let _lock = DB_MODE_TEST_LOCK.lock().expect("db mode test lock");
+        let _reset = ResetDbMode;
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let _home = EnvVarGuard::set("HOME", temp_home.path());
+        let prod_path = production_db_path();
+        create_encrypted_prod_db(&prod_path);
+
+        set_db_mode(DbMode::Live);
+        ActionDb::open_readonly_at(&prod_path, Arc::new(FixtureDbKeyProvider::new()))
+            .expect("Live mode must allow production DB read path");
     }
 }
 

--- a/src-tauri/src/db/key_provider.rs
+++ b/src-tauri/src/db/key_provider.rs
@@ -751,6 +751,8 @@ fn rekey_database_standalone_inner(
     new_key: &EncryptionKey,
     rollback_after_rekey_failure: bool,
 ) -> Result<()> {
+    crate::db::guard_path_for_mode(db_path).map_err(|e| e.to_string())?;
+
     let conn = Connection::open(db_path)
         .map_err(|e| format!("Failed to open encrypted DB for key rotation: {e}"))?;
     conn.execute_batch(&old_key.to_pragma())
@@ -814,6 +816,8 @@ fn rollback_after_completed_rekey(
 }
 
 fn verify_database_key(db_path: &Path, key: &EncryptionKey) -> Result<()> {
+    crate::db::guard_path_for_mode(db_path).map_err(|e| e.to_string())?;
+
     let conn = Connection::open(db_path)
         .map_err(|e| format!("Failed to reopen encrypted DB for key verification: {e}"))?;
     conn.execute_batch(&key.to_pragma())

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -5,6 +5,7 @@ pub(crate) use std::collections::HashMap;
 pub(crate) use crate::entity::{DbEntity, EntityType};
 pub(crate) use crate::types::LinkedEntity;
 pub(crate) use chrono::Utc;
+pub(crate) use core::guard_path_for_mode;
 pub(crate) use rusqlite::params;
 
 pub mod accounts;

--- a/src-tauri/src/db/types.rs
+++ b/src-tauri/src/db/types.rs
@@ -39,7 +39,7 @@ pub enum DbError {
     #[error("Invalid argument: {0}")]
     InvalidArgument(String),
 
-    /// Structural prod-open deny (DOS-821 / 820-A). An attempt was made to open
+    /// Structural prod-open deny. An attempt was made to open
     /// the production database while `db_mode()` is not `Live`. The dev workflow
     /// must never touch the production DB; this is the path-layer barrier.
     #[error("Refused to open production database in {mode} mode (path: {path}). Run with --live / DAILYOS_DB_MODE=live to use the production database.")]

--- a/src-tauri/src/db/types.rs
+++ b/src-tauri/src/db/types.rs
@@ -38,6 +38,12 @@ pub enum DbError {
     /// variant). Indicates a programming error, not a runtime fault.
     #[error("Invalid argument: {0}")]
     InvalidArgument(String),
+
+    /// Structural prod-open deny (DOS-821 / 820-A). An attempt was made to open
+    /// the production database while `db_mode()` is not `Live`. The dev workflow
+    /// must never touch the production DB; this is the path-layer barrier.
+    #[error("Refused to open production database in {mode} mode (path: {path}). Run with --live / DAILYOS_DB_MODE=live to use the production database.")]
+    ProdOpenDenied { mode: String, path: String },
 }
 
 /// A row from the `actions` table.

--- a/src-tauri/src/db_service.rs
+++ b/src-tauri/src/db_service.rs
@@ -644,6 +644,8 @@ impl DbService {
         path: PathBuf,
         key_provider: Arc<dyn DbKeyProvider>,
     ) -> Result<Arc<Self>, DbError> {
+        crate::db::guard_path_for_mode(&path)?;
+
         let path_for_writer = path.clone();
         let path_for_readers = path.to_string_lossy().to_string();
         let writer_key_provider = key_provider.clone();
@@ -838,6 +840,8 @@ impl DbService {
         path: PathBuf,
         encryption_key: EncryptionKey,
     ) -> Result<Connection, DbError> {
+        crate::db::guard_path_for_mode(&path)?;
+
         let started = Instant::now();
         let path = path.to_string_lossy().to_string();
         let writer = self.writer();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,8 @@ compile_error!(
 );
 
 fn main() {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
     if let Some(code) = dailyos_lib::doctor::run_from_args(std::env::args()) {
         std::process::exit(code);
     }

--- a/src-tauri/src/mcp/main.rs
+++ b/src-tauri/src/mcp/main.rs
@@ -1675,8 +1675,16 @@ fn account_status_has_assessment_content(value: &serde_json::Value) -> bool {
 // Main
 // =============================================================================
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    dailyos_lib::db::resolve_and_set_db_mode_from_process();
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     if std::env::var(DAILYOS_MCP_LEGACY_V1_ENV).as_deref() == Ok("1") {
         return run_legacy_v1_server().await;
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -562,7 +562,7 @@ fn recovery_status_from_db_error(err: &crate::db::DbError) -> DatabaseRecoverySt
         crate::db::DbError::InvalidArgument(message) => {
             DatabaseRecoveryStatus::required("internal_invalid_argument", message.clone())
         }
-        // DOS-821: a deliberate prod-open deny is not a database fault — never
+        // a deliberate prod-open deny is not a database fault — never
         // trigger recovery (which would misclassify the guard as corruption).
         crate::db::DbError::ProdOpenDenied { .. } => DatabaseRecoveryStatus::not_required(),
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -562,6 +562,9 @@ fn recovery_status_from_db_error(err: &crate::db::DbError) -> DatabaseRecoverySt
         crate::db::DbError::InvalidArgument(message) => {
             DatabaseRecoveryStatus::required("internal_invalid_argument", message.clone())
         }
+        // DOS-821: a deliberate prod-open deny is not a database fault — never
+        // trigger recovery (which would misclassify the guard as corruption).
+        crate::db::DbError::ProdOpenDenied { .. } => DatabaseRecoveryStatus::not_required(),
     }
 }
 


### PR DESCRIPTION
## Linear ticket

[DOS-821](https://linear.app/a8c/issue/DOS-821) (820-A, child of DOS-820) · v1.4.9 W1

## Summary

Makes the dev workflow structurally incapable of touching the production DB. Introduces `DbMode {Live, Replica, Mock}` (process-wide, fail-closed: debug→Replica, release→Live) and a structural prod-open deny (`DbError::ProdOpenDenied`) enforced at **every** connection-open chokepoint — so a `pnpm tauri dev` rebuild/`pkill` loop can never open `~/.dailyos/dailyos.db`. This is the safety core that unblocks nuking + fresh-installing the corrupt prod DB (the 2026-05-28 incident).

## What changed

- `db/core.rs`: `DbMode` enum + process-wide `DB_MODE` (Acquire/Release); `set_db_mode`/`db_mode` with fail-closed default; `resolve_and_set_db_mode_from_process` (`--live`/`--replica`/`--mock` + `DAILYOS_DB_MODE`); `guard_path_for_mode` (lexical-normalized + macOS case-folded path compare) wired into **all** open chokepoints — write (`prepare_encrypted_connection`, `..._no_recovery`, `open_resolved_path` svc branch) AND read (`open_readonly_at`); `db_path()` branches per mode; legacy `is_dev_db_mode`/`set_dev_db_mode` kept as Mock/Live shims.
- `db_service.rs`: guard at `open_at` + `open_fresh_serialized`.
- `db/key_provider.rs`: guard at rekey + verify direct opens.
- `db/types.rs`: typed `DbError::ProdOpenDenied`. `state.rs`: deny classified not-recovery.
- `main.rs`, `mcp/main.rs`, all `bin/*`: bootstrap mode resolution before any open/thread. Prod-mutating bins require explicit `--live`.
- `scripts/check_db_open_guard_allowlist.sh` + preflight/CI wiring: fails on new unguarded `Connection::open` of a db path outside the allowlist.
- L0 plan (Tier 1 HTML). (A docs/research deck reframe is bundled in branch history; non-code.)

## Test plan

- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --lib` — 3089 passed, 0 failed, 11 ignored
- [x] `check_db_open_guard_allowlist.sh` passes
- [x] Deny tests exercise `open_readonly_at` directly incl. absent-prod-file + redundant-`./` spellings

## Definition of Done

- [x] Structural guard covers every open path (verified by ce-security-reviewer: "GUARD HOLDS", findings: [])
- [x] No stubs/TODOs; 820-B (workspace/config + subdir isolation) and 820-C (replica-refresh clone) are separate tickets
- [x] Gates green

## §4 Security

`security_auditor_invoked: true`

**Exemption rationale**: N/A — security review performed. The prod-open deny is a trust boundary; reviewed twice by `ce-security-reviewer` (initial: 2×P0 + 2×P1 found; re-verify after fix: GUARD HOLDS, findings: []). Touches `.github/workflows/**` (the CI gate wiring).

## Follow-ups (path-α, non-blocking → Codebase Maintenance / 820-B)

- Direct deny tests for `DbService::open_at`/`open_fresh_serialized`/rekey (covered by inspection today).
- Maintenance-bin implicit-default-refusal end-to-end test.
- `guard_path_for_mode` symlink/`~` resolution only matters if a future caller passes an untrusted path (no channel today).

## Notes for review

L2: AC-scoped (`l2-bounded-reviewer`) + `ce-security-reviewer`, both initially REQUEST_CHANGES on the read-path bypass, both resolved; re-verify APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)