### PR TITLE
v1.5.0 List Surfaces: shared entity selection

### DIFF
--- a/.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md
+++ b/.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md
@@ -1,0 +1,151 @@
+# v1.5.0 List-Surfaces PR A L0 Packet - Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05` (W0 merged)  
+**Linear:** DOS-826. Related but out of this PR: DOS-830, DOS-828, DOS-829. DOS-827 lands through W5 per-type config.  
+**Origination class:** Dogfood UX failure surfaced in v1.5.0 wave planning.  
+**Trust topology:** Single local OS user, Tauri app surface only. This slice adds no backend write path.
+
+## 0. Premise Check
+
+The wave plan marks List-Surfaces as a parallel lane and makes premise-check a gate before AC, not advisory. Current-dev source inspection confirms the DOS-826 premise:
+
+- `EntityListShell` owns header, archive tabs, filter tabs, and ending only; it has no shared selection state, action bar, or select-all contract (`src/components/entity/EntityListShell.tsx:42`, `:83`, `:108`).
+- `EntityRow` exposes navigation, accent/avatar, text, metadata, and indentation props only; no checkbox, selected state, or selection callback exists (`src/components/entity/EntityRow.tsx:5`).
+- Accounts derive filters locally and render rows through `AccountTreeNode` / `AccountRow` without selection props (`src/pages/AccountsPage.tsx:343`, `:759`, `:908`).
+- Projects filter active rows locally and render `ProjectTreeNode` / archived rows without selection props (`src/pages/ProjectsPage.tsx:173`, `:359`, `:498`).
+- People filter/sort locally and render `PersonRow` / `ArchivedPersonRow` without selection props (`src/pages/PeoplePage.tsx:171`, `:577`, `:599`).
+- Archive commands are single-entity only (`archive_account`, `archive_project`, `archive_person`) and are intentionally not changed by this PR (`src-tauri/src/commands/projects_data.rs:459`, `:503`, `:525`).
+
+This packet therefore scopes PR A to the foundational affordance: select rows consistently across Accounts, Projects, and People so DOS-830 can add a real bulk archive action in the next slice without rebuilding selection three times.
+
+## 1. Scope
+
+### In
+
+- Add a shared selection model for entity list pages.
+- Add optional semantic checkbox selection affordance to `EntityRow`, visually compatible with the existing row language but not copied from `ActionRow`'s visual button implementation.
+- Add a selection action bar for `EntityListShell` consumers when one or more active rows are selected.
+- Support select visible, clear selection, individual row toggles, and shift-click range select.
+- Wire Accounts, Projects, and People active-list rows into the shared selection model.
+- Preserve selection across search/filter/tab changes within the same page when the selected entity still belongs to the active list.
+- Clear selection when switching to archived mode, navigating away, or reloading into a different entity-list page.
+- Add frontend tests that pin selection behavior, keyboard/ARIA basics, and the no-nested-interactive-controls row structure.
+
+### Out
+
+- Bulk archive mutation and confirmation flow (DOS-830).
+- Workspace folder move/tombstone/reconciliation on archive (DOS-828).
+- Drag-and-drop reparenting (DOS-829).
+- Editable lifecycle stages and canonical per-type lifecycle config (DOS-827 / W5).
+- Backend commands, DB schema, claims, migrations, source attribution, or signals in this PR.
+
+## 2. Intelligence Loop Check
+
+| Question | PR A answer |
+|---|---|
+| Claim model | Selection is local UI state. It is not an intelligence claim, does not describe a subject, and must not be persisted as display-only data. |
+| Provenance + trust | No provenance or trust scoring changes. Rows keep their existing rendered data and links. |
+| Signals + invalidation | No mutation, so no signal emission in PR A. DOS-830 must reuse existing archive services and signal propagation. |
+| Runtime + surfaces | Tauri React pages only. No MCP, local-loopback, filesystem, or command-surface expansion. |
+| Feedback loop | None for selection itself. Later archive/reparent/lifecycle slices must define feedback/signal semantics at their own L0. |
+
+## 3. K-In Discovery
+
+- ADR-0047 and ADR-0048 establish that workspace files are durable user-owned archive material, not disposable UI cache. This matters for DOS-828, so PR A must not fake archive by hiding rows client-side.
+- ADR-0059 defines the entity directory template and durable workspace convention. DOS-828 should build a service-owned reconciliation/move path against that convention.
+- ADR-0040 treats archive reconciliation as deterministic Rust work. That is the right substrate family for orphan-folder repair, not a React concern.
+- ADR-0056 establishes account parent-child hierarchy through structural `parent_id`. DOS-829 should use existing graph semantics and cycle prevention; PR A must not introduce drag/drop state that looks like a graph mutation.
+- ADR-0079 and the v1.5.0 wave plan tie lifecycle vocabulary to presets/per-type config. DOS-827 belongs with W5, not this selection slice.
+- Existing services already enforce mutation discipline for archive: account archive checks `ServiceContext`, writes through a transaction, emits `entity_archived` / `entity_unarchived`, and clears queued enrichment (`src-tauri/src/services/accounts.rs:2762`). PR A must leave that path untouched.
+
+## 4. Implementation Plan
+
+### U1 - Shared Selection Contracts
+
+Add a small shared type/hook under `src/components/entity/` or `src/hooks/`:
+
+- Selection key: entity id string. The page owns entity type by route, so no mixed-type key is needed inside one page.
+- Inputs: ordered visible active ids and optional all-active ids.
+- Outputs: `selectedIds`, `selectedCount`, `isSelected(id)`, `toggle(id, opts)`, `selectVisible()`, `clear()`, `pruneTo(ids)`.
+- Shift range uses the current ordered visible ids, not database order.
+- `pruneTo(activeIds)` runs after active-list data refresh so stale ids cannot remain selected after an entity disappears.
+
+### U2 - Entity Row Selection Affordance
+
+Extend `EntityRow` with an optional `selection` prop:
+
+- Render `EntityRow` as an outer row container when it has any interactive row controls. The selection checkbox, entity navigation link/anchor, and any inline row controls must be sibling interactive elements, not nested inside each other.
+- Checkbox rendered before the entity navigation region when supplied.
+- Use a native `<input type="checkbox">` unless implementation proves an equivalent custom checkbox is needed. If custom, it must expose `role="checkbox"`, `aria-checked`, and keyboard toggle behavior.
+- Checkbox click and Space-key toggle select the row and must not trigger entity navigation.
+- Row navigation remains available through the entity identity/link region; selection is explicit through checkbox.
+- Existing Accounts/Projects expand controls must move out of the link-wrapped name suffix into a dedicated sibling control slot or equivalent structure that preserves independent focus and click behavior.
+- Selected rows get a restrained state style using existing design tokens.
+- ARIA: checkbox has an accessible label derived from row name, row link remains a link, action-bar buttons have accessible names, and all interactive controls show visible focus states.
+
+### U3 - Selection Action Bar
+
+Add a shared `EntitySelectionBar` or `selectionActions` slot in `EntityListShell`:
+
+- Shows selected count.
+- Offers select visible and clear.
+- Hosts page-provided future action buttons through `children`.
+- Does not render destructive actions in PR A.
+- Compact enough for the magazine shell; no nested cards.
+
+### U4 - Page Wiring
+
+Wire the shared hook/bar/row prop into:
+
+- Accounts: flatten rendered active account tree in visual order, including expanded children. Archived tab clears selection and has no selection affordance.
+- Projects: same active tree behavior as Accounts.
+- People: active sorted/grouped rows only. Archived tab clears selection and has no selection affordance.
+
+### U5 - Tests
+
+Add focused frontend coverage:
+
+- Shared hook/unit coverage for individual toggle, select visible, clear, prune stale ids, and shift range.
+- `EntityRow` coverage that checkbox toggles without navigation and selected styling/ARIA is present.
+- Row-structure coverage that selection checkbox and existing expand controls are not nested inside entity links.
+- Page-level smoke for at least one grouped/tree page and one flat/grouped page showing the selection bar and clearing on archived mode.
+
+## 5. Acceptance Criteria
+
+1. Accounts, Projects, and People active list rows show a checkbox selection affordance.
+2. Selecting one or more rows shows a shared selection action bar with count, select-visible, clear, and an action slot.
+3. Shift-click range selection works against the currently visible active rows.
+4. Selection persists across search/filter changes within a page, then prunes ids that disappear after data refresh.
+5. Selection clears when switching to archived mode or leaving the route.
+6. Archived rows are not selectable in PR A.
+7. Row navigation still works when clicking row content; checkbox clicks do not navigate.
+8. Entity-row markup contains no nested interactive controls: checkbox, navigation link, and expand controls are separate focus targets.
+9. Selection uses native checkbox semantics, or an equivalent accessible checkbox with `role="checkbox"`, `aria-checked`, Space-key toggle, accessible labels, and visible focus states.
+10. Selection action-bar buttons have accessible names and visible focus states.
+11. No backend commands, services, migrations, claims, or signal policies are changed in PR A.
+12. Tests cover the shared selection behavior, row accessibility/interaction behavior, and at least one tree/grouped integration path.
+
+## 6. Verification Plan
+
+- `pnpm test EntityRow entity-list-selection`
+- `pnpm test`
+- `pnpm tsc --noEmit`
+- `git diff --check`
+- Browser/L4 proof before PR: Accounts, Projects, People active lists show selection; shift-range works; archived mode clears selection; mobile width does not overlap row content.
+
+Rust gates are not expected to be required for PR A if no Rust files change. If implementation touches Tauri or service code, run `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` and `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1`.
+
+## 7. L0 Reviewer Routing
+
+- Default: `/codex challenge`.
+- Planning reviewer: `ce-design-lens-reviewer` because this is a user-facing list interaction and visual/accessibility affordance.
+- K-in: `ce-learnings-researcher` with the cited ADR/docs hits above.
+- No Amendment 3 add-on for PR A because there is no write path, filesystem path, MCP path, claim/provenance mutation, or privacy-boundary expansion.
+
+## 8. Follow-On Slices
+
+- **PR B / DOS-830 + DOS-828:** bulk archive action and archive-folder reconciliation must share one L0 because DOS-830 explicitly says archive behavior should land consistently with folder reconciliation. Decide move-vs-tombstone there; prefer reversible move/tombstone, not delete.
+- **PR C / DOS-829:** drag-and-drop reparenting with cycle prevention, service-owned graph mutation, signal emission, and invalidation of hierarchy-dependent derived state.
+- **W5 / DOS-827:** per-type lifecycle stages in the type config surface; list tabs consume canonical config instead of emergent data values.

