### PR TITLE
docs(v1.4.9): correct W1 status — app+file single-writer shipped, 647/758 re-scoped

### DIFF
--- a/.docs/plans/v1.4.9-waves.html
+++ b/.docs/plans/v1.4.9-waves.html
@@ -35,13 +35,13 @@
   <h1 class="plans-title">I correct it once, and it stays corrected — everywhere.</h1>
   <p class="plans-kicker">Substrate Reset &amp; Judgment Maturation. L0 plan-altitude converged (cycle 4).</p>
   <p class="plans-lede">
-    A claim carries provenance and a trust band. The user dismisses, contradicts, or re-scopes it — in the app or by editing the claim's readable file — and the source's reliability updates, derived claims invalidate, and what surfaces next visibly changes across the macOS app and MCP, surviving re-enrichment and rebuild. Single-writer is the only hard gate for that loop; storage hardening, security, and transcript run parallel.
+    A claim carries provenance and a trust band. The user dismisses, contradicts, or re-scopes it — in the app or by editing the claim's readable file — and the source's reliability updates, derived claims invalidate, and what surfaces next visibly changes across the macOS app and MCP, surviving re-enrichment and rebuild. The app+file single-writer substrate that loop needs already shipped (757 · PR #365 · W0 · 820); storage hardening, security, MCP-surface DB ownership, and transcript run parallel.
   </p>
   <div class="plans-meta">
     <span>2026 (DRAFT, L0 converged)</span>
     <span>Waves: 6</span>
     <span>Linear: 874a7361</span>
-    <span>Critical path: single-writer → W3 → W4 → W5</span>
+    <span>Critical path: W3 → W4 → W5 (app+file single-writer shipped)</span>
   </div>
 </section>
 
@@ -61,13 +61,14 @@
 <section class="plans-section" aria-labelledby="seq">
   <header class="plans-section-header">
     <p class="plans-section-eyebrow">Execution sequencing</p>
-    <h2 id="seq" class="plans-section-title">Single-writer is the only loop gate; storage runs parallel.</h2>
-    <p class="plans-section-lede">Cycle-1 feasibility proved the correction loop has no code dependency on cipher-drop or rebuild — only on single-writer DB ownership. The storage-reset-first spine was an inverted critical path. Corrected below.</p>
+    <h2 id="seq" class="plans-section-title">App+file single-writer already shipped; the W1 residual is MCP-surface ownership.</h2>
+    <p class="plans-section-lede"><strong>Corrected 2026-05-31 (L0 K-in audit).</strong> The original "single-writer is the only loop gate" framing was wrong on two counts. First, the app+file single-writer substrate the correction loop (W3/W4) depends on <em>already merged to dev</em> — typed errors (DOS-757, <code>097d8171</code>), foreground-contention read-purity (PR #365), DB-throughput W0 (<code>81292e62</code>), DB-mode isolation (820-A/B, #418/#419). Second, the residual 647/758 work is <em>MCP-surface</em> DB ownership, which mainly unblocks W5 parity and is NOT a W3/W4 gate. The loop's real critical path runs through W3→W4 on substrate that exists today.</p>
   </header>
-  <pre class="plans-flow">W1a single-writer (647/758) + safety close-out (823)  ── the ONLY hard gate for the loop
-        ├──> W3 claims→files ──> W4 correction loop (HEADLINE) ──> W5 MCP parity   [CRITICAL PATH]
+  <pre class="plans-flow">W3 claims→files ──> W4 correction loop (HEADLINE) ──> W5 MCP parity   [CRITICAL PATH — app+file single-writer already shipped]
+        ├──> W1 DOS-758 MCP handler context (Track B) ── PARALLEL; L0 APPROVED + MERGED (#421); unblocks W5
+        ├──> W1 DOS-823 replica-refresh + guards ── PARALLEL; L0'd, ready
         ├──> W1b storage hardening (cipher-drop 831, rebuild 832) ── PARALLEL (832 lands after W3)
-        ├──> W2 security right-size (833 auth + 510) ── PARALLEL
+        ├──> W2 security right-size (833 auth + 510) ── PARALLEL; owns MCP cross-process single-writer (DOS-759)
         └──> W6 transcript substrate ── PARALLEL; release valve</pre>
 </section>
 
@@ -79,7 +80,7 @@
   <table class="reviewer-matrix">
     <thead><tr><th>Wave</th><th>Theme</th><th>Carries</th><th>Role</th></tr></thead>
     <tbody>
-      <tr><td>W1</td><td>DB ownership + storage hardening</td><td>W1a (gating): 647 · 758 · 823. W1b (parallel): 831 · 832 · 767 · 768 · 770 · 812</td><td>substrate</td></tr>
+      <tr><td>W1</td><td>DB ownership + storage hardening</td><td>W1a (parallel, not gating): 757 ✓shipped · 758 (Track B, L0✓ merged #421) · 823 ready. 759 cross-process → W2. W1b: 831 · 832 · 767 · 768 · 770 · 812</td><td>substrate</td></tr>
       <tr><td>W2</td><td>Security right-size</td><td>833 auth overhaul · 510</td><td>substrate (parallel)</td></tr>
       <tr><td>W3</td><td>Claims → editable readable files</td><td>628 (projection + corrections sidecar + write-back)</td><td>first loop slice</td></tr>
       <tr><td>W4</td><td>Judgment moat / correction loop</td><td>8 · 318 · 443 · 447 · 316 · 811 · 338 · 446 · 278 · 277 · 317 · 834 (keystone)</td><td>HEADLINE</td></tr>
@@ -99,7 +100,7 @@
     <article class="callout"><h3 class="callout-title">2 · Decrypt-then-drop</h3><p class="callout-prose">Split build + one-shot decrypt (mirror of <code>migrate_to_encrypted</code>) + sentinel that exits before old auto-encrypt runs; both <code>core.rs:506,650</code> sites deleted. Fallback: rebuild.</p></article>
     <article class="callout"><h3 class="callout-title">3 · Corrections survive rebuild</h3><p class="callout-prose">Content-identity correction-journal sidecar (<code>compute_dedup_key</code> shape, not raw runtime dedup_key); replay respects <code>claim_state</code> (no tombstone resurrection); tie-break + orphan-when-ambiguous; exact derivation → DOS-832 L0. Amends ADR-0048 P-4.</p></article>
     <article class="callout"><h3 class="callout-title">4 · Files-as-projection</h3><p class="callout-prose">Edit = correction input via <code>services/claims.rs</code> typed <code>FeedbackAction</code> (ADR-0123/0126); Actor::User; workspace-confined; sensitivity re-validated. Never files-as-truth.</p></article>
-    <article class="callout"><h3 class="callout-title">5 · Single-writer ownership</h3><p class="callout-prose">647/758 consume ADR-0133/0134 + the db-lock-storm-class doc verbatim. The only hard prerequisite for the loop.</p></article>
+    <article class="callout"><h3 class="callout-title">5 · Single-writer ownership</h3><p class="callout-prose">Consumes ADR-0133/0134 + the db-lock-storm-class doc verbatim. <strong>Corrected:</strong> app+file single-writer already shipped (757/PR#365/W0/820); no priority lane (ADR-0133 §3 forbids it). DOS-758 (L0✓) gives the MCP sidecar one owned connection; cross-process MCP↔app-writer routing is W2-coupled (DOS-759). Not the loop's gate — W3/W4 run on shipped substrate.</p></article>
     <article class="callout"><h3 class="callout-title">6 · Centralized trust rendering</h3><p class="callout-prose">One provenance + trust-band + sensitivity renderer for app and MCP (ADR-0105/0108). W5 is parity, not a second renderer.</p></article>
     <article class="callout"><h3 class="callout-title">7 · MCP writes via ADR-0128 §D</h3><p class="callout-prose">169/170 reconcile against §D (already authorizes <code>submit.action</code>/<code>submit.action_status</code>) — confirm it survived reconciliation; not a new amendment.</p></article>
     <article class="callout"><h3 class="callout-title">8 · Migration slots</h3><p class="callout-prose">Dev head v273. W1b v274–277 · W2 v278–279 · W3 v280–283 · W4 v284–289 · W6 v290–295. Wave lead writes confirmed numbers before branch-open.</p></article>
@@ -112,8 +113,8 @@
     <h2 id="detail" class="plans-section-title">What each wave carries and proves.</h2>
   </header>
 
-  <h3 class="plans-subhead">W1 — DB ownership + storage hardening · substrate</h3>
-  <p><strong>W1a (gating):</strong> DOS-647 single-writer + priority lane; DOS-758 request-scoped DB/services + nested-writer guard; DOS-823 (820-C) replica-refresh (consumes shipped 820-A DbMode + run_chunked_backup) + destructive-command guards, completes DOS-820.</p>
+  <h3 class="plans-subhead">W1 — DB ownership + storage hardening · substrate (parallel, not gating)</h3>
+  <p><strong>W1a:</strong> DOS-757 typed DB errors — <strong>SHIPPED</strong> (<code>097d8171</code>). DOS-758 request-scoped <code>McpHandlerContext</code> giving the out-of-process MCP sidecar one owned connection (replaces N per-handler/audit self-opens) + bounded CI gate + behavioral test — <strong>L0 APPROVED, packet merged #421</strong>; L1 in progress. DOS-823 (820-C) replica-refresh (consumes shipped 820-A DbMode + run_chunked_backup) + destructive-command guards, completes DOS-820 — L0'd, ready. <em>No priority lane</em> (ADR-0133 §3 forbids it; superseded by the merged foreground-contention read-purity work, PR #365). DOS-759 cross-process MCP↔app-writer single-writer + retry consumer + nested-writer guard is <strong>W2-coupled</strong> (needs the transport/IPC layer W2 owns).</p>
   <p><strong>W1b (parallel):</strong> DOS-831 cipher-drop (ADR-0136 + 820-A DB-mode ADR; decrypt-then-drop); DOS-832 rebuild-from-canonical, corrections-preserving (depends on W3); DOS-767/768/770/812 ingestion-hygiene.</p>
   <p><strong>Proof —</strong> substrate; replica-refresh clones prod→replica read-only, prod-destroyers refuse outside the guard, a rebuild reproduces the working DB <em>including user corrections</em>.</p>
 
@@ -146,7 +147,7 @@
   </header>
   <ul>
     <li>Headline proven + felt: a correction in app, file, and MCP each changes a surfacing the user did not directly touch, survives re-enrichment + rebuild, measured by DOS-338.</li>
-    <li>Substrate reset: plain SQLite (ADR-0136 landed); decrypt-then-drop done; rebuild preserves corrections; single-writer; replica-refresh + guards (DOS-820 closed); auth right-sized + threat-model/0102 supersession.</li>
+    <li>Substrate reset: plain SQLite (ADR-0136 landed); decrypt-then-drop done; rebuild preserves corrections; app+file single-writer (shipped) + MCP sidecar one-owned-connection (DOS-758); replica-refresh + guards (DOS-820 closed); auth right-sized + threat-model/0102 supersession.</li>
     <li>Cross-surface parity modulo the ADR-0125 sensitivity gate (Confidential/UserOnly app-only).</li>
     <li>No stubs in shipped waves: contradiction.rs / render_rules.rs / deviation.rs / recommendations/eval.rs real.</li>
     <li>Gates green: <code>cargo clippy -- -D warnings &amp;&amp; cargo test &amp;&amp; pnpm tsc --noEmit</code> (DOS-824 flake tracked separately).</li>

--- a/.docs/research/2026-05-25-dailyos-work-record.html
+++ b/.docs/research/2026-05-25-dailyos-work-record.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Can you define trust in code? &middot; DailyOS Demo Day</title>
+  <title>Democratizing Personal Intelligence &middot; DailyOS RSM Final Update</title>
 
   <link rel="stylesheet" href="../design/reference/_shared/fonts.css">
   <link rel="stylesheet" href="../design/reference/_shared/styles/design-tokens.css">
@@ -530,15 +530,12 @@
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite demo-cover">
       <p class="d-eyebrow">DailyOS &middot; RSM Final Update</p>
       <h1 class="d-headline">
-        Can we codify trust?
+        Democratizing Personal Intelligence
       </h1>
-      <p class="d-lede d-lede--wide">
-        AI at work relies on solving this one thing.
-      </p>
     </section>
 
     <!-- 2. THE TRUST GAP (HALLUCINATION) ===================== -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgTerracotta">
+    <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite" style="background: linear-gradient(rgba(196,101,74,0.15), rgba(196,101,74,0.15)), var(--color-paper-warm-white);">
       <p class="d-eyebrow">The pain</p>
       <h2 class="d-headline d-headline--med">
         Is this a fact, or did the AI just make it up?
@@ -621,13 +618,10 @@
         whether anyone still believes it. A fact that travels with its signals is what we
         call a claim.
       </p>
-      <p class="d-meta" style="margin-top: 24px;">
-        Most systems keep the fact and forget everything around it.
-      </p>
     </section>
 
     <!-- 5. THE BLIND SPOT ==================================== -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgEucalyptus">
+    <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite" style="background: linear-gradient(rgba(107,168,164,0.16), rgba(107,168,164,0.16)), var(--color-paper-warm-white);">
       <p class="d-eyebrow">The blind spot</p>
       <h2 class="d-headline d-headline--med">
         Smart isn&rsquo;t the same as trustworthy.
@@ -639,9 +633,9 @@
         The whole field is racing to give AI a better memory.
       </p>
       <p class="d-lede d-lede--wide">
-        But it&rsquo;s all the same move. Remember more, recall it faster. None of it
-        decides what matters, or what to leave out. The memory keeps getting smarter
-        without getting any more trustworthy.
+        But memory is only half of it. The other half is judgment &mdash; knowing what to
+        trust, what to flag, what to leave out. The field is racing on memory, and almost
+        nobody is building judgment.
       </p>
       <p class="d-lede d-lede--narrow">
         How does smart memory know what matters?
@@ -656,7 +650,7 @@
       </h2>
       <p class="d-lede d-lede--wide">
         Today&rsquo;s AI memory is flat. Ask about an account and it returns
-        everything it has, at the same volume, with no internal sense of what to believe
+        everything it has, at the same volume, with no judgment about what to believe
         more, what to flag, or what to leave out.
       </p>
 
@@ -710,7 +704,7 @@
     </section>
 
     <!-- 7. THE FIVE PILLARS (DIAGRAM C) ====================== -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgSage">
+    <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite" style="background: linear-gradient(rgba(126,170,123,0.15), rgba(126,170,123,0.15)), var(--color-paper-warm-white);">
       <p class="d-eyebrow">The five pillars</p>
       <h2 class="d-headline d-headline--med">
         The micro-signals every claim carries.
@@ -798,9 +792,9 @@
       </p>
     </section>
 
-    <!-- 11. THE WHOLE LOOP (DIAGRAM D) ======================= -->
+    <!-- 10. THE INTELLIGENCE LOOP (DIAGRAM D + runtime, merged) = -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite">
-      <p class="d-eyebrow">The whole loop</p>
+      <p class="d-eyebrow">The Intelligence Loop</p>
       <h2 class="d-headline d-headline--sm" style="margin-bottom: 8px;">
         Signals in. Surfaces out. Feedback closes the loop.
       </h2>
@@ -822,9 +816,9 @@
           <line x1="480" y1="100" x2="480" y2="150" stroke="var(--color-desk-ink)" stroke-width="1.5" opacity="0.7" marker-end="url(#arrow)"/>
           <text x="495" y="130" class="d-loop-edge-label">Signals</text>
 
-          <!-- Claim substrate -->
+          <!-- Claims -->
           <rect x="240" y="160" width="480" height="68" rx="10" fill="var(--color-paper-warm-white)" stroke="var(--color-desk-ink)" stroke-width="1.5"/>
-          <text x="480" y="184" text-anchor="middle" class="d-loop-node-sub">Claim substrate</text>
+          <text x="480" y="184" text-anchor="middle" class="d-loop-node-sub">Claims</text>
           <text x="480" y="208" text-anchor="middle" class="d-loop-node-label">subject &middot; time &middot; sensitivity &middot; lifecycle &middot; salience</text>
 
           <!-- Trust arrow -->
@@ -849,63 +843,19 @@
           <text x="910" y="260" text-anchor="middle" class="d-loop-edge-label" fill="var(--color-spice-terracotta)" transform="rotate(90 910 260)">Feedback</text>
         </svg>
       </div>
-    </section>
 
-    <!-- 12. WHY AN ABILITIES RUNTIME ========================= -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgLinen">
-      <p class="d-eyebrow">Why an abilities runtime</p>
-      <h2 class="d-headline d-headline--med">
-        One front door for everything the system can do.
-      </h2>
-      <p class="d-lede d-lede--wide">
-        An <em>ability</em> is a single thing DailyOS knows how to do, like
-        <code>prepare_meeting</code>, <code>get_entity_context</code>, or
-        <code>detect_risk_shift</code>. The runtime is the one registry that hosts them.
-        Every call routes through it, which is how provenance, versioning, and permissions
-        stay consistent everywhere they show up.
-      </p>
-
-      <div class="d-fanout">
-        <svg viewBox="0 0 880 400" xmlns="http://www.w3.org/2000/svg" aria-label="Abilities runtime stack">
-          <defs>
-            <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-              <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-desk-ink)" opacity="0.7"/>
-            </marker>
-          </defs>
-
-          <!-- Abilities (named capabilities) -->
-          <rect x="80" y="20" width="720" height="76" rx="10" fill="none" stroke="var(--color-desk-ink)" stroke-width="1.4" stroke-dasharray="3 4" opacity="0.7"/>
-          <text x="440" y="46" text-anchor="middle" class="d-fanout-sub">Abilities</text>
-          <text x="440" y="74" text-anchor="middle" class="d-fanout-surface">prepare_meeting &middot; get_entity_context &middot; detect_risk_shift &middot; ...</text>
-
-          <line x1="440" y1="100" x2="440" y2="150" stroke="var(--color-desk-ink)" stroke-width="1.5" opacity="0.7" marker-end="url(#arrow2)"/>
-
-          <!-- Runtime -->
-          <rect x="40" y="158" width="800" height="120" rx="12" fill="var(--color-paper-warm-white)" stroke="var(--color-desk-ink)" stroke-width="1.8"/>
-          <text x="440" y="186" text-anchor="middle" class="d-fanout-sub">Abilities runtime</text>
-          <text x="440" y="216" text-anchor="middle" class="d-fanout-runtime">one registry &middot; one entrypoint</text>
-          <text x="440" y="248" text-anchor="middle" class="d-fanout-sub">provenance &middot; versioning &middot; actor filtering &middot; contracts</text>
-
-          <line x1="440" y1="282" x2="440" y2="328" stroke="var(--color-desk-ink)" stroke-width="1.5" opacity="0.7" marker-end="url(#arrow2)"/>
-
-          <!-- Single surface -->
-          <rect x="280" y="333" width="320" height="60" rx="10" fill="none" stroke="var(--color-desk-ink)" stroke-width="1.4"/>
-          <text x="440" y="358" text-anchor="middle" class="d-fanout-sub">Surface</text>
-          <text x="440" y="380" text-anchor="middle" class="d-fanout-surface">where the answer shows up</text>
-        </svg>
-      </div>
-
-      <p class="d-meta" style="margin-top: 28px;">
-        Without this front door, every consumer of the substrate ends up inventing its
-        own context, its own prompts, its own provenance. With it, those things live once.
+      <p class="d-meta" style="margin-top: 24px; max-width: 80ch;">
+        The runtime is the one front door. An <em>ability</em> like <code>prepare_meeting</code>
+        or <code>get_entity_context</code> routes through it, so provenance, versioning, and
+        permissions stay consistent everywhere the answer shows up.
       </p>
     </section>
 
     <!-- 11. WHAT 33 DAYS SHIPPED ============================= -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite">
-      <p class="d-eyebrow">Substrate, by the numbers</p>
+      <p class="d-eyebrow">The Intelligence Loop, by the numbers</p>
       <h2 class="d-headline d-headline--med">
-        One month. A new substrate.
+        One month. A working Intelligence Loop.
       </h2>
 
       <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; max-width: 940px; width: 100%; margin-top: 16px;">
@@ -917,7 +867,7 @@
         <div>
           <p class="d-bignum" style="font-size: clamp(64px, 8vw, 104px);">+613k</p>
           <p class="d-bignum-label">net tracked lines</p>
-          <p class="d-bignum-sub">4,042 files &middot; substrate more than doubled</p>
+          <p class="d-bignum-sub">4,042 files &middot; the codebase more than doubled</p>
         </div>
         <div>
           <p class="d-bignum" style="font-size: clamp(64px, 8vw, 104px);">22.4B</p>
@@ -967,7 +917,7 @@
       </div>
 
       <p class="d-lede d-lede--wide" style="margin-top: 56px;">
-        Industry estimators say a substrate this size needs a sustained team and
+        Industry estimators say a system this size needs a sustained team and
         years of runway. RSM did it in one month. Me, plus agents.
       </p>
 
@@ -977,101 +927,101 @@
       </p>
     </section>
 
-    <!-- 12. WHAT WISER PRODUCES ============================= -->
+    <!-- 13. THE UNLOCK ====================================== -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite" style="background: var(--color-paper-cream);">
       <p class="d-eyebrow">So what?</p>
       <h2 class="d-headline d-headline--med">
-        A trustworthy workspace produces output you can act on.
+        Great context is the thing everything else needs.
       </h2>
       <p class="d-lede d-lede--wide">
-        When every claim carries its own evidence, the briefings get sharper, the prep
-        gets shorter, the decisions get easier. The better the output, the better the
-        work it lets you do.
+        Every good deck, doc, and analysis starts with great context. Trustworthy personal
+        intelligence is that context &mdash; the part you don&rsquo;t have to double-check. Get
+        memory and judgment right, and everything downstream gets better: sharper briefings,
+        shorter prep, decisions you can stand behind.
+      </p>
+      <p class="d-lede d-lede--wide">
+        Trust at the core is what makes all the AI work built on top of it actually worth doing.
       </p>
     </section>
 
-    <!-- 13. THE PAIN THE SOLUTION CREATES ==================== -->
+    <!-- 14. THE VALUE TRAVELS =============================== -->
     <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite">
-      <p class="d-eyebrow">The pain we just created</p>
+      <p class="d-eyebrow">Where it goes</p>
       <h2 class="d-headline d-headline--med">
-        The more we trust the output, the more we&rsquo;ll generate.
+        What you know is worth more when it moves.
       </h2>
       <p class="d-lede d-lede--wide">
-        Markdown notes, HTML plans, prep docs, transcripts, six versions of an onboarding
-        screen. A trustworthy substrate is also a productive one. All that rich output
-        has to live somewhere.
-      </p>
-
-      <div style="max-width: 760px; width: 100%; margin-top: 32px; padding-top: 28px; border-top: 1px solid rgba(42,43,61,0.18);">
-        <h3 class="d-headline d-headline--sm" style="margin-bottom: 14px;">
-          Sound familiar?
-        </h3>
-        <p class="d-lede d-lede--wide" style="margin-bottom: 0;">
-          At Automattic we&rsquo;ve been solving content management for over twenty years.
-          Now we need to solve it locally. Not just remotely.
-        </p>
-      </div>
-    </section>
-
-    <!-- 15b. ONE MORE THING — SURFACES REVEAL ================ -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgLinen">
-      <p class="d-eyebrow">One more thing</p>
-      <h2 class="d-headline d-headline--med">
-        What if it wasn&rsquo;t just an app?
-      </h2>
-      <p class="d-lede d-lede--wide">
-        The runtime works inside WordPress, where we already spend our time. It works
-        inside Claude or Codex over MCP, where people are spending more and more of
-        theirs. Same claims, same trust bands, same provenance.
+        Trustworthy intelligence isn&rsquo;t a private vault. It&rsquo;s the raw material of
+        the work you hand to other people. A briefing becomes your team&rsquo;s shared
+        picture. A month of research becomes the post your network actually reads. The better
+        the source, the more it&rsquo;s worth passing on.
       </p>
 
       <div class="d-fanout">
-        <svg viewBox="0 0 880 380" xmlns="http://www.w3.org/2000/svg" aria-label="DailyOS runtime, multiple surfaces">
+        <svg viewBox="0 0 880 380" xmlns="http://www.w3.org/2000/svg" aria-label="Trustworthy intelligence, shared across surfaces">
           <defs>
             <marker id="arrow4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
               <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-desk-ink)" opacity="0.7"/>
             </marker>
           </defs>
 
-          <!-- Runtime hub -->
+          <!-- Source hub -->
           <circle cx="440" cy="190" r="108" fill="var(--color-paper-warm-white)" stroke="var(--color-desk-ink)" stroke-width="1.8"/>
-          <text x="440" y="178" text-anchor="middle" class="d-fanout-sub">DailyOS runtime</text>
-          <text x="440" y="206" text-anchor="middle" class="d-fanout-runtime">one substrate</text>
+          <text x="440" y="178" text-anchor="middle" class="d-fanout-sub">What you know</text>
+          <text x="440" y="206" text-anchor="middle" class="d-fanout-runtime">trustworthy intelligence</text>
 
-          <!-- Surface: Tauri app -->
+          <!-- Destination: team -->
           <rect x="40"  y="40"  width="200" height="68" rx="10" fill="none" stroke="var(--color-desk-ink)" stroke-width="1.4"/>
-          <text x="140" y="68"  text-anchor="middle" class="d-fanout-sub">Today</text>
-          <text x="140" y="92"  text-anchor="middle" class="d-fanout-surface">Desktop app</text>
+          <text x="140" y="68"  text-anchor="middle" class="d-fanout-sub">Your team</text>
+          <text x="140" y="92"  text-anchor="middle" class="d-fanout-surface">a P2</text>
 
-          <!-- Surface: MCP -->
+          <!-- Destination: tools -->
           <rect x="640" y="40"  width="200" height="68" rx="10" fill="none" stroke="var(--color-desk-ink)" stroke-width="1.4"/>
-          <text x="740" y="68"  text-anchor="middle" class="d-fanout-sub">What if</text>
-          <text x="740" y="92"  text-anchor="middle" class="d-fanout-surface">Claude &middot; Codex via MCP</text>
+          <text x="740" y="68"  text-anchor="middle" class="d-fanout-sub">Your tools</text>
+          <text x="740" y="92"  text-anchor="middle" class="d-fanout-surface">Claude &middot; Codex over MCP</text>
 
-          <!-- Surface: WordPress -->
+          <!-- Destination: network -->
           <rect x="340" y="312" width="200" height="68" rx="10" fill="none" stroke="var(--color-desk-ink)" stroke-width="1.4"/>
-          <text x="440" y="340" text-anchor="middle" class="d-fanout-sub">What if</text>
-          <text x="440" y="364" text-anchor="middle" class="d-fanout-surface">Local WordPress layer</text>
+          <text x="440" y="340" text-anchor="middle" class="d-fanout-sub">Your network</text>
+          <text x="440" y="364" text-anchor="middle" class="d-fanout-surface">your own site</text>
 
-          <!-- Lines -->
-          <line x1="240" y1="74"  x2="350" y2="148" stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
-          <line x1="640" y1="74"  x2="530" y2="148" stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
-          <line x1="440" y1="312" x2="440" y2="300" stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
+          <!-- Lines — value flows OUT from the hub to each destination -->
+          <line x1="350" y1="148" x2="240" y2="74"  stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
+          <line x1="530" y1="148" x2="640" y2="74"  stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
+          <line x1="440" y1="298" x2="440" y2="312" stroke="var(--color-desk-ink)" stroke-width="1.4" opacity="0.7" marker-end="url(#arrow4)"/>
         </svg>
       </div>
-
     </section>
 
-    <!-- 15. CLOSE ============================================ -->
-    <section class="monthly-wrapped_slide monthly-wrapped_bgEucalyptus demo-close">
+    <!-- 15. THE GOOD PROBLEM ================================ -->
+    <section class="monthly-wrapped_slide monthly-wrapped_bgLinen">
+      <p class="d-eyebrow">What comes next</p>
+      <h2 class="d-headline d-headline--med">
+        The more you trust it, the more you make.
+      </h2>
+      <p class="d-lede d-lede--wide">
+        Trust compounds. The more you rely on your personal intelligence, the more you produce
+        with it &mdash; briefings, analyses, decisions, a growing record of work you can stand behind.
+      </p>
+      <p class="d-lede d-lede--wide">
+        All of it has to live somewhere. Stay organized. Stay findable. The better personal
+        intelligence gets, the more managing what it produces becomes the real problem.
+      </p>
+    </section>
+
+    <!-- 16. CLOSE ============================================ -->
+    <section class="monthly-wrapped_slide monthly-wrapped_bgWarmWhite demo-close" style="background: linear-gradient(rgba(107,168,164,0.18), rgba(107,168,164,0.18)), var(--color-paper-warm-white);">
       <p class="d-eyebrow">Why all this earth had to move</p>
       <h2 class="d-headline">
         Memory. Judgment. Trust.
       </h2>
       <p class="d-lede d-lede--wide">
-        Memory knows what happened. Judgment decides what matters.
-        Trust is what they produce together when the substrate is doing its job.
-        That&rsquo;s the bet. That&rsquo;s what RSM was for.
+        Memory is what happened. Judgment is what matters. Trust is the difference between
+        AI you check and AI you rely on.
+      </p>
+      <p class="d-lede d-lede--wide">
+        We&rsquo;re betting personal intelligence is the next opportunity for software
+        that&rsquo;s open, private, and yours. The next thing WordPress is for.
       </p>
 
       <div class="d-pills">
@@ -1081,7 +1031,7 @@
       </div>
 
       <p class="d-meta" style="margin-top: 56px;">
-        Demo Day &middot; May 25, 2026.
+        RSM Final Update &middot; May 2026.
         Stats anchored to <code>public/dev</code> on May 25. Open PRs not included.
       </p>
     </section>


### PR DESCRIPTION
## Linear ticket

[DOS-758](https://linear.app/a8c/issue/DOS-758) (and the v1.4.9 wave program, project 874a7361)

## Summary

Corrects two framing errors in the v1.4.9 wave plan that the L0 K-in audit (2026-05-31) surfaced. Doc-only.

## What changed

- `.docs/plans/v1.4.9-waves.html`:
  - The "single-writer is the only loop gate" framing was wrong. The app+file single-writer substrate the W3/W4 correction loop depends on **already merged to dev**: typed errors (DOS-757, `097d8171`), foreground-contention read-purity (PR #365), DB-throughput W0 (`81292e62`), DB-mode isolation (820-A/B, #418/#419).
  - The residual 647/758 work is **MCP-surface** DB ownership — unblocks W5 parity, NOT a W3/W4 gate. The loop's real critical path is W3→W4 on substrate that exists today.
  - **No priority lane** (ADR-0133 §3 forbids it; superseded by PR #365's read-purity approach).
  - Reflects DOS-758 re-scoped Track-B-only (MCP sidecar one owned connection), L0 APPROVED + packet merged #421; DOS-759 cross-process routing is W2-coupled.
  - Edited: cover lede, critical-path meta, sequencing block, wave-shape row, decision #5, W1 detail, DoD substrate line.

## Test plan

n-a-doc-only — plan document only; no code paths changed. Status reflects merged commits and the unanimous L0 verdict on DOS-758.

## §4 Security

`security_auditor_invoked: false`

**Exemption ID**: `EXEMPT-DOC-ONLY`

**Exemption rationale**: Planning-document status correction; no source, migration, prompt, or config changes.

- [ ] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table?
- [ ] Changes a prompt template?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs, tool registry, or skill definitions?

## L2-status

n-a-doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)