--- a/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
+++ b/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
@@ -106,3 +106,14 @@ Not run for PR A. The diff is frontend-only and does not touch Tauri, services, 
 ## Remaining Gates
 
 - Browser/L4 surface proof before PR if local Tauri/browser environment is available without entering the replica/production database path currently under separate investigation.
+
+## L4 Attempt - 2026-06-02
+
+Result: blocked by environment, not by a PR A code finding.
+
+- `DAILYOS_DB_MODE=replica RUST_LOG=warn pnpm tauri dev` launched Vite and compiled the PR A backend, but startup entered database recovery because the shared replica DB is already at schema version 274 from the later PR B stack while PR A supports schema version 273.
+- No recovery, downgrade, or production/live DB action was attempted.
+- `DAILYOS_DB_MODE=mock RUST_LOG=warn pnpm tauri dev` launched against the fixture DB path and completed startup migrations for `dailyos-dev.db`; only expected mock/dev warnings were observed.
+- Native surface inspection was blocked because the macOS session was at the lock screen, and the agent must not unlock the machine or enter credentials.
+
+Draft status remains appropriate until native Tauri L4 proof can be captured from an unlocked session or after PR A is evaluated against a compatible branch/database state.

--- a/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
+++ b/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
@@ -1,0 +1,108 @@
+# v1.5.0 List-Surfaces PR A Proof Bundle - DOS-826 Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05`  
+**Scope:** frontend-only shared selection affordance for active Accounts, Projects, and People list rows.
+
+## Acceptance Evidence
+
+- Active Accounts, Projects, and People rows now receive semantic checkbox selection props.
+- Archived rows do not receive selection props.
+- Shared `useEntityListSelection` handles individual toggle, select visible, clear, stale-id pruning, and visible-order shift ranges.
+- `EntityRow` renders checkbox, navigation link/anchor, and row controls as sibling focus targets.
+- Accounts/Projects expand controls moved out of link-wrapped row content.
+- Selection bars clear in archived mode.
+- People relationship tabs now filter from the active people list client-side so hidden-but-active selections can persist across tab changes.
+- No backend commands, services, migrations, claims, source attribution, filesystem behavior, or signal policy changed.
+
+## Verification
+
+### L2 diff review
+
+Artifact:
+
+```text
+.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
+```
+
+Result: APPROVE, no findings.
+
+### Focused frontend tests
+
+Command:
+
+```bash
+pnpm test EntityRow EntityListShell useEntityListSelection ProjectsPage.selection PeoplePage.selection
+```
+
+Result:
+
+```text
+Test Files  5 passed (5)
+Tests       10 passed (10)
+```
+
+### TypeScript
+
+Command:
+
+```bash
+pnpm tsc --noEmit
+```
+
+Result: pass.
+
+### Full frontend tests
+
+Command:
+
+```bash
+pnpm test
+```
+
+Result:
+
+```text
+Test Files  53 passed (53)
+Tests       284 passed (284)
+```
+
+### Production frontend build
+
+Command:
+
+```bash
+pnpm build
+```
+
+Result: pass. Vite emitted its existing large-chunk warning.
+
+### Targeted lint
+
+Commands:
+
+```bash
+pnpm exec eslint src/components/entity/EntityListShell.tsx src/components/entity/EntityRow.tsx src/components/entity/useEntityListSelection.ts src/pages/AccountsPage.tsx src/pages/ProjectsPage.tsx src/pages/PeoplePage.tsx src/components/entity/EntityListShell.test.tsx src/components/entity/EntityRow.test.tsx src/components/entity/useEntityListSelection.test.tsx src/pages/ProjectsPage.selection.test.tsx src/pages/PeoplePage.selection.test.tsx --max-warnings 9999
+pnpm exec stylelint "src/components/entity/EntityListShell.module.css" "src/components/entity/EntityRow.module.css"
+```
+
+Result: pass. ESLint reported one existing `AccountsPage` warning for the unrelated `discoveryEnabled` folio-action memo dependency; the PR-introduced archived-mode selection dependency warnings were fixed before final verification.
+
+### Diff check
+
+Command:
+
+```bash
+git diff --check public/dev
+```
+
+Result: pass.
+
+## Rust Gates
+
+Not run for PR A. The diff is frontend-only and does not touch Tauri, services, migrations, commands, or Rust tests.
+
+## Remaining Gates
+
+- Browser/L4 surface proof before PR if local Tauri/browser environment is available without entering the replica/production database path currently under separate investigation.

--- a/.docs/reviews/v1.5.0-list-surfaces-pr-a-l0-2026-06-01.md
+++ b/.docs/reviews/v1.5.0-list-surfaces-pr-a-l0-2026-06-01.md
@@ -1,0 +1,70 @@
+# v1.5.0 List-Surfaces PR A L0 Review - DOS-826 Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05`  
+**Plan packet:** `.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md`
+
+## Verdict
+
+**APPROVE.** L0 is passed for PR A / DOS-826.
+
+## Reviewer Results
+
+### `/codex challenge`
+
+**Cycle 1 verdict:** APPROVE.
+
+Findings: none.
+
+Notes:
+
+- Packet scope matches the List-Surfaces lane: DOS-826 multi-select first; DOS-830/DOS-828 bulk archive and folder reconciliation later; DOS-829 reparent later; DOS-827 lifecycle via W5.
+- Current source supports the premise: `EntityListShell` and `EntityRow` have no selection substrate, and Accounts/Projects/People render rows without selection props.
+- The plan avoids backend/write-path changes, so the Intelligence Loop answer and no-Amendment-3-add-on routing are acceptable for PR A.
+- PR B should explicitly dedupe parent/child selections before bulk archive because account/project archive services cascade children. Follow-on design detail, not a PR A blocker.
+
+### `ce-design-lens-reviewer`
+
+**Cycle 1 verdict:** REQUEST_CHANGES.
+
+Blockers:
+
+1. The plan needed to explicitly prevent nested interactive controls in `EntityRow`.
+2. Accessibility ACs were not concrete enough for L2.
+3. "Modeled on ActionRow checkbox pattern" was risky because `ActionRow` uses a visual button pattern, not native checkbox semantics.
+
+Resolution:
+
+- Updated the packet to require an outer row container where checkbox, navigation link/anchor, and inline controls are sibling focus targets.
+- Required native checkbox semantics by default, or equivalent `role="checkbox"` / `aria-checked` / Space-key behavior if custom.
+- Required visible focus states, accessible names, and tests proving checkbox interaction does not navigate.
+- Required Accounts/Projects expand controls to move out of link-wrapped name content.
+
+**Cycle 2 verdict:** APPROVE.
+
+Residual risk: normal L1 execution risk around restructuring existing account/project expand controls without regressing navigation.
+
+### `ce-learnings-researcher`
+
+**Cycle 1 verdict:** APPROVE.
+
+No blocking K-in issue found. Searches across `docs/solutions/`, `.docs/decisions/`, and relevant frontend source paths found no prior documented/shared entity-list selection primitive for `useSelection`, `selectedIds`, `selectVisible`, shift selection, selection bar, or checkbox selection.
+
+Cited constraints:
+
+- `docs/solutions/README.md`: K-in is mandatory at L0; documented substrate reinvention blocks approval.
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`: search by substrate type, not proposed module name.
+- `.docs/decisions/0054-list-page-design-pattern.md`: list pages must remain flat, dense, signal-first rows.
+- `.docs/decisions/0048-three-tier-data-model.md`, `.docs/decisions/0040-archive-reconciliation.md`, `.docs/decisions/0059-entity-directory-template.md`: archive and workspace-folder behavior belongs in durable service/Rust follow-on work, not PR A.
+- `.docs/decisions/0056-parent-child-accounts.md`, `.docs/decisions/0087-entity-hierarchy-intelligence.md`: hierarchy changes are structural graph work for DOS-829, not selection state.
+- `.docs/decisions/0079-role-presets.md`, `.docs/decisions/0127-presets-as-intelligence-contracts.md`: lifecycle configuration belongs in W5/DOS-827.
+- `.docs/decisions/0101-service-boundary-enforcement.md`, `.docs/decisions/0115-signal-granularity-audit.md`: service mutations and signal policy stay out of PR A.
+
+## L1 Entry Constraints
+
+- Implement DOS-826 only: shared local UI selection state for active entity list rows.
+- Do not add backend commands, services, migrations, claims, source attribution, filesystem behavior, archive behavior, graph reparenting, or lifecycle config.
+- Preserve DailyOS flat list density and magazine shell.
+- Avoid nested interactive markup in `EntityRow`.
+- Add tests for shared selection behavior, row accessibility/interaction behavior, and at least one tree/grouped integration path.

--- a/.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
+++ b/.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
@@ -1,0 +1,39 @@
+# v1.5.0 List Surfaces PR A L2 Review
+
+Date: 2026-06-01  
+Branch: `codex/v1.5.0-list-surfaces`  
+Base: `public/dev` at W0 merged state  
+Scope: DOS-826, multi-select entity rows for Accounts, Projects, and People list surfaces
+
+## Verdict
+
+APPROVE
+
+## Review Route
+
+- Default L2: `/codex review` via `l2-bounded-reviewer`.
+- Specialist scope considered: UI/accessibility and list selection behavior.
+- No backend, schema, claim, trust, signal, filesystem, MCP, or write-path changes were present in this PR A diff.
+
+## Findings
+
+None.
+
+## Verification
+
+- Active Accounts, Projects, and People rows expose semantic checkbox selection.
+- Archived rows are not selectable and selection clears in archived mode.
+- Row navigation, checkbox selection, and hierarchy expand controls are sibling focus targets.
+- Shift-range selection follows rendered visible order through the shared selection hook.
+- Hidden-but-active People selections survive relationship tab changes.
+- The diff does not introduce backend, Rust, schema, claims, signals, filesystem, or persistence changes.
+
+Commands run by the L2 reviewer:
+
+```bash
+pnpm test EntityRow EntityListShell useEntityListSelection ProjectsPage.selection PeoplePage.selection
+pnpm tsc --noEmit
+git diff --check public/dev
+```
+
+Results: all passed.

--- a/src/components/entity/EntityListShell.module.css
+++ b/src/components/entity/EntityListShell.module.css
@@ -49,3 +49,57 @@
   padding: 8px 0;
   outline: none;
 }
+
+.selectionBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 10px 0;
+  margin: var(--space-md) 0;
+  border-top: 1px solid var(--color-rule-light);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.selectionCount {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.selectionActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.selectionButton {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.selectionButton:disabled {
+  color: var(--color-text-tertiary);
+  cursor: default;
+  text-decoration: none;
+}
+
+.selectionButton:focus-visible {
+  outline: 2px solid var(--color-garden-larkspur);
+  outline-offset: 3px;
+}

--- a/src/components/entity/EntityListShell.test.tsx
+++ b/src/components/entity/EntityListShell.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EntitySelectionBar } from "./EntityListShell";
+
+describe("EntitySelectionBar", () => {
+  it("stays hidden until rows are selected", () => {
+    const { container } = render(
+      <EntitySelectionBar
+        selectedCount={0}
+        visibleCount={2}
+        onSelectVisible={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders accessible selection actions", () => {
+    const onSelectVisible = vi.fn();
+    const onClear = vi.fn();
+
+    render(
+      <EntitySelectionBar
+        selectedCount={2}
+        visibleCount={4}
+        onSelectVisible={onSelectVisible}
+        onClear={onClear}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("2 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select 4 visible rows" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear selected rows" }));
+
+    expect(onSelectVisible).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/entity/EntityListShell.tsx
+++ b/src/components/entity/EntityListShell.tsx
@@ -131,6 +131,52 @@ export function FilterTabs<T extends string>({
   );
 }
 
+// ─── Selection Bar ───────────────────────────────────────────────────────────
+
+export function EntitySelectionBar({
+  selectedCount,
+  visibleCount,
+  onSelectVisible,
+  onClear,
+  children,
+}: {
+  selectedCount: number;
+  visibleCount: number;
+  onSelectVisible: () => void;
+  onClear: () => void;
+  children?: ReactNode;
+}) {
+  if (selectedCount <= 0) return null;
+
+  return (
+    <div className={styles.selectionBar} role="status" aria-live="polite">
+      <span className={styles.selectionCount}>
+        {selectedCount} selected
+      </span>
+      <div className={styles.selectionActions}>
+        {children}
+        <button
+          type="button"
+          className={styles.selectionButton}
+          onClick={onSelectVisible}
+          disabled={visibleCount === 0}
+          aria-label={`Select ${visibleCount} visible ${visibleCount === 1 ? "row" : "rows"}`}
+        >
+          Select visible
+        </button>
+        <button
+          type="button"
+          className={styles.selectionButton}
+          onClick={onClear}
+          aria-label="Clear selected rows"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
  
 export function EntityListEndMark(_props?: { text?: string }) {
   return <FinisMarker />;

--- a/src/components/entity/EntityRow.module.css
+++ b/src/components/entity/EntityRow.module.css
@@ -5,11 +5,43 @@
   align-items: flex-start;
   gap: 12px;
   padding: 14px 0;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.rowSelected {
+  background: var(--color-surface-primary);
+}
+
+.rowBody,
+.rowLink {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
   text-decoration: none;
+  color: inherit;
+}
+
+.rowLink:focus-visible,
+.checkbox:focus-visible,
+.controls :is(button, a):focus-visible {
+  outline: 2px solid var(--color-garden-larkspur);
+  outline-offset: 3px;
 }
 
 .rowBorder {
   border-bottom: 1px solid var(--color-rule-light);
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin: 4px 0 0;
+  accent-color: var(--color-garden-larkspur);
+  cursor: pointer;
 }
 
 .dot {
@@ -51,4 +83,12 @@
   align-items: baseline;
   gap: 16px;
   flex-shrink: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-top: 1px;
 }

--- a/src/components/entity/EntityRow.test.tsx
+++ b/src/components/entity/EntityRow.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { EntityRow } from "./EntityRow";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+describe("EntityRow", () => {
+  it("renders selection, navigation, and row controls as separate focus targets", () => {
+    const onSelect = vi.fn();
+    const onExpand = vi.fn();
+
+    render(
+      <EntityRow
+        to="/accounts/$accountId"
+        params={{ accountId: "acct-1" }}
+        name="Example Account"
+        showBorder
+        selection={{
+          selected: false,
+          label: "Select Example Account",
+          onChange: onSelect,
+        }}
+        controls={(
+          <button type="button" onClick={onExpand}>
+            Expand
+          </button>
+        )}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select Example Account" });
+    const link = screen.getByRole("link", { name: "Example Account" });
+    const expand = screen.getByRole("button", { name: "Expand" });
+
+    expect(link).not.toContainElement(checkbox);
+    expect(link).not.toContainElement(expand);
+
+    fireEvent.click(checkbox);
+    expect(onSelect).toHaveBeenCalledWith({ shiftKey: false });
+    expect(onExpand).not.toHaveBeenCalled();
+
+    fireEvent.click(expand);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes shift-key checkbox interaction to the selection handler", () => {
+    const onSelect = vi.fn();
+
+    render(
+      <EntityRow
+        to="/people/$personId"
+        params={{ personId: "person-1" }}
+        name="Example Person"
+        showBorder={false}
+        selection={{
+          selected: true,
+          label: "Select Example Person",
+          onChange: onSelect,
+        }}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select Example Person" });
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox, { shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith({ shiftKey: true });
+  });
+});

--- a/src/components/entity/EntityRow.tsx
+++ b/src/components/entity/EntityRow.tsx
@@ -1,6 +1,12 @@
-import { type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import s from "./EntityRow.module.css";
+
+interface EntityRowSelection {
+  selected: boolean;
+  label?: string;
+  onChange: (options: { shiftKey: boolean }) => void;
+}
 
 interface EntityRowProps {
   to?: string;
@@ -18,6 +24,10 @@ interface EntityRowProps {
   children?: ReactNode;
   /** Optional avatar element to replace the accent dot */
   avatar?: ReactNode;
+  /** Optional row-level selection control */
+  selection?: EntityRowSelection;
+  /** Interactive row controls rendered outside the entity link */
+  controls?: ReactNode;
 }
 
 export function EntityRow({
@@ -32,9 +42,15 @@ export function EntityRow({
   subtitle,
   children,
   avatar,
+  selection,
+  controls,
 }: EntityRowProps) {
-  const className = `${s.row} ${showBorder ? s.rowBorder : ""}`;
-  const rowStyle = { paddingLeft };
+  const className = [
+    s.row,
+    showBorder ? s.rowBorder : "",
+    selection?.selected ? s.rowSelected : "",
+  ].filter(Boolean).join(" ");
+  const rowStyle: CSSProperties = { paddingLeft };
   const content = (
     <>
       {/* Avatar or accent dot */}
@@ -72,37 +88,54 @@ export function EntityRow({
     </>
   );
 
+  const bodyClassName = to || href ? s.rowLink : s.rowBody;
+
+  let body: ReactNode;
   if (href) {
-    return (
+    body = (
       <a
         href={href}
         target="_blank"
         rel="noreferrer"
-        className={className}
-        style={rowStyle}
+        className={bodyClassName}
       >
         {content}
       </a>
     );
-  }
-
-  if (to) {
-    return (
+  } else if (to) {
+    body = (
       <Link
         to={to}
         params={params ?? {}}
-        className={className}
-        // Runtime hierarchy controls nested row indentation.
-        style={rowStyle}
+        className={bodyClassName}
       >
         {content}
       </Link>
     );
+  } else {
+    body = <div className={bodyClassName}>{content}</div>;
   }
 
   return (
     <div className={className} style={rowStyle}>
-      {content}
+      {selection && (
+        <input
+          type="checkbox"
+          className={s.checkbox}
+          checked={selection.selected}
+          aria-label={selection.label ?? `Select ${name}`}
+          onChange={(event) => {
+            const nativeEvent = event.nativeEvent as Event & { shiftKey?: boolean };
+            selection.onChange({ shiftKey: Boolean(nativeEvent.shiftKey) });
+          }}
+        />
+      )}
+      {body}
+      {controls && (
+        <div className={s.controls}>
+          {controls}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/entity/useEntityListSelection.test.tsx
+++ b/src/components/entity/useEntityListSelection.test.tsx
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+} from "./useEntityListSelection";
+
+function SelectionHarness({
+  visibleIds,
+  activeIds = visibleIds,
+}: {
+  visibleIds: string[];
+  activeIds?: string[];
+}) {
+  const selection = useEntityListSelection({ visibleIds, activeIds });
+
+  return (
+    <div>
+      <output data-testid="selected">{selection.selectedIds.join(",")}</output>
+      {activeIds.map((id) => (
+        <button
+          key={id}
+          type="button"
+          onClick={(event) => selection.toggle(id, { shiftKey: event.shiftKey })}
+        >
+          Toggle {id}
+        </button>
+      ))}
+      <button type="button" onClick={selection.selectVisible}>
+        Select visible
+      </button>
+      <button type="button" onClick={selection.clear}>
+        Clear
+      </button>
+      <button type="button" onClick={() => selection.pruneTo(["a", "b"])}>
+        Prune to a-b
+      </button>
+    </div>
+  );
+}
+
+describe("useEntityListSelection", () => {
+  it("toggles individual ids, selects visible ids, and clears", () => {
+    render(<SelectionHarness visibleIds={["a", "b"]} activeIds={["a", "b", "c"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle c" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select visible" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("a,b,c");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("");
+  });
+
+  it("uses visible row order for shift range selection", () => {
+    render(<SelectionHarness visibleIds={["a", "b", "c", "d"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle b" }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle d" }), { shiftKey: true });
+
+    expect(screen.getByTestId("selected")).toHaveTextContent("b,c,d");
+  });
+
+  it("prunes stale ids against the active list without clearing hidden active selections", () => {
+    const { rerender } = render(
+      <SelectionHarness visibleIds={["a", "b"]} activeIds={["a", "b", "c"]} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle c" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    rerender(<SelectionHarness visibleIds={["a"]} activeIds={["a", "b", "c"]} />);
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    rerender(<SelectionHarness visibleIds={["a"]} activeIds={["a", "b"]} />);
+    expect(screen.getByTestId("selected")).toHaveTextContent("");
+  });
+
+  it("flattens entity trees in rendered visual order", () => {
+    const roots = [
+      { id: "parent", isParent: true },
+      { id: "peer" },
+    ];
+    const children = {
+      parent: [{ id: "child" }],
+    };
+
+    expect(flattenEntityTreeIds(roots, children, {
+      expandedOnly: true,
+      expandedParents: new Set(["parent"]),
+    })).toEqual(["parent", "child", "peer"]);
+
+    expect(flattenEntityTreeIds(roots, children, {
+      expandedOnly: true,
+      expandedParents: new Set(),
+    })).toEqual(["parent", "peer"]);
+  });
+});

--- a/src/components/entity/useEntityListSelection.ts
+++ b/src/components/entity/useEntityListSelection.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+interface UseEntityListSelectionOptions {
+  visibleIds: readonly string[];
+  activeIds?: readonly string[];
+}
+
+export interface EntityListSelectionToggleOptions {
+  shiftKey?: boolean;
+}
+
+export interface EntityListSelectionApi {
+  selectedIds: string[];
+  selectedCount: number;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string, options?: EntityListSelectionToggleOptions) => void;
+  selectVisible: () => void;
+  clear: () => void;
+  pruneTo: (ids: readonly string[]) => void;
+}
+
+interface EntityTreeNode {
+  id: string;
+  isParent?: boolean;
+}
+
+interface FlattenEntityTreeOptions {
+  expandedParents?: ReadonlySet<string>;
+  expandedOnly?: boolean;
+}
+
+function orderSelection(ids: Iterable<string>, order: readonly string[]): string[] {
+  const selected = new Set(ids);
+  const ordered = order.filter((id) => selected.has(id));
+  for (const id of selected) {
+    if (!order.includes(id)) ordered.push(id);
+  }
+  return ordered;
+}
+
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((id, index) => id === b[index]);
+}
+
+export function flattenEntityTreeIds<T extends EntityTreeNode>(
+  roots: readonly T[],
+  childrenByParent: Record<string, readonly T[]>,
+  options: FlattenEntityTreeOptions = {},
+): string[] {
+  const result: string[] = [];
+  const expandedParents = options.expandedParents;
+
+  function walk(items: readonly T[]) {
+    for (const item of items) {
+      result.push(item.id);
+      const children = childrenByParent[item.id] ?? [];
+      if (children.length === 0) continue;
+      if (options.expandedOnly && !expandedParents?.has(item.id)) continue;
+      walk(children);
+    }
+  }
+
+  walk(roots);
+  return result;
+}
+
+export function useEntityListSelection({
+  visibleIds,
+  activeIds = visibleIds,
+}: UseEntityListSelectionOptions): EntityListSelectionApi {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const pruneTo = useCallback((ids: readonly string[]) => {
+    const active = new Set(ids);
+    setSelectedIds((current) => {
+      const next = current.filter((id) => active.has(id));
+      return sameIds(current, next) ? current : next;
+    });
+    setLastSelectedId((current) => current && active.has(current) ? current : null);
+  }, []);
+
+  useEffect(() => {
+    pruneTo(activeIds);
+  }, [activeIds, pruneTo]);
+
+  const clear = useCallback(() => {
+    setSelectedIds([]);
+    setLastSelectedId(null);
+  }, []);
+
+  const toggle = useCallback((id: string, options: EntityListSelectionToggleOptions = {}) => {
+    setSelectedIds((current) => {
+      if (options.shiftKey && lastSelectedId) {
+        const start = visibleIds.indexOf(lastSelectedId);
+        const end = visibleIds.indexOf(id);
+        if (start !== -1 && end !== -1) {
+          const [from, to] = start < end ? [start, end] : [end, start];
+          const range = visibleIds.slice(from, to + 1);
+          return orderSelection([...current, ...range], activeIds);
+        }
+      }
+
+      if (current.includes(id)) {
+        return current.filter((selectedId) => selectedId !== id);
+      }
+      return orderSelection([...current, id], activeIds);
+    });
+    setLastSelectedId(id);
+  }, [activeIds, lastSelectedId, visibleIds]);
+
+  const selectVisible = useCallback(() => {
+    setSelectedIds((current) => orderSelection([...current, ...visibleIds], activeIds));
+    if (visibleIds.length > 0) {
+      setLastSelectedId(visibleIds[visibleIds.length - 1]);
+    }
+  }, [activeIds, visibleIds]);
+
+  const isSelected = useCallback((id: string) => selectedSet.has(id), [selectedSet]);
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.length,
+    isSelected,
+    toggle,
+    selectVisible,
+    clear,
+    pruneTo,
+  };
+}

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -15,8 +15,14 @@ import {
   EntityListHeader,
   EntityListEndMark,
   FilterTabs,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { EphemeralBriefing } from "@/components/editorial/EphemeralBriefing";
@@ -421,6 +427,30 @@ export default function AccountsPage() {
   const isArchived = archiveTab === "archived";
   const displayList = isArchived ? filteredArchived : filtered;
   const activeCount = accounts.filter((a) => !a.archived).length;
+  const activeAccountIds = useMemo(
+    () => flattenEntityTreeIds(accounts.filter((a) => !a.archived), childrenCache),
+    [accounts, childrenCache],
+  );
+  const visibleAccountIds = useMemo(() => {
+    if (isArchived) return [];
+    const ids: string[] = [];
+    for (const { type } of ACCOUNT_SECTIONS) {
+      ids.push(...flattenEntityTreeIds(groupedAccounts[type] ?? [], childrenCache, {
+        expandedOnly: true,
+        expandedParents,
+      }));
+    }
+    return ids;
+  }, [childrenCache, expandedParents, groupedAccounts, isArchived]);
+  const accountSelection = useEntityListSelection({
+    visibleIds: visibleAccountIds,
+    activeIds: activeAccountIds,
+  });
+  const { clear: clearAccountSelection } = accountSelection;
+
+  useEffect(() => {
+    if (isArchived) clearAccountSelection();
+  }, [clearAccountSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -552,6 +582,15 @@ export default function AccountsPage() {
           />
         )}
       </EntityListHeader>
+
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={accountSelection.selectedCount}
+          visibleCount={visibleAccountIds.length}
+          onSelectVisible={accountSelection.selectVisible}
+          onClear={accountSelection.clear}
+        />
+      )}
 
       {/* Discovery panel */}
       {discoveryOpen && !isArchived && (
@@ -801,6 +840,7 @@ export default function AccountsPage() {
                     childrenCache={childrenCache}
                     toggleExpand={toggleExpand}
                     isLastSibling={i === sectionAccounts.length - 1}
+                    selection={accountSelection}
                   />
                 ))}
               </div>
@@ -823,6 +863,7 @@ function AccountTreeNode({
   childrenCache,
   toggleExpand,
   isLastSibling,
+  selection,
 }: {
   account: AccountListItem;
   depth: number;
@@ -830,6 +871,7 @@ function AccountTreeNode({
   childrenCache: Record<string, AccountListItem[]>;
   toggleExpand: (id: string) => void;
   isLastSibling: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const isExpanded = expandedParents.has(account.id);
   const children = childrenCache[account.id] ?? [];
@@ -844,6 +886,7 @@ function AccountTreeNode({
         isExpanded={isExpanded}
         onToggleExpand={account.isParent ? () => toggleExpand(account.id) : undefined}
         showBorder={!isLastSibling || hasExpandedChildren}
+        selection={selection}
       />
       {hasExpandedChildren &&
         children.map((child, ci) => (
@@ -855,6 +898,7 @@ function AccountTreeNode({
             childrenCache={childrenCache}
             toggleExpand={toggleExpand}
             isLastSibling={ci === children.length - 1 && isLastSibling}
+            selection={selection}
           />
         ))}
     </div>
@@ -869,6 +913,7 @@ function AccountRow({
   onToggleExpand,
   depth = 0,
   showBorder,
+  selection,
 }: {
   account: AccountListItem;
   isExpanded?: boolean;
@@ -876,6 +921,7 @@ function AccountRow({
   isChild?: boolean; // kept for call-site compat
   depth?: number;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const nameSuffix = (
     <>
@@ -884,20 +930,17 @@ function AccountRow({
           {account.accountType === "partner" ? "Partner" : "Internal"}
         </span>
       )}
-      {onToggleExpand && (
-        <button
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          className={styles.expandToggle}
-        >
-          {isExpanded ? "\u25BE" : "\u25B8"} {account.childCount} BU{account.childCount !== 1 ? "s" : ""}
-        </button>
-      )}
     </>
   );
+  const controls = onToggleExpand ? (
+    <button
+      onClick={onToggleExpand}
+      className={styles.expandToggle}
+      type="button"
+    >
+      {isExpanded ? "\u25BE" : "\u25B8"} {account.childCount} BU{account.childCount !== 1 ? "s" : ""}
+    </button>
+  ) : undefined;
 
   const ih = account.intelligenceHealth;
   const healthAvatar = ih ? (
@@ -915,6 +958,12 @@ function AccountRow({
       nameSuffix={nameSuffix}
       subtitle={undefined}
       avatar={healthAvatar}
+      controls={controls}
+      selection={{
+        selected: selection.isSelected(account.id),
+        label: `Select ${account.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(account.id, { shiftKey }),
+      }}
     >
       {account.arr != null && (
         <span className={styles.archivedArrLabel}>

--- a/src/pages/PeoplePage.selection.test.tsx
+++ b/src/pages/PeoplePage.selection.test.tsx
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PeoplePage from "./PeoplePage";
+import type { PersonListItem } from "@/types";
+
+const invokeMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => navigateMock,
+  useSearch: () => ({}),
+}));
+
+const externalPerson: PersonListItem = {
+  id: "external-person",
+  email: "external@example.com",
+  name: "External Person",
+  organization: "Example Account",
+  role: "Champion",
+  relationship: "external",
+  meetingCount: 3,
+  updatedAt: "2026-06-01T00:00:00Z",
+  archived: false,
+  temperature: "hot",
+  trend: "steady",
+};
+
+const internalPerson: PersonListItem = {
+  id: "internal-person",
+  email: "internal@example.com",
+  name: "Internal Person",
+  organization: "DailyOS",
+  role: "CSM",
+  relationship: "internal",
+  meetingCount: 4,
+  updatedAt: "2026-06-01T00:00:00Z",
+  archived: false,
+  temperature: "warm",
+  trend: "steady",
+};
+
+describe("PeoplePage selection", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "get_people") return Promise.resolve([externalPerson, internalPerson]);
+      if (command === "get_archived_people") return Promise.resolve([]);
+      if (command === "get_duplicate_people") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+  });
+
+  it("preserves selected active people when relationship tabs hide them", async () => {
+    render(<PeoplePage />);
+
+    const internalCheckbox = await screen.findByRole("checkbox", { name: "Select Internal Person" });
+    expect(screen.getByRole("checkbox", { name: "Select External Person" })).toBeInTheDocument();
+
+    fireEvent.click(internalCheckbox);
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "external" }));
+
+    expect(screen.queryByRole("checkbox", { name: "Select Internal Person" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select External Person" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+  });
+});

--- a/src/pages/PeoplePage.tsx
+++ b/src/pages/PeoplePage.tsx
@@ -25,11 +25,16 @@ import {
   EntityListEndMark,
   ArchiveToggle,
   FilterTabs,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import shellStyles from "@/components/entity/EntityListShell.module.css";
 import s from "./PeoplePage.module.css";
 import { EditorialPageHeader } from "@/components/editorial/EditorialPageHeader";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { Avatar } from "@/components/ui/Avatar";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
@@ -41,6 +46,11 @@ type RelationshipTab = "all" | "external" | "internal" | "unknown";
 type HygieneFilter = "unnamed" | "duplicates";
 
 const relationshipTabs: readonly RelationshipTab[] = ["all", "external", "internal", "unknown"];
+const PEOPLE_SECTIONS: { type: string; title: string }[] = [
+  { type: "external", title: "Your Contacts" },
+  { type: "internal", title: "Your Team" },
+  { type: "unknown", title: "Unclassified" },
+];
 
 const tempOrder: Record<string, number> = {
   hot: 0,
@@ -126,9 +136,8 @@ export default function PeoplePage() {
     try {
       setLoading(true);
       setError(null);
-      const filter = tab === "all" ? undefined : tab;
       const result = await invoke<PersonListItem[]>("get_people", {
-        relationship: filter ?? null,
+        relationship: null,
       });
       setPeople(result);
     } catch (e) {
@@ -136,7 +145,7 @@ export default function PeoplePage() {
     } finally {
       setLoading(false);
     }
-  }, [tab]);
+  }, []);
 
   const loadArchivedPeople = useCallback(async () => {
     try {
@@ -169,15 +178,20 @@ export default function PeoplePage() {
   useTauriEvent("people-updated", onPeopleUpdated);
 
   // Filters
+  const relationshipFiltered = useMemo(
+    () => tab === "all" ? people : people.filter((p) => p.relationship === tab),
+    [people, tab],
+  );
+
   const filtered = searchQuery
-    ? people.filter(
+    ? relationshipFiltered.filter(
         (p) =>
           p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
           p.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
           (p.organization ?? "").toLowerCase().includes(searchQuery.toLowerCase()) ||
           (p.role ?? "").toLowerCase().includes(searchQuery.toLowerCase())
       )
-    : people;
+    : relationshipFiltered;
 
   const hygieneFiltered =
     activeHygieneFilter === "unnamed"
@@ -207,13 +221,6 @@ export default function PeoplePage() {
   const isArchived = archiveTab === "archived";
   const showRelationship = tab === "all";
 
-  // Group people by relationship when showing "all" tab
-  const PEOPLE_SECTIONS: { type: string; title: string }[] = [
-    { type: "external", title: "Your Contacts" },
-    { type: "internal", title: "Your Team" },
-    { type: "unknown", title: "Unclassified" },
-  ];
-
   const groupedPeople = useMemo(() => {
     if (!showRelationship) return null; // flat list when filtered to one tab
     const groups: Record<string, PersonListItem[]> = {
@@ -226,6 +233,23 @@ export default function PeoplePage() {
     }
     return groups;
   }, [sorted, showRelationship]);
+  const activePersonIds = useMemo(() => people.map((person) => person.id), [people]);
+  const visiblePersonIds = useMemo(() => {
+    if (isArchived) return [];
+    if (!groupedPeople) return sorted.map((person) => person.id);
+    return PEOPLE_SECTIONS.flatMap(({ type }) => (
+      groupedPeople[type] ?? []
+    ).map((person) => person.id));
+  }, [groupedPeople, isArchived, sorted]);
+  const personSelection = useEntityListSelection({
+    visibleIds: visiblePersonIds,
+    activeIds: activePersonIds,
+  });
+  const { clear: clearPersonSelection } = personSelection;
+
+  useEffect(() => {
+    if (isArchived) clearPersonSelection();
+  }, [clearPersonSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -323,6 +347,15 @@ export default function PeoplePage() {
           />
         )}
       </EntityListHeader>
+
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={personSelection.selectedCount}
+          visibleCount={visiblePersonIds.length}
+          onSelectVisible={personSelection.selectVisible}
+          onClear={personSelection.clear}
+        />
+      )}
 
       {/* Add person form */}
       {!isArchived && showAddForm && (
@@ -505,7 +538,13 @@ export default function PeoplePage() {
                 <div key={type}>
                   <ChapterHeading title={title} />
                   {sectionPeople.map((person, i) => (
-                    <PersonRow key={person.id} person={person} showRelationship={false} showBorder={i < sectionPeople.length - 1} />
+                    <PersonRow
+                      key={person.id}
+                      person={person}
+                      showRelationship={false}
+                      showBorder={i < sectionPeople.length - 1}
+                      selection={personSelection}
+                    />
                   ))}
                 </div>
               );
@@ -515,7 +554,13 @@ export default function PeoplePage() {
           /* Flat view: single relationship tab selected */
           <div className={s.personList}>
             {sorted.map((person, i) => (
-              <PersonRow key={person.id} person={person} showRelationship={false} showBorder={i < sorted.length - 1} />
+              <PersonRow
+                key={person.id}
+                person={person}
+                showRelationship={false}
+                showBorder={i < sorted.length - 1}
+                selection={personSelection}
+              />
             ))}
           </div>
         )}
@@ -541,10 +586,12 @@ function PersonRow({
   person,
   showRelationship,
   showBorder,
+  selection,
 }: {
   person: PersonListItem;
   showRelationship: boolean;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const nameSuffix = showRelationship && person.relationship !== "unknown" ? (
     <span
@@ -583,6 +630,11 @@ function PersonRow({
       nameSuffix={nameSuffix}
       subtitle={subtitle}
       avatar={avatar}
+      selection={{
+        selected: selection.isSelected(person.id),
+        label: `Select ${person.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(person.id, { shiftKey }),
+      }}
     />
   );
 }

--- a/src/pages/ProjectsPage.selection.test.tsx
+++ b/src/pages/ProjectsPage.selection.test.tsx
@@ -1,0 +1,95 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectsPage from "./ProjectsPage";
+import type { ProjectListItem } from "@/types";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const parentProject: ProjectListItem = {
+  id: "parent-project",
+  name: "Parent Project",
+  status: "active",
+  openActionCount: 0,
+  archived: false,
+  childCount: 1,
+  isParent: true,
+};
+
+const childProject: ProjectListItem = {
+  id: "child-project",
+  name: "Child Project",
+  status: "on_hold",
+  openActionCount: 0,
+  archived: false,
+  parentId: "parent-project",
+  parentName: "Parent Project",
+  childCount: 0,
+  isParent: false,
+};
+
+const peerProject: ProjectListItem = {
+  id: "peer-project",
+  name: "Peer Project",
+  status: "completed",
+  openActionCount: 2,
+  archived: false,
+  childCount: 0,
+  isParent: false,
+};
+
+describe("ProjectsPage selection", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string, args?: Record<string, unknown>) => {
+      if (command === "get_projects_list") {
+        return Promise.resolve([parentProject, peerProject]);
+      }
+      if (command === "get_child_projects_list" && args?.parentId === "parent-project") {
+        return Promise.resolve([childProject]);
+      }
+      if (command === "get_archived_projects") {
+        return Promise.resolve([
+          {
+            id: "archived-project",
+            name: "Archived Project",
+            status: "completed",
+            openActionCount: 0,
+            archived: true,
+            childCount: 0,
+            isParent: false,
+          },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("selects active tree rows and clears selection in archived mode", async () => {
+    render(<ProjectsPage />);
+
+    const parentCheckbox = await screen.findByRole("checkbox", { name: "Select Parent Project" });
+    expect(await screen.findByRole("checkbox", { name: "Select Child Project" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select Peer Project" })).toBeInTheDocument();
+
+    fireEvent.click(parentCheckbox);
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: /archived/i }));
+    expect(await screen.findByText("Archived Project")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Select Archived Project" })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -13,10 +13,16 @@ import {
   EntityListHeader,
   EntityListEndMark,
   ArchiveToggle,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import shellStyles from "@/components/entity/EntityListShell.module.css";
 import { EditorialPageHeader } from "@/components/editorial/EditorialPageHeader";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { usePersonality } from "@/hooks/usePersonality";
 import { getPersonalityCopy } from "@/lib/personality";
@@ -171,7 +177,7 @@ export default function ProjectsPage() {
   }
 
   // Filters — archived/active split handled by archiveTab; no status sub-filter
-  const activeProjects = projects.filter((p) => !p.archived);
+  const activeProjects = useMemo(() => projects.filter((p) => !p.archived), [projects]);
 
   const filtered = useMemo(() => {
     if (!searchQuery) return activeProjects;
@@ -199,6 +205,28 @@ export default function ProjectsPage() {
   const isArchived = archiveTab === "archived";
   const displayList = isArchived ? filteredArchived : filtered;
   const activeCount = activeProjects.length;
+  const activeProjectIds = useMemo(
+    () => flattenEntityTreeIds(activeProjects, childrenCache),
+    [activeProjects, childrenCache],
+  );
+  const visibleProjectIds = useMemo(
+    () => isArchived
+      ? []
+      : flattenEntityTreeIds(filtered, childrenCache, {
+        expandedOnly: true,
+        expandedParents,
+      }),
+    [childrenCache, expandedParents, filtered, isArchived],
+  );
+  const projectSelection = useEntityListSelection({
+    visibleIds: visibleProjectIds,
+    activeIds: activeProjectIds,
+  });
+  const { clear: clearProjectSelection } = projectSelection;
+
+  useEffect(() => {
+    if (isArchived) clearProjectSelection();
+  }, [clearProjectSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -304,6 +332,15 @@ export default function ProjectsPage() {
         <ArchiveToggle archiveTab={archiveTab} onTabChange={setArchiveTab} />
       </EntityListHeader>
 
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={projectSelection.selectedCount}
+          visibleCount={visibleProjectIds.length}
+          onSelectVisible={projectSelection.selectVisible}
+          onClear={projectSelection.clear}
+        />
+      )}
+
       {/* Create form */}
       {creating && !isArchived && (
         <div style={{ marginBottom: 16 }}>
@@ -376,6 +413,7 @@ export default function ProjectsPage() {
                     childrenCache={childrenCache}
                     toggleExpand={toggleExpand}
                     isLastSibling={i === filtered.length - 1}
+                    selection={projectSelection}
                   />
                 ))}
           </div>
@@ -396,6 +434,7 @@ function ProjectTreeNode({
   childrenCache,
   toggleExpand,
   isLastSibling,
+  selection,
 }: {
   project: ProjectListItem;
   depth: number;
@@ -403,6 +442,7 @@ function ProjectTreeNode({
   childrenCache: Record<string, ProjectListItem[]>;
   toggleExpand: (id: string) => void;
   isLastSibling: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const isExpanded = expandedParents.has(project.id);
   const children = childrenCache[project.id] ?? [];
@@ -416,6 +456,7 @@ function ProjectTreeNode({
         isExpanded={isExpanded}
         onToggleExpand={project.isParent ? () => toggleExpand(project.id) : undefined}
         showBorder={!isLastSibling || hasExpandedChildren}
+        selection={selection}
       />
       {hasExpandedChildren &&
         children.map((child, ci) => (
@@ -427,6 +468,7 @@ function ProjectTreeNode({
             childrenCache={childrenCache}
             toggleExpand={toggleExpand}
             isLastSibling={ci === children.length - 1 && isLastSibling}
+            selection={selection}
           />
         ))}
     </div>
@@ -441,12 +483,14 @@ function ProjectRow({
   isExpanded,
   onToggleExpand,
   showBorder,
+  selection,
 }: {
   project: ProjectListItem;
   depth?: number;
   isExpanded?: boolean;
   onToggleExpand?: () => void;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const subtitle = [
     project.owner,
@@ -471,28 +515,25 @@ function ProjectRow({
       >
         {statusLabel[project.status] ?? project.status}
       </span>
-      {onToggleExpand && (
-        <button
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            color: "var(--color-text-tertiary)",
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
-          }}
-        >
-          {isExpanded ? "\u25BE" : "\u25B8"} {project.childCount} sub{project.childCount !== 1 ? "s" : ""}
-        </button>
-      )}
     </>
   );
+  const controls = onToggleExpand ? (
+    <button
+      onClick={onToggleExpand}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color: "var(--color-text-tertiary)",
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        padding: 0,
+      }}
+      type="button"
+    >
+      {isExpanded ? "\u25BE" : "\u25B8"} {project.childCount} sub{project.childCount !== 1 ? "s" : ""}
+    </button>
+  ) : undefined;
 
   return (
     <EntityRow
@@ -504,6 +545,12 @@ function ProjectRow({
       paddingLeft={depth > 0 ? depth * 28 : 0}
       nameSuffix={nameSuffix}
       subtitle={subtitle || undefined}
+      controls={controls}
+      selection={{
+        selected: selection.isSelected(project.id),
+        label: `Select ${project.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(project.id, { shiftKey }),
+      }}
     >
       {project.targetDate && (
         <span style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-text-tertiary)" }}>


### PR DESCRIPTION
## Summary

- Adds shared active-row selection for Accounts, Projects, and People list surfaces.
- Adds native checkbox selection, selected-row styling, and a shared selection action bar.
- Keeps checkbox, navigation, and hierarchy controls as sibling focus targets.
- Preserves hidden-but-active People selections across relationship tabs and clears selection in archived mode.

## Verification

- L0 passed: `.docs/reviews/v1.5.0-list-surfaces-pr-a-l0-2026-06-01.md`
- L2 passed: `.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md`
- `pnpm test EntityRow EntityListShell useEntityListSelection ProjectsPage.selection PeoplePage.selection`
- `pnpm test`
- `pnpm tsc --noEmit`
- `pnpm build`
- `git diff --check public/dev`
- Targeted ESLint/stylelint on touched files; one unrelated existing `AccountsPage` warning remains documented in the proof bundle.

## §4 Security

`security_auditor_invoked: false`

**Exemption ID**: `EXEMPT-STYLE`

**Exemption rationale**: Frontend-only shared selection state and styling; no services, commands, migrations, claim substrate, auth, redaction, MCP config, dependencies, or privileged actions.

## Remaining

- Draft until native L4 surface proof can be captured. The latest attempt is documented in the proof bundle: replica startup is blocked because this branch supports schema version 273 while the shared replica has already advanced to version 274 from the later stack, mock-mode startup succeeds, and native surface inspection was blocked by the macOS lock screen.

Proof bundle: `.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md`
