### PR TITLE
v1.5.0 list surfaces: bulk archive and folder reconciliation

### DIFF
--- a/.docs/plans/v1.5.0-list-surfaces-bulk-archive-l0-packet.md
+++ b/.docs/plans/v1.5.0-list-surfaces-bulk-archive-l0-packet.md
@@ -1,0 +1,331 @@
+# v1.5.0 List-Surfaces PR B L0 Packet - Bulk Archive + Archive Folder Reconciliation
+
+**Date:** 2026-06-01
+**Branch:** `codex/v1.5.0-list-surfaces-pr-b`
+**Base:** stacked on PR A commit `564d51eb` (`codex/v1.5.0-list-surfaces`)
+**Linear:** DOS-830, DOS-828. Depends on DOS-826 / PR A shared selection.
+**Origination class:** Extension plus dogfood UX failure from the v1.5.0 List-Surfaces lane.
+**Scope tier:** Wave-tier slice. Escalated Amendment 3 because this touches Tauri write commands, service-owned DB mutations, signal propagation, filesystem moves, destructive data flows, and workspace path confinement.
+**Trust topology:** local-to-local single-user Tauri app, with filesystem write-path and DB-mode isolation constraints.
+
+## 0. Premise Check
+
+Linear DOS-830 asks for a bulk archive action from selected entity-list rows. Linear DOS-828 asks archive to reconcile workspace folders instead of leaving active folders behind. Current source inspection confirms the premise:
+
+- PR A adds shared selection state and an `EntitySelectionBar` child action slot, but no destructive bulk action yet (`src/components/entity/EntityListShell.tsx`).
+- List pages refresh active/archived data through `loadAccounts`, `loadProjects`, and `loadPeople`; archive actions are not present on list rows (`src/pages/AccountsPage.tsx`, `src/pages/ProjectsPage.tsx`, `src/pages/PeoplePage.tsx`).
+- Existing Tauri archive commands are single-entity only: `archive_account`, `archive_project`, and `archive_person` (`src-tauri/src/commands/projects_data.rs`).
+- Existing detail hooks call those single-entity commands for archive/unarchive (`src/hooks/useAccountDetail.ts`, `src/hooks/useProjectDetail.ts`, `src/hooks/usePersonDetail.ts`).
+- Account archive is service-owned, transactional, and propagates signals. Project and Person archive are service-owned but currently log signal failures (`emit_or_log` / `emit_and_propagate_or_log`) instead of failing the mutation on propagation failure.
+- Account and Project archive cascade direct children in `db.archive_account` / `db.archive_project`; Person has no child cascade.
+- Current Account/Project services collect direct child IDs only for queue cleanup and emit only the selected parent signal. Cascaded child mutations are DB-visible but not service-visible.
+- Archive currently flips DB flags only. It does not move `Accounts/{name}`, `Projects/{name}`, or `People/{name}` workspace folders; shipped source also has explicit internal-account `tracker_path` values under `Internal/{name}` that are not reconciled by archive.
+- Entity workspace paths are built through `entity_dir(workspace, dir_name, entity_name)` and per-type helpers. Account rows may carry `tracker_path`; ADR-0056 and ADR-0070 make `tracker_path` / `Accounts/{Company}` the documented authority for accounts, while current source also creates some internal account paths under `Internal/`. PR B must not settle that cross-ADR/source drift. It must consume a validated row `tracker_path` when present, fall back through the existing account directory behavior when absent, reject unsafe/cross-root paths, and avoid introducing any repair that migrates internal accounts between `Accounts/` and `Internal/` without a separate ADR/L0.
+- Active workspace path is mode-scoped by `state::resolved_workspace_path()` / config normalization: Live uses configured workspace, Replica uses `~/.dailyos/replica-workspace`, Mock uses `~/.dailyos/dev-workspace`. PR B must consume the already resolved config path and must not derive production paths manually.
+- `delete_all_data` currently deletes the active-mode database and scratch `_today` state only, despite the UI copy saying workspace files are included. It does not reconcile active entity folders after DB deletion.
+
+## 1. Scope
+
+### In
+
+- Add a bulk archive action to the PR A selection bar on Accounts, Projects, and People active-list pages.
+- Add a confirmation step that shows selected count and backend-computed direct child cascade count before archive.
+- Add backend preview and execute commands for per-type bulk archive.
+- Introduce a service-level archive outcome contract so selected IDs, cascaded child IDs, already-archived rows, and not-found rows are explicit before folder moves or UI reporting.
+- Reuse the same service-owned archive path for bulk commands and existing single-entity archive/unarchive commands; no bulk-only folder behavior.
+- Normalize Project and Person archive/unarchive signal behavior so propagation failures are returned and roll back the DB mutation, not silently logged.
+- Add service-owned archive-folder reconciliation:
+  - Archive moves active entity folders out of `Accounts/`, `Projects/`, and `People/` into a managed archive area; existing explicit internal-account `tracker_path` values under `Internal/` are supported as a compatibility path but not declared the canonical account root.
+  - Unarchive restores folders to the active workspace.
+  - Already archived DB rows with active folders can be repaired through an explicit plan/apply command.
+  - Active folders with no live DB row are reported by default; quarantine requires explicit user confirmation.
+  - Delete/reset/restore flows have exact mode-scoped behavior instead of implicit production workspace access.
+- Report per-entity DB and filesystem failures to the frontend. No silent partial failure.
+- Keep DB writer closures limited to DB mutations and required signal emission; filesystem moves and intel-queue cleanup run outside writer closures with repairable status.
+- Add archive-folder metadata at registered migration version 274, the next free registered slot after the current registry's version 273. The SQL file is `274_entity_archive_folders.sql`, registered as version 274. This follows the current v268+ SQL migration pattern and the `migrations.rs` comment that registered `version` is authoritative; the older off-by-one solution note is stale for this range and must not be used for PR B implementation.
+- Add Rust and frontend tests for batch behavior, folder moves, repair, signal behavior, DB-mode isolation, and list-page UX.
+
+### Out
+
+- Drag/drop reparenting (DOS-829).
+- Editable lifecycle stages / per-type lifecycle config (DOS-827 / W5).
+- Recursive cascade behavior beyond current single-entity archive semantics. PR B preserves direct-child cascade only unless L1 proves existing code already supports deeper cascade.
+- Any replica/production investigation or DB-mode bootstrap changes. PR B only consumes the existing DB-mode path resolver and proves it does so.
+- Claim/provenance schema changes. Archive is entity lifecycle state and workspace projection movement, not a new intelligence claim.
+- Exposing repair as an autonomous scheduled maintenance ability or MCP tool. PR B may add a user-invoked Tauri repair command; any scheduled/agent-invoked repair must be a separate Maintenance ability with full ADR-0103 audit.
+
+## 2. Intelligence Loop Check
+
+| Question | PR B answer |
+|---|---|
+| Claim model | Entity archive status is existing lifecycle metadata, not a new claim. Folder movement is a workspace projection side effect. No claim fields are added. |
+| Provenance + trust | No trust scoring or source attribution changes. Existing signals must propagate so derived surfaces invalidate correctly after archive/restore. |
+| Signals + invalidation | Archive/restore must emit `entity_archived` / registry-backed `entity_restored` through service-owned propagation for every DB-mutated entity, including direct children cascaded by Account/Project archive. PR B must replace existing `entity_unarchived` call sites with `entity_restored`; adding a new unarchive signal is out of scope for this PR. Project and Person must match Account's fail-loud propagation behavior before batch archive depends on them. |
+| Runtime + surfaces | Tauri React list pages and existing detail archive hooks consume the behavior. No MCP command surface is added. Workspace filesystem repair is service-owned behind Tauri commands. |
+| Feedback loop | User confirmation is the feedback gate. Per-entity failures are shown and repair remains invokable; there is no hidden "successful" archive when folder reconciliation failed. |
+
+## 3. K-In Discovery
+
+- ADR-0017 says archive file movement is pure Rust. PR B should implement deterministic Rust services, not invoke AI or scripts.
+- ADR-0040 says archive reconciliation is deterministic mechanical cleanup. PR B should implement reconciliation as service-owned mechanics, not frontend-only hiding.
+- ADR-0047 says entity dashboards and folders are durable operational intelligence artifacts. Deleting or ignoring them on archive would break the archive-as-product contract.
+- ADR-0048 says the filesystem is the durable layer and SQLite is the working store. PR B must keep DB lifecycle state and workspace projection state reconciled without pretending either layer is disposable.
+- ADR-0056 and ADR-0070 document accounts, including internal accounts, as account folders resolved through `tracker_path` / `Accounts/{Company}`. Current source has drifted by writing some internal account `tracker_path` values under `Internal/`. PR B consumes validated existing paths but does not settle or worsen the canonical-root question; any deliberate root migration or default change needs a separate ADR/L0.
+- ADR-0101 says all domain mutations go through services, emit signals, use transactions for related writes, propagate user-data-loss errors, and keep reads side-effect-free.
+- ADR-0103 applies to autonomous maintenance abilities. PR B's repair command is user-invoked and not registered as an ability, but it adopts the safe pieces that matter here: plan/apply, dry-run, idempotency, explicit change budgets, confirmation for destructive/quarantine actions, and PII-safe operation summaries. It explicitly excludes background scheduling and MCP/ability exposure.
+- ADR-0104 and ADR-0133 require write-path discipline: bounded DB-only writer closures, no external work inside DB transactions, no extra writer connections, and no locks/permits held across awaits.
+- ADR-0115 names durable invalidation and policy drift risk. Archive signal policy cannot be implicit at the call site; fail-loud archive mutations must make signal emission part of the service contract.
+- ADR-0133 and the DB lock-storm solution doc reject new DB handles and long writer closures. Bulk archive must use `state.db_write` / service transactions and move folders after commit.
+- The `emit_or_log` solution doc says best-effort signal wrappers are correct only for genuinely best-effort sites. Archive lifecycle mutation is not best-effort; propagation failure must surface.
+- `WorkspaceSourceRegistry::open_validated()` is the existing strict read-side path trust boundary for workspace ingestion. PR B needs a sibling move boundary that copies its lexical/canonical/root-confinement discipline rather than a weaker ad hoc validator.
+- Existing People merge/delete uses best-effort `remove_dir_all`; DOS-828 explicitly prefers reversible move/tombstone. PR B must not extend delete-as-cleanup to normal archive.
+- Migration convention conflict: `docs/solutions/conventions/migration-filename-version-offset-2026-05-18.md` documents an older off-by-one filename convention, but current `migrations.rs` says filenames have historical drift and registered `version` is authoritative, and recent SQL migrations use matching file/version numbers (`268`, `270`, `272`). PR B resolves the L0 ambiguity by using `274_entity_archive_folders.sql` registered as version 274. Refreshing the stale solution note is K-out follow-up, not a reason to encode the older convention in this PR.
+
+## 4. Design Decisions
+
+### D1 - Reversible Move, Not Delete
+
+Normal archive/unarchive uses reversible move semantics:
+
+- Active folder: `workspace/{Accounts|Projects|People}/{sanitized name}` or the row's `tracker_path` when present and validated under an allowed active root. For accounts, the documented canonical root remains `Accounts/`; explicit existing `tracker_path` values under `Internal/` are accepted only as current-code compatibility, not as a new resolver default.
+- Archived folder: `workspace/_archive/entities/{account|project|person}/{entity_id}--{sanitized name}`.
+- Each archived folder gets a small `.dailyos-archive.json` manifest with entity id, entity type, original relative path, archived-at timestamp, chosen archived relative path, and archive operation id.
+- The DB is the restore-selection authority. Registered migration version 274 (`274_entity_archive_folders.sql`) adds a small `entity_archive_folders` table recording `operation_id`, `entity_type`, `entity_id`, `original_relative_path`, `archived_relative_path`, `folder_state`, `archived_at`, `restored_at`, `updated_at`, and a PII-safe `last_error_code`. Folder states are at minimum `archive_pending`, `archived`, `archive_failed`, `missing_source`, `restore_pending`, `restored`, and `restore_failed`. Archive inserts or updates an `archive_pending` row before any folder rename and finalizes it to `archived` only after the rename and manifest write complete. Restore selects the latest `archived` row for the entity/type and never guesses from directory names alone. The manifest remains an audit/repair sidecar, not the primary selector.
+- If the active folder is missing, archive still succeeds in DB but returns `folder_status: missing_source`.
+- If the archive target already exists, PR B must pick a collision-safe suffix and record the chosen target in the manifest/result.
+- Unarchive restores from the latest `entity_archive_folders.folder_state = archived` row to the current active relative path. If the active target exists, return a conflict instead of overwriting user files.
+- PR B must not change future internal-account creation defaults. If an internal-account row has `tracker_path`, archive/restore validates and uses that relative path when it stays under an allowed account root (`Accounts/` per ADR-0070, or existing-source `Internal/` compatibility). If `tracker_path` is missing, fallback remains the documented account path. If both roots contain plausible folders, return a structured ambiguity status and require a separate repair/ADR decision; do not move between `Accounts/` and `Internal/` as part of archive reconciliation.
+
+### D2 - Lifecycle DB First, Durable Filesystem State After Commit
+
+Bulk archive is not a cross-resource transaction. The lifecycle DB mutation commits first through service logic, then filesystem moves run after the DB writer closure exits. The filesystem side-effect service may perform its own short `state.db_write` calls before and after renames to record durable folder state, but it must not hold a DB transaction open across filesystem work.
+
+Rationale: SQLite status is the lifecycle source of truth; filesystem work can be repaired. Moving folders before the DB commit can leave hidden live entities if the DB update fails.
+
+Failure behavior:
+
+- DB failure: item is not archived; no folder move attempted.
+- Signal propagation failure inside a service transaction: item is not archived; no folder move attempted.
+- Archive folder state sequence: after lifecycle DB success, resolve/preflight the active source and allocate the non-overwrite archive target; if the source is present, insert or update an `archive_pending` metadata row with the chosen original and archived relative paths before any rename. If that pending write fails, no folder move is attempted and the item returns `folder_status: metadata_failed`. If the rename or manifest write fails, leave `archive_pending` in place when possible or update it to `archive_failed`; repair can retry because the authoritative original/target pair was captured before the move. If the rename succeeds but final metadata update fails, the row remains `archive_pending` and the item returns `folder_status: metadata_pending`; repair completes the `archived` finalization from the pending row and observed target path.
+- Missing source after lifecycle DB success records `missing_source` when metadata is available and returns `folder_status: missing_source`; no restore selector is created for a folder that was never moved.
+- Restore preflights the latest `archived` metadata row and the active target before lifecycle DB restore. If the active target exists, it returns conflict before DB mutation or signal emission. Successful restore marks the row `restore_pending` in the same service transaction that restores the entity lifecycle and emits `entity_restored`, then moves the folder after commit and finalizes `restored`. Move/finalize failures leave `restore_pending` or `restore_failed` for repair instead of silently reporting success.
+- Batch result separates `db_failed`, `signal_failed`, `metadata_failed`, `metadata_pending`, `folder_failed`, `folder_missing`, `folder_skipped`, `restore_conflict`, and `succeeded`.
+
+### D3 - Archive Mutation Outcome Contract
+
+Before adding bulk commands, the single-entity service shape changes from `Result<(), String>` to an explicit outcome:
+
+- `ArchiveMutationOutcome`
+  - `requested_id`
+  - `entity_type`
+  - `changed_ids`
+  - `selected_id_changed`
+  - `cascaded_child_ids`
+  - `already_in_target_state_ids`
+  - `not_found_ids`
+  - `intel_queue_cleanup_ids`
+  - `operation_id`
+
+For Account and Project archive, the service reads the active direct-child IDs before mutation, executes the DB archive in a transaction, emits `entity_archived` for the selected entity and every direct child whose DB row changed, and returns all changed IDs. For unarchive, it preserves current single-entity semantics unless existing code already restores children; the returned outcome must state exactly which IDs changed. Person has no child cascade.
+
+Project and Person archive/restore must move the DB update and `emit_and_propagate` into `db.with_transaction`, matching Account's fail-loud rollback semantics. Existing unarchive code must stop emitting legacy `entity_unarchived` and must use registry-backed `entity_restored`; adding/registering a new `EntityUnarchived` policy is out of PR B scope. This is not just a helper swap.
+
+### D4 - Batch Shape And Deduping
+
+Add per-type preview and execute commands instead of a mixed-type command:
+
+- `preview_bulk_archive_accounts(ids)`
+- `bulk_archive_accounts(ids)`
+- `preview_bulk_archive_projects(ids)`
+- `bulk_archive_projects(ids)`
+- `preview_bulk_archive_people(ids)`
+- `bulk_archive_people(ids)`
+
+List pages are type-specific, so per-type commands keep payloads simple and avoid mixed-type authorization/path handling.
+
+Preview computes an `ArchiveExecutionPlan` from the current DB:
+
+- selected IDs that exist and are active,
+- selected IDs not found,
+- selected IDs already archived,
+- direct active children that would be cascaded by selected Account/Project parents,
+- selected child IDs covered by a selected parent, so execute does not double-call them,
+- total DB-mutated count and direct cascade count for confirmation.
+
+Preview also returns a short-lived `plan_id`, `plan_fingerprint`, `expires_at`, and the confirmed changed-id set/counts. The fingerprint covers the requested IDs, direct cascade IDs, selected-child coverage, already-archived/not-found buckets, and the entity row version fields or `updated_at` values used to compute the plan. Execute accepts the preview token and recomputes the plan inside the writer path before mutating. If the recomputed changed-id set expands beyond the confirmed set, the direct cascade count increases, selected-child coverage changes in a way that would mutate an unconfirmed ID, or any fingerprinted row version changes, execute aborts with `preview_stale` and no archive mutation. A shrink caused by rows already archived or deleted since preview is allowed only when the result reports the shrink explicitly.
+
+After preview binding succeeds, execute applies one service-owned single-entity archive operation per requested root not already covered by a selected parent, accumulates `ArchiveMutationOutcome` values, dedupes changed IDs and `intel_queue_cleanup_ids`, then runs post-commit side effects after the DB writer closure exits: first intel-queue cleanup for returned cleanup IDs, then durable filesystem archive for the changed IDs.
+
+### D5 - Single-Entity Parity
+
+Folder reconciliation is not bulk-only. Existing commands and hooks remain valid but route through the same service path:
+
+- `archive_account`, `archive_project`, and `archive_person` archive calls move folders after DB commit.
+- `archive_account`, `archive_project`, and `archive_person` unarchive calls restore folders after DB commit.
+- Existing restore-specific commands, including `restore_account` if still present, either delegate to the same service path or are updated to do so.
+- Detail hooks do not need replacement commands unless L1 finds the current command signatures cannot return the new structured status safely.
+
+This closes the DOS-828 gap for detail pages as well as list pages.
+
+### D6 - Path Trust Boundary For Moves
+
+Add a service-owned move boundary, likely in `services::entity_archive_folders`, that mirrors `WorkspaceSourceRegistry::open_validated()` discipline for write paths:
+
+- Resolve the already mode-scoped workspace root from `AppState`; never compute Live/Replica/Mock roots manually.
+- Canonicalize the workspace root and the active root before validating a source. Valid active roots are `Accounts/` for all accounts, `Projects/` for projects, and `People/` for people. `Internal/` is allowed only when an account row's explicit `tracker_path` already points there and the path passes the same relative-path, canonicalization, and root-confinement checks; missing account `tracker_path` values do not fall back to `Internal/`.
+- Accept `tracker_path` only if it is relative and resolves under the matching active root. Reject absolute paths, `..`, NUL, non-UTF8, cross-type roots, `_archive`, `_today`, database/config roots, and any path outside the workspace. Invalid `tracker_path` values are never joined directly; L1 may fall back to the canonical active path only after the fallback path passes the same root checks.
+- Reject source paths with symlink components, non-directory terminal entries, or hardlinked regular-file descendants (`nlink > 1`) before rename. Missing source is a structured `missing_source` status, not success.
+- Allocate targets only under canonical `workspace/_archive/entities/{type}`. Canonicalize the target parent immediately before rename and reject if it no longer resolves under the archive type root.
+- Use non-overwrite rename semantics. If the chosen target exists, allocate a suffix before moving; never merge or overwrite folders.
+- Revalidate source metadata immediately before rename and test a TOCTOU swap between validation and move. The pre-rename scan records device/inode for the source root and rejects device changes or new hardlinked/symlinked descendants before moving.
+- Do not copy on cross-device rename failure in PR B; return a repairable `folder_failed` result. Copy/delete semantics need a separate L0 because they change the data-loss envelope.
+- Logs, telemetry, and snapshots use status codes plus relative path categories only. They must not include absolute paths, entity names, or manifest contents. UI may show names already rendered on screen.
+
+### D7 - Repair, Reset, Delete, And Restore Behavior
+
+Repair is plan/apply and idempotent:
+
+- `plan_entity_archive_folder_reconciliation()` returns counts and item statuses without mutation.
+- `apply_entity_archive_folder_reconciliation(input)` recomputes the plan, enforces a change budget, applies only confirmed classes, and returns a structured result.
+- Archived DB rows with active folders may be moved to the managed archive area.
+- Active folders with no live DB row are report-only by default. A separate explicit `quarantine_orphaned_entity_folders` option may move them to `workspace/_archive/entities/orphaned/{operation_id}/...`; it must never infer ownership and must never delete.
+- No repair runs automatically at startup in PR B.
+
+Delete/reset/restore flows are pinned:
+
+- `delete_all_data` is the only destructive flow that may remove workspace entity roots. After its existing DELETE confirmation, it removes the resolved mode-scoped `Accounts/`, `Projects/`, `People/`, and `_archive/entities/` roots only after passing the same root-confinement checks. In Replica/Mock, those roots are under the Replica/Mock workspace and Live is untouched.
+- Before `delete_all_data` closes or deletes the active-mode DB, it snapshots only the DB-referenced account `tracker_path` values that validate under mode-scoped `Internal/`. It may remove those exact validated referenced paths, and only those paths, after the same root-confinement checks. It must not remove an unreferenced `Internal/` root or sentinel merely because the directory name exists. If those referenced removals leave an empty `Internal/` root, leaving the empty root behind is acceptable; deleting the entire root is out of PR B scope unless a DB row explicitly referenced the root itself and validation proves it is DailyOS-managed.
+- The Settings danger-zone copy must be corrected to name the exact mode-scoped workspace effect instead of broadly saying all workspace files/configuration are deleted.
+- `start_fresh_database` must not delete, move, or quarantine entity folders. It leaves `Accounts/`, `Projects/`, `People/`, `_archive/entities/`, and any existing mode-scoped `Internal/` root untouched; after the fresh DB opens and migrates, the recovery/data-management UI surfaces a dry-run archive-folder repair report for the current mode workspace so the user can decide whether to quarantine orphan folders.
+- `restore_database_from_backup` must not silently delete, move, or quarantine folders. After the restored DB opens and migrates, the command returns a dry-run archive-folder repair report against the restored DB; the UI displays that report and requires a separate repair/quarantine confirmation before any folder reconciliation happens.
+- Mode-isolation tests must create Live, Replica, and Mock workspace sentinels, run each destructive/recovery flow in Replica and Mock, and assert Live DB files plus Live `Accounts/`, `Projects/`, `People/`, `_archive/entities/`, and any existing Live `Internal/` sentinels are untouched.
+- Normal archive and repair never delete user folders.
+
+## 5. Implementation Plan
+
+### U1 - Shared Archive Result Contracts
+
+Add shared TS/Rust DTOs:
+
+- `BulkArchivePreview`
+- `ArchiveExecutionPlan`
+- `ArchiveMutationOutcome`
+- `BulkArchiveResult`
+- `BulkArchiveItemResult`
+- `ArchiveFolderStatus`
+- `ArchiveFolderRepairPlan`
+- `ArchiveFolderRepairResult`
+
+Keep logs and backend errors PII-safe. UI can show entity names already on screen.
+
+### U2 - Backend Archive Service Hardening
+
+- Update Account/Project/Person archive services to return `ArchiveMutationOutcome`.
+- Normalize `services::projects::archive_project` and `services::people::archive_person` to use `db.with_transaction` plus fail-loud `emit_and_propagate` behavior equivalent to Account.
+- Update Account/Project archive services to emit and propagate for every DB-mutated direct child in addition to the selected parent.
+- Preserve intel-queue cleanup behavior for archived entities and cascaded children by returning `intel_queue_cleanup_ids`; perform queue cleanup after the writer closure commits, never from inside the DB writer closure.
+- Add tests proving Project/Person archive returns signal failures rather than logging them as success and proving signal failure rolls back DB state.
+
+### U3 - Filesystem Archive Service
+
+Add a service module, likely `src-tauri/src/services/entity_archive_folders.rs`, that owns:
+
+- Entity descriptor resolution from DB rows and `ArchiveMutationOutcome`.
+- Active relative path resolution from `tracker_path` with fallback to canonical `entity_dir` / account directory behavior; no new internal namespace resolver.
+- Type-root allowlisting for `Accounts/`, `Projects/`, and `People/`, plus explicit-row `Internal/` compatibility for account `tracker_path` values, and workspace/archive root confinement.
+- `entity_archive_folders` metadata writes/reads for pending, successful, failed, and repair-completed archive/restore operations.
+- Detection of ambiguous account folders when both `Accounts/` and `Internal/` variants exist for the same account; report ambiguity instead of moving between roots in PR B.
+- Symlink/traversal/cross-type/hardlink/TOCTOU rejection.
+- Collision-safe archive target allocation.
+- Archive manifest write.
+- Move-to-archive and restore-to-active operations.
+- Repair plan/apply operations for already archived DB rows with active folders, pending/failed metadata rows, restored DB rows with archived folders, and orphaned active folders.
+
+Filesystem operations return structured status and never run from command handlers directly.
+
+### U4 - Command Wiring
+
+Commands call services only:
+
+1. Resolve the already mode-scoped workspace path from `AppState`.
+2. Preview through service functions using `state.db_read`; execute requires the preview `plan_id` / `plan_fingerprint` and returns `preview_stale` before mutation if the confirmed plan no longer matches.
+3. Mutate lifecycle state through service functions using `state.db_write`.
+4. Run post-commit service-owned side effects after DB commit: intel-queue cleanup, then filesystem archive/restore/repair with short metadata `state.db_write` calls before and after renames.
+5. Return structured per-item result.
+
+Bulk commands use the new preview/execute flow. Existing single-entity commands use the same service and folder reconciliation path so detail-page archive/unarchive stays consistent.
+
+### U5 - List Surface UX
+
+For Accounts, Projects, and People active lists:
+
+- Add an Archive action in `EntitySelectionBar`.
+- Open an `AlertDialog` confirmation with selected count and backend-computed direct child cascade count.
+- Disable action while preview/archive is in flight.
+- After execute: refresh active and archived lists, clear successful selections, keep failed selections if retry is useful, and show per-entity failures.
+- Archived tab remains non-selectable.
+
+### U6 - Repair And Data Management UX
+
+Add repair entry points in Settings/Diagnostics or the existing data-management surface:
+
+- Dry-run shows counts and item classes.
+- Apply can move archived DB rows' active folders to archive.
+- Orphan quarantine is opt-in and names the operation class, not raw absolute paths.
+- Delete-all copy names the exact resolved mode-scoped roots affected.
+- Results use counts, status codes, and generic path categories; no verbose path dumps in toast/log surfaces.
+
+## 6. Acceptance Criteria
+
+1. Accounts, Projects, and People active list selection bars show a bulk Archive action when one or more rows are selected.
+2. Bulk archive requires confirmation and displays selected count plus backend-computed direct child cascade count for Accounts/Projects.
+3. Bulk archive reuses service-owned per-entity archive logic; command handlers do not write DB or filesystem directly.
+4. Archive services return explicit mutation outcomes listing selected and cascaded changed IDs.
+5. Project and Person archive/restore signal failures fail loudly and roll back DB state, matching Account behavior.
+6. Successful archive emits `entity_archived` propagation for each DB-mutated selected entity and cascaded direct child.
+7. Successful restore emits registry-backed `entity_restored` propagation for each DB-mutated entity; no PR B call site emits legacy `entity_unarchived`.
+8. Existing single-entity archive/unarchive commands reconcile folders through the same path as bulk archive.
+9. Successful archive moves active entity folders into `workspace/_archive/entities/{type}/...` with a manifest; active `Accounts/`, `Projects/`, and `People/` roots, plus explicit existing internal-account `tracker_path` roots under `Internal/`, no longer show archived entities.
+10. Unarchive restores archived folders to the active workspace without overwriting existing folders.
+11. Folder move failures are reported per entity and do not appear as silent success.
+12. Repair dry-run/apply identifies already-archived DB entities with active folders and active folders with no live DB entity; orphan folders are report-only unless explicitly quarantined.
+13. `delete_all_data`, `start_fresh_database`, and `restore_database_from_backup` have exact mode-scoped workspace behavior and tests proving Replica/Mock do not touch Live workspace roots or Live DB files.
+14. Filesystem operations are workspace-root-confined and reject traversal, absolute-path escape, cross-type roots, `_archive`/scratch roots, symlink components, hardlinked regular-file descendants, restore active-target conflicts, non-overwrite races, and TOCTOU swaps. Archive target existence allocates a suffix and records the chosen target; it is not treated as a rejection.
+15. Backend logs, telemetry, and test snapshots avoid absolute paths, entity names, and manifest contents; UI may show names already present on screen.
+16. Batch result preserves child cascade behavior parity with single-entity archive and dedupes selected children covered by selected parents.
+17. List pages refresh active/archived data after archive and clear successful selections.
+18. Execute aborts with `preview_stale` and no DB mutation if the cascade/changed-id set expands or the fingerprinted row versions change after confirmation.
+19. Folder metadata is durable before rename: post-rename finalization failure leaves a repairable pending row, and restore active-target conflict is detected before lifecycle restore or signal emission.
+20. `delete_all_data` removes only DB-referenced, validated `Internal/` paths and preserves unreferenced `Internal/` sentinels.
+21. Tests cover Rust service behavior, command result DTOs, folder archive/restore/repair, DB-mode workspace isolation, and frontend confirmation/result flows.
+
+## 7. Verification Plan
+
+- Rust unit tests for `entity_archive_folders` path confinement, type-root allowlisting, account rows with missing/invalid/cross-root `tracker_path`, explicit `Internal/` compatibility only when `tracker_path` is present, ambiguous account-root detection, move/restore, collision suffix, missing source, restore conflict before lifecycle mutation, symlink rejection, hardlinked regular-file descendant rejection, TOCTOU swap, metadata-table restore selection, pending/finalized metadata repair, post-move finalization failure repair, and repair.
+- Rust service tests for Account/Project cascaded child outcomes/signals, `entity_restored` restore signals, Project/Person fail-loud signal propagation rollback, and queue cleanup happening only from returned post-commit cleanup IDs.
+- Rust command/service tests for bulk account/project/person archive result shaping, dedupe, child cascade counts, preview-token execution, and stale-preview abort when a selected parent gains a direct child after confirmation.
+- Rust tests for `delete_all_data`, `start_fresh_database`, and `restore_database_from_backup` mode-scoped workspace behavior, including DB-referenced `Internal/` cleanup and unreferenced `Internal/` sentinel preservation.
+- Frontend tests for Accounts/Projects/People selection bar Archive action, confirmation text, successful refresh/clear, and per-item failure rendering.
+- Frontend tests for Settings/Data Management copy and repair result surfaces.
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
+- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1`
+- `pnpm test`
+- `pnpm tsc --noEmit`
+- `pnpm build`
+- `git diff --check`
+- L4 browser proof after confirming the dev build is operating on the Replica workspace and migrations complete there without touching Live.
+
+## 8. L0 Reviewer Routing
+
+- Default: `/codex challenge`.
+- K-in: `ce-learnings-researcher`.
+- Planning reviewers: `ce-feasibility-reviewer` and `ce-security-lens-reviewer`.
+- Add `ce-design-lens-reviewer` if L0 reviewers consider the confirmation/repair UI interaction beyond routine existing `AlertDialog` patterns.
+- L2 must include `ce-security-reviewer`, `ce-reliability-reviewer`, `ce-data-migrations-reviewer`, and `l2-bounded-reviewer`.
+
+## 9. Open Risks For Review
+
+- Whether orphan quarantine belongs in PR B. This packet keeps report-only orphan detection in scope and makes quarantine opt-in if the UX remains small.
+- Whether `delete_all_data` should remove only entity roots or broader workspace files. This packet limits deletion to DailyOS-managed entity roots and updates copy accordingly.
+- Whether adding child signals for Account/Project cascade changes downstream invalidation volume materially. This packet treats missing child invalidation as the correctness bug and requires tests.
+- Internal-account root drift remains outside PR B's decision surface. The implementation must preserve safe existing `tracker_path` behavior and must not migrate between `Accounts/` and `Internal/` without a separate ADR/L0.

--- a/.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md
+++ b/.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md
@@ -1,0 +1,151 @@
+# v1.5.0 List-Surfaces PR A L0 Packet - Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05` (W0 merged)  
+**Linear:** DOS-826. Related but out of this PR: DOS-830, DOS-828, DOS-829. DOS-827 lands through W5 per-type config.  
+**Origination class:** Dogfood UX failure surfaced in v1.5.0 wave planning.  
+**Trust topology:** Single local OS user, Tauri app surface only. This slice adds no backend write path.
+
+## 0. Premise Check
+
+The wave plan marks List-Surfaces as a parallel lane and makes premise-check a gate before AC, not advisory. Current-dev source inspection confirms the DOS-826 premise:
+
+- `EntityListShell` owns header, archive tabs, filter tabs, and ending only; it has no shared selection state, action bar, or select-all contract (`src/components/entity/EntityListShell.tsx:42`, `:83`, `:108`).
+- `EntityRow` exposes navigation, accent/avatar, text, metadata, and indentation props only; no checkbox, selected state, or selection callback exists (`src/components/entity/EntityRow.tsx:5`).
+- Accounts derive filters locally and render rows through `AccountTreeNode` / `AccountRow` without selection props (`src/pages/AccountsPage.tsx:343`, `:759`, `:908`).
+- Projects filter active rows locally and render `ProjectTreeNode` / archived rows without selection props (`src/pages/ProjectsPage.tsx:173`, `:359`, `:498`).
+- People filter/sort locally and render `PersonRow` / `ArchivedPersonRow` without selection props (`src/pages/PeoplePage.tsx:171`, `:577`, `:599`).
+- Archive commands are single-entity only (`archive_account`, `archive_project`, `archive_person`) and are intentionally not changed by this PR (`src-tauri/src/commands/projects_data.rs:459`, `:503`, `:525`).
+
+This packet therefore scopes PR A to the foundational affordance: select rows consistently across Accounts, Projects, and People so DOS-830 can add a real bulk archive action in the next slice without rebuilding selection three times.
+
+## 1. Scope
+
+### In
+
+- Add a shared selection model for entity list pages.
+- Add optional semantic checkbox selection affordance to `EntityRow`, visually compatible with the existing row language but not copied from `ActionRow`'s visual button implementation.
+- Add a selection action bar for `EntityListShell` consumers when one or more active rows are selected.
+- Support select visible, clear selection, individual row toggles, and shift-click range select.
+- Wire Accounts, Projects, and People active-list rows into the shared selection model.
+- Preserve selection across search/filter/tab changes within the same page when the selected entity still belongs to the active list.
+- Clear selection when switching to archived mode, navigating away, or reloading into a different entity-list page.
+- Add frontend tests that pin selection behavior, keyboard/ARIA basics, and the no-nested-interactive-controls row structure.
+
+### Out
+
+- Bulk archive mutation and confirmation flow (DOS-830).
+- Workspace folder move/tombstone/reconciliation on archive (DOS-828).
+- Drag-and-drop reparenting (DOS-829).
+- Editable lifecycle stages and canonical per-type lifecycle config (DOS-827 / W5).
+- Backend commands, DB schema, claims, migrations, source attribution, or signals in this PR.
+
+## 2. Intelligence Loop Check
+
+| Question | PR A answer |
+|---|---|
+| Claim model | Selection is local UI state. It is not an intelligence claim, does not describe a subject, and must not be persisted as display-only data. |
+| Provenance + trust | No provenance or trust scoring changes. Rows keep their existing rendered data and links. |
+| Signals + invalidation | No mutation, so no signal emission in PR A. DOS-830 must reuse existing archive services and signal propagation. |
+| Runtime + surfaces | Tauri React pages only. No MCP, local-loopback, filesystem, or command-surface expansion. |
+| Feedback loop | None for selection itself. Later archive/reparent/lifecycle slices must define feedback/signal semantics at their own L0. |
+
+## 3. K-In Discovery
+
+- ADR-0047 and ADR-0048 establish that workspace files are durable user-owned archive material, not disposable UI cache. This matters for DOS-828, so PR A must not fake archive by hiding rows client-side.
+- ADR-0059 defines the entity directory template and durable workspace convention. DOS-828 should build a service-owned reconciliation/move path against that convention.
+- ADR-0040 treats archive reconciliation as deterministic Rust work. That is the right substrate family for orphan-folder repair, not a React concern.
+- ADR-0056 establishes account parent-child hierarchy through structural `parent_id`. DOS-829 should use existing graph semantics and cycle prevention; PR A must not introduce drag/drop state that looks like a graph mutation.
+- ADR-0079 and the v1.5.0 wave plan tie lifecycle vocabulary to presets/per-type config. DOS-827 belongs with W5, not this selection slice.
+- Existing services already enforce mutation discipline for archive: account archive checks `ServiceContext`, writes through a transaction, emits `entity_archived` / `entity_unarchived`, and clears queued enrichment (`src-tauri/src/services/accounts.rs:2762`). PR A must leave that path untouched.
+
+## 4. Implementation Plan
+
+### U1 - Shared Selection Contracts
+
+Add a small shared type/hook under `src/components/entity/` or `src/hooks/`:
+
+- Selection key: entity id string. The page owns entity type by route, so no mixed-type key is needed inside one page.
+- Inputs: ordered visible active ids and optional all-active ids.
+- Outputs: `selectedIds`, `selectedCount`, `isSelected(id)`, `toggle(id, opts)`, `selectVisible()`, `clear()`, `pruneTo(ids)`.
+- Shift range uses the current ordered visible ids, not database order.
+- `pruneTo(activeIds)` runs after active-list data refresh so stale ids cannot remain selected after an entity disappears.
+
+### U2 - Entity Row Selection Affordance
+
+Extend `EntityRow` with an optional `selection` prop:
+
+- Render `EntityRow` as an outer row container when it has any interactive row controls. The selection checkbox, entity navigation link/anchor, and any inline row controls must be sibling interactive elements, not nested inside each other.
+- Checkbox rendered before the entity navigation region when supplied.
+- Use a native `<input type="checkbox">` unless implementation proves an equivalent custom checkbox is needed. If custom, it must expose `role="checkbox"`, `aria-checked`, and keyboard toggle behavior.
+- Checkbox click and Space-key toggle select the row and must not trigger entity navigation.
+- Row navigation remains available through the entity identity/link region; selection is explicit through checkbox.
+- Existing Accounts/Projects expand controls must move out of the link-wrapped name suffix into a dedicated sibling control slot or equivalent structure that preserves independent focus and click behavior.
+- Selected rows get a restrained state style using existing design tokens.
+- ARIA: checkbox has an accessible label derived from row name, row link remains a link, action-bar buttons have accessible names, and all interactive controls show visible focus states.
+
+### U3 - Selection Action Bar
+
+Add a shared `EntitySelectionBar` or `selectionActions` slot in `EntityListShell`:
+
+- Shows selected count.
+- Offers select visible and clear.
+- Hosts page-provided future action buttons through `children`.
+- Does not render destructive actions in PR A.
+- Compact enough for the magazine shell; no nested cards.
+
+### U4 - Page Wiring
+
+Wire the shared hook/bar/row prop into:
+
+- Accounts: flatten rendered active account tree in visual order, including expanded children. Archived tab clears selection and has no selection affordance.
+- Projects: same active tree behavior as Accounts.
+- People: active sorted/grouped rows only. Archived tab clears selection and has no selection affordance.
+
+### U5 - Tests
+
+Add focused frontend coverage:
+
+- Shared hook/unit coverage for individual toggle, select visible, clear, prune stale ids, and shift range.
+- `EntityRow` coverage that checkbox toggles without navigation and selected styling/ARIA is present.
+- Row-structure coverage that selection checkbox and existing expand controls are not nested inside entity links.
+- Page-level smoke for at least one grouped/tree page and one flat/grouped page showing the selection bar and clearing on archived mode.
+
+## 5. Acceptance Criteria
+
+1. Accounts, Projects, and People active list rows show a checkbox selection affordance.
+2. Selecting one or more rows shows a shared selection action bar with count, select-visible, clear, and an action slot.
+3. Shift-click range selection works against the currently visible active rows.
+4. Selection persists across search/filter changes within a page, then prunes ids that disappear after data refresh.
+5. Selection clears when switching to archived mode or leaving the route.
+6. Archived rows are not selectable in PR A.
+7. Row navigation still works when clicking row content; checkbox clicks do not navigate.
+8. Entity-row markup contains no nested interactive controls: checkbox, navigation link, and expand controls are separate focus targets.
+9. Selection uses native checkbox semantics, or an equivalent accessible checkbox with `role="checkbox"`, `aria-checked`, Space-key toggle, accessible labels, and visible focus states.
+10. Selection action-bar buttons have accessible names and visible focus states.
+11. No backend commands, services, migrations, claims, or signal policies are changed in PR A.
+12. Tests cover the shared selection behavior, row accessibility/interaction behavior, and at least one tree/grouped integration path.
+
+## 6. Verification Plan
+
+- `pnpm test EntityRow entity-list-selection`
+- `pnpm test`
+- `pnpm tsc --noEmit`
+- `git diff --check`
+- Browser/L4 proof before PR: Accounts, Projects, People active lists show selection; shift-range works; archived mode clears selection; mobile width does not overlap row content.
+
+Rust gates are not expected to be required for PR A if no Rust files change. If implementation touches Tauri or service code, run `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` and `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1`.
+
+## 7. L0 Reviewer Routing
+
+- Default: `/codex challenge`.
+- Planning reviewer: `ce-design-lens-reviewer` because this is a user-facing list interaction and visual/accessibility affordance.
+- K-in: `ce-learnings-researcher` with the cited ADR/docs hits above.
+- No Amendment 3 add-on for PR A because there is no write path, filesystem path, MCP path, claim/provenance mutation, or privacy-boundary expansion.
+
+## 8. Follow-On Slices
+
+- **PR B / DOS-830 + DOS-828:** bulk archive action and archive-folder reconciliation must share one L0 because DOS-830 explicitly says archive behavior should land consistently with folder reconciliation. Decide move-vs-tombstone there; prefer reversible move/tombstone, not delete.
+- **PR C / DOS-829:** drag-and-drop reparenting with cycle prevention, service-owned graph mutation, signal emission, and invalidation of hierarchy-dependent derived state.
+- **W5 / DOS-827:** per-type lifecycle stages in the type config surface; list tabs consume canonical config instead of emergent data values.

--- a/.docs/plans/v1.5.0-waves.html
+++ b/.docs/plans/v1.5.0-waves.html
@@ -197,8 +197,8 @@
       <p class="callout-prose">Pin <code>@dnd-kit/core@6.3.1</code> + <code>@dnd-kit/sortable@10.0.0</code> (the React-18 line — stable, not stale) for reorder in edit mode only. Layout config is ours. DOS-829 reparent shares the dep.</p>
     </article>
     <article class="callout">
-      <h3 class="callout-title">Migration slot — SQL namespace</h3>
-      <p class="callout-prose">The layout-overlay table is one <code>NNN_</code> SQL migration; latest registered is <strong>272</strong> (file <code>272_…</code>), so the next free slot is <strong>273</strong> — take it at kickoff. Not the <code>vNNN</code> Rust series.</p>
+      <h3 class="callout-title">Migration slots — SQL namespace</h3>
+      <p class="callout-prose">Latest registered is <strong>273</strong> (<code>migrate_v273_recommendation_w2_shape_repair</code>). The List-Surfaces archive-folder metadata PR is the active migration owner and reserves registered version <strong>274</strong> with SQL file <code>274_entity_archive_folders.sql</code>. This follows the current v268+ SQL migration pattern and <code>migrations.rs</code> rule that registered <code>version</code> is authoritative; the older off-by-one solution note is stale for this range. Layout-overlay must take the next free registered slot after rebasing, currently expected as <strong>275</strong> if List-Surfaces lands first. Any additional SQL migration in v1.5.0 must update this slot list before implementation. Not the <code>vNNN</code> Rust series.</p>
     </article>
   </div>
 </section>

--- a/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
+++ b/.docs/proofs/v1.5.0/list-surfaces-pr-a-proof-bundle.md
@@ -1,0 +1,108 @@
+# v1.5.0 List-Surfaces PR A Proof Bundle - DOS-826 Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05`  
+**Scope:** frontend-only shared selection affordance for active Accounts, Projects, and People list rows.
+
+## Acceptance Evidence
+
+- Active Accounts, Projects, and People rows now receive semantic checkbox selection props.
+- Archived rows do not receive selection props.
+- Shared `useEntityListSelection` handles individual toggle, select visible, clear, stale-id pruning, and visible-order shift ranges.
+- `EntityRow` renders checkbox, navigation link/anchor, and row controls as sibling focus targets.
+- Accounts/Projects expand controls moved out of link-wrapped row content.
+- Selection bars clear in archived mode.
+- People relationship tabs now filter from the active people list client-side so hidden-but-active selections can persist across tab changes.
+- No backend commands, services, migrations, claims, source attribution, filesystem behavior, or signal policy changed.
+
+## Verification
+
+### L2 diff review
+
+Artifact:
+
+```text
+.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
+```
+
+Result: APPROVE, no findings.
+
+### Focused frontend tests
+
+Command:
+
+```bash
+pnpm test EntityRow EntityListShell useEntityListSelection ProjectsPage.selection PeoplePage.selection
+```
+
+Result:
+
+```text
+Test Files  5 passed (5)
+Tests       10 passed (10)
+```
+
+### TypeScript
+
+Command:
+
+```bash
+pnpm tsc --noEmit
+```
+
+Result: pass.
+
+### Full frontend tests
+
+Command:
+
+```bash
+pnpm test
+```
+
+Result:
+
+```text
+Test Files  53 passed (53)
+Tests       284 passed (284)
+```
+
+### Production frontend build
+
+Command:
+
+```bash
+pnpm build
+```
+
+Result: pass. Vite emitted its existing large-chunk warning.
+
+### Targeted lint
+
+Commands:
+
+```bash
+pnpm exec eslint src/components/entity/EntityListShell.tsx src/components/entity/EntityRow.tsx src/components/entity/useEntityListSelection.ts src/pages/AccountsPage.tsx src/pages/ProjectsPage.tsx src/pages/PeoplePage.tsx src/components/entity/EntityListShell.test.tsx src/components/entity/EntityRow.test.tsx src/components/entity/useEntityListSelection.test.tsx src/pages/ProjectsPage.selection.test.tsx src/pages/PeoplePage.selection.test.tsx --max-warnings 9999
+pnpm exec stylelint "src/components/entity/EntityListShell.module.css" "src/components/entity/EntityRow.module.css"
+```
+
+Result: pass. ESLint reported one existing `AccountsPage` warning for the unrelated `discoveryEnabled` folio-action memo dependency; the PR-introduced archived-mode selection dependency warnings were fixed before final verification.
+
+### Diff check
+
+Command:
+
+```bash
+git diff --check public/dev
+```
+
+Result: pass.
+
+## Rust Gates
+
+Not run for PR A. The diff is frontend-only and does not touch Tauri, services, migrations, commands, or Rust tests.
+
+## Remaining Gates
+
+- Browser/L4 surface proof before PR if local Tauri/browser environment is available without entering the replica/production database path currently under separate investigation.

--- a/.docs/reviews/v1.5.0-list-surfaces-pr-a-l0-2026-06-01.md
+++ b/.docs/reviews/v1.5.0-list-surfaces-pr-a-l0-2026-06-01.md
@@ -1,0 +1,70 @@
+# v1.5.0 List-Surfaces PR A L0 Review - DOS-826 Shared Entity Selection
+
+**Date:** 2026-06-01  
+**Branch:** `codex/v1.5.0-list-surfaces`  
+**Base:** `public/dev` at `f4caeb05`  
+**Plan packet:** `.docs/plans/v1.5.0-list-surfaces-selection-l0-packet.md`
+
+## Verdict
+
+**APPROVE.** L0 is passed for PR A / DOS-826.
+
+## Reviewer Results
+
+### `/codex challenge`
+
+**Cycle 1 verdict:** APPROVE.
+
+Findings: none.
+
+Notes:
+
+- Packet scope matches the List-Surfaces lane: DOS-826 multi-select first; DOS-830/DOS-828 bulk archive and folder reconciliation later; DOS-829 reparent later; DOS-827 lifecycle via W5.
+- Current source supports the premise: `EntityListShell` and `EntityRow` have no selection substrate, and Accounts/Projects/People render rows without selection props.
+- The plan avoids backend/write-path changes, so the Intelligence Loop answer and no-Amendment-3-add-on routing are acceptable for PR A.
+- PR B should explicitly dedupe parent/child selections before bulk archive because account/project archive services cascade children. Follow-on design detail, not a PR A blocker.
+
+### `ce-design-lens-reviewer`
+
+**Cycle 1 verdict:** REQUEST_CHANGES.
+
+Blockers:
+
+1. The plan needed to explicitly prevent nested interactive controls in `EntityRow`.
+2. Accessibility ACs were not concrete enough for L2.
+3. "Modeled on ActionRow checkbox pattern" was risky because `ActionRow` uses a visual button pattern, not native checkbox semantics.
+
+Resolution:
+
+- Updated the packet to require an outer row container where checkbox, navigation link/anchor, and inline controls are sibling focus targets.
+- Required native checkbox semantics by default, or equivalent `role="checkbox"` / `aria-checked` / Space-key behavior if custom.
+- Required visible focus states, accessible names, and tests proving checkbox interaction does not navigate.
+- Required Accounts/Projects expand controls to move out of link-wrapped name content.
+
+**Cycle 2 verdict:** APPROVE.
+
+Residual risk: normal L1 execution risk around restructuring existing account/project expand controls without regressing navigation.
+
+### `ce-learnings-researcher`
+
+**Cycle 1 verdict:** APPROVE.
+
+No blocking K-in issue found. Searches across `docs/solutions/`, `.docs/decisions/`, and relevant frontend source paths found no prior documented/shared entity-list selection primitive for `useSelection`, `selectedIds`, `selectVisible`, shift selection, selection bar, or checkbox selection.
+
+Cited constraints:
+
+- `docs/solutions/README.md`: K-in is mandatory at L0; documented substrate reinvention blocks approval.
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`: search by substrate type, not proposed module name.
+- `.docs/decisions/0054-list-page-design-pattern.md`: list pages must remain flat, dense, signal-first rows.
+- `.docs/decisions/0048-three-tier-data-model.md`, `.docs/decisions/0040-archive-reconciliation.md`, `.docs/decisions/0059-entity-directory-template.md`: archive and workspace-folder behavior belongs in durable service/Rust follow-on work, not PR A.
+- `.docs/decisions/0056-parent-child-accounts.md`, `.docs/decisions/0087-entity-hierarchy-intelligence.md`: hierarchy changes are structural graph work for DOS-829, not selection state.
+- `.docs/decisions/0079-role-presets.md`, `.docs/decisions/0127-presets-as-intelligence-contracts.md`: lifecycle configuration belongs in W5/DOS-827.
+- `.docs/decisions/0101-service-boundary-enforcement.md`, `.docs/decisions/0115-signal-granularity-audit.md`: service mutations and signal policy stay out of PR A.
+
+## L1 Entry Constraints
+
+- Implement DOS-826 only: shared local UI selection state for active entity list rows.
+- Do not add backend commands, services, migrations, claims, source attribution, filesystem behavior, archive behavior, graph reparenting, or lifecycle config.
+- Preserve DailyOS flat list density and magazine shell.
+- Avoid nested interactive markup in `EntityRow`.
+- Add tests for shared selection behavior, row accessibility/interaction behavior, and at least one tree/grouped integration path.

--- a/.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
+++ b/.docs/reviews/v1.5.0-list-surfaces-pr-a-l2-2026-06-01.md
@@ -1,0 +1,39 @@
+# v1.5.0 List Surfaces PR A L2 Review
+
+Date: 2026-06-01  
+Branch: `codex/v1.5.0-list-surfaces`  
+Base: `public/dev` at W0 merged state  
+Scope: DOS-826, multi-select entity rows for Accounts, Projects, and People list surfaces
+
+## Verdict
+
+APPROVE
+
+## Review Route
+
+- Default L2: `/codex review` via `l2-bounded-reviewer`.
+- Specialist scope considered: UI/accessibility and list selection behavior.
+- No backend, schema, claim, trust, signal, filesystem, MCP, or write-path changes were present in this PR A diff.
+
+## Findings
+
+None.
+
+## Verification
+
+- Active Accounts, Projects, and People rows expose semantic checkbox selection.
+- Archived rows are not selectable and selection clears in archived mode.
+- Row navigation, checkbox selection, and hierarchy expand controls are sibling focus targets.
+- Shift-range selection follows rendered visible order through the shared selection hook.
+- Hidden-but-active People selections survive relationship tab changes.
+- The diff does not introduce backend, Rust, schema, claims, signals, filesystem, or persistence changes.
+
+Commands run by the L2 reviewer:
+
+```bash
+pnpm test EntityRow EntityListShell useEntityListSelection ProjectsPage.selection PeoplePage.selection
+pnpm tsc --noEmit
+git diff --check public/dev
+```
+
+Results: all passed.

--- a/.docs/reviews/v1.5.0-list-surfaces-pr-b-l0-2026-06-02.md
+++ b/.docs/reviews/v1.5.0-list-surfaces-pr-b-l0-2026-06-02.md
@@ -1,0 +1,75 @@
+# v1.5.0 List-Surfaces PR B L0 Review - DOS-830/DOS-828 Bulk Archive
+
+**Date:** 2026-06-02
+**Branch:** `codex/v1.5.0-list-surfaces-pr-b`
+**Base:** stacked on PR A commit `564d51eb` (`codex/v1.5.0-list-surfaces`)
+**Plan packet:** `.docs/plans/v1.5.0-list-surfaces-bulk-archive-l0-packet.md`
+**Wave plan:** `.docs/plans/v1.5.0-waves.html`
+
+## Verdict
+
+**APPROVE.** L0 is passed for PR B / DOS-830 + DOS-828.
+
+## Reviewer Results
+
+### `/codex challenge`
+
+**Final-cycle verdict:** APPROVE. Session `56951`.
+
+Prior blockers resolved:
+
+- Durable folder metadata now records `archive_pending` before rename and has repairable finalization states.
+- Bulk execute now binds to a preview `plan_id` / `plan_fingerprint` and aborts stale expanded cascades before mutation.
+- `delete_all_data` now limits `Internal/` cleanup to DB-referenced, validated mode-scoped paths.
+- Migration slot now names one file/version pair: registered version 274 with `274_entity_archive_folders.sql`.
+
+### `ce-learnings-researcher`
+
+**Final-cycle verdict:** APPROVE. Session `70525`.
+
+K-in notes:
+
+- ADR-0056 and ADR-0070 remain authoritative for account paths: use validated `tracker_path`, preserve `Accounts/{Company}` as the canonical internal-account root, and treat existing `Internal/` rows as compatibility only.
+- ADR-0101, ADR-0104, ADR-0115, ADR-0133, the DB lock-storm solution, and the `emit_or_log` solution support the packet's service-owned, fail-loud, bounded-writer shape.
+- `WorkspaceSourceRegistry::open_validated()` is the correct substrate to mirror for lexical/canonical workspace confinement.
+- The migration-convention conflict is resolved by current source: `migrations.rs` states registered `version` is authoritative, current SQL migrations use matching file/version numbers, and the older off-by-one solution note is stale for this range.
+
+### `ce-feasibility-reviewer`
+
+**Final-cycle verdict:** APPROVE. Session `70265`.
+
+Feasibility notes:
+
+- The migration ambiguity is resolved: latest registered slot is 273, PR B reserves registered version 274, and L1 should create/register `274_entity_archive_folders.sql`.
+- Existing seams are concrete enough for L1: single-entity archive commands, service-owned archive functions, PR A selection-bar child actions, mode-scoped workspace resolution, and the hardened workspace path-validation model.
+- The packet specifies repairable DB/filesystem sequencing, preview/execute staleness checks, single-entity parity, and test targets.
+
+### `ce-security-lens-reviewer`
+
+**Final-cycle verdict:** APPROVE. Session `67555`.
+
+Security notes:
+
+- Workspace moves are mode-scoped through `AppState`; PR B must not manually derive Live/Replica/Mock roots.
+- The path boundary requires root confinement, symlink/hardlink/TOCTOU checks, non-overwrite archive targets, and PII-safe logs.
+- Destructive data flows are pinned: `delete_all_data` gets exact mode-scoped entity-root behavior, while `start_fresh_database` and `restore_database_from_backup` remain non-destructive and return dry-run repair reports.
+- Durable metadata states cover post-commit filesystem/metadata failures without silent success.
+
+## Cycle History
+
+- Cycles 1-2: strengthened the packet around service-owned mutations, confirmation UX, folder-reconciliation scope, signal behavior, and testability.
+- Cycle 3: resolved internal-account fallback and archive/restore collision semantics.
+- Cycle 4: resolved ADR/source drift for `Internal/` account roots and reserved the migration slot in the wave plan.
+- Cycle 5: resolved durable metadata state, stale-preview execution, and `Internal/` delete-boundary blockers.
+- Final cycle: resolved the migration filename conflict by choosing current source practice: `274_entity_archive_folders.sql` registered as version 274.
+
+## L1 Entry Constraints
+
+- Implement DOS-830 and DOS-828 only; do not start DOS-829 drag/drop reparenting or DOS-827 lifecycle config.
+- Use service-owned mutations only. Command handlers do not write DB rows or perform filesystem moves directly.
+- Keep DB writer closures bounded and DB-only except required signal emission; filesystem moves and intel-queue cleanup happen after lifecycle commit.
+- Preserve fail-loud archive/restore signal behavior for Account, Project, and Person, including cascaded direct children.
+- Add the `entity_archive_folders` table at registered migration version 274 using `274_entity_archive_folders.sql`.
+- Archive/restore folders through a durable pending/finalized metadata state machine and repair path.
+- Execute bulk archive only against the confirmed preview plan; abort stale expanded cascades before mutation.
+- Prove Replica/Mock workspace destructive and recovery flows do not touch Live DB files or Live workspace sentinels before L4.

--- a/scripts/check_signal_policy_registry.sh
+++ b/scripts/check_signal_policy_registry.sh
@@ -2,10 +2,20 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-INVENTORY="$ROOT_DIR/.docs/plans/wave-W1/W1-B-channel-inventory.md"
+INVENTORY_CANDIDATES=(
+  "$ROOT_DIR/.docs/plans/wave-W1/W1-B-channel-inventory.md"
+  "$ROOT_DIR/.docs/_archive/plans-pre-v1.4.9/wave-W1/W1-B-channel-inventory.md"
+)
+INVENTORY=""
+for candidate in "${INVENTORY_CANDIDATES[@]}"; do
+  if [ -f "$candidate" ]; then
+    INVENTORY="$candidate"
+    break
+  fi
+done
 
-if [ ! -f "$INVENTORY" ]; then
-  echo "missing channel inventory: $INVENTORY" >&2
+if [ -z "$INVENTORY" ]; then
+  echo "missing channel inventory: ${INVENTORY_CANDIDATES[*]}" >&2
   exit 1
 fi
 

--- a/src-tauri/scripts/ability_surface_allowlist.txt
+++ b/src-tauri/scripts/ability_surface_allowlist.txt
@@ -388,6 +388,17 @@ export_all_data
 get_data_summary
 clear_intelligence
 delete_all_data
+# v1.5.0 list surfaces: user-invoked Tauri archive/repair commands for the
+# existing React entity-list and data-management workflows. Not MCP tools and
+# not autonomous abilities.
+preview_bulk_archive_accounts
+bulk_archive_accounts
+preview_bulk_archive_projects
+bulk_archive_projects
+preview_bulk_archive_people
+bulk_archive_people
+plan_entity_archive_folder_reconciliation
+apply_entity_archive_folder_reconciliation
 get_feature_flags
 get_db_growth_report
 bulk_recompute_health

--- a/src-tauri/scripts/check_workspace_mutation_allowlist.sh
+++ b/src-tauri/scripts/check_workspace_mutation_allowlist.sh
@@ -16,7 +16,7 @@ fi
 allowed_regex='services/workspace_ingestion/|tests/workspace_ingestion_|tests/workspace_mutation_allowlist_test\.rs|tests/watcher_fixture_|src/accounts\.rs|src/processor/|src/projects\.rs|src/commands/app_support\.rs|src/commands/workspace\.rs|src/db_backup\.rs|src/services/accounts\.rs'
 table_pattern='(INSERT([[:space:]]+OR[[:space:]]+(IGNORE|REPLACE))?[[:space:]]+INTO|REPLACE[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(workspace_file_lifecycle|document_ingestion_runs|document_entity_links)\b'
 fs_pattern='(std::fs::(write|rename|copy|remove_file|remove_dir|remove_dir_all|create_dir|create_dir_all)|tokio::fs::(write|rename|copy|remove_file|remove_dir|remove_dir_all|create_dir|create_dir_all))'
-comment_allowlist_pattern='dos7-allowed: (drive-staging-v146|inbox-bootstrap|entity-markdown-regen|content-index-cache|transcript-direct-write-v146|devtools-w5-backfill-fixture|v146-validation-fixture)'
+comment_allowlist_pattern='dos7-allowed: (drive-staging-v146|inbox-bootstrap|entity-markdown-regen|content-index-cache|transcript-direct-write-v146|devtools-w5-backfill-fixture|v146-validation-fixture|entity-archive-folder-v150)'
 
 filter_comment_allowlist() {
   local matches="$1"

--- a/src-tauri/src/commands/app_support.rs
+++ b/src-tauri/src/commands/app_support.rs
@@ -579,11 +579,7 @@ pub fn get_latency_rollups() -> crate::latency::LatencyRollupsPayload {
 /// console scraping. Budget set to 100 ms so any sample IS a violation.
 #[tauri::command]
 pub fn record_frontend_main_thread_stall(duration_ms: u64) {
-    crate::latency::record_latency(
-        "frontend.main_thread_stall",
-        u128::from(duration_ms),
-        100,
-    );
+    crate::latency::record_latency("frontend.main_thread_stall", u128::from(duration_ms), 100);
 }
 
 #[allow(
@@ -1543,6 +1539,25 @@ pub async fn delete_all_data(state: State<'_, Arc<AppState>>) -> Result<(), Stri
     let db_path = crate::db::ActionDb::db_path_public()
         .map(|p| p.to_string_lossy().to_string())
         .ok();
+    let internal_tracker_paths = match state
+        .db_read(crate::services::entity_archive_folders::snapshot_internal_tracker_paths)
+        .await
+    {
+        Ok(paths) => paths,
+        Err(error) => {
+            log::warn!(
+                "snapshot Internal tracker paths before data deletion failed; continuing without Internal folder deletion: {error}"
+            );
+            Vec::new()
+        }
+    };
+    let workspace_path = {
+        let configured = {
+            let guard = state.config.read();
+            guard.as_ref().map(|config| config.workspace_path.clone())
+        };
+        crate::state::resolved_workspace_path(configured.as_deref())?
+    };
 
     // Close async DB service
     {
@@ -1579,6 +1594,11 @@ pub async fn delete_all_data(state: State<'_, Arc<AppState>>) -> Result<(), Stri
         )]
         let _ = std::fs::remove_dir_all(&workspace);
     }
+
+    crate::services::entity_archive_folders::delete_mode_scoped_entity_roots(
+        &workspace_path,
+        &internal_tracker_paths,
+    )?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/projects_data.rs
+++ b/src-tauri/src/commands/projects_data.rs
@@ -63,6 +63,16 @@ pub struct ProjectChildSummary {
     pub open_action_count: usize,
 }
 
+/// Single-entity archive/restore command outcome.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveEntityCommandResult {
+    pub status: String,
+    pub changed_ids: Vec<String>,
+    pub children_restored: usize,
+    pub item_results: Vec<crate::services::entity_archive_folders::BulkArchiveItemResult>,
+}
+
 #[allow(
     clippy::let_underscore_must_use,
     reason = "tauri::command macro emits internal Result glue that discards generated metadata"
@@ -223,7 +233,7 @@ pub fn list_database_backups() -> Result<Vec<crate::db_backup::BackupInfo>, Stri
 pub async fn restore_database_from_backup(
     backup_path: String,
     state: tauri::State<'_, Arc<AppState>>,
-) -> Result<(), String> {
+) -> Result<crate::services::entity_archive_folders::ArchiveFolderRepairPlan, String> {
     // Timeout on user-facing permit acquisition.
     let _permit = match tokio::time::timeout(
         std::time::Duration::from_secs(10),
@@ -260,7 +270,7 @@ pub async fn restore_database_from_backup(
     }
 
     state.clear_database_recovery_required();
-    Ok(())
+    Ok(plan_entity_archive_folder_reconciliation_after_reset(state.inner().clone()).await)
 }
 
 #[allow(
@@ -268,13 +278,33 @@ pub async fn restore_database_from_backup(
     reason = "tauri::command macro emits internal Result glue that discards generated metadata"
 )]
 #[tauri::command]
-pub async fn start_fresh_database(state: tauri::State<'_, Arc<AppState>>) -> Result<(), String> {
+pub async fn start_fresh_database(
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::ArchiveFolderRepairPlan, String> {
     // Drop async DB service before deleting files.
     {
         let mut db_service_guard = state.db_service.write().await;
         *db_service_guard = None;
     }
-    crate::db_backup::start_fresh_database()
+    crate::db_backup::start_fresh_database()?;
+    state.init_db_service().await?;
+    Ok(plan_entity_archive_folder_reconciliation_after_reset(state.inner().clone()).await)
+}
+
+async fn plan_entity_archive_folder_reconciliation_after_reset(
+    state: Arc<AppState>,
+) -> crate::services::entity_archive_folders::ArchiveFolderRepairPlan {
+    match crate::services::entity_archive_folders::plan_entity_archive_folder_reconciliation(state)
+        .await
+    {
+        Ok(plan) => plan,
+        Err(error) => {
+            log::warn!(
+                "archive folder reconciliation planning skipped after database reset: {error}"
+            );
+            crate::services::entity_archive_folders::ArchiveFolderRepairPlan::default()
+        }
+    }
 }
 
 #[tauri::command]
@@ -450,6 +480,187 @@ pub async fn get_duplicate_people_for_person(
 // Archive / Unarchive Entities
 // =============================================================================
 
+async fn preview_bulk_archive(
+    state: State<'_, Arc<AppState>>,
+    entity_type: crate::services::entity_archive_folders::EntityArchiveType,
+    ids: Vec<String>,
+) -> Result<crate::services::entity_archive_folders::BulkArchivePreview, String> {
+    state
+        .db_read(move |db| {
+            crate::services::entity_archive_folders::preview_bulk_archive(db, entity_type, ids)
+        })
+        .await
+        .map_err(String::from)
+}
+
+async fn bulk_archive(
+    state: State<'_, Arc<AppState>>,
+    entity_type: crate::services::entity_archive_folders::EntityArchiveType,
+    ids: Vec<String>,
+    plan_id: String,
+    plan_fingerprint: String,
+) -> Result<crate::services::entity_archive_folders::BulkArchiveResult, String> {
+    let app_state = state.inner().clone();
+    let state_for_ctx = app_state.clone();
+    let plan_id_for_db = plan_id.clone();
+    let plan_fingerprint_for_db = plan_fingerprint.clone();
+    let (preview, outcomes) = state
+        .db_write(move |db| {
+            let ctx = state_for_ctx.live_service_context();
+            crate::services::entity_archive_folders::execute_bulk_archive(
+                &ctx,
+                db,
+                &app_state,
+                entity_type,
+                ids,
+                &plan_id_for_db,
+                &plan_fingerprint_for_db,
+            )
+        })
+        .await
+        .map_err(String::from)?;
+
+    if bulk_archive_preview_stale(&preview, &outcomes, &plan_id, &plan_fingerprint) {
+        return Ok(crate::services::entity_archive_folders::BulkArchiveResult {
+            status: "preview_stale".to_string(),
+            changed_ids: Vec::new(),
+            already_archived_ids: preview.already_archived_ids.clone(),
+            not_found_ids: preview.not_found_ids.clone(),
+            preview,
+            outcomes,
+            item_results: Vec::new(),
+        });
+    }
+
+    let app_state = state.inner().clone();
+    crate::services::entity_archive_folders::remove_intel_queue_entries(&app_state, &outcomes);
+    let item_results =
+        crate::services::entity_archive_folders::archive_folders_for_outcomes(app_state, &outcomes)
+            .await;
+    let changed_ids = outcomes
+        .iter()
+        .flat_map(|outcome| outcome.changed_ids.iter().cloned())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let has_failure = item_results.iter().any(|item| {
+        matches!(
+            item.folder_status.as_str(),
+            "folder_failed" | "metadata_failed" | "metadata_pending" | "missing_source"
+        )
+    });
+
+    Ok(crate::services::entity_archive_folders::BulkArchiveResult {
+        status: if has_failure {
+            "partial".to_string()
+        } else {
+            "succeeded".to_string()
+        },
+        changed_ids,
+        already_archived_ids: preview.already_archived_ids.clone(),
+        not_found_ids: preview.not_found_ids.clone(),
+        preview,
+        outcomes,
+        item_results,
+    })
+}
+
+fn bulk_archive_preview_stale(
+    preview: &crate::services::entity_archive_folders::BulkArchivePreview,
+    outcomes: &[crate::services::entity_archive_folders::ArchiveMutationOutcome],
+    plan_id: &str,
+    plan_fingerprint: &str,
+) -> bool {
+    outcomes.is_empty()
+        && (preview.plan_id != plan_id || preview.plan_fingerprint != plan_fingerprint)
+}
+
+async fn archive_entity_command(
+    state: State<'_, Arc<AppState>>,
+    entity_type: crate::services::entity_archive_folders::EntityArchiveType,
+    id: String,
+    archived: bool,
+) -> Result<ArchiveEntityCommandResult, String> {
+    let app_state = state.inner().clone();
+    if !archived {
+        crate::services::entity_archive_folders::preflight_restore_targets(
+            app_state.clone(),
+            entity_type,
+            vec![id.clone()],
+        )
+        .await?;
+    }
+
+    let state_for_ctx = app_state.clone();
+    let id_for_db = id.clone();
+    let outcome = state
+        .db_write(move |db| {
+            let ctx = state_for_ctx.live_service_context();
+            crate::services::entity_archive_folders::archive_entity_with_outcome(
+                &ctx,
+                db,
+                &app_state,
+                entity_type,
+                &id_for_db,
+                archived,
+            )
+        })
+        .await
+        .map_err(String::from)?;
+
+    let app_state = state.inner().clone();
+    crate::services::entity_archive_folders::remove_intel_queue_entries(
+        &app_state,
+        std::slice::from_ref(&outcome),
+    );
+    let item_results = if archived {
+        crate::services::entity_archive_folders::archive_folders_for_outcomes(
+            app_state,
+            std::slice::from_ref(&outcome),
+        )
+        .await
+    } else {
+        crate::services::entity_archive_folders::restore_folders_for_outcomes(
+            app_state,
+            std::slice::from_ref(&outcome),
+        )
+        .await
+    };
+    Ok(archive_entity_command_result(&outcome, item_results, 0))
+}
+
+fn archive_entity_command_result(
+    outcome: &crate::services::entity_archive_folders::ArchiveMutationOutcome,
+    item_results: Vec<crate::services::entity_archive_folders::BulkArchiveItemResult>,
+    children_restored: usize,
+) -> ArchiveEntityCommandResult {
+    let has_failure = item_results.iter().any(folder_reconciliation_failed);
+    ArchiveEntityCommandResult {
+        status: if has_failure {
+            "partial".to_string()
+        } else {
+            "succeeded".to_string()
+        },
+        changed_ids: outcome.changed_ids.clone(),
+        children_restored,
+        item_results,
+    }
+}
+
+fn folder_reconciliation_failed(
+    item: &crate::services::entity_archive_folders::BulkArchiveItemResult,
+) -> bool {
+    matches!(
+        item.folder_status.as_str(),
+        "folder_failed"
+            | "metadata_failed"
+            | "metadata_pending"
+            | "missing_source"
+            | "folder_missing"
+            | "restore_conflict"
+    )
+}
+
 /// Archive or unarchive an account. Cascades to children when archiving.
 #[allow(
     clippy::let_underscore_must_use,
@@ -460,16 +671,14 @@ pub async fn archive_account(
     id: String,
     archived: bool,
     state: State<'_, Arc<AppState>>,
-) -> Result<(), String> {
-    let app_state = state.inner().clone();
-    let state_for_ctx = app_state.clone();
-    state
-        .db_write(move |db| {
-            let ctx = state_for_ctx.live_service_context();
-            crate::services::accounts::archive_account(&ctx, db, &app_state, &id, archived)
-        })
-        .await
-        .map_err(String::from)
+) -> Result<ArchiveEntityCommandResult, String> {
+    archive_entity_command(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Account,
+        id,
+        archived,
+    )
+    .await
 }
 
 /// Merge source account into target account.
@@ -504,16 +713,14 @@ pub async fn archive_project(
     id: String,
     archived: bool,
     state: State<'_, Arc<AppState>>,
-) -> Result<(), String> {
-    let app_state = state.inner().clone();
-    let state_for_ctx = app_state.clone();
-    state
-        .db_write(move |db| {
-            let ctx = state_for_ctx.live_service_context();
-            crate::services::projects::archive_project(&ctx, db, &app_state, &id, archived)
-        })
-        .await
-        .map_err(String::from)
+) -> Result<ArchiveEntityCommandResult, String> {
+    archive_entity_command(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Project,
+        id,
+        archived,
+    )
+    .await
 }
 
 /// Archive or unarchive a person.
@@ -526,16 +733,104 @@ pub async fn archive_person(
     id: String,
     archived: bool,
     state: State<'_, Arc<AppState>>,
-) -> Result<(), String> {
-    let app_state = state.inner().clone();
-    let state_for_ctx = app_state.clone();
-    state
-        .db_write(move |db| {
-            let ctx = state_for_ctx.live_service_context();
-            crate::services::people::archive_person(&ctx, db, &app_state, &id, archived)
-        })
-        .await
-        .map_err(String::from)
+) -> Result<ArchiveEntityCommandResult, String> {
+    archive_entity_command(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Person,
+        id,
+        archived,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn preview_bulk_archive_accounts(
+    ids: Vec<String>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchivePreview, String> {
+    preview_bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Account,
+        ids,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn bulk_archive_accounts(
+    ids: Vec<String>,
+    plan_id: String,
+    plan_fingerprint: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchiveResult, String> {
+    bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Account,
+        ids,
+        plan_id,
+        plan_fingerprint,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn preview_bulk_archive_projects(
+    ids: Vec<String>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchivePreview, String> {
+    preview_bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Project,
+        ids,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn bulk_archive_projects(
+    ids: Vec<String>,
+    plan_id: String,
+    plan_fingerprint: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchiveResult, String> {
+    bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Project,
+        ids,
+        plan_id,
+        plan_fingerprint,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn preview_bulk_archive_people(
+    ids: Vec<String>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchivePreview, String> {
+    preview_bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Person,
+        ids,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn bulk_archive_people(
+    ids: Vec<String>,
+    plan_id: String,
+    plan_fingerprint: String,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::BulkArchiveResult, String> {
+    bulk_archive(
+        state,
+        crate::services::entity_archive_folders::EntityArchiveType::Person,
+        ids,
+        plan_id,
+        plan_fingerprint,
+    )
+    .await
 }
 
 /// Get archived accounts.
@@ -596,16 +891,124 @@ pub async fn restore_account(
     account_id: String,
     restore_children: bool,
     state: State<'_, Arc<AppState>>,
-) -> Result<usize, String> {
+) -> Result<ArchiveEntityCommandResult, String> {
     let app_state = state.inner().clone();
-    let state_for_ctx = app_state.clone();
-    state
-        .db_write(move |db| {
-            let ctx = state_for_ctx.live_service_context();
-            crate::services::accounts::restore_account(&ctx, db, &account_id, restore_children)
+    let account_id_for_preflight = account_id.clone();
+    let restore_target_ids = state
+        .db_read(move |db| {
+            crate::services::entity_archive_folders::restore_account_target_ids(
+                db,
+                &account_id_for_preflight,
+                restore_children,
+            )
         })
         .await
-        .map_err(String::from)
+        .map_err(String::from)?;
+    crate::services::entity_archive_folders::preflight_restore_targets(
+        app_state.clone(),
+        crate::services::entity_archive_folders::EntityArchiveType::Account,
+        restore_target_ids,
+    )
+    .await?;
+    let state_for_ctx = app_state.clone();
+    let outcome = state
+        .db_write(move |db| {
+            let ctx = state_for_ctx.live_service_context();
+            crate::services::entity_archive_folders::restore_account_with_outcome(
+                &ctx,
+                db,
+                &app_state,
+                &account_id,
+                restore_children,
+            )
+        })
+        .await
+        .map_err(String::from)?;
+    let children_restored = outcome.cascaded_child_ids.len();
+    let app_state = state.inner().clone();
+    let item_results = crate::services::entity_archive_folders::restore_folders_for_outcomes(
+        app_state,
+        std::slice::from_ref(&outcome),
+    )
+    .await;
+    Ok(archive_entity_command_result(
+        &outcome,
+        item_results,
+        children_restored,
+    ))
+}
+
+#[tauri::command]
+pub async fn plan_entity_archive_folder_reconciliation(
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::ArchiveFolderRepairPlan, String> {
+    crate::services::entity_archive_folders::plan_entity_archive_folder_reconciliation(
+        state.inner().clone(),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn apply_entity_archive_folder_reconciliation(
+    confirmed_statuses: Vec<String>,
+    max_changes: usize,
+    state: State<'_, Arc<AppState>>,
+) -> Result<crate::services::entity_archive_folders::ArchiveFolderRepairResult, String> {
+    crate::services::entity_archive_folders::apply_entity_archive_folder_reconciliation(
+        state.inner().clone(),
+        confirmed_statuses,
+        max_changes,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod archive_command_tests {
+    use super::bulk_archive_preview_stale;
+    use crate::services::entity_archive_folders::{BulkArchivePreview, EntityArchiveType};
+
+    fn preview() -> BulkArchivePreview {
+        BulkArchivePreview {
+            entity_type: EntityArchiveType::Project,
+            requested_ids: vec!["project-1".to_string()],
+            root_ids: vec!["project-1".to_string()],
+            changed_ids: vec!["project-1".to_string()],
+            selected_ids: vec!["project-1".to_string()],
+            cascaded_child_ids: Vec::new(),
+            covered_child_ids: Vec::new(),
+            not_found_ids: Vec::new(),
+            already_archived_ids: Vec::new(),
+            total_changed_count: 1,
+            direct_cascade_count: 0,
+            plan_id: "bulk-archive-plan".to_string(),
+            plan_fingerprint: "bulk-archive:v1:fingerprint".to_string(),
+            expires_at: "2026-06-02T12:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_bulk_archive_outcomes_are_stale_when_plan_id_mismatches() {
+        let preview = preview();
+
+        assert!(bulk_archive_preview_stale(
+            &preview,
+            &[],
+            "different-plan",
+            &preview.plan_fingerprint,
+        ));
+    }
+
+    #[test]
+    fn empty_bulk_archive_outcomes_can_be_clean_noops_when_plan_binding_matches() {
+        let preview = preview();
+
+        assert!(!bulk_archive_preview_stale(
+            &preview,
+            &[],
+            &preview.plan_id,
+            &preview.plan_fingerprint,
+        ));
+    }
 }
 
 // =============================================================================

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -2549,7 +2549,7 @@ impl ActionDb {
     }
 
     /// The column list shared by all account SELECT queries.
-    const ACCOUNT_COLUMNS: &'static str =
+    pub(crate) const ACCOUNT_COLUMNS: &'static str =
         "id, name, lifecycle, arr, health, contract_start, contract_end, \
          nps, tracker_path, parent_id, account_type, updated_at, archived, \
          keywords, keywords_extracted_at, metadata, commercial_stage, \

--- a/src-tauri/src/db/people.rs
+++ b/src-tauri/src/db/people.rs
@@ -998,7 +998,7 @@ impl ActionDb {
     }
 
     /// Helper: map a row to `DbPerson`.
-    fn map_person_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DbPerson> {
+    pub(crate) fn map_person_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DbPerson> {
         Ok(DbPerson {
             id: row.get(0)?,
             email: row.get(1)?,

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -762,6 +762,9 @@ pub fn purge_mock_data(_state: &AppState) -> Result<String, String> {
     let n = delete_mock("account_events", "account_id");
     summary.push(format!("account_events: {}", n));
 
+    let n = delete_mock("entity_archive_folders", "operation_id");
+    summary.push(format!("entity_archive_folders: {}", n));
+
     // --- Primary tables ---
     let n = delete_mock("accounts", "id");
     summary.push(format!("accounts: {}", n));
@@ -1603,6 +1606,29 @@ pub(crate) fn seed_database(db: &ActionDb) -> Result<(), String> {
         "INSERT OR REPLACE INTO accounts (id, name, lifecycle, arr, health, contract_end, nps, tracker_path, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         rusqlite::params!["mock-globex-holdings", "Globex Holdings", "steady-state", 185_000.0, "green", "2026-05-01", 67, "Accounts/Globex Holdings/dashboard.md", &today],
     ).map_err(|e| e.to_string())?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO entity_archive_folders (
+            operation_id,
+            entity_type,
+            entity_id,
+            original_relative_path,
+            archived_relative_path,
+            folder_state,
+            archived_at,
+            restored_at,
+            updated_at,
+            last_error_code
+        ) VALUES (?1, 'account', ?2, ?3, ?4, 'restored', ?5, ?5, ?5, NULL)",
+        rusqlite::params![
+            "mock-archive-acme-restored",
+            "mock-acme-corp",
+            "Accounts/Acme Corp",
+            "_archive/entities/accounts/mock-acme-corp--acme-corp",
+            &today,
+        ],
+    )
+    .map_err(|e| format!("Seed entity_archive_folders: {}", e))?;
 
     // --- Account Domains (inbox-to-account matching) ---
     // Populated here from mock data. In production, domains are populated via:

--- a/src-tauri/src/intelligence/glean_provider.rs
+++ b/src-tauri/src/intelligence/glean_provider.rs
@@ -309,9 +309,10 @@ impl GleanIntelligenceProvider {
                 // succeed; per-dim filenames preserve forensic state across
                 // parallel failures.
                 {
+                    // dos259-exempt: temp debug filename disambiguator; not persisted intelligence state.
                     let ts = chrono::Utc::now().timestamp_millis();
-                    let debug_path = std::env::temp_dir()
-                        .join(format!("dailyos-glean-{}-{}.txt", dim_name, ts));
+                    let debug_path =
+                        std::env::temp_dir().join(format!("dailyos-glean-{}-{}.txt", dim_name, ts));
                     if let Err(e) = std::fs::write(&debug_path, &response_text) {
                         log::warn!(
                             "[I574] Failed to write debug response for {}: {}",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1163,6 +1163,12 @@ pub fn run() {
             commands::archive_account,
             commands::archive_project,
             commands::archive_person,
+            commands::preview_bulk_archive_accounts,
+            commands::bulk_archive_accounts,
+            commands::preview_bulk_archive_projects,
+            commands::bulk_archive_projects,
+            commands::preview_bulk_archive_people,
+            commands::bulk_archive_people,
             commands::get_archived_accounts,
             commands::get_archived_projects,
             commands::get_archived_people,
@@ -1349,6 +1355,8 @@ pub fn run() {
             commands::get_data_summary,
             commands::clear_intelligence,
             commands::delete_all_data,
+            commands::plan_entity_archive_folder_reconciliation,
+            commands::apply_entity_archive_folder_reconciliation,
             // Feature Flags
             commands::get_feature_flags,
             // DB Growth Monitoring

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1101,6 +1101,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 273,
         apply: migrate_v273_recommendation_w2_shape_repair,
     },
+    // v1.5.0 List-Surfaces PR B — durable entity folder archive/restore metadata.
+    Migration::Sql {
+        version: 274,
+        sql: include_str!("migrations/274_entity_archive_folders.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -3395,6 +3400,7 @@ fn run_immediate_migration_transaction(
                 clippy::let_underscore_must_use,
                 reason = "intentional best-effort cleanup after migration failure"
             )]
+            // best-effort: rollback after migration failure preserves the original migration error.
             let _ = conn.execute_batch("ROLLBACK;");
             Err(error)
         }
@@ -7518,7 +7524,7 @@ mod tests {
         let conn = mem_db();
         conn.execute_batch(
             "CREATE TABLE intelligence_claims (id TEXT PRIMARY KEY);
-            INSERT INTO intelligence_claims (id) VALUES ('claim-old');
+            INSERT INTO intelligence_claims /* dos7-allowed: migration 273 fixture seeds parent claim row */ (id) VALUES ('claim-old');
 
             CREATE TABLE surfacing_decisions (
                 id TEXT PRIMARY KEY,
@@ -7878,7 +7884,7 @@ mod tests {
         let conn = mem_db();
         conn.execute_batch(
             "CREATE TABLE intelligence_claims (id TEXT PRIMARY KEY);
-             INSERT INTO intelligence_claims (id) VALUES ('claim-final');",
+             INSERT INTO intelligence_claims /* dos7-allowed: migration 273 fixture seeds parent claim row */ (id) VALUES ('claim-final');",
         )
         .expect("create parent claim table");
         migrate_v271_recommendation_surfacing(&conn).expect("create final surfacing schema");

--- a/src-tauri/src/migrations/274_entity_archive_folders.sql
+++ b/src-tauri/src/migrations/274_entity_archive_folders.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS entity_archive_folders (
+    operation_id TEXT NOT NULL,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('account', 'project', 'person')),
+    entity_id TEXT NOT NULL,
+    original_relative_path TEXT NOT NULL,
+    archived_relative_path TEXT,
+    folder_state TEXT NOT NULL CHECK (
+        folder_state IN (
+            'archive_pending',
+            'archived',
+            'archive_failed',
+            'missing_source',
+            'restore_pending',
+            'restored',
+            'restore_failed'
+        )
+    ),
+    archived_at TEXT,
+    restored_at TEXT,
+    updated_at TEXT NOT NULL,
+    last_error_code TEXT,
+    PRIMARY KEY (operation_id, entity_type, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_archive_folders_entity_state
+    ON entity_archive_folders(entity_type, entity_id, folder_state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_entity_archive_folders_state
+    ON entity_archive_folders(folder_state, updated_at DESC);

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -396,6 +396,10 @@ const CLAIM_UPDATE_ALLOWED_COLUMNS: &[&str] = &[
     // backfill. Not assertion identity — it is a per-row version counter
     // for the three-view consistency contract.
     "claim_version",
+    // Recommendation feedback mutates a controlled metadata envelope branch
+    // through the claim service helper below. Callers outside this module
+    // still fail the direct-runtime-update lint.
+    "metadata_json",
 ];
 
 fn execute_claims_update<P>(conn: &Connection, sql: &str, params: P) -> Result<usize, ClaimError>
@@ -3926,6 +3930,24 @@ pub fn load_claim_by_id(
     } else {
         Ok(None)
     }
+}
+
+pub(crate) fn update_recommendation_feedback_metadata(
+    tx: &ActionDb,
+    claim_id: &str,
+    feedback_state_json: &str,
+    conversion_state_json: &str,
+) -> Result<usize, ClaimError> {
+    execute_claims_update(
+        tx.conn_ref(),
+        "UPDATE intelligence_claims
+         SET metadata_json = json_set(metadata_json,
+             '$.recommendation.feedbackState', json(?1),
+             '$.recommendation.conversionState', json(?2))
+         WHERE id = ?3
+           AND json_extract(metadata_json, '$.recommendation.feedbackState') = 'pending'",
+        params![feedback_state_json, conversion_state_json, claim_id],
+    )
 }
 
 fn record_shadow_canonicalization_for_committed_claim(

--- a/src-tauri/src/services/entity_archive_folders.rs
+++ b/src-tauri/src/services/entity_archive_folders.rs
@@ -1,0 +1,3824 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::db::{ActionDb, DbAccount, DbPerson, DbProject};
+use crate::services::context::ServiceContext;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EntityArchiveType {
+    Account,
+    Project,
+    Person,
+}
+
+impl EntityArchiveType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Account => "account",
+            Self::Project => "project",
+            Self::Person => "person",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, String> {
+        match value {
+            "account" => Ok(Self::Account),
+            "project" => Ok(Self::Project),
+            "person" => Ok(Self::Person),
+            _ => Err(format!("unknown entity archive type: {value}")),
+        }
+    }
+
+    fn active_root(self) -> &'static str {
+        match self {
+            Self::Account => "Accounts",
+            Self::Project => "Projects",
+            Self::Person => "People",
+        }
+    }
+
+    fn archive_root(self) -> &'static str {
+        match self {
+            Self::Account => "account",
+            Self::Project => "project",
+            Self::Person => "person",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EntityDescriptor {
+    entity_type: EntityArchiveType,
+    id: String,
+    name: String,
+    tracker_path: Option<String>,
+    parent_id: Option<String>,
+    updated_at: String,
+    archived: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkArchivePreview {
+    pub entity_type: EntityArchiveType,
+    pub requested_ids: Vec<String>,
+    pub root_ids: Vec<String>,
+    pub changed_ids: Vec<String>,
+    pub selected_ids: Vec<String>,
+    pub cascaded_child_ids: Vec<String>,
+    pub covered_child_ids: Vec<String>,
+    pub not_found_ids: Vec<String>,
+    pub already_archived_ids: Vec<String>,
+    pub total_changed_count: usize,
+    pub direct_cascade_count: usize,
+    pub plan_id: String,
+    pub plan_fingerprint: String,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveMutationOutcome {
+    pub requested_id: String,
+    pub entity_type: EntityArchiveType,
+    pub changed_ids: Vec<String>,
+    pub selected_id_changed: bool,
+    pub cascaded_child_ids: Vec<String>,
+    pub already_in_target_state_ids: Vec<String>,
+    pub not_found_ids: Vec<String>,
+    pub intel_queue_cleanup_ids: Vec<String>,
+    pub operation_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkArchiveItemResult {
+    pub entity_type: EntityArchiveType,
+    pub entity_id: String,
+    pub folder_status: String,
+    pub message: Option<String>,
+    pub original_relative_path: Option<String>,
+    pub archived_relative_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkArchiveResult {
+    pub status: String,
+    pub preview: BulkArchivePreview,
+    pub outcomes: Vec<ArchiveMutationOutcome>,
+    pub item_results: Vec<BulkArchiveItemResult>,
+    pub changed_ids: Vec<String>,
+    pub already_archived_ids: Vec<String>,
+    pub not_found_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveFolderRepairItem {
+    pub entity_type: EntityArchiveType,
+    pub entity_id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveFolderRepairPlan {
+    pub archived_db_active_folder_count: usize,
+    pub pending_metadata_count: usize,
+    pub orphan_active_folder_count: usize,
+    pub items: Vec<ArchiveFolderRepairItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveFolderRepairResult {
+    pub status: String,
+    pub plan: ArchiveFolderRepairPlan,
+    pub changed_count: usize,
+    pub item_results: Vec<BulkArchiveItemResult>,
+}
+
+#[derive(Debug, Clone)]
+struct FolderMetadata {
+    operation_id: String,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    original_relative_path: String,
+    archived_relative_path: Option<String>,
+    folder_state: String,
+}
+
+#[derive(Debug, Clone)]
+struct ArchivedDescendantFolderMove {
+    descriptor: EntityDescriptor,
+    metadata: FolderMetadata,
+    current_relative_path: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArchiveManifest<'a> {
+    entity_type: &'a str,
+    entity_id: &'a str,
+    original_relative_path: &'a str,
+    archived_relative_path: &'a str,
+    archived_at: &'a str,
+    operation_id: &'a str,
+}
+
+pub fn preview_bulk_archive(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    ids: Vec<String>,
+) -> Result<BulkArchivePreview, String> {
+    let requested_ids = normalize_ids(ids);
+    let mut selected_rows = Vec::new();
+    let mut not_found_ids = Vec::new();
+    let mut already_archived_ids = Vec::new();
+
+    for id in &requested_ids {
+        match load_descriptor(db, entity_type, id)? {
+            Some(row) if row.archived => already_archived_ids.push(id.clone()),
+            Some(row) => selected_rows.push(row),
+            None => not_found_ids.push(id.clone()),
+        }
+    }
+
+    let selected_set: BTreeSet<String> = selected_rows.iter().map(|row| row.id.clone()).collect();
+    let mut covered_child_ids = Vec::new();
+    for row in &selected_rows {
+        if has_selected_ancestor(db, entity_type, row, &selected_set)? {
+            covered_child_ids.push(row.id.clone());
+        }
+    }
+    let covered_set: BTreeSet<String> = covered_child_ids.iter().cloned().collect();
+
+    let root_rows: Vec<EntityDescriptor> = selected_rows
+        .iter()
+        .filter(|row| !covered_set.contains(&row.id))
+        .cloned()
+        .collect();
+    let root_ids: Vec<String> = root_rows.iter().map(|row| row.id.clone()).collect();
+
+    let mut cascade_rows = Vec::new();
+    for row in &root_rows {
+        cascade_rows.extend(load_active_descendants(db, entity_type, &row.id)?);
+    }
+    let cascaded_child_ids = dedupe_strings(cascade_rows.iter().map(|row| row.id.clone()));
+
+    let mut changed_ids = root_ids.clone();
+    changed_ids.extend(cascaded_child_ids.clone());
+    changed_ids = dedupe_strings(changed_ids);
+
+    let mut fingerprint_rows = BTreeMap::new();
+    for row in selected_rows.iter().chain(cascade_rows.iter()) {
+        fingerprint_rows.insert(
+            row.id.clone(),
+            serde_json::json!({
+                "archived": row.archived,
+                "parentId": row.parent_id,
+                "updatedAt": row.updated_at,
+            }),
+        );
+    }
+
+    let fingerprint_payload = serde_json::json!({
+        "entityType": entity_type.as_str(),
+        "requestedIds": requested_ids,
+        "rootIds": root_ids,
+        "changedIds": changed_ids,
+        "cascadedChildIds": cascaded_child_ids,
+        "coveredChildIds": covered_child_ids,
+        "notFoundIds": not_found_ids,
+        "alreadyArchivedIds": already_archived_ids,
+        "rows": fingerprint_rows,
+    });
+    let serialized = serde_json::to_vec(&fingerprint_payload)
+        .map_err(|e| format!("preview fingerprint serialization failed: {e}"))?;
+    let digest = hex::encode(Sha256::digest(&serialized));
+    let plan_fingerprint = format!("bulk-archive:v1:{digest}");
+    let plan_id = format!("bulk-archive-{}", &digest[..16]);
+    let expires_at = (Utc::now() + Duration::minutes(10)).to_rfc3339();
+
+    let selected_ids: Vec<String> = selected_rows.iter().map(|row| row.id.clone()).collect();
+    Ok(BulkArchivePreview {
+        entity_type,
+        requested_ids,
+        root_ids,
+        changed_ids: changed_ids.clone(),
+        selected_ids,
+        cascaded_child_ids: cascaded_child_ids.clone(),
+        covered_child_ids,
+        not_found_ids,
+        already_archived_ids,
+        total_changed_count: changed_ids.len(),
+        direct_cascade_count: cascaded_child_ids.len(),
+        plan_id,
+        plan_fingerprint,
+        expires_at,
+    })
+}
+
+pub fn execute_bulk_archive(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    state: &AppState,
+    entity_type: EntityArchiveType,
+    ids: Vec<String>,
+    plan_id: &str,
+    plan_fingerprint: &str,
+) -> Result<(BulkArchivePreview, Vec<ArchiveMutationOutcome>), String> {
+    let preview = preview_bulk_archive(db, entity_type, ids)?;
+    if preview.plan_id != plan_id || preview.plan_fingerprint != plan_fingerprint {
+        return Ok((preview, Vec::new()));
+    }
+
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    let root_ids = preview.root_ids.clone();
+    let outcomes = db.with_transaction(|tx| {
+        let mut outcomes = Vec::new();
+        for root_id in &root_ids {
+            outcomes.push(archive_entity_with_outcome_in_tx(
+                ctx,
+                tx,
+                state,
+                entity_type,
+                root_id,
+                true,
+                archive_operation_id(entity_type, true),
+            )?);
+        }
+        Ok(outcomes)
+    })?;
+    Ok((preview, outcomes))
+}
+
+fn archive_operation_id(entity_type: EntityArchiveType, archived: bool) -> String {
+    format!(
+        "{}-{}-{}",
+        if archived { "archive" } else { "restore" },
+        entity_type.as_str(),
+        uuid::Uuid::new_v4()
+    )
+}
+
+fn has_selected_ancestor(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    row: &EntityDescriptor,
+    selected_set: &BTreeSet<String>,
+) -> Result<bool, String> {
+    let mut parent_id = row.parent_id.clone();
+    while let Some(parent) = parent_id {
+        if selected_set.contains(&parent) {
+            return Ok(true);
+        }
+        parent_id = load_descriptor(db, entity_type, &parent)?.and_then(|parent| parent.parent_id);
+    }
+    Ok(false)
+}
+
+fn apply_lifecycle_archive_state(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    root_id: &str,
+    descendant_ids: &[String],
+    archived: bool,
+) -> Result<(), String> {
+    match entity_type {
+        EntityArchiveType::Account => {
+            db.archive_account(root_id, archived)
+                .map_err(|e| e.to_string())?;
+            for descendant_id in descendant_ids {
+                db.archive_account(descendant_id, archived)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        EntityArchiveType::Project => {
+            db.archive_project(root_id, archived)
+                .map_err(|e| e.to_string())?;
+            for descendant_id in descendant_ids {
+                db.archive_project(descendant_id, archived)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+        EntityArchiveType::Person => {
+            db.archive_person(root_id, archived)
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+pub fn archive_entity_with_outcome(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    state: &AppState,
+    entity_type: EntityArchiveType,
+    id: &str,
+    archived: bool,
+) -> Result<ArchiveMutationOutcome, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    let operation_id = archive_operation_id(entity_type, archived);
+    db.with_transaction(|tx| {
+        archive_entity_with_outcome_in_tx(ctx, tx, state, entity_type, id, archived, operation_id)
+    })
+}
+
+fn archive_entity_with_outcome_in_tx(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    state: &AppState,
+    entity_type: EntityArchiveType,
+    id: &str,
+    archived: bool,
+    operation_id: String,
+) -> Result<ArchiveMutationOutcome, String> {
+    let Some(row) = load_descriptor(db, entity_type, id)? else {
+        return Ok(ArchiveMutationOutcome {
+            requested_id: id.to_string(),
+            entity_type,
+            changed_ids: Vec::new(),
+            selected_id_changed: false,
+            cascaded_child_ids: Vec::new(),
+            already_in_target_state_ids: Vec::new(),
+            not_found_ids: vec![id.to_string()],
+            intel_queue_cleanup_ids: Vec::new(),
+            operation_id,
+        });
+    };
+
+    if row.archived == archived {
+        return Ok(ArchiveMutationOutcome {
+            requested_id: id.to_string(),
+            entity_type,
+            changed_ids: Vec::new(),
+            selected_id_changed: false,
+            cascaded_child_ids: Vec::new(),
+            already_in_target_state_ids: vec![id.to_string()],
+            not_found_ids: Vec::new(),
+            intel_queue_cleanup_ids: Vec::new(),
+            operation_id,
+        });
+    }
+
+    let cascaded_child_ids: Vec<String> = if archived {
+        load_active_descendants(db, entity_type, id)?
+            .into_iter()
+            .map(|row| row.id)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut changed_ids = vec![id.to_string()];
+    changed_ids.extend(cascaded_child_ids.clone());
+    changed_ids = dedupe_strings(changed_ids);
+    let signal_type = if archived {
+        "entity_archived"
+    } else {
+        "entity_restored"
+    };
+
+    apply_lifecycle_archive_state(db, entity_type, id, &cascaded_child_ids, archived)?;
+    if !archived {
+        record_restore_intent_for_changed_ids(db, entity_type, &changed_ids)?;
+    }
+    for changed_id in &changed_ids {
+        crate::services::signals::emit_and_propagate(
+            ctx,
+            db,
+            &state.signals.engine,
+            entity_type.as_str(),
+            changed_id,
+            signal_type,
+            "user_action",
+            None,
+            0.9,
+        )
+        .map_err(|e| format!("signal emit failed: {e}"))?;
+    }
+
+    Ok(ArchiveMutationOutcome {
+        requested_id: id.to_string(),
+        entity_type,
+        changed_ids: changed_ids.clone(),
+        selected_id_changed: true,
+        cascaded_child_ids,
+        already_in_target_state_ids: Vec::new(),
+        not_found_ids: Vec::new(),
+        intel_queue_cleanup_ids: if archived { changed_ids } else { Vec::new() },
+        operation_id,
+    })
+}
+
+pub fn restore_account_with_outcome(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    state: &AppState,
+    account_id: &str,
+    restore_children: bool,
+) -> Result<ArchiveMutationOutcome, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    let operation_id = format!("restore-account-{}", uuid::Uuid::new_v4());
+    let Some(row) = load_descriptor(db, EntityArchiveType::Account, account_id)? else {
+        return Ok(ArchiveMutationOutcome {
+            requested_id: account_id.to_string(),
+            entity_type: EntityArchiveType::Account,
+            changed_ids: Vec::new(),
+            selected_id_changed: false,
+            cascaded_child_ids: Vec::new(),
+            already_in_target_state_ids: Vec::new(),
+            not_found_ids: vec![account_id.to_string()],
+            intel_queue_cleanup_ids: Vec::new(),
+            operation_id,
+        });
+    };
+    let child_ids = if restore_children {
+        load_archived_descendants(db, EntityArchiveType::Account, account_id)?
+            .into_iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    if !row.archived && child_ids.is_empty() {
+        return Ok(ArchiveMutationOutcome {
+            requested_id: account_id.to_string(),
+            entity_type: EntityArchiveType::Account,
+            changed_ids: Vec::new(),
+            selected_id_changed: false,
+            cascaded_child_ids: Vec::new(),
+            already_in_target_state_ids: vec![account_id.to_string()],
+            not_found_ids: Vec::new(),
+            intel_queue_cleanup_ids: Vec::new(),
+            operation_id,
+        });
+    }
+
+    let mut changed_ids = if row.archived {
+        vec![account_id.to_string()]
+    } else {
+        Vec::new()
+    };
+    changed_ids.extend(child_ids.clone());
+    changed_ids = dedupe_strings(changed_ids);
+
+    db.with_transaction(|tx| {
+        tx.restore_account(account_id, restore_children)
+            .map_err(|e| e.to_string())?;
+        for child_id in &child_ids {
+            tx.archive_account(child_id, false)
+                .map_err(|e| e.to_string())?;
+        }
+        record_restore_intent_for_changed_ids(tx, EntityArchiveType::Account, &changed_ids)?;
+        for changed_id in &changed_ids {
+            crate::services::signals::emit_and_propagate(
+                ctx,
+                tx,
+                &state.signals.engine,
+                "account",
+                changed_id,
+                "entity_restored",
+                "user_action",
+                None,
+                0.9,
+            )
+            .map_err(|e| format!("signal emit failed: {e}"))?;
+        }
+        Ok(())
+    })?;
+
+    Ok(ArchiveMutationOutcome {
+        requested_id: account_id.to_string(),
+        entity_type: EntityArchiveType::Account,
+        changed_ids,
+        selected_id_changed: row.archived,
+        cascaded_child_ids: child_ids,
+        already_in_target_state_ids: if row.archived {
+            Vec::new()
+        } else {
+            vec![account_id.to_string()]
+        },
+        not_found_ids: Vec::new(),
+        intel_queue_cleanup_ids: Vec::new(),
+        operation_id,
+    })
+}
+
+pub fn restore_account_target_ids(
+    db: &ActionDb,
+    account_id: &str,
+    restore_children: bool,
+) -> Result<Vec<String>, String> {
+    let mut ids = vec![account_id.to_string()];
+    if restore_children {
+        ids.extend(
+            load_archived_descendants(db, EntityArchiveType::Account, account_id)?
+                .into_iter()
+                .map(|row| row.id),
+        );
+    }
+    Ok(dedupe_strings(ids))
+}
+
+pub fn remove_intel_queue_entries(state: &AppState, outcomes: &[ArchiveMutationOutcome]) {
+    let mut ids = BTreeSet::new();
+    for outcome in outcomes {
+        for id in &outcome.intel_queue_cleanup_ids {
+            ids.insert(id.clone());
+        }
+    }
+    for id in ids {
+        state.intel_queue.remove_by_entity_id(&id);
+    }
+}
+
+pub async fn archive_folders_for_outcomes(
+    state: Arc<AppState>,
+    outcomes: &[ArchiveMutationOutcome],
+) -> Vec<BulkArchiveItemResult> {
+    let mut results = Vec::new();
+    for outcome in outcomes {
+        let (move_ids, skipped_ids) =
+            match folder_move_targets_for_outcome(state.clone(), outcome).await {
+                Ok(targets) => targets,
+                Err(message) => {
+                    results.push(BulkArchiveItemResult {
+                        entity_type: outcome.entity_type,
+                        entity_id: outcome.requested_id.clone(),
+                        folder_status: "folder_failed".to_string(),
+                        message: Some(message),
+                        original_relative_path: None,
+                        archived_relative_path: None,
+                    });
+                    continue;
+                }
+            };
+        let mut outcome_results = Vec::new();
+        for entity_id in move_ids {
+            outcome_results.push(
+                archive_folder_for_entity(
+                    state.clone(),
+                    outcome.entity_type,
+                    entity_id,
+                    outcome.operation_id.clone(),
+                )
+                .await,
+            );
+        }
+        for entity_id in skipped_ids {
+            outcome_results.push(
+                record_skipped_descendant_metadata(
+                    state.clone(),
+                    outcome,
+                    entity_id,
+                    &outcome_results,
+                )
+                .await,
+            );
+        }
+        results.extend(outcome_results);
+    }
+    results
+}
+
+async fn folder_move_targets_for_outcome(
+    state: Arc<AppState>,
+    outcome: &ArchiveMutationOutcome,
+) -> Result<(Vec<String>, BTreeSet<String>), String> {
+    let workspace = resolved_workspace_root(&state)?;
+    let entity_type = outcome.entity_type;
+    let changed_ids = outcome.changed_ids.clone();
+    state
+        .db_read(move |db| {
+            let mut descriptors = Vec::new();
+            for entity_id in &changed_ids {
+                if let Some(descriptor) = load_descriptor(db, entity_type, entity_id)? {
+                    descriptors.push(descriptor);
+                }
+            }
+            partition_folder_move_targets(descriptors, Some(&workspace))
+        })
+        .await
+        .map_err(String::from)
+}
+
+pub async fn preflight_restore_targets(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    ids: Vec<String>,
+) -> Result<(), String> {
+    let workspace = resolved_workspace_root(&state)?;
+    for id in ids {
+        let Some(metadata) =
+            latest_archived_metadata(state.clone(), entity_type, id.clone()).await?
+        else {
+            continue;
+        };
+        let original_relative_path = parse_relative_path(&metadata.original_relative_path)?;
+        let active_existing =
+            validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+        if active_existing.is_some()
+            && archived_source_exists(&workspace, &metadata.archived_relative_path)?
+        {
+            return Err("restore_conflict: active target already exists".to_string());
+        }
+    }
+    Ok(())
+}
+
+pub async fn restore_folders_for_outcomes(
+    state: Arc<AppState>,
+    outcomes: &[ArchiveMutationOutcome],
+) -> Vec<BulkArchiveItemResult> {
+    let mut results = Vec::new();
+    for outcome in outcomes {
+        for entity_id in &outcome.changed_ids {
+            results.push(
+                restore_folder_for_entity(state.clone(), outcome.entity_type, entity_id.clone())
+                    .await,
+            );
+        }
+    }
+    results
+}
+
+pub fn snapshot_internal_tracker_paths(db: &ActionDb) -> Result<Vec<String>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT tracker_path FROM accounts
+             WHERE tracker_path IS NOT NULL
+               AND (tracker_path = 'Internal' OR tracker_path LIKE 'Internal/%')",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())
+}
+
+pub fn delete_mode_scoped_entity_roots(
+    workspace: &Path,
+    internal_tracker_paths: &[String],
+) -> Result<(), String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    for root in ["Accounts", "Projects", "People"] {
+        remove_validated_root(&workspace, Path::new(root))?;
+    }
+    let archive_entities_root = PathBuf::from("_archive").join("entities");
+    remove_validated_root(&workspace, &archive_entities_root)?;
+    for tracker_path in internal_tracker_paths {
+        let relative = parse_relative_path(tracker_path)?;
+        if first_component(&relative).as_deref() == Some("Internal") {
+            remove_validated_root(&workspace, &relative)?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn plan_entity_archive_folder_reconciliation(
+    state: Arc<AppState>,
+) -> Result<ArchiveFolderRepairPlan, String> {
+    let workspace = resolved_workspace_root(&state)?;
+    state
+        .db_read(move |db| plan_reconciliation_sync(db, &workspace))
+        .await
+        .map_err(String::from)
+}
+
+fn plan_reconciliation_sync(
+    db: &ActionDb,
+    workspace: &Path,
+) -> Result<ArchiveFolderRepairPlan, String> {
+    let mut plan = ArchiveFolderRepairPlan::default();
+    for entity_type in [
+        EntityArchiveType::Account,
+        EntityArchiveType::Project,
+        EntityArchiveType::Person,
+    ] {
+        for row in load_archived_descriptors(db, entity_type)? {
+            if let Ok(relative) = active_relative_path(&row, Some(workspace)) {
+                if workspace.join(relative).exists() {
+                    plan.archived_db_active_folder_count += 1;
+                    plan.items.push(ArchiveFolderRepairItem {
+                        entity_type,
+                        entity_id: row.id,
+                        status: "archived_db_active_folder".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    let repair_metadata = load_repair_metadata_rows(db)?;
+    plan.pending_metadata_count = repair_metadata.len();
+    for row in repair_metadata {
+        plan.items.push(ArchiveFolderRepairItem {
+            entity_type: row.entity_type,
+            entity_id: row.entity_id,
+            status: row.folder_state,
+        });
+    }
+    plan.orphan_active_folder_count = count_orphan_active_folders(db, workspace)?;
+    Ok(plan)
+}
+
+pub async fn apply_entity_archive_folder_reconciliation(
+    state: Arc<AppState>,
+    confirmed_statuses: Vec<String>,
+    max_changes: usize,
+) -> Result<ArchiveFolderRepairResult, String> {
+    if max_changes == 0 {
+        return Err("repair budget must be greater than zero".to_string());
+    }
+    let confirmed_statuses = confirmed_statuses
+        .into_iter()
+        .map(|status| status.trim().to_string())
+        .filter(|status| !status.is_empty())
+        .collect::<BTreeSet<_>>();
+    if confirmed_statuses.is_empty() {
+        return Err("at least one repair status must be confirmed".to_string());
+    }
+
+    let plan = plan_entity_archive_folder_reconciliation(state.clone()).await?;
+    let mut candidates = plan
+        .items
+        .iter()
+        .filter(|item| confirmed_statuses.contains(&item.status))
+        .cloned()
+        .collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        (
+            left.status.as_str(),
+            left.entity_type,
+            left.entity_id.as_str(),
+        )
+            .cmp(&(
+                right.status.as_str(),
+                right.entity_type,
+                right.entity_id.as_str(),
+            ))
+    });
+    candidates.dedup_by(|left, right| {
+        left.status == right.status
+            && left.entity_type == right.entity_type
+            && left.entity_id == right.entity_id
+    });
+
+    if candidates.len() > max_changes {
+        return Err(format!(
+            "repair_budget_exceeded: {} candidate repairs exceed max_changes {max_changes}",
+            candidates.len()
+        ));
+    }
+
+    let mut item_results = Vec::new();
+    for item in candidates {
+        item_results.push(apply_repair_item(state.clone(), item).await);
+    }
+    let has_failure = item_results
+        .iter()
+        .any(|item| !matches!(item.folder_status.as_str(), "succeeded" | "folder_skipped"));
+    let status = if item_results.is_empty() {
+        "noop"
+    } else if has_failure {
+        "partial"
+    } else {
+        "succeeded"
+    };
+
+    Ok(ArchiveFolderRepairResult {
+        status: status.to_string(),
+        plan,
+        changed_count: item_results.len(),
+        item_results,
+    })
+}
+
+async fn apply_repair_item(
+    state: Arc<AppState>,
+    item: ArchiveFolderRepairItem,
+) -> BulkArchiveItemResult {
+    match item.status.as_str() {
+        "archived_db_active_folder" => {
+            let operation_id = format!(
+                "repair-archive-{}-{}",
+                item.entity_type.as_str(),
+                uuid::Uuid::new_v4()
+            );
+            archive_folder_for_entity(state, item.entity_type, item.entity_id, operation_id).await
+        }
+        "archive_pending" | "archive_failed" => {
+            repair_archive_metadata_row(state, item.entity_type, item.entity_id, item.status).await
+        }
+        "restore_pending" | "restore_failed" => {
+            repair_restore_metadata_row(state, item.entity_type, item.entity_id, item.status).await
+        }
+        _ => BulkArchiveItemResult {
+            entity_type: item.entity_type,
+            entity_id: item.entity_id,
+            folder_status: "folder_skipped".to_string(),
+            message: Some("repair status not supported".to_string()),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn repair_archive_metadata_row(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    folder_state: String,
+) -> BulkArchiveItemResult {
+    match repair_archive_metadata_row_inner(state, entity_type, &entity_id, &folder_state).await {
+        Ok(result) => result,
+        Err(message) => BulkArchiveItemResult {
+            entity_type,
+            entity_id,
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn repair_archive_metadata_row_inner(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    folder_state: &str,
+) -> Result<BulkArchiveItemResult, String> {
+    let metadata = latest_repair_metadata(
+        state.clone(),
+        entity_type,
+        entity_id.to_string(),
+        vec![folder_state],
+    )
+    .await?
+    .ok_or_else(|| "repair metadata no longer exists".to_string())?;
+    let archived_relative_path = metadata
+        .archived_relative_path
+        .clone()
+        .ok_or_else(|| "archive repair metadata has no target".to_string())?;
+    let workspace = resolved_workspace_root(&state)?;
+    let original_relative_path = parse_relative_path(&metadata.original_relative_path)?;
+    let original_relative_path_string = path_to_string(&original_relative_path);
+
+    let archived_source = validated_existing_archive_source(&workspace, &archived_relative_path)?;
+    let active_source =
+        validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+
+    if archived_source.is_some() && active_source.is_some() {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_failed".to_string(),
+            message: Some(
+                "archive repair conflict: source and archive target both exist".to_string(),
+            ),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    if let Some(archive_path) = archived_source {
+        write_archive_manifest_for_metadata(&archive_path, &metadata)?;
+        update_folder_state(
+            state,
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "archived",
+            None,
+        )
+        .await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "succeeded".to_string(),
+            message: None,
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    let Some(source_path) = active_source else {
+        update_folder_state(
+            state,
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "archive_failed",
+            Some("missing_source"),
+        )
+        .await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_missing".to_string(),
+            message: Some("archive source and target are both missing".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    };
+
+    let archive_path = archive_target_from_metadata(&workspace, &archived_relative_path)?;
+    move_directory_no_overwrite(&source_path, &archive_path)?;
+    write_archive_manifest_for_metadata(&archive_path, &metadata)?;
+    update_folder_state(
+        state,
+        &metadata.operation_id,
+        entity_type,
+        entity_id,
+        "archived",
+        None,
+    )
+    .await?;
+    Ok(BulkArchiveItemResult {
+        entity_type,
+        entity_id: entity_id.to_string(),
+        folder_status: "succeeded".to_string(),
+        message: None,
+        original_relative_path: Some(original_relative_path_string),
+        archived_relative_path: Some(archived_relative_path),
+    })
+}
+
+async fn repair_restore_metadata_row(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    folder_state: String,
+) -> BulkArchiveItemResult {
+    match repair_restore_metadata_row_inner(state, entity_type, &entity_id, &folder_state).await {
+        Ok(result) => result,
+        Err(message) => BulkArchiveItemResult {
+            entity_type,
+            entity_id,
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn repair_restore_metadata_row_inner(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    folder_state: &str,
+) -> Result<BulkArchiveItemResult, String> {
+    let metadata = latest_repair_metadata(
+        state.clone(),
+        entity_type,
+        entity_id.to_string(),
+        vec![folder_state],
+    )
+    .await?
+    .ok_or_else(|| "repair metadata no longer exists".to_string())?;
+    let archived_relative_path = metadata
+        .archived_relative_path
+        .clone()
+        .ok_or_else(|| "restore repair metadata has no archive source".to_string())?;
+    let workspace = resolved_workspace_root(&state)?;
+    let original_relative_path = parse_relative_path(&metadata.original_relative_path)?;
+    let original_relative_path_string = path_to_string(&original_relative_path);
+    let active_existing =
+        validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+    let archived_source = validated_existing_archive_source(&workspace, &archived_relative_path)?;
+
+    if active_existing.is_some() {
+        if archived_source.is_some() {
+            return Ok(BulkArchiveItemResult {
+                entity_type,
+                entity_id: entity_id.to_string(),
+                folder_status: "restore_conflict".to_string(),
+                message: Some(
+                    "restore repair conflict: active target and archive source both exist"
+                        .to_string(),
+                ),
+                original_relative_path: Some(original_relative_path_string),
+                archived_relative_path: Some(archived_relative_path),
+            });
+        }
+        update_folder_restored(state, &metadata.operation_id, entity_type, entity_id).await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "succeeded".to_string(),
+            message: None,
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    let Some(archived_source) = archived_source else {
+        update_folder_state(
+            state,
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "restore_failed",
+            Some("missing_source"),
+        )
+        .await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_missing".to_string(),
+            message: Some("restore source folder missing".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    };
+
+    let Some(active_target) =
+        validated_restore_target(&workspace, entity_type, &original_relative_path)?
+    else {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "restore_conflict".to_string(),
+            message: Some("active target already exists".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    };
+    move_directory_no_overwrite(&archived_source, &active_target)?;
+    update_folder_restored(state, &metadata.operation_id, entity_type, entity_id).await?;
+    Ok(BulkArchiveItemResult {
+        entity_type,
+        entity_id: entity_id.to_string(),
+        folder_status: "succeeded".to_string(),
+        message: None,
+        original_relative_path: Some(original_relative_path_string),
+        archived_relative_path: Some(archived_relative_path),
+    })
+}
+
+async fn archive_folder_for_entity(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    operation_id: String,
+) -> BulkArchiveItemResult {
+    match archive_folder_for_entity_inner(state, entity_type, &entity_id, &operation_id).await {
+        Ok(result) => result,
+        Err(message) => BulkArchiveItemResult {
+            entity_type,
+            entity_id,
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn archive_folder_for_entity_inner(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    operation_id: &str,
+) -> Result<BulkArchiveItemResult, String> {
+    let workspace = resolved_workspace_root(&state)?;
+    let descriptor = load_descriptor_async(state.clone(), entity_type, entity_id.to_string())
+        .await?
+        .ok_or_else(|| "entity not found after archive mutation".to_string())?;
+    let original_relative_path = active_relative_path(&descriptor, Some(&workspace))?;
+    let source_path = validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+    let Some(source_path) = source_path else {
+        upsert_folder_metadata(
+            state,
+            FolderMetadataWrite {
+                operation_id: operation_id.to_string(),
+                entity_type,
+                entity_id: entity_id.to_string(),
+                original_relative_path: path_to_string(&original_relative_path),
+                archived_relative_path: None,
+                folder_state: "missing_source".to_string(),
+                archived_at: None,
+                restored_at: None,
+                last_error_code: Some("missing_source".to_string()),
+            },
+        )
+        .await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "missing_source".to_string(),
+            message: None,
+            original_relative_path: Some(path_to_string(&original_relative_path)),
+            archived_relative_path: None,
+        });
+    };
+
+    let archive_relative_path =
+        allocate_archive_relative_path(&workspace, entity_type, entity_id, &descriptor.name)?;
+    let archive_path = workspace.join(&archive_relative_path);
+    let archived_at = Utc::now().to_rfc3339();
+
+    let pending = FolderMetadataWrite {
+        operation_id: operation_id.to_string(),
+        entity_type,
+        entity_id: entity_id.to_string(),
+        original_relative_path: path_to_string(&original_relative_path),
+        archived_relative_path: Some(path_to_string(&archive_relative_path)),
+        folder_state: "archive_pending".to_string(),
+        archived_at: Some(archived_at.clone()),
+        restored_at: None,
+        last_error_code: None,
+    };
+    upsert_folder_metadata(state.clone(), pending.clone()).await?;
+
+    if let Err(error) = move_directory_no_overwrite(&source_path, &archive_path) {
+        let message = if let Err(metadata_error) = upsert_folder_metadata(
+            state,
+            FolderMetadataWrite {
+                folder_state: "archive_failed".to_string(),
+                last_error_code: Some("move_failed".to_string()),
+                ..pending
+            },
+        )
+        .await
+        {
+            format!("{error}; metadata update failed: {metadata_error}")
+        } else {
+            error
+        };
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: Some(path_to_string(&original_relative_path)),
+            archived_relative_path: Some(path_to_string(&archive_relative_path)),
+        });
+    }
+
+    let original_relative_path_string = path_to_string(&original_relative_path);
+    let archive_relative_path_string = path_to_string(&archive_relative_path);
+    let manifest = ArchiveManifest {
+        entity_type: entity_type.as_str(),
+        entity_id,
+        original_relative_path: &original_relative_path_string,
+        archived_relative_path: &archive_relative_path_string,
+        archived_at: &archived_at,
+        operation_id,
+    };
+    if let Err(error) = write_archive_manifest(&archive_path, &manifest) {
+        let message = if let Err(metadata_error) = upsert_folder_metadata(
+            state,
+            FolderMetadataWrite {
+                folder_state: "archive_failed".to_string(),
+                last_error_code: Some("manifest_failed".to_string()),
+                ..pending
+            },
+        )
+        .await
+        {
+            format!("{error}; metadata update failed: {metadata_error}")
+        } else {
+            error
+        };
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: Some(path_to_string(&original_relative_path)),
+            archived_relative_path: Some(path_to_string(&archive_relative_path)),
+        });
+    }
+
+    match upsert_folder_metadata(
+        state,
+        FolderMetadataWrite {
+            folder_state: "archived".to_string(),
+            last_error_code: None,
+            ..pending
+        },
+    )
+    .await
+    {
+        Ok(()) => Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "succeeded".to_string(),
+            message: None,
+            original_relative_path: Some(path_to_string(&original_relative_path)),
+            archived_relative_path: Some(path_to_string(&archive_relative_path)),
+        }),
+        Err(error) => Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "metadata_pending".to_string(),
+            message: Some(error),
+            original_relative_path: Some(path_to_string(&original_relative_path)),
+            archived_relative_path: Some(path_to_string(&archive_relative_path)),
+        }),
+    }
+}
+
+async fn restore_folder_for_entity(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+) -> BulkArchiveItemResult {
+    match restore_folder_for_entity_inner(state, entity_type, &entity_id).await {
+        Ok(result) => result,
+        Err(message) => BulkArchiveItemResult {
+            entity_type,
+            entity_id,
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn restore_folder_for_entity_inner(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+) -> Result<BulkArchiveItemResult, String> {
+    let workspace = resolved_workspace_root(&state)?;
+    let Some(metadata) =
+        latest_archived_metadata(state.clone(), entity_type, entity_id.to_string()).await?
+    else {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_skipped".to_string(),
+            message: Some("no archived folder metadata".to_string()),
+            original_relative_path: None,
+            archived_relative_path: None,
+        });
+    };
+    let Some(archived_relative_path) = metadata.archived_relative_path.clone() else {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_skipped".to_string(),
+            message: Some("archived folder metadata has no target".to_string()),
+            original_relative_path: Some(metadata.original_relative_path),
+            archived_relative_path: None,
+        });
+    };
+    let original_relative_path = parse_relative_path(&metadata.original_relative_path)?;
+    let original_relative_path_string = path_to_string(&original_relative_path);
+    let archived_source = validated_existing_archive_source(&workspace, &archived_relative_path)?;
+    let active_existing =
+        validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+
+    if active_existing.is_some() {
+        if archived_source.is_some() {
+            return Ok(BulkArchiveItemResult {
+                entity_type,
+                entity_id: entity_id.to_string(),
+                folder_status: "restore_conflict".to_string(),
+                message: Some("active target already exists".to_string()),
+                original_relative_path: Some(original_relative_path_string),
+                archived_relative_path: Some(archived_relative_path),
+            });
+        }
+        update_folder_restored(state, &metadata.operation_id, entity_type, entity_id).await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "succeeded".to_string(),
+            message: Some("active folder already restored".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    let Some(active_target) =
+        validated_restore_target(&workspace, entity_type, &original_relative_path)?
+    else {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "restore_conflict".to_string(),
+            message: Some("active target already exists".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    };
+    let Some(archived_source) = archived_source else {
+        update_folder_state(
+            state.clone(),
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "restore_failed",
+            Some("missing_source"),
+        )
+        .await?;
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_missing".to_string(),
+            message: Some("archived source folder missing".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    };
+
+    update_folder_state(
+        state.clone(),
+        &metadata.operation_id,
+        entity_type,
+        entity_id,
+        "restore_pending",
+        None,
+    )
+    .await?;
+
+    if let Err(error) = preserve_archived_descendant_folders_for_parent_restore(
+        state.clone(),
+        entity_type,
+        entity_id,
+        &workspace,
+        &original_relative_path,
+        &archived_relative_path,
+    )
+    .await
+    {
+        let message = if let Err(metadata_error) = update_folder_state(
+            state,
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "restore_failed",
+            Some("descendant_preserve_failed"),
+        )
+        .await
+        {
+            format!("{error}; metadata update failed: {metadata_error}")
+        } else {
+            error
+        };
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    if let Err(error) = move_directory_no_overwrite(&archived_source, &active_target) {
+        let message = if let Err(metadata_error) = update_folder_state(
+            state,
+            &metadata.operation_id,
+            entity_type,
+            entity_id,
+            "restore_failed",
+            Some("move_failed"),
+        )
+        .await
+        {
+            format!("{error}; metadata update failed: {metadata_error}")
+        } else {
+            error
+        };
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_failed".to_string(),
+            message: Some(message),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: Some(archived_relative_path),
+        });
+    }
+
+    update_folder_restored(state, &metadata.operation_id, entity_type, entity_id).await?;
+    Ok(BulkArchiveItemResult {
+        entity_type,
+        entity_id: entity_id.to_string(),
+        folder_status: "succeeded".to_string(),
+        message: None,
+        original_relative_path: Some(original_relative_path_string),
+        archived_relative_path: Some(archived_relative_path),
+    })
+}
+
+async fn record_skipped_descendant_metadata(
+    state: Arc<AppState>,
+    outcome: &ArchiveMutationOutcome,
+    entity_id: String,
+    ancestor_results: &[BulkArchiveItemResult],
+) -> BulkArchiveItemResult {
+    match record_skipped_descendant_metadata_inner(
+        state,
+        outcome.entity_type,
+        &entity_id,
+        &outcome.operation_id,
+        ancestor_results,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(message) => BulkArchiveItemResult {
+            entity_type: outcome.entity_type,
+            entity_id,
+            folder_status: "metadata_pending".to_string(),
+            message: Some(message),
+            original_relative_path: None,
+            archived_relative_path: None,
+        },
+    }
+}
+
+async fn record_skipped_descendant_metadata_inner(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    operation_id: &str,
+    ancestor_results: &[BulkArchiveItemResult],
+) -> Result<BulkArchiveItemResult, String> {
+    let workspace = resolved_workspace_root(&state)?;
+    let descriptor = load_descriptor_async(state.clone(), entity_type, entity_id.to_string())
+        .await?
+        .ok_or_else(|| "descendant entity not found after archive mutation".to_string())?;
+    let original_relative_path = active_relative_path(&descriptor, Some(&workspace))?;
+    let original_relative_path_string = path_to_string(&original_relative_path);
+
+    let Some((archived_relative_path, ancestor_failed)) =
+        descendant_archive_relative_path(&original_relative_path, ancestor_results)?
+    else {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_skipped".to_string(),
+            message: Some("folder moved with archived ancestor".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: None,
+        });
+    };
+    let archived_relative_path_string = path_to_string(&archived_relative_path);
+
+    let active_existing =
+        validated_existing_source(&workspace, entity_type, &original_relative_path)?;
+    let archived_existing =
+        validated_existing_archive_source(&workspace, &archived_relative_path_string)?;
+    if active_existing.is_some() || archived_existing.is_none() {
+        return Ok(BulkArchiveItemResult {
+            entity_type,
+            entity_id: entity_id.to_string(),
+            folder_status: "folder_skipped".to_string(),
+            message: Some("folder moved with archived ancestor".to_string()),
+            original_relative_path: Some(original_relative_path_string),
+            archived_relative_path: None,
+        });
+    }
+
+    upsert_folder_metadata(
+        state,
+        FolderMetadataWrite {
+            operation_id: operation_id.to_string(),
+            entity_type,
+            entity_id: entity_id.to_string(),
+            original_relative_path: original_relative_path_string.clone(),
+            archived_relative_path: Some(archived_relative_path_string.clone()),
+            folder_state: if ancestor_failed {
+                "archive_failed".to_string()
+            } else {
+                "archived".to_string()
+            },
+            archived_at: Some(Utc::now().to_rfc3339()),
+            restored_at: None,
+            last_error_code: ancestor_failed.then(|| "ancestor_archive_failed".to_string()),
+        },
+    )
+    .await?;
+
+    Ok(BulkArchiveItemResult {
+        entity_type,
+        entity_id: entity_id.to_string(),
+        folder_status: "folder_skipped".to_string(),
+        message: Some("folder moved with archived ancestor".to_string()),
+        original_relative_path: Some(original_relative_path_string),
+        archived_relative_path: Some(archived_relative_path_string),
+    })
+}
+
+async fn preserve_archived_descendant_folders_for_parent_restore(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    workspace: &Path,
+    original_relative_path: &Path,
+    archived_relative_path: &str,
+) -> Result<(), String> {
+    if entity_type == EntityArchiveType::Person {
+        return Ok(());
+    }
+
+    let parent_original_relative_path = original_relative_path.to_path_buf();
+    let parent_archived_relative_path = parse_relative_path(archived_relative_path)?;
+    let workspace_for_read = workspace.to_path_buf();
+    let entity_id = entity_id.to_string();
+    let mut moves = state
+        .db_read(move |db| {
+            let mut moves = Vec::new();
+            for descriptor in load_archived_descendants(db, entity_type, &entity_id)? {
+                let descendant_original_relative_path =
+                    active_relative_path(&descriptor, Some(&workspace_for_read))?;
+                if !descendant_original_relative_path.starts_with(&parent_original_relative_path) {
+                    continue;
+                }
+                let Some(metadata) =
+                    latest_archived_metadata_sync(db, entity_type, &descriptor.id)?
+                else {
+                    return Err(format!(
+                        "archived descendant folder metadata missing: {}",
+                        descriptor.id
+                    ));
+                };
+                let Some(current_archived_relative_path) =
+                    metadata.archived_relative_path.as_deref()
+                else {
+                    continue;
+                };
+                let current_relative_path = parse_relative_path(current_archived_relative_path)?;
+                if current_relative_path.starts_with(&parent_archived_relative_path) {
+                    moves.push(ArchivedDescendantFolderMove {
+                        descriptor,
+                        metadata,
+                        current_relative_path,
+                    });
+                }
+            }
+            Ok(moves)
+        })
+        .await
+        .map_err(String::from)?;
+
+    moves.sort_by(|left, right| {
+        right
+            .current_relative_path
+            .components()
+            .count()
+            .cmp(&left.current_relative_path.components().count())
+            .then_with(|| left.descriptor.id.cmp(&right.descriptor.id))
+    });
+
+    for candidate in moves {
+        let source_relative_path = path_to_string(&candidate.current_relative_path);
+        let Some(source_path) =
+            validated_existing_archive_source(workspace, &source_relative_path)?
+        else {
+            continue;
+        };
+        let target_relative_path = allocate_archive_relative_path(
+            workspace,
+            entity_type,
+            &candidate.descriptor.id,
+            &candidate.descriptor.name,
+        )?;
+        let target_path = workspace.join(&target_relative_path);
+        move_directory_no_overwrite(&source_path, &target_path)?;
+
+        let target_relative_path_string = path_to_string(&target_relative_path);
+        if let Err(error) = update_archived_relative_path(
+            state.clone(),
+            &candidate.metadata.operation_id,
+            entity_type,
+            &candidate.metadata.entity_id,
+            &target_relative_path_string,
+        )
+        .await
+        {
+            if let Err(rollback_error) = move_directory_no_overwrite(&target_path, &source_path) {
+                return Err(format!(
+                    "{error}; descendant archive rollback failed: {rollback_error}"
+                ));
+            }
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct FolderMetadataWrite {
+    operation_id: String,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    original_relative_path: String,
+    archived_relative_path: Option<String>,
+    folder_state: String,
+    archived_at: Option<String>,
+    restored_at: Option<String>,
+    last_error_code: Option<String>,
+}
+
+async fn upsert_folder_metadata(
+    state: Arc<AppState>,
+    write: FolderMetadataWrite,
+) -> Result<(), String> {
+    state
+        .db_write(move |db| {
+            db.conn_ref()
+                .execute(
+                    "INSERT INTO entity_archive_folders (
+                        operation_id, entity_type, entity_id, original_relative_path,
+                        archived_relative_path, folder_state, archived_at, restored_at,
+                        updated_at, last_error_code
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                     ON CONFLICT(operation_id, entity_type, entity_id) DO UPDATE SET
+                        original_relative_path = excluded.original_relative_path,
+                        archived_relative_path = excluded.archived_relative_path,
+                        folder_state = excluded.folder_state,
+                        archived_at = COALESCE(excluded.archived_at, entity_archive_folders.archived_at),
+                        restored_at = excluded.restored_at,
+                        updated_at = excluded.updated_at,
+                        last_error_code = excluded.last_error_code",
+                    params![
+                        write.operation_id,
+                        write.entity_type.as_str(),
+                        write.entity_id,
+                        write.original_relative_path,
+                        write.archived_relative_path,
+                        write.folder_state,
+                        write.archived_at,
+                        write.restored_at,
+                        Utc::now().to_rfc3339(),
+                        write.last_error_code,
+                    ],
+                )
+                .map_err(|e| format!("folder metadata write failed: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+async fn update_archived_relative_path(
+    state: Arc<AppState>,
+    operation_id: &str,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    archived_relative_path: &str,
+) -> Result<(), String> {
+    let operation_id = operation_id.to_string();
+    let entity_id = entity_id.to_string();
+    let archived_relative_path = archived_relative_path.to_string();
+    state
+        .db_write(move |db| {
+            db.conn_ref()
+                .execute(
+                    "UPDATE entity_archive_folders
+                        SET archived_relative_path = ?1,
+                            updated_at = ?2
+                      WHERE operation_id = ?3
+                        AND entity_type = ?4
+                        AND entity_id = ?5",
+                    params![
+                        archived_relative_path,
+                        Utc::now().to_rfc3339(),
+                        operation_id,
+                        entity_type.as_str(),
+                        entity_id,
+                    ],
+                )
+                .map_err(|e| format!("folder metadata archive path update failed: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+async fn update_folder_state(
+    state: Arc<AppState>,
+    operation_id: &str,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    folder_state: &str,
+    last_error_code: Option<&str>,
+) -> Result<(), String> {
+    let operation_id = operation_id.to_string();
+    let entity_id = entity_id.to_string();
+    let folder_state = folder_state.to_string();
+    let last_error_code = last_error_code.map(str::to_string);
+    state
+        .db_write(move |db| {
+            db.conn_ref()
+                .execute(
+                    "UPDATE entity_archive_folders
+                        SET folder_state = ?1,
+                            updated_at = ?2,
+                            last_error_code = ?3
+                      WHERE operation_id = ?4
+                        AND entity_type = ?5
+                        AND entity_id = ?6",
+                    params![
+                        folder_state,
+                        Utc::now().to_rfc3339(),
+                        last_error_code,
+                        operation_id,
+                        entity_type.as_str(),
+                        entity_id,
+                    ],
+                )
+                .map_err(|e| format!("folder metadata update failed: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+async fn update_folder_restored(
+    state: Arc<AppState>,
+    operation_id: &str,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+) -> Result<(), String> {
+    let operation_id = operation_id.to_string();
+    let entity_id = entity_id.to_string();
+    state
+        .db_write(move |db| {
+            db.conn_ref()
+                .execute(
+                    "UPDATE entity_archive_folders
+                        SET folder_state = 'restored',
+                            restored_at = ?1,
+                            updated_at = ?1,
+                            last_error_code = NULL
+                      WHERE operation_id = ?2
+                        AND entity_type = ?3
+                        AND entity_id = ?4",
+                    params![
+                        Utc::now().to_rfc3339(),
+                        operation_id,
+                        entity_type.as_str(),
+                        entity_id
+                    ],
+                )
+                .map_err(|e| format!("folder metadata restore update failed: {e}"))?;
+            Ok(())
+        })
+        .await
+        .map_err(String::from)?;
+    Ok(())
+}
+
+async fn latest_archived_metadata(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+) -> Result<Option<FolderMetadata>, String> {
+    state
+        .db_read(move |db| latest_archived_metadata_sync(db, entity_type, &entity_id))
+        .await
+        .map_err(String::from)
+}
+
+fn latest_archived_metadata_sync(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+) -> Result<Option<FolderMetadata>, String> {
+    db.conn_ref()
+        .query_row(
+            "SELECT operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state
+               FROM entity_archive_folders
+              WHERE entity_type = ?1
+                AND entity_id = ?2
+                AND folder_state IN (
+                    'archived',
+                    'restore_pending',
+                    'restore_failed',
+                    'archive_pending',
+                    'archive_failed'
+                )
+                AND archived_relative_path IS NOT NULL
+              ORDER BY updated_at DESC
+              LIMIT 1",
+            params![entity_type.as_str(), entity_id],
+            |row| {
+                Ok(FolderMetadata {
+                    operation_id: row.get(0)?,
+                    entity_type,
+                    entity_id: row.get(2)?,
+                    original_relative_path: row.get(3)?,
+                    archived_relative_path: row.get(4)?,
+                    folder_state: row.get(5)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|e| format!("folder metadata read failed: {e}"))
+}
+
+fn archived_source_exists(
+    workspace: &Path,
+    archived_relative_path: &Option<String>,
+) -> Result<bool, String> {
+    let Some(archived_relative_path) = archived_relative_path else {
+        return Ok(false);
+    };
+    validated_existing_archive_source(workspace, archived_relative_path)
+        .map(|source| source.is_some())
+}
+
+fn record_restore_intent_for_changed_ids(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    changed_ids: &[String],
+) -> Result<(), String> {
+    for entity_id in changed_ids {
+        if let Some(metadata) = latest_archived_metadata_sync(db, entity_type, entity_id)? {
+            update_folder_state_sync(
+                db,
+                &metadata.operation_id,
+                entity_type,
+                entity_id,
+                "restore_pending",
+                None,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn update_folder_state_sync(
+    db: &ActionDb,
+    operation_id: &str,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    folder_state: &str,
+    last_error_code: Option<&str>,
+) -> Result<(), String> {
+    db.conn_ref()
+        .execute(
+            "UPDATE entity_archive_folders
+                SET folder_state = ?1,
+                    updated_at = ?2,
+                    last_error_code = ?3
+              WHERE operation_id = ?4
+                AND entity_type = ?5
+                AND entity_id = ?6",
+            params![
+                folder_state,
+                Utc::now().to_rfc3339(),
+                last_error_code,
+                operation_id,
+                entity_type.as_str(),
+                entity_id,
+            ],
+        )
+        .map_err(|e| format!("folder metadata update failed: {e}"))?;
+    Ok(())
+}
+
+async fn latest_repair_metadata(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+    folder_states: Vec<&str>,
+) -> Result<Option<FolderMetadata>, String> {
+    let states = folder_states
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    state
+        .db_read(move |db| latest_repair_metadata_sync(db, entity_type, &entity_id, &states))
+        .await
+        .map_err(String::from)
+}
+
+fn latest_repair_metadata_sync(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    folder_states: &[String],
+) -> Result<Option<FolderMetadata>, String> {
+    let rows = load_repair_metadata_rows(db)?;
+    Ok(rows.into_iter().find(|row| {
+        row.entity_type == entity_type
+            && row.entity_id == entity_id
+            && folder_states.iter().any(|state| state == &row.folder_state)
+    }))
+}
+
+fn load_repair_metadata_rows(db: &ActionDb) -> Result<Vec<FolderMetadata>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state
+               FROM entity_archive_folders
+              WHERE folder_state IN ('archive_pending','archive_failed','restore_pending','restore_failed')
+              ORDER BY updated_at DESC, operation_id DESC",
+        )
+        .map_err(|e| format!("folder metadata repair read failed: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let entity_type_raw: String = row.get(1)?;
+            let entity_type = EntityArchiveType::from_db(&entity_type_raw)
+                .map_err(rusqlite::Error::InvalidParameterName)?;
+            Ok(FolderMetadata {
+                operation_id: row.get(0)?,
+                entity_type,
+                entity_id: row.get(2)?,
+                original_relative_path: row.get(3)?,
+                archived_relative_path: row.get(4)?,
+                folder_state: row.get(5)?,
+            })
+        })
+        .map_err(|e| format!("folder metadata repair read failed: {e}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("folder metadata repair row failed: {e}"))
+}
+
+async fn load_descriptor_async(
+    state: Arc<AppState>,
+    entity_type: EntityArchiveType,
+    entity_id: String,
+) -> Result<Option<EntityDescriptor>, String> {
+    state
+        .db_read(move |db| load_descriptor(db, entity_type, &entity_id))
+        .await
+        .map_err(String::from)
+}
+
+fn load_descriptor(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    id: &str,
+) -> Result<Option<EntityDescriptor>, String> {
+    match entity_type {
+        EntityArchiveType::Account => Ok(db
+            .get_account(id)
+            .map_err(|e| e.to_string())?
+            .map(descriptor_from_account)),
+        EntityArchiveType::Project => Ok(db
+            .get_project(id)
+            .map_err(|e| e.to_string())?
+            .map(descriptor_from_project)),
+        EntityArchiveType::Person => Ok(db
+            .get_person(id)
+            .map_err(|e| e.to_string())?
+            .map(descriptor_from_person)),
+    }
+}
+
+fn load_active_descendants(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    parent_id: &str,
+) -> Result<Vec<EntityDescriptor>, String> {
+    match entity_type {
+        EntityArchiveType::Account => query_descendant_accounts(db, parent_id, false),
+        EntityArchiveType::Project => query_descendant_projects(db, parent_id, false),
+        EntityArchiveType::Person => Ok(Vec::new()),
+    }
+}
+
+fn load_archived_descendants(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+    parent_id: &str,
+) -> Result<Vec<EntityDescriptor>, String> {
+    match entity_type {
+        EntityArchiveType::Account => query_descendant_accounts(db, parent_id, true),
+        EntityArchiveType::Project => query_descendant_projects(db, parent_id, true),
+        EntityArchiveType::Person => Ok(Vec::new()),
+    }
+}
+
+fn load_archived_descriptors(
+    db: &ActionDb,
+    entity_type: EntityArchiveType,
+) -> Result<Vec<EntityDescriptor>, String> {
+    match entity_type {
+        EntityArchiveType::Account => Ok(db
+            .get_archived_accounts()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(descriptor_from_account)
+            .collect()),
+        EntityArchiveType::Project => Ok(db
+            .get_archived_projects()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(descriptor_from_project)
+            .collect()),
+        EntityArchiveType::Person => {
+            let mut stmt = db
+                .conn_ref()
+                .prepare(
+                    "SELECT id, email, name, organization, role, relationship, notes,
+                            tracker_path, last_seen, first_seen, meeting_count, updated_at, archived,
+                            linkedin_url, twitter_handle, phone, photo_url, bio, title_history,
+                            company_industry, company_size, company_hq, last_enriched_at, enrichment_sources
+                       FROM people WHERE archived = 1 ORDER BY name",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([], ActionDb::map_person_row)
+                .map_err(|e| e.to_string())?;
+            let people = rows
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())?;
+            Ok(people.into_iter().map(descriptor_from_person).collect())
+        }
+    }
+}
+
+fn partition_folder_move_targets(
+    descriptors: Vec<EntityDescriptor>,
+    workspace: Option<&Path>,
+) -> Result<(Vec<String>, BTreeSet<String>), String> {
+    let mut paths = Vec::new();
+    for descriptor in descriptors {
+        paths.push((
+            descriptor.id.clone(),
+            active_relative_path(&descriptor, workspace)?,
+        ));
+    }
+
+    let mut move_ids = Vec::new();
+    let mut skipped_ids = BTreeSet::new();
+    for (entity_id, relative_path) in &paths {
+        let nested_under_changed_ancestor = paths.iter().any(|(other_id, other_path)| {
+            other_id != entity_id
+                && relative_path != other_path
+                && relative_path.starts_with(other_path)
+        });
+        if nested_under_changed_ancestor {
+            skipped_ids.insert(entity_id.clone());
+        } else {
+            move_ids.push(entity_id.clone());
+        }
+    }
+    Ok((move_ids, skipped_ids))
+}
+
+fn descendant_archive_relative_path(
+    descendant_original_path: &Path,
+    ancestor_results: &[BulkArchiveItemResult],
+) -> Result<Option<(PathBuf, bool)>, String> {
+    let mut best: Option<(usize, PathBuf, bool)> = None;
+    for result in ancestor_results {
+        let Some(original_relative_path) = result.original_relative_path.as_deref() else {
+            continue;
+        };
+        let Some(archived_relative_path) = result.archived_relative_path.as_deref() else {
+            continue;
+        };
+        let ancestor_original = parse_relative_path(original_relative_path)?;
+        if descendant_original_path == ancestor_original
+            || !descendant_original_path.starts_with(&ancestor_original)
+        {
+            continue;
+        }
+        let ancestor_archived = parse_relative_path(archived_relative_path)?;
+        let suffix = descendant_original_path
+            .strip_prefix(&ancestor_original)
+            .map_err(|e| format!("descendant archive path derivation failed: {e}"))?;
+        let candidate = ancestor_archived.join(suffix);
+        let depth = ancestor_original.components().count();
+        let ancestor_failed = result.folder_status == "folder_failed";
+        if best
+            .as_ref()
+            .is_none_or(|(best_depth, _, _)| depth > *best_depth)
+        {
+            best = Some((depth, candidate, ancestor_failed));
+        }
+    }
+    Ok(best.map(|(_, path, ancestor_failed)| (path, ancestor_failed)))
+}
+
+fn query_descendant_accounts(
+    db: &ActionDb,
+    parent_id: &str,
+    archived: bool,
+) -> Result<Vec<EntityDescriptor>, String> {
+    let sql = format!(
+        "WITH RECURSIVE descendants(id, depth) AS (
+            SELECT id, 1 FROM accounts WHERE parent_id = ?1
+            UNION ALL
+            SELECT accounts.id, descendants.depth + 1
+              FROM accounts
+              JOIN descendants ON accounts.parent_id = descendants.id
+             WHERE descendants.depth < 10
+         )
+         SELECT {} FROM accounts
+          WHERE id IN (SELECT id FROM descendants)
+            AND archived = ?2
+          ORDER BY name",
+        ActionDb::ACCOUNT_COLUMNS
+    );
+    let mut stmt = db.conn_ref().prepare(&sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(
+            params![parent_id, archived as i32],
+            ActionDb::map_account_row,
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows.into_iter().map(descriptor_from_account).collect())
+}
+
+fn query_descendant_projects(
+    db: &ActionDb,
+    parent_id: &str,
+    archived: bool,
+) -> Result<Vec<EntityDescriptor>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "WITH RECURSIVE descendants(id, depth) AS (
+                SELECT id, 1 FROM projects WHERE parent_id = ?1
+                UNION ALL
+                SELECT projects.id, descendants.depth + 1
+                  FROM projects
+                  JOIN descendants ON projects.parent_id = descendants.id
+                 WHERE descendants.depth < 10
+             )
+             SELECT id, name, status, milestone, owner, target_date,
+                    tracker_path, parent_id, updated_at, archived,
+                    keywords, keywords_extracted_at, metadata,
+                    description, milestones, notes
+               FROM projects
+              WHERE id IN (SELECT id FROM descendants)
+                AND archived = ?2
+              ORDER BY name",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(
+            params![parent_id, archived as i32],
+            ActionDb::map_project_row,
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| e.to_string())?;
+    Ok(rows.into_iter().map(descriptor_from_project).collect())
+}
+
+fn descriptor_from_account(account: DbAccount) -> EntityDescriptor {
+    EntityDescriptor {
+        entity_type: EntityArchiveType::Account,
+        id: account.id,
+        name: account.name,
+        tracker_path: account.tracker_path,
+        parent_id: account.parent_id,
+        updated_at: account.updated_at,
+        archived: account.archived,
+    }
+}
+
+fn descriptor_from_project(project: DbProject) -> EntityDescriptor {
+    EntityDescriptor {
+        entity_type: EntityArchiveType::Project,
+        id: project.id,
+        name: project.name,
+        tracker_path: project.tracker_path,
+        parent_id: project.parent_id,
+        updated_at: project.updated_at,
+        archived: project.archived,
+    }
+}
+
+fn descriptor_from_person(person: DbPerson) -> EntityDescriptor {
+    EntityDescriptor {
+        entity_type: EntityArchiveType::Person,
+        id: person.id,
+        name: person.name,
+        tracker_path: person.tracker_path,
+        parent_id: None,
+        updated_at: person.updated_at,
+        archived: person.archived,
+    }
+}
+
+fn count_orphan_active_folders(db: &ActionDb, workspace: &Path) -> Result<usize, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let known_paths = known_entity_relative_paths(db, &workspace)?;
+    let mut count = 0;
+    for root in ["Accounts", "Projects", "People"] {
+        let root_path = workspace.join(root);
+        if !root_path.exists() {
+            continue;
+        }
+        let canonical_root = root_path
+            .canonicalize()
+            .map_err(|e| format!("canonicalize active root failed: {e}"))?;
+        if !canonical_root.starts_with(&workspace) {
+            return Err("active root escaped workspace root".to_string());
+        }
+        for entry in std::fs::read_dir(&canonical_root)
+            .map_err(|e| format!("read active root failed: {e}"))?
+        {
+            let entry = entry.map_err(|e| format!("read active root entry failed: {e}"))?;
+            let file_name = entry.file_name();
+            if file_name.to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let metadata = entry
+                .metadata()
+                .map_err(|e| format!("active root entry metadata failed: {e}"))?;
+            if !metadata.is_dir() {
+                continue;
+            }
+            let relative = PathBuf::from(root).join(file_name);
+            if !known_paths.contains(&relative) {
+                count += 1;
+            }
+        }
+    }
+    Ok(count)
+}
+
+fn known_entity_relative_paths(
+    db: &ActionDb,
+    workspace: &Path,
+) -> Result<BTreeSet<PathBuf>, String> {
+    let mut paths = BTreeSet::new();
+    for account in db.get_all_accounts().map_err(|e| e.to_string())? {
+        paths.insert(active_relative_path(
+            &descriptor_from_account(account),
+            Some(workspace),
+        )?);
+    }
+    for project in db.get_all_projects().map_err(|e| e.to_string())? {
+        paths.insert(active_relative_path(
+            &descriptor_from_project(project),
+            Some(workspace),
+        )?);
+    }
+    for person in db.get_people(None).map_err(|e| e.to_string())? {
+        paths.insert(active_relative_path(
+            &descriptor_from_person(person),
+            Some(workspace),
+        )?);
+    }
+    for entity_type in [
+        EntityArchiveType::Account,
+        EntityArchiveType::Project,
+        EntityArchiveType::Person,
+    ] {
+        for descriptor in load_archived_descriptors(db, entity_type)? {
+            paths.insert(active_relative_path(&descriptor, Some(workspace))?);
+        }
+    }
+    Ok(paths)
+}
+
+fn active_relative_path(
+    descriptor: &EntityDescriptor,
+    workspace: Option<&Path>,
+) -> Result<PathBuf, String> {
+    if let Some(tracker_path) = descriptor.tracker_path.as_deref() {
+        if let Some(relative) =
+            normalized_tracker_relative_path(descriptor.entity_type, tracker_path, workspace)?
+        {
+            return Ok(relative);
+        }
+    }
+
+    Ok(PathBuf::from(descriptor.entity_type.active_root())
+        .join(crate::util::sanitize_for_filesystem(&descriptor.name)))
+}
+
+fn normalized_tracker_relative_path(
+    entity_type: EntityArchiveType,
+    tracker_path: &str,
+    workspace: Option<&Path>,
+) -> Result<Option<PathBuf>, String> {
+    let tracker_path = Path::new(tracker_path);
+    let mut candidate = if tracker_path.is_absolute() {
+        let Some(workspace) = workspace else {
+            return Ok(None);
+        };
+        match tracker_path.strip_prefix(workspace) {
+            Ok(relative) => relative.to_path_buf(),
+            Err(_) => return Ok(None),
+        }
+    } else {
+        tracker_path.to_path_buf()
+    };
+
+    if entity_type == EntityArchiveType::Person
+        && candidate.file_name().and_then(|name| name.to_str()) == Some("person.json")
+    {
+        let Some(parent) = candidate.parent() else {
+            return Ok(None);
+        };
+        candidate = parent.to_path_buf();
+    }
+
+    let relative = match parse_relative_path(&path_to_string(&candidate)) {
+        Ok(relative) => relative,
+        Err(_) => return Ok(None),
+    };
+    let first = first_component(&relative);
+    let allowed = match entity_type {
+        EntityArchiveType::Account => {
+            matches!(first.as_deref(), Some("Accounts") | Some("Internal"))
+        }
+        _ => first.as_deref() == Some(entity_type.active_root()),
+    };
+    let has_child_component = relative
+        .components()
+        .filter(|component| matches!(component, Component::Normal(_)))
+        .count()
+        > 1;
+    if allowed && has_child_component {
+        Ok(Some(relative))
+    } else {
+        Ok(None)
+    }
+}
+
+fn resolved_workspace_root(state: &AppState) -> Result<PathBuf, String> {
+    let configured = {
+        let guard = state.config.read();
+        guard.as_ref().map(|config| config.workspace_path.clone())
+    };
+    crate::state::resolved_workspace_path(configured.as_deref())
+}
+
+fn ensure_canonical_workspace(workspace: &Path) -> Result<PathBuf, String> {
+    // dos7-allowed: entity-archive-folder-v150 owns mode-scoped archive folder moves.
+    std::fs::create_dir_all(workspace).map_err(|e| format!("create workspace root failed: {e}"))?;
+    workspace
+        .canonicalize()
+        .map_err(|e| format!("canonicalize workspace root failed: {e}"))
+}
+
+fn validated_existing_source(
+    workspace: &Path,
+    entity_type: EntityArchiveType,
+    relative_path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let first = first_component(relative_path);
+    let allowed = match entity_type {
+        EntityArchiveType::Account => {
+            matches!(first.as_deref(), Some("Accounts") | Some("Internal"))
+        }
+        _ => first.as_deref() == Some(entity_type.active_root()),
+    };
+    if !allowed {
+        return Err("source path root is not allowed".to_string());
+    }
+    validated_existing_dir(&workspace, relative_path)
+}
+
+fn validated_existing_archive_source(
+    workspace: &Path,
+    relative_path: &str,
+) -> Result<Option<PathBuf>, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let relative = parse_relative_path(relative_path)?;
+    if first_component(&relative).as_deref() != Some("_archive") {
+        return Err("archived source path root is not allowed".to_string());
+    }
+    validated_existing_dir(&workspace, &relative)
+}
+
+fn validated_restore_target(
+    workspace: &Path,
+    entity_type: EntityArchiveType,
+    relative_path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let first = first_component(relative_path);
+    let allowed = match entity_type {
+        EntityArchiveType::Account => {
+            matches!(first.as_deref(), Some("Accounts") | Some("Internal"))
+        }
+        _ => first.as_deref() == Some(entity_type.active_root()),
+    };
+    if !allowed {
+        return Err("restore target root is not allowed".to_string());
+    }
+
+    let target = workspace.join(relative_path);
+    match std::fs::symlink_metadata(&target) {
+        Ok(_) => return Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("restore target metadata read failed: {error}")),
+    }
+
+    let Some(parent_relative_path) = relative_path.parent() else {
+        return Err("restore target parent is missing".to_string());
+    };
+    ensure_normal_parent_path(&workspace, parent_relative_path)?;
+    Ok(Some(target))
+}
+
+fn ensure_normal_parent_path(workspace: &Path, relative_parent: &Path) -> Result<(), String> {
+    let relative_parent = parse_relative_path(&path_to_string(relative_parent))?;
+    let mut current = workspace.to_path_buf();
+    for component in relative_parent.components() {
+        let Component::Normal(name) = component else {
+            return Err("restore target parent contains invalid component".to_string());
+        };
+        current.push(name);
+        ensure_normal_dir_component(workspace, &current)?;
+    }
+    Ok(())
+}
+
+fn ensure_normal_dir_component(workspace: &Path, path: &Path) -> Result<(), String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err("restore target parent symlink rejected".to_string());
+            }
+            if !metadata.is_dir() {
+                return Err("restore target parent is not a directory".to_string());
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir(path).map_err(|e| format!("create restore parent failed: {e}"))?;
+        }
+        Err(error) => return Err(format!("restore parent metadata read failed: {error}")),
+    }
+
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("canonicalize restore parent failed: {e}"))?;
+    if !canonical.starts_with(workspace) {
+        return Err("restore target parent escaped workspace root".to_string());
+    }
+    Ok(())
+}
+
+fn validated_existing_dir(
+    workspace: &Path,
+    relative_path: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let target = workspace.join(relative_path);
+    if !target.exists() {
+        return Ok(None);
+    }
+    let target_metadata = std::fs::symlink_metadata(&target)
+        .map_err(|e| format!("source metadata read failed: {e}"))?;
+    if target_metadata.file_type().is_symlink() {
+        return Err("symlink path rejected".to_string());
+    }
+    if !target_metadata.is_dir() {
+        return Err("source path is not a directory".to_string());
+    }
+    let canonical = target
+        .canonicalize()
+        .map_err(|e| format!("canonicalize source failed: {e}"))?;
+    if !canonical.starts_with(workspace) {
+        return Err("source path escaped workspace root".to_string());
+    }
+    reject_unsafe_tree(&canonical)?;
+    Ok(Some(canonical))
+}
+
+fn allocate_archive_relative_path(
+    workspace: &Path,
+    entity_type: EntityArchiveType,
+    entity_id: &str,
+    name: &str,
+) -> Result<PathBuf, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let base_dir = PathBuf::from("_archive")
+        .join("entities")
+        .join(entity_type.archive_root());
+    ensure_normal_parent_path(&workspace, &base_dir)?;
+    let archive_dir = workspace.join(&base_dir);
+    let canonical_parent = archive_dir
+        .canonicalize()
+        .map_err(|e| format!("canonicalize archive folder failed: {e}"))?;
+    if !canonical_parent.starts_with(&workspace) {
+        return Err("archive target escaped workspace root".to_string());
+    }
+
+    let slug = crate::util::slugify(name);
+    let base_name = format!("{entity_id}--{slug}");
+    for suffix in 0..1000 {
+        let candidate_name = if suffix == 0 {
+            base_name.clone()
+        } else {
+            format!("{base_name}--{suffix}")
+        };
+        let candidate = base_dir.join(candidate_name);
+        if !workspace.join(&candidate).exists() {
+            return Ok(candidate);
+        }
+    }
+    Err("could not allocate archive target".to_string())
+}
+
+fn move_directory_no_overwrite(source: &Path, target: &Path) -> Result<(), String> {
+    if target.exists() {
+        return Err("target already exists".to_string());
+    }
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create target parent failed: {e}"))?;
+    }
+    reject_unsafe_tree(source)?;
+    std::fs::rename(source, target).map_err(|e| format!("folder rename failed: {e}"))
+}
+
+fn write_archive_manifest(path: &Path, manifest: &ArchiveManifest<'_>) -> Result<(), String> {
+    let content = serde_json::to_string_pretty(manifest)
+        .map_err(|e| format!("archive manifest serialization failed: {e}"))?;
+    std::fs::write(path.join(".dailyos-archive.json"), content)
+        .map_err(|e| format!("archive manifest write failed: {e}"))
+}
+
+fn write_archive_manifest_for_metadata(
+    path: &Path,
+    metadata: &FolderMetadata,
+) -> Result<(), String> {
+    let Some(archived_relative_path) = metadata.archived_relative_path.as_deref() else {
+        return Err("archive manifest metadata missing archived path".to_string());
+    };
+    let archived_at = Utc::now().to_rfc3339();
+    let manifest = ArchiveManifest {
+        entity_type: metadata.entity_type.as_str(),
+        entity_id: &metadata.entity_id,
+        original_relative_path: &metadata.original_relative_path,
+        archived_relative_path,
+        archived_at: &archived_at,
+        operation_id: &metadata.operation_id,
+    };
+    write_archive_manifest(path, &manifest)
+}
+
+fn archive_target_from_metadata(workspace: &Path, relative_path: &str) -> Result<PathBuf, String> {
+    let workspace = ensure_canonical_workspace(workspace)?;
+    let relative = parse_relative_path(relative_path)?;
+    if first_component(&relative).as_deref() != Some("_archive") {
+        return Err("archive repair target root is not allowed".to_string());
+    }
+    let target = workspace.join(&relative);
+    if let Some(parent_relative_path) = relative.parent() {
+        ensure_normal_parent_path(&workspace, parent_relative_path)?;
+        let parent = workspace.join(parent_relative_path);
+        let canonical_parent = parent
+            .canonicalize()
+            .map_err(|e| format!("canonicalize archive repair target parent failed: {e}"))?;
+        if !canonical_parent.starts_with(&workspace) {
+            return Err("archive repair target escaped workspace root".to_string());
+        }
+    }
+    Ok(target)
+}
+
+fn parse_relative_path(value: &str) -> Result<PathBuf, String> {
+    if value.contains('\0') {
+        return Err("path contains NUL".to_string());
+    }
+    let path = Path::new(value);
+    if path.is_absolute() {
+        return Err("path must be relative".to_string());
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => normalized.push(value),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("path traversal is not allowed".to_string());
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err("path must not be empty".to_string());
+    }
+    Ok(normalized)
+}
+
+fn first_component(path: &Path) -> Option<String> {
+    path.components().find_map(|component| match component {
+        Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+        _ => None,
+    })
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn remove_validated_root(workspace: &Path, relative_path: &Path) -> Result<(), String> {
+    let relative_path = parse_relative_path(&path_to_string(relative_path))?;
+    let target = workspace.join(&relative_path);
+    let metadata = match std::fs::symlink_metadata(&target) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("delete target metadata read failed: {error}")),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err("delete target symlink rejected".to_string());
+    }
+    if !metadata.is_dir() {
+        return Err("delete target is not a directory".to_string());
+    }
+    reject_symlink_path_components(workspace, &relative_path)?;
+    let canonical = target
+        .canonicalize()
+        .map_err(|e| format!("canonicalize delete target failed: {e}"))?;
+    if !canonical.starts_with(workspace) {
+        return Err("delete target escaped workspace root".to_string());
+    }
+    reject_unsafe_tree(&target)?;
+    // dos7-allowed: entity-archive-folder-v150 removes only validated mode-scoped archive roots.
+    std::fs::remove_dir_all(target).map_err(|e| format!("delete workspace folder failed: {e}"))
+}
+
+fn reject_symlink_path_components(workspace: &Path, relative_path: &Path) -> Result<(), String> {
+    let mut current = workspace.to_path_buf();
+    for component in relative_path.components() {
+        let Component::Normal(name) = component else {
+            return Err("delete target path contains invalid component".to_string());
+        };
+        current.push(name);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err("delete target symlink rejected".to_string());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(format!("delete target metadata read failed: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn reject_unsafe_tree(root: &Path) -> Result<(), String> {
+    let metadata =
+        std::fs::symlink_metadata(root).map_err(|e| format!("metadata read failed: {e}"))?;
+    if metadata.file_type().is_symlink() {
+        return Err("symlink path rejected".to_string());
+    }
+    if metadata.is_file() && has_multiple_hardlinks(&metadata) {
+        return Err("hardlinked file rejected".to_string());
+    }
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(root).map_err(|e| format!("read dir failed: {e}"))? {
+            let entry = entry.map_err(|e| format!("read dir entry failed: {e}"))?;
+            reject_unsafe_tree(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn has_multiple_hardlinks(metadata: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    metadata.nlink() > 1
+}
+
+#[cfg(not(unix))]
+fn has_multiple_hardlinks(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+fn normalize_ids(ids: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for id in ids {
+        let id = id.trim();
+        if !id.is_empty() && seen.insert(id.to_string()) {
+            out.push(id.to_string());
+        }
+    }
+    out
+}
+
+fn dedupe_strings(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for value in values {
+        if seen.insert(value.clone()) {
+            out.push(value);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{AccountType, DbAccount, DbProject};
+
+    fn test_db() -> ActionDb {
+        ActionDb::from_connection_for_tests(crate::migrations::migrated_in_memory_for_tests())
+    }
+
+    fn insert_account(
+        db: &ActionDb,
+        id: &str,
+        name: &str,
+        parent_id: Option<&str>,
+        archived: bool,
+    ) {
+        db.upsert_account(&DbAccount {
+            id: id.to_string(),
+            name: name.to_string(),
+            tracker_path: Some(if let Some(parent) = parent_id {
+                format!("Accounts/Parent/{name}-{parent}")
+            } else {
+                format!("Accounts/{name}")
+            }),
+            parent_id: parent_id.map(str::to_string),
+            account_type: AccountType::Customer,
+            updated_at: Utc::now().to_rfc3339(),
+            archived,
+            ..Default::default()
+        })
+        .expect("insert account");
+    }
+
+    fn insert_project(
+        db: &ActionDb,
+        id: &str,
+        name: &str,
+        parent_id: Option<&str>,
+        archived: bool,
+    ) {
+        db.upsert_project(&DbProject {
+            id: id.to_string(),
+            name: name.to_string(),
+            status: "active".to_string(),
+            tracker_path: Some(if let Some(parent) = parent_id {
+                format!("Projects/Parent/{name}-{parent}")
+            } else {
+                format!("Projects/{name}")
+            }),
+            parent_id: parent_id.map(str::to_string),
+            updated_at: Utc::now().to_rfc3339(),
+            archived,
+            ..Default::default()
+        })
+        .expect("insert project");
+    }
+
+    async fn test_state_with_workspace(
+        db_path: PathBuf,
+        workspace_path: &Path,
+    ) -> (Arc<AppState>, PathBuf) {
+        let db_service =
+            crate::db_service::DbService::open_at_with_fixture_provider_for_tests(db_path)
+                .await
+                .expect("open db service");
+        let state = Arc::new(AppState::test_with_db_service(db_service));
+        let config: crate::types::Config = serde_json::from_value(serde_json::json!({
+            "workspacePath": workspace_path.to_string_lossy().to_string()
+        }))
+        .expect("test config");
+        *state.config.write() = Some(config);
+        let resolved_workspace =
+            crate::state::resolved_workspace_path(Some(&workspace_path.to_string_lossy()))
+                .expect("resolved test workspace");
+        std::fs::create_dir_all(&resolved_workspace).expect("create resolved test workspace");
+        (state, resolved_workspace)
+    }
+
+    #[test]
+    fn preview_bulk_archive_dedupes_covered_children_and_reports_non_active_inputs() {
+        let db = test_db();
+        insert_account(&db, "parent-account", "Parent", None, false);
+        insert_account(&db, "child-account", "Child", Some("parent-account"), false);
+        insert_account(
+            &db,
+            "grandchild-account",
+            "Grandchild",
+            Some("child-account"),
+            false,
+        );
+        insert_account(
+            &db,
+            "archived-child",
+            "Archived Child",
+            Some("parent-account"),
+            true,
+        );
+
+        let preview = preview_bulk_archive(
+            &db,
+            EntityArchiveType::Account,
+            vec![
+                "parent-account".to_string(),
+                "child-account".to_string(),
+                "child-account".to_string(),
+                "grandchild-account".to_string(),
+                "archived-child".to_string(),
+                "missing-account".to_string(),
+            ],
+        )
+        .expect("preview");
+
+        assert_eq!(
+            preview.requested_ids,
+            vec![
+                "parent-account",
+                "child-account",
+                "grandchild-account",
+                "archived-child",
+                "missing-account"
+            ]
+        );
+        assert_eq!(preview.root_ids, vec!["parent-account"]);
+        assert_eq!(
+            preview.covered_child_ids,
+            vec!["child-account", "grandchild-account"]
+        );
+        assert_eq!(
+            preview.cascaded_child_ids,
+            vec!["child-account", "grandchild-account"]
+        );
+        assert_eq!(
+            preview.changed_ids,
+            vec!["parent-account", "child-account", "grandchild-account"]
+        );
+        assert_eq!(preview.total_changed_count, 3);
+        assert_eq!(preview.direct_cascade_count, 2);
+        assert_eq!(preview.already_archived_ids, vec!["archived-child"]);
+        assert_eq!(preview.not_found_ids, vec!["missing-account"]);
+    }
+
+    #[test]
+    fn archive_outcome_archives_active_descendants() {
+        let db = test_db();
+        insert_account(&db, "parent-account", "Parent", None, false);
+        insert_account(&db, "child-account", "Child", Some("parent-account"), false);
+        insert_account(
+            &db,
+            "grandchild-account",
+            "Grandchild",
+            Some("child-account"),
+            false,
+        );
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        let outcome = archive_entity_with_outcome(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Account,
+            "parent-account",
+            true,
+        )
+        .expect("archive parent");
+
+        assert_eq!(
+            outcome.changed_ids,
+            vec!["parent-account", "child-account", "grandchild-account"]
+        );
+        assert_eq!(
+            outcome.cascaded_child_ids,
+            vec!["child-account", "grandchild-account"]
+        );
+        for id in ["parent-account", "child-account", "grandchild-account"] {
+            assert!(
+                db.get_account(id)
+                    .expect("read account")
+                    .expect("account exists")
+                    .archived,
+                "{id} should be archived"
+            );
+        }
+    }
+
+    #[test]
+    fn single_entity_restore_does_not_restore_archived_descendants() {
+        let db = test_db();
+        insert_account(&db, "parent-account", "Parent", None, true);
+        insert_account(&db, "child-account", "Child", Some("parent-account"), true);
+        insert_account(
+            &db,
+            "grandchild-account",
+            "Grandchild",
+            Some("child-account"),
+            true,
+        );
+        insert_project(&db, "parent-project", "Parent", None, true);
+        insert_project(&db, "child-project", "Child", Some("parent-project"), true);
+        insert_project(
+            &db,
+            "grandchild-project",
+            "Grandchild",
+            Some("child-project"),
+            true,
+        );
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        let account_outcome = archive_entity_with_outcome(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Account,
+            "parent-account",
+            false,
+        )
+        .expect("restore selected account");
+        let project_outcome = archive_entity_with_outcome(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Project,
+            "parent-project",
+            false,
+        )
+        .expect("restore selected project");
+
+        assert_eq!(account_outcome.changed_ids, vec!["parent-account"]);
+        assert!(account_outcome.cascaded_child_ids.is_empty());
+        assert_eq!(project_outcome.changed_ids, vec!["parent-project"]);
+        assert!(project_outcome.cascaded_child_ids.is_empty());
+        assert!(
+            db.get_account("child-account")
+                .expect("read child account")
+                .expect("child account exists")
+                .archived
+        );
+        assert!(
+            db.get_account("grandchild-account")
+                .expect("read grandchild account")
+                .expect("grandchild account exists")
+                .archived
+        );
+        assert!(
+            db.get_project("child-project")
+                .expect("read child project")
+                .expect("child project exists")
+                .archived
+        );
+        assert!(
+            db.get_project("grandchild-project")
+                .expect("read grandchild project")
+                .expect("grandchild project exists")
+                .archived
+        );
+    }
+
+    #[test]
+    fn bulk_archive_rolls_back_prior_roots_when_later_root_fails() {
+        let db = test_db();
+        insert_account(&db, "first-account", "First", None, false);
+        insert_account(&db, "second-account", "Second", None, false);
+        let ids = vec!["first-account".to_string(), "second-account".to_string()];
+        let preview =
+            preview_bulk_archive(&db, EntityArchiveType::Account, ids.clone()).expect("preview");
+        db.conn_ref()
+            .execute(
+                "CREATE TRIGGER fail_second_archive
+                 BEFORE UPDATE OF archived ON accounts
+                 WHEN NEW.id = 'second-account' AND NEW.archived = 1
+                 BEGIN
+                   SELECT RAISE(FAIL, 'forced archive failure');
+                 END;",
+                [],
+            )
+            .expect("install failure trigger");
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        let error = execute_bulk_archive(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Account,
+            ids,
+            &preview.plan_id,
+            &preview.plan_fingerprint,
+        )
+        .expect_err("bulk archive fails");
+
+        assert!(error.contains("forced archive failure"));
+        assert!(
+            !db.get_account("first-account")
+                .expect("read first")
+                .expect("first exists")
+                .archived
+        );
+        assert!(
+            !db.get_account("second-account")
+                .expect("read second")
+                .expect("second exists")
+                .archived
+        );
+    }
+
+    #[test]
+    fn folder_move_targets_skip_children_nested_under_changed_parent() {
+        let db = test_db();
+        insert_account(&db, "parent-account", "Parent", None, false);
+        insert_account(&db, "child-account", "Child", Some("parent-account"), false);
+        let descriptors = vec![
+            load_descriptor(&db, EntityArchiveType::Account, "parent-account")
+                .expect("load parent")
+                .expect("parent exists"),
+            load_descriptor(&db, EntityArchiveType::Account, "child-account")
+                .expect("load child")
+                .expect("child exists"),
+        ];
+
+        let (move_ids, skipped_ids) =
+            partition_folder_move_targets(descriptors, None).expect("partition targets");
+
+        assert_eq!(move_ids, vec!["parent-account"]);
+        assert!(skipped_ids.contains("child-account"));
+    }
+
+    #[tokio::test]
+    async fn archive_folders_records_metadata_for_child_skipped_under_parent() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let (state, workspace_path) =
+            test_state_with_workspace(db_dir.path().join("dailyos.db"), workspace.path()).await;
+        state
+            .db_write(|db| {
+                insert_account(db, "parent-account", "Parent", None, false);
+                insert_account(db, "child-account", "Child", Some("parent-account"), false);
+                Ok(())
+            })
+            .await
+            .expect("seed accounts");
+        std::fs::create_dir_all(workspace_path.join("Accounts/Parent/Child-parent-account"))
+            .expect("create nested child folder");
+
+        let results = archive_folders_for_outcomes(
+            state.clone(),
+            &[ArchiveMutationOutcome {
+                requested_id: "parent-account".to_string(),
+                entity_type: EntityArchiveType::Account,
+                changed_ids: vec!["parent-account".to_string(), "child-account".to_string()],
+                selected_id_changed: true,
+                cascaded_child_ids: vec!["child-account".to_string()],
+                already_in_target_state_ids: Vec::new(),
+                not_found_ids: Vec::new(),
+                intel_queue_cleanup_ids: Vec::new(),
+                operation_id: "archive-op".to_string(),
+            }],
+        )
+        .await;
+
+        let child_result = results
+            .iter()
+            .find(|result| result.entity_id == "child-account")
+            .expect("child result");
+        assert_eq!(child_result.folder_status, "folder_skipped");
+        let archived_child_path = child_result
+            .archived_relative_path
+            .as_ref()
+            .expect("child archived path");
+        assert!(workspace_path.join(archived_child_path).exists());
+
+        let child_metadata: (String, String) = state
+            .db_read(|db| {
+                db.conn_ref()
+                    .query_row(
+                        "SELECT folder_state, archived_relative_path
+                           FROM entity_archive_folders
+                          WHERE operation_id = 'archive-op'
+                            AND entity_type = 'account'
+                            AND entity_id = 'child-account'",
+                        [],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("read child metadata");
+        assert_eq!(child_metadata.0, "archived");
+        assert_eq!(child_metadata.1, *archived_child_path);
+
+        let restore_result = restore_folder_for_entity(
+            state.clone(),
+            EntityArchiveType::Account,
+            "child-account".to_string(),
+        )
+        .await;
+
+        assert_eq!(restore_result.folder_status, "succeeded");
+        assert!(workspace_path
+            .join("Accounts/Parent/Child-parent-account")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn parent_only_restore_keeps_archived_descendant_folder_in_archive() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let (state, workspace_path) =
+            test_state_with_workspace(db_dir.path().join("dailyos.db"), workspace.path()).await;
+        state
+            .db_write(|db| {
+                insert_account(db, "parent-account", "Parent", None, false);
+                insert_account(db, "child-account", "Child", Some("parent-account"), false);
+                Ok(())
+            })
+            .await
+            .expect("seed accounts");
+        let child_active_path = workspace_path.join("Accounts/Parent/Child-parent-account");
+        std::fs::create_dir_all(&child_active_path).expect("create nested child folder");
+        std::fs::write(child_active_path.join("notes.md"), "child workspace data")
+            .expect("write child data");
+
+        let archive_results = archive_folders_for_outcomes(
+            state.clone(),
+            &[ArchiveMutationOutcome {
+                requested_id: "parent-account".to_string(),
+                entity_type: EntityArchiveType::Account,
+                changed_ids: vec!["parent-account".to_string(), "child-account".to_string()],
+                selected_id_changed: true,
+                cascaded_child_ids: vec!["child-account".to_string()],
+                already_in_target_state_ids: Vec::new(),
+                not_found_ids: Vec::new(),
+                intel_queue_cleanup_ids: Vec::new(),
+                operation_id: "archive-op".to_string(),
+            }],
+        )
+        .await;
+        assert!(archive_results
+            .iter()
+            .any(|result| result.entity_id == "child-account"
+                && result.folder_status == "folder_skipped"));
+        state
+            .db_write(|db| {
+                db.archive_account("parent-account", true)
+                    .map_err(|error| error.to_string())?;
+                db.archive_account("child-account", true)
+                    .map_err(|error| error.to_string())?;
+                db.archive_account("parent-account", false)
+                    .map_err(|error| error.to_string())?;
+                record_restore_intent_for_changed_ids(
+                    db,
+                    EntityArchiveType::Account,
+                    &["parent-account".to_string()],
+                )?;
+                Ok(())
+            })
+            .await
+            .expect("restore parent db only");
+
+        let restore_result = restore_folder_for_entity(
+            state.clone(),
+            EntityArchiveType::Account,
+            "parent-account".to_string(),
+        )
+        .await;
+
+        assert_eq!(restore_result.folder_status, "succeeded");
+        assert!(workspace_path.join("Accounts/Parent").exists());
+        assert!(
+            !child_active_path.exists(),
+            "child folder must not become active while child row remains archived"
+        );
+        assert!(state
+            .db_read(|db| {
+                Ok(db
+                    .get_account("child-account")
+                    .map_err(|error| error.to_string())?
+                    .expect("child account exists")
+                    .archived)
+            })
+            .await
+            .expect("read child archive state"));
+        let child_metadata: (String, String) = state
+            .db_read(|db| {
+                db.conn_ref()
+                    .query_row(
+                        "SELECT folder_state, archived_relative_path
+                           FROM entity_archive_folders
+                          WHERE operation_id = 'archive-op'
+                            AND entity_type = 'account'
+                            AND entity_id = 'child-account'",
+                        [],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("read child metadata");
+        assert_eq!(child_metadata.0, "archived");
+        assert!(workspace_path.join(&child_metadata.1).exists());
+        assert_ne!(
+            child_metadata.1,
+            "_archive/entities/account/parent-account--parent/Child-parent-account"
+        );
+    }
+
+    #[test]
+    fn restore_account_outcome_restores_archived_children_when_parent_already_active() {
+        let db = test_db();
+        insert_account(&db, "parent-account", "Parent", None, false);
+        insert_account(&db, "child-account", "Child", Some("parent-account"), true);
+        insert_account(
+            &db,
+            "grandchild-account",
+            "Grandchild",
+            Some("child-account"),
+            true,
+        );
+        let restore_target_ids =
+            restore_account_target_ids(&db, "parent-account", true).expect("restore targets");
+        assert_eq!(
+            restore_target_ids,
+            vec!["parent-account", "child-account", "grandchild-account"]
+        );
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        let outcome = restore_account_with_outcome(&ctx, &db, &state, "parent-account", true)
+            .expect("restore account");
+
+        assert!(!outcome.selected_id_changed);
+        assert_eq!(outcome.already_in_target_state_ids, vec!["parent-account"]);
+        assert_eq!(
+            outcome.changed_ids,
+            vec!["child-account", "grandchild-account"]
+        );
+        assert_eq!(
+            outcome.cascaded_child_ids,
+            vec!["child-account", "grandchild-account"]
+        );
+        for id in ["child-account", "grandchild-account"] {
+            assert!(
+                !db.get_account(id)
+                    .expect("read account")
+                    .expect("account exists")
+                    .archived,
+                "{id} should be restored"
+            );
+        }
+    }
+
+    #[test]
+    fn restore_outcome_records_restore_intent_before_commit() {
+        let db = test_db();
+        insert_account(&db, "archived-account", "Archived", None, true);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO entity_archive_folders (
+                    operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state, archived_at, restored_at,
+                    updated_at, last_error_code
+                 ) VALUES (?1, 'account', ?2, ?3, ?4, 'archived', ?5, NULL, ?5, NULL)",
+                params![
+                    "archive-op",
+                    "archived-account",
+                    "Accounts/Archived",
+                    "_archive/entities/account/archived-account--archived",
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .expect("insert archive metadata");
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        let outcome = archive_entity_with_outcome(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Account,
+            "archived-account",
+            false,
+        )
+        .expect("restore entity");
+
+        assert_eq!(outcome.changed_ids, vec!["archived-account"]);
+        let folder_state: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT folder_state FROM entity_archive_folders
+                 WHERE operation_id = 'archive-op'
+                   AND entity_type = 'account'
+                   AND entity_id = 'archived-account'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read folder state");
+        assert_eq!(folder_state, "restore_pending");
+    }
+
+    #[test]
+    fn restore_outcome_records_restore_intent_for_pending_archive_target() {
+        let db = test_db();
+        insert_account(&db, "archived-account", "Archived", None, true);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO entity_archive_folders (
+                    operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state, archived_at, restored_at,
+                    updated_at, last_error_code
+                 ) VALUES (?1, 'account', ?2, ?3, ?4, 'archive_pending', ?5, NULL, ?5, NULL)",
+                params![
+                    "archive-op",
+                    "archived-account",
+                    "Accounts/Archived",
+                    "_archive/entities/account/archived-account--archived",
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .expect("insert archive metadata");
+
+        let clock = crate::services::context::SystemClock;
+        let rng = crate::services::context::SystemRng;
+        let external = crate::services::context::ExternalClients::default();
+        let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+            .with_actor("agent:test");
+        let state = crate::state::AppState::new();
+        archive_entity_with_outcome(
+            &ctx,
+            &db,
+            &state,
+            EntityArchiveType::Account,
+            "archived-account",
+            false,
+        )
+        .expect("restore entity");
+
+        let folder_state: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT folder_state FROM entity_archive_folders
+                 WHERE operation_id = 'archive-op'
+                   AND entity_type = 'account'
+                   AND entity_id = 'archived-account'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read folder state");
+        assert_eq!(folder_state, "restore_pending");
+    }
+
+    #[tokio::test]
+    async fn restore_folder_recovers_failed_archive_when_active_folder_already_exists() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let (state, workspace_path) =
+            test_state_with_workspace(db_dir.path().join("dailyos.db"), workspace.path()).await;
+        state
+            .db_write(|db| {
+                insert_account(db, "archived-account", "Archived", None, true);
+                db.conn_ref()
+                    .execute(
+                        "INSERT INTO entity_archive_folders (
+                            operation_id, entity_type, entity_id, original_relative_path,
+                            archived_relative_path, folder_state, archived_at, restored_at,
+                            updated_at, last_error_code
+                         ) VALUES (?1, 'account', ?2, ?3, ?4, 'archive_failed', ?5, NULL, ?5, 'move_failed')",
+                        params![
+                            "archive-op",
+                            "archived-account",
+                            "Accounts/Archived",
+                            "_archive/entities/account/archived-account--archived",
+                            Utc::now().to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            })
+            .await
+            .expect("seed archive metadata");
+        std::fs::create_dir_all(workspace_path.join("Accounts/Archived"))
+            .expect("create active folder");
+
+        preflight_restore_targets(
+            state.clone(),
+            EntityArchiveType::Account,
+            vec!["archived-account".to_string()],
+        )
+        .await
+        .expect("preflight permits already-active failed archive");
+        let result = restore_folder_for_entity(
+            state.clone(),
+            EntityArchiveType::Account,
+            "archived-account".to_string(),
+        )
+        .await;
+
+        assert_eq!(result.folder_status, "succeeded");
+        let folder_state: String = state
+            .db_read(|db| {
+                db.conn_ref()
+                    .query_row(
+                        "SELECT folder_state FROM entity_archive_folders
+                         WHERE operation_id = 'archive-op'
+                           AND entity_type = 'account'
+                           AND entity_id = 'archived-account'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("read folder state");
+        assert_eq!(folder_state, "restored");
+    }
+
+    #[tokio::test]
+    async fn restore_folder_marks_missing_archive_source_as_failed() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let (state, workspace_path) =
+            test_state_with_workspace(db_dir.path().join("dailyos.db"), workspace.path()).await;
+        state
+            .db_write(|db| {
+                insert_account(db, "archived-account", "Archived", None, true);
+                db.conn_ref()
+                    .execute(
+                        "INSERT INTO entity_archive_folders (
+                            operation_id, entity_type, entity_id, original_relative_path,
+                            archived_relative_path, folder_state, archived_at, restored_at,
+                            updated_at, last_error_code
+                         ) VALUES (?1, 'account', ?2, ?3, ?4, 'archived', ?5, NULL, ?5, NULL)",
+                        params![
+                            "archive-op",
+                            "archived-account",
+                            "Accounts/MissingSource/Archived",
+                            "_archive/entities/account/archived-account--archived",
+                            Utc::now().to_rfc3339(),
+                        ],
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            })
+            .await
+            .expect("seed archive metadata");
+
+        let result = restore_folder_for_entity(
+            state.clone(),
+            EntityArchiveType::Account,
+            "archived-account".to_string(),
+        )
+        .await;
+
+        assert_eq!(result.folder_status, "folder_missing");
+        assert!(!workspace_path
+            .join("Accounts/MissingSource/Archived")
+            .exists());
+        let metadata: (String, Option<String>) = state
+            .db_read(|db| {
+                db.conn_ref()
+                    .query_row(
+                        "SELECT folder_state, last_error_code FROM entity_archive_folders
+                         WHERE operation_id = 'archive-op'
+                           AND entity_type = 'account'
+                           AND entity_id = 'archived-account'",
+                        [],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("read folder metadata");
+        assert_eq!(metadata.0, "restore_failed");
+        assert_eq!(metadata.1.as_deref(), Some("missing_source"));
+    }
+
+    #[test]
+    fn active_relative_path_uses_sanitized_fallback_name() {
+        let descriptor = EntityDescriptor {
+            entity_type: EntityArchiveType::Person,
+            id: "person-a".to_string(),
+            name: "A/B".to_string(),
+            tracker_path: None,
+            parent_id: None,
+            updated_at: Utc::now().to_rfc3339(),
+            archived: false,
+        };
+
+        let relative = active_relative_path(&descriptor, None).expect("resolve path");
+
+        assert_eq!(relative, PathBuf::from("People").join("A-B"));
+    }
+
+    #[test]
+    fn active_relative_path_normalizes_person_json_tracker_path() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let relative_descriptor = EntityDescriptor {
+            entity_type: EntityArchiveType::Person,
+            id: "person-a".to_string(),
+            name: "Person A".to_string(),
+            tracker_path: Some("People/Person A/person.json".to_string()),
+            parent_id: None,
+            updated_at: Utc::now().to_rfc3339(),
+            archived: false,
+        };
+        let absolute_descriptor = EntityDescriptor {
+            tracker_path: Some(
+                workspace
+                    .path()
+                    .join("People/Person A/person.json")
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            ..relative_descriptor.clone()
+        };
+
+        assert_eq!(
+            active_relative_path(&relative_descriptor, Some(workspace.path()))
+                .expect("relative person path"),
+            PathBuf::from("People").join("Person A")
+        );
+        assert_eq!(
+            active_relative_path(&absolute_descriptor, Some(workspace.path()))
+                .expect("absolute person path"),
+            PathBuf::from("People").join("Person A")
+        );
+    }
+
+    #[test]
+    fn active_relative_path_ignores_root_only_tracker_path() {
+        let account = EntityDescriptor {
+            entity_type: EntityArchiveType::Account,
+            id: "account-root".to_string(),
+            name: "RootAccount".to_string(),
+            tracker_path: Some("Accounts".to_string()),
+            parent_id: None,
+            updated_at: Utc::now().to_rfc3339(),
+            archived: false,
+        };
+        let internal = EntityDescriptor {
+            entity_type: EntityArchiveType::Account,
+            id: "internal-root".to_string(),
+            name: "InternalAccount".to_string(),
+            tracker_path: Some("Internal".to_string()),
+            parent_id: None,
+            updated_at: Utc::now().to_rfc3339(),
+            archived: false,
+        };
+        let project = EntityDescriptor {
+            entity_type: EntityArchiveType::Project,
+            id: "project-root".to_string(),
+            name: "Launch".to_string(),
+            tracker_path: Some("Projects".to_string()),
+            parent_id: None,
+            updated_at: Utc::now().to_rfc3339(),
+            archived: false,
+        };
+
+        assert_eq!(
+            active_relative_path(&account, None).expect("account path"),
+            PathBuf::from("Accounts").join("RootAccount")
+        );
+        assert_eq!(
+            active_relative_path(&internal, None).expect("internal path"),
+            PathBuf::from("Accounts").join("InternalAccount")
+        );
+        assert_eq!(
+            active_relative_path(&project, None).expect("project path"),
+            PathBuf::from("Projects").join("Launch")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_target_rejects_symlink_parent() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("Accounts"))
+            .expect("symlink active root");
+
+        let error = validated_restore_target(
+            workspace.path(),
+            EntityArchiveType::Account,
+            Path::new("Accounts/Archived"),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("symlink"));
+        assert!(!outside.path().join("Archived").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allocate_archive_relative_path_rejects_symlink_archive_root_before_creating_children() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("_archive"))
+            .expect("symlink archive root");
+
+        let error = allocate_archive_relative_path(
+            workspace.path(),
+            EntityArchiveType::Account,
+            "account-id",
+            "Account",
+        )
+        .unwrap_err();
+
+        assert!(error.contains("symlink"));
+        assert!(!outside.path().join("entities").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn archive_target_from_metadata_rejects_symlink_archive_root_before_creating_children() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("_archive"))
+            .expect("symlink archive root");
+
+        let error = archive_target_from_metadata(
+            workspace.path(),
+            "_archive/entities/account/account-id--account",
+        )
+        .unwrap_err();
+
+        assert!(error.contains("symlink"));
+        assert!(!outside.path().join("entities").exists());
+    }
+
+    #[test]
+    fn delete_mode_scoped_roots_only_removes_internal_paths_referenced_by_db() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        for relative in [
+            "Accounts/Customer",
+            "Projects/Launch",
+            "People/Contact",
+            "_archive/entities/account/archive",
+            "Internal/Referenced",
+            "Internal/Unreferenced",
+        ] {
+            std::fs::create_dir_all(workspace.path().join(relative)).expect("create folder");
+        }
+
+        delete_mode_scoped_entity_roots(workspace.path(), &["Internal/Referenced".to_string()])
+            .expect("delete mode roots");
+
+        assert!(!workspace.path().join("Accounts").exists());
+        assert!(!workspace.path().join("Projects").exists());
+        assert!(!workspace.path().join("People").exists());
+        assert!(!workspace.path().join("_archive/entities").exists());
+        assert!(!workspace.path().join("Internal/Referenced").exists());
+        assert!(workspace.path().join("Internal/Unreferenced").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_mode_scoped_roots_rejects_symlink_roots_before_recursing() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::fs::create_dir_all(outside.path().join("Preserve")).expect("outside folder");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("Accounts"))
+            .expect("symlink account root");
+
+        let error = delete_mode_scoped_entity_roots(workspace.path(), &[]).unwrap_err();
+
+        assert!(error.contains("symlink"));
+        assert!(outside.path().join("Preserve").exists());
+    }
+
+    #[test]
+    fn repair_plan_reports_actionable_metadata_and_true_orphans() {
+        let db = test_db();
+        let workspace = tempfile::tempdir().expect("workspace");
+        insert_account(&db, "active-account", "Active", None, false);
+        insert_account(&db, "archived-account", "Archived", None, true);
+
+        for relative in ["Accounts/Active", "Accounts/Archived", "Accounts/Orphan"] {
+            std::fs::create_dir_all(workspace.path().join(relative)).expect("create folder");
+        }
+
+        db.conn_ref()
+            .execute(
+                "INSERT INTO entity_archive_folders (
+                    operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state, archived_at, restored_at,
+                    updated_at, last_error_code
+                 ) VALUES (?1, 'account', ?2, ?3, ?4, ?5, ?6, NULL, ?6, NULL)",
+                params![
+                    "archive-op",
+                    "active-account",
+                    "Accounts/Active",
+                    "_archive/entities/account/active-account--active",
+                    "archive_pending",
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .expect("insert archive metadata");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO entity_archive_folders (
+                    operation_id, entity_type, entity_id, original_relative_path,
+                    archived_relative_path, folder_state, archived_at, restored_at,
+                    updated_at, last_error_code
+                 ) VALUES (?1, 'account', ?2, ?3, ?4, ?5, ?6, NULL, ?6, NULL)",
+                params![
+                    "restore-op",
+                    "archived-account",
+                    "Accounts/Archived",
+                    "_archive/entities/account/archived-account--archived",
+                    "restore_failed",
+                    Utc::now().to_rfc3339(),
+                ],
+            )
+            .expect("insert restore metadata");
+
+        let plan = plan_reconciliation_sync(&db, workspace.path()).expect("repair plan");
+
+        assert_eq!(plan.archived_db_active_folder_count, 1);
+        assert_eq!(plan.pending_metadata_count, 2);
+        assert_eq!(plan.orphan_active_folder_count, 1);
+        assert!(plan.items.iter().any(|item| {
+            item.entity_type == EntityArchiveType::Account
+                && item.entity_id == "archived-account"
+                && item.status == "archived_db_active_folder"
+        }));
+        assert!(plan.items.iter().any(|item| {
+            item.entity_type == EntityArchiveType::Account
+                && item.entity_id == "active-account"
+                && item.status == "archive_pending"
+        }));
+        assert!(plan.items.iter().any(|item| {
+            item.entity_type == EntityArchiveType::Account
+                && item.entity_id == "archived-account"
+                && item.status == "restore_failed"
+        }));
+    }
+}

--- a/src-tauri/src/services/intelligence.rs
+++ b/src-tauri/src/services/intelligence.rs
@@ -5693,7 +5693,7 @@ mod mutation_smoke_tests {
         StakeholderInsight, StrategicPriority, SuccessMetric, SupportHealth,
     };
     use crate::intelligence::prompts::InferredRelationship;
-    use crate::intelligence::write_fence::post_commit_fenced_write;
+    use crate::intelligence::write_fence::{fenced_write_intelligence_json, FenceCycle};
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
     use crate::signals::propagation::PropagationEngine;
     use crate::state::AppState;
@@ -5701,6 +5701,7 @@ mod mutation_smoke_tests {
     use rusqlite::{params, OptionalExtension};
     use std::path::Path;
     use std::sync::Arc;
+    use std::time::Duration;
 
     fn test_ctx<'a>(
         clock: &'a FixedClock,
@@ -5729,6 +5730,22 @@ mod mutation_smoke_tests {
             keywords_extracted_at: None,
             metadata: None,
             ..Default::default()
+        }
+    }
+
+    fn seed_disk_intelligence(db: &crate::db::ActionDb, dir: &Path, intel: &IntelligenceJson) {
+        for attempt in 0..100 {
+            match FenceCycle::capture(db) {
+                Ok(cycle) => {
+                    fenced_write_intelligence_json(&cycle, db, dir, intel)
+                        .expect("seed disk intelligence");
+                    return;
+                }
+                Err(err) if err.contains("paused") && attempt < 99 => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(err) => panic!("capture seed disk fence: {err}"),
+            }
         }
     }
 
@@ -9717,7 +9734,7 @@ mod mutation_smoke_tests {
             ..Default::default()
         };
         db.upsert_entity_intelligence(&old_intel).unwrap();
-        post_commit_fenced_write(&db, dir.path(), &old_intel, "seed disk intelligence");
+        seed_disk_intelligence(&db, dir.path(), &old_intel);
         let before_disk =
             std::fs::read_to_string(dir.path().join("intelligence.json")).expect("read seed disk");
 
@@ -9812,7 +9829,7 @@ mod mutation_smoke_tests {
             ..Default::default()
         };
         db.upsert_entity_intelligence(&old_intel).unwrap();
-        post_commit_fenced_write(&db, dir.path(), &old_intel, "seed disk intelligence");
+        seed_disk_intelligence(&db, dir.path(), &old_intel);
         let before_disk =
             std::fs::read_to_string(dir.path().join("intelligence.json")).expect("read seed disk");
 
@@ -9914,7 +9931,7 @@ mod mutation_smoke_tests {
             ..Default::default()
         };
         db.upsert_entity_intelligence(&prior).unwrap();
-        post_commit_fenced_write(&db, dir.path(), &prior, "seed disk intelligence");
+        seed_disk_intelligence(&db, dir.path(), &prior);
         let before_disk =
             std::fs::read_to_string(dir.path().join("intelligence.json")).expect("read seed disk");
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -21,6 +21,7 @@ pub mod derived_state;
 pub mod emails;
 pub mod enrichment_side_effects;
 pub mod entities;
+pub mod entity_archive_folders;
 pub mod entity_context;
 pub mod entity_intelligence;
 pub mod entity_linking;

--- a/src-tauri/src/services/recommendations/feedback.rs
+++ b/src-tauri/src/services/recommendations/feedback.rs
@@ -8,13 +8,13 @@
 use abilities_runtime::abilities::recommendations::contracts as runtime;
 use abilities_runtime::abilities::registry::Actor;
 use chrono::{DateTime, Utc};
-use rusqlite::params;
 
 use crate::abilities::claims::ClaimType;
 use crate::abilities::feedback::FeedbackAction;
 use crate::db::ActionDb;
 use crate::services::claims::{
-    load_claim_by_id, record_claim_feedback, with_claim_transaction, ClaimError, ClaimFeedbackInput,
+    load_claim_by_id, record_claim_feedback, update_recommendation_feedback_metadata,
+    with_claim_transaction, ClaimError, ClaimFeedbackInput,
 };
 use crate::services::context::ServiceContext;
 use crate::services::recommendations::contracts as app;
@@ -55,14 +55,11 @@ pub fn record_recommendation_feedback(
 
         parse_recommendation_metadata(claim.metadata_json.as_deref())?;
 
-        let rows_affected = tx.conn_ref().execute(
-            "UPDATE intelligence_claims
-             SET metadata_json = json_set(metadata_json,
-                 '$.recommendation.feedbackState', json(?1),
-                 '$.recommendation.conversionState', json(?2))
-             WHERE id = ?3
-               AND json_extract(metadata_json, '$.recommendation.feedbackState') = 'pending'",
-            params![&feedback_state_json, &conversion_state_json, &claim_id.0],
+        let rows_affected = update_recommendation_feedback_metadata(
+            tx,
+            &claim_id.0,
+            &feedback_state_json,
+            &conversion_state_json,
         )?;
 
         if rows_affected == 0 {
@@ -409,6 +406,7 @@ mod tests {
     use abilities_runtime::abilities::registry::{ScopeSet, SurfaceClientId, SurfaceScope};
     use abilities_runtime::sensitivity::RenderSurface;
     use chrono::TimeZone;
+    use rusqlite::params;
     use serde_json::json;
 
     use crate::db::ActionDb;

--- a/src-tauri/src/services/recommendations/surfacing.rs
+++ b/src-tauri/src/services/recommendations/surfacing.rs
@@ -1362,9 +1362,20 @@ mod tests {
     }
 
     fn insert_recommendation_claim(db: &ActionDb, id: &str, trust_score: f64, source_asof: &str) {
+        insert_recommendation_claim_with_metadata_source(db, id, id, trust_score, source_asof);
+    }
+
+    fn insert_recommendation_claim_with_metadata_source(
+        db: &ActionDb,
+        id: &str,
+        metadata_source_id: &str,
+        trust_score: f64,
+        source_asof: &str,
+    ) {
         let (clock, rng, external) = test_ctx();
         let ctx = live_ctx(&clock, &rng, &external);
-        let metadata = metadata_envelope(&super_recommendation_draft(id, source_asof));
+        let metadata =
+            metadata_envelope(&super_recommendation_draft(metadata_source_id, source_asof));
         let proposal = ClaimProposal {
             id: None,
             expected_claim_version: None,
@@ -1792,23 +1803,13 @@ mod tests {
     fn material_baseline_uses_subject_action_render_for_duplicate_claims() {
         let db = test_db();
         insert_recommendation_claim(&db, "claim-subject-action-1", 0.95, "2026-05-26T10:00:00Z");
-        insert_recommendation_claim(&db, "claim-subject-action-2", 0.95, "2026-05-26T10:00:00Z");
-        let shared_metadata_json: String = db
-            .conn_ref()
-            .query_row(
-                "SELECT metadata_json FROM intelligence_claims WHERE id = 'claim-subject-action-1'",
-                [],
-                |row| row.get(0),
-            )
-            .expect("read shared metadata");
-        db.conn_ref()
-            .execute(
-                "UPDATE intelligence_claims
-                    SET metadata_json = ?1
-                  WHERE id = 'claim-subject-action-2'",
-                [shared_metadata_json],
-            )
-            .expect("share action signature");
+        insert_recommendation_claim_with_metadata_source(
+            &db,
+            "claim-subject-action-2",
+            "claim-subject-action-1",
+            0.95,
+            "2026-05-26T10:00:00Z",
+        );
         let (clock, rng, external) = test_ctx();
         let ctx = live_ctx(&clock, &rng, &external);
         let engine = PropagationEngine::new();

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -14,6 +14,16 @@ pub struct AggregateTelemetryStatus {
     pub preview: Vec<crate::observability::aggregate_metric::AggregateMetricPreview>,
 }
 
+fn workspace_path_for_request(
+    mode: crate::db::DbMode,
+    path: &str,
+) -> Result<std::path::PathBuf, String> {
+    if !std::path::Path::new(path).is_absolute() {
+        return Err("Workspace path must be absolute".to_string());
+    }
+    crate::state::workspace_path_for_mode(mode, Some(path))
+}
+
 fn validate_ai_model_choice(tier: &str, model: &str) -> Result<(), String> {
     let valid_tiers = ["synthesis", "extraction", "background", "mechanical"];
     if !valid_tiers.contains(&tier) {
@@ -87,11 +97,8 @@ pub async fn set_workspace_path(
     state: &AppState,
 ) -> Result<Config, String> {
     ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
-    let workspace = std::path::Path::new(path);
-
-    if !workspace.is_absolute() {
-        return Err("Workspace path must be absolute".to_string());
-    }
+    let path = workspace_path_for_request(crate::db::db_mode(), path)?;
+    let workspace = path.as_path();
 
     let entity_mode = state
         .config
@@ -102,7 +109,7 @@ pub async fn set_workspace_path(
 
     crate::state::initialize_workspace(workspace, &entity_mode)?;
 
-    let path = path.to_string();
+    let path = path.to_string_lossy().to_string();
     let config = crate::state::create_or_update_config(state, |config| {
         config.workspace_path = path.clone();
     })?;
@@ -526,7 +533,37 @@ pub async fn set_user_profile(
 #[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
-    use super::validate_ai_model_choice;
+    use super::{validate_ai_model_choice, workspace_path_for_request};
+    use crate::db::DbMode;
+
+    #[test]
+    fn workspace_request_preserves_live_path() {
+        let requested = std::env::temp_dir().join("DailyOS-live-request");
+        let resolved =
+            workspace_path_for_request(DbMode::Live, &requested.to_string_lossy()).unwrap();
+
+        assert_eq!(resolved, requested);
+    }
+
+    #[test]
+    fn workspace_request_uses_replica_scoped_path_before_scaffolding() {
+        let requested = std::env::temp_dir().join("DailyOS-live-default");
+        let resolved =
+            workspace_path_for_request(DbMode::Replica, &requested.to_string_lossy()).unwrap();
+
+        assert_ne!(resolved, requested);
+        assert_eq!(
+            resolved.file_name().and_then(|name| name.to_str()),
+            Some("replica-workspace")
+        );
+    }
+
+    #[test]
+    fn workspace_request_rejects_relative_path_before_mode_scoping() {
+        let error = workspace_path_for_request(DbMode::Replica, "DailyOS").unwrap_err();
+
+        assert_eq!(error, "Workspace path must be absolute");
+    }
 
     #[test]
     fn validates_background_ai_model_choice() {

--- a/src-tauri/tests/workspace_ingestion_w2b_no_new_direct_writes.rs
+++ b/src-tauri/tests/workspace_ingestion_w2b_no_new_direct_writes.rs
@@ -84,6 +84,7 @@ fn workspace_ingestion_w2b_no_new_direct_writes() {
         "transcript-direct-write-v146",
         "devtools-w5-backfill-fixture",
         "v146-validation-fixture",
+        "entity-archive-folder-v150",
     ] {
         assert!(script.contains(token), "script recognizes {token}");
     }

--- a/src/components/entity/BulkArchiveSelectionAction.test.tsx
+++ b/src/components/entity/BulkArchiveSelectionAction.test.tsx
@@ -1,0 +1,133 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BulkArchiveSelectionAction,
+  type BulkArchivePreview,
+  type BulkArchiveResult,
+} from "./BulkArchiveSelectionAction";
+
+const { invokeMock, toastMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  toastMock: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+const preview: BulkArchivePreview = {
+  entityType: "project",
+  requestedIds: ["parent-project", "child-project"],
+  rootIds: ["parent-project"],
+  changedIds: ["parent-project", "child-project"],
+  selectedIds: ["parent-project", "child-project"],
+  cascadedChildIds: ["child-project"],
+  coveredChildIds: ["child-project"],
+  notFoundIds: [],
+  alreadyArchivedIds: [],
+  totalChangedCount: 2,
+  directCascadeCount: 1,
+  planId: "bulk-archive-plan",
+  planFingerprint: "bulk-archive:v1:fingerprint",
+  expiresAt: "2026-06-02T12:00:00Z",
+};
+
+function renderAction({
+  onArchived = vi.fn(),
+  onClearSelection = vi.fn(),
+}: {
+  onArchived?: (result: BulkArchiveResult) => void | Promise<void>;
+  onClearSelection?: () => void;
+} = {}) {
+  render(
+    <BulkArchiveSelectionAction
+      selectedIds={["parent-project", "child-project"]}
+      entityLabel="project"
+      entityPluralLabel="projects"
+      previewCommand="preview_bulk_archive_projects"
+      executeCommand="bulk_archive_projects"
+      onArchived={onArchived}
+      onClearSelection={onClearSelection}
+    />,
+  );
+  return { onArchived, onClearSelection };
+}
+
+describe("BulkArchiveSelectionAction", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    toastMock.error.mockReset();
+    toastMock.success.mockReset();
+    toastMock.warning.mockReset();
+  });
+
+  it("executes archive against the preview plan binding", async () => {
+    const result: BulkArchiveResult = {
+      status: "succeeded",
+      preview,
+      changedIds: preview.changedIds,
+      alreadyArchivedIds: [],
+      notFoundIds: [],
+      itemResults: [],
+    };
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "preview_bulk_archive_projects") return Promise.resolve(preview);
+      if (command === "bulk_archive_projects") return Promise.resolve(result);
+      return Promise.resolve(null);
+    });
+    const { onArchived, onClearSelection } = renderAction();
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive 2 selected projects" }));
+    expect(await screen.findByText(/Archive 2 projects, including 1 descendant row/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Archive$/ }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("bulk_archive_projects", {
+        ids: preview.requestedIds,
+        planId: preview.planId,
+        planFingerprint: preview.planFingerprint,
+      });
+    });
+    expect(onArchived).toHaveBeenCalledWith(result);
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(toastMock.success).toHaveBeenCalledWith("Archived 2 projects");
+  });
+
+  it("keeps selection when the preview is stale", async () => {
+    const staleResult: BulkArchiveResult = {
+      status: "preview_stale",
+      preview,
+      changedIds: [],
+      alreadyArchivedIds: [],
+      notFoundIds: [],
+      itemResults: [],
+    };
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "preview_bulk_archive_projects") return Promise.resolve(preview);
+      if (command === "bulk_archive_projects") return Promise.resolve(staleResult);
+      return Promise.resolve(null);
+    });
+    const { onArchived, onClearSelection } = renderAction();
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive 2 selected projects" }));
+    await screen.findByText(/Archive 2 projects/);
+    fireEvent.click(screen.getByRole("button", { name: /^Archive$/ }));
+
+    await waitFor(() => {
+      expect(toastMock.warning).toHaveBeenCalledWith("Archive preview changed. Review again before archiving.");
+    });
+    expect(onArchived).not.toHaveBeenCalled();
+    expect(onClearSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/entity/BulkArchiveSelectionAction.tsx
+++ b/src/components/entity/BulkArchiveSelectionAction.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import styles from "./EntityListShell.module.css";
+
+export interface BulkArchivePreview {
+  entityType: "account" | "project" | "person";
+  requestedIds: string[];
+  rootIds: string[];
+  changedIds: string[];
+  selectedIds: string[];
+  cascadedChildIds: string[];
+  coveredChildIds: string[];
+  notFoundIds: string[];
+  alreadyArchivedIds: string[];
+  totalChangedCount: number;
+  directCascadeCount: number;
+  planId: string;
+  planFingerprint: string;
+  expiresAt: string;
+}
+
+export interface BulkArchiveResult {
+  status: "succeeded" | "partial" | "preview_stale";
+  preview: BulkArchivePreview;
+  changedIds: string[];
+  alreadyArchivedIds: string[];
+  notFoundIds: string[];
+  itemResults: Array<{
+    entityType: "account" | "project" | "person";
+    entityId: string;
+    folderStatus: string;
+    message?: string | null;
+    originalRelativePath?: string | null;
+    archivedRelativePath?: string | null;
+  }>;
+}
+
+interface BulkArchiveSelectionActionProps {
+  selectedIds: readonly string[];
+  entityLabel: string;
+  entityPluralLabel: string;
+  previewCommand: string;
+  executeCommand: string;
+  onArchived: (result: BulkArchiveResult) => void | Promise<void>;
+  onClearSelection: () => void;
+}
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : plural;
+}
+
+function formatPreviewMessage(
+  preview: BulkArchivePreview,
+  entityLabel: string,
+  entityPluralLabel: string,
+): string {
+  const changedLabel = pluralize(preview.totalChangedCount, entityLabel, entityPluralLabel);
+  if (preview.totalChangedCount === 0) {
+    return `No active ${entityPluralLabel} will be archived.`;
+  }
+  if (preview.directCascadeCount === 0) {
+    return `Archive ${preview.totalChangedCount} ${changedLabel}.`;
+  }
+  const childLabel = pluralize(preview.directCascadeCount, "descendant row", "descendant rows");
+  return `Archive ${preview.totalChangedCount} ${changedLabel}, including ${preview.directCascadeCount} ${childLabel}.`;
+}
+
+export function BulkArchiveSelectionAction({
+  selectedIds,
+  entityLabel,
+  entityPluralLabel,
+  previewCommand,
+  executeCommand,
+  onArchived,
+  onClearSelection,
+}: BulkArchiveSelectionActionProps) {
+  const [open, setOpen] = useState(false);
+  const [preview, setPreview] = useState<BulkArchivePreview | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [executing, setExecuting] = useState(false);
+
+  useEffect(() => {
+    if (selectedIds.length === 0) {
+      setOpen(false);
+      setPreview(null);
+    }
+  }, [selectedIds.length]);
+
+  const previewMessage = useMemo(() => (
+    preview ? formatPreviewMessage(preview, entityLabel, entityPluralLabel) : ""
+  ), [entityLabel, entityPluralLabel, preview]);
+
+  async function handlePreview() {
+    if (selectedIds.length === 0 || loadingPreview) return;
+    setLoadingPreview(true);
+    try {
+      const nextPreview = await invoke<BulkArchivePreview>(previewCommand, {
+        ids: selectedIds,
+      });
+      setPreview(nextPreview);
+      setOpen(true);
+    } catch (err) {
+      toast.error("Archive preview failed", {
+        description: String(err),
+      });
+    } finally {
+      setLoadingPreview(false);
+    }
+  }
+
+  async function handleArchive() {
+    if (!preview || executing) return;
+    setExecuting(true);
+    try {
+      const result = await invoke<BulkArchiveResult>(executeCommand, {
+        ids: preview.requestedIds,
+        planId: preview.planId,
+        planFingerprint: preview.planFingerprint,
+      });
+
+      if (result.status === "preview_stale") {
+        toast.warning("Archive preview changed. Review again before archiving.");
+        setPreview(null);
+        setOpen(false);
+        return;
+      }
+
+      await onArchived(result);
+      onClearSelection();
+      setOpen(false);
+      setPreview(null);
+
+      if (result.status === "partial") {
+        const failedCount = result.itemResults.filter((item) => item.folderStatus !== "succeeded").length;
+        toast.warning("Archived, but folders need attention", {
+          description: failedCount > 0 ? `${failedCount} folder ${failedCount === 1 ? "result needs" : "results need"} review.` : undefined,
+        });
+      } else {
+        const changedCount = result.changedIds.length;
+        const changedLabel = pluralize(changedCount, entityLabel, entityPluralLabel);
+        toast.success(`Archived ${changedCount} ${changedLabel}`);
+      }
+    } catch (err) {
+      toast.error("Archive failed", {
+        description: String(err),
+      });
+    } finally {
+      setExecuting(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.selectionButton}
+        onClick={handlePreview}
+        disabled={selectedIds.length === 0 || loadingPreview}
+        aria-label={`Archive ${selectedIds.length} selected ${pluralize(selectedIds.length, entityLabel, entityPluralLabel)}`}
+      >
+        {loadingPreview ? "Previewing..." : "Archive selected"}
+      </button>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive selected {entityPluralLabel}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {previewMessage}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {preview && (
+            <div className={styles.archivePreviewDetails}>
+              {preview.coveredChildIds.length > 0 && (
+                <p>
+                  {preview.coveredChildIds.length} selected child {preview.coveredChildIds.length === 1 ? "row is" : "rows are"} already covered by a selected parent.
+                </p>
+              )}
+              {preview.alreadyArchivedIds.length > 0 && (
+                <p>{preview.alreadyArchivedIds.length} already archived.</p>
+              )}
+              {preview.notFoundIds.length > 0 && (
+                <p>{preview.notFoundIds.length} no longer found.</p>
+              )}
+            </div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={executing}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={executing || !preview || preview.totalChangedCount === 0}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleArchive();
+              }}
+            >
+              {executing ? "Archiving..." : "Archive"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/entity/EntityListShell.module.css
+++ b/src/components/entity/EntityListShell.module.css
@@ -49,3 +49,57 @@
   padding: 8px 0;
   outline: none;
 }
+
+.selectionBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 10px 0;
+  margin: var(--space-md) 0;
+  border-top: 1px solid var(--color-rule-light);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.selectionCount {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.selectionActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.selectionButton {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.selectionButton:disabled {
+  color: var(--color-text-tertiary);
+  cursor: default;
+  text-decoration: none;
+}
+
+.selectionButton:focus-visible {
+  outline: 2px solid var(--color-garden-larkspur);
+  outline-offset: 3px;
+}

--- a/src/components/entity/EntityListShell.module.css
+++ b/src/components/entity/EntityListShell.module.css
@@ -103,3 +103,9 @@
   outline: 2px solid var(--color-garden-larkspur);
   outline-offset: 3px;
 }
+
+.archivePreviewDetails {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}

--- a/src/components/entity/EntityListShell.test.tsx
+++ b/src/components/entity/EntityListShell.test.tsx
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EntitySelectionBar } from "./EntityListShell";
+
+describe("EntitySelectionBar", () => {
+  it("stays hidden until rows are selected", () => {
+    const { container } = render(
+      <EntitySelectionBar
+        selectedCount={0}
+        visibleCount={2}
+        onSelectVisible={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders accessible selection actions", () => {
+    const onSelectVisible = vi.fn();
+    const onClear = vi.fn();
+
+    render(
+      <EntitySelectionBar
+        selectedCount={2}
+        visibleCount={4}
+        onSelectVisible={onSelectVisible}
+        onClear={onClear}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("2 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select 4 visible rows" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear selected rows" }));
+
+    expect(onSelectVisible).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/entity/EntityListShell.tsx
+++ b/src/components/entity/EntityListShell.tsx
@@ -131,6 +131,52 @@ export function FilterTabs<T extends string>({
   );
 }
 
+// ─── Selection Bar ───────────────────────────────────────────────────────────
+
+export function EntitySelectionBar({
+  selectedCount,
+  visibleCount,
+  onSelectVisible,
+  onClear,
+  children,
+}: {
+  selectedCount: number;
+  visibleCount: number;
+  onSelectVisible: () => void;
+  onClear: () => void;
+  children?: ReactNode;
+}) {
+  if (selectedCount <= 0) return null;
+
+  return (
+    <div className={styles.selectionBar} role="status" aria-live="polite">
+      <span className={styles.selectionCount}>
+        {selectedCount} selected
+      </span>
+      <div className={styles.selectionActions}>
+        {children}
+        <button
+          type="button"
+          className={styles.selectionButton}
+          onClick={onSelectVisible}
+          disabled={visibleCount === 0}
+          aria-label={`Select ${visibleCount} visible ${visibleCount === 1 ? "row" : "rows"}`}
+        >
+          Select visible
+        </button>
+        <button
+          type="button"
+          className={styles.selectionButton}
+          onClick={onClear}
+          aria-label="Clear selected rows"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
  
 export function EntityListEndMark(_props?: { text?: string }) {
   return <FinisMarker />;

--- a/src/components/entity/EntityRow.module.css
+++ b/src/components/entity/EntityRow.module.css
@@ -5,11 +5,43 @@
   align-items: flex-start;
   gap: 12px;
   padding: 14px 0;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.rowSelected {
+  background: var(--color-surface-primary);
+}
+
+.rowBody,
+.rowLink {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
   text-decoration: none;
+  color: inherit;
+}
+
+.rowLink:focus-visible,
+.checkbox:focus-visible,
+.controls :is(button, a):focus-visible {
+  outline: 2px solid var(--color-garden-larkspur);
+  outline-offset: 3px;
 }
 
 .rowBorder {
   border-bottom: 1px solid var(--color-rule-light);
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  margin: 4px 0 0;
+  accent-color: var(--color-garden-larkspur);
+  cursor: pointer;
 }
 
 .dot {
@@ -51,4 +83,12 @@
   align-items: baseline;
   gap: 16px;
   flex-shrink: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-top: 1px;
 }

--- a/src/components/entity/EntityRow.test.tsx
+++ b/src/components/entity/EntityRow.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { EntityRow } from "./EntityRow";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+describe("EntityRow", () => {
+  it("renders selection, navigation, and row controls as separate focus targets", () => {
+    const onSelect = vi.fn();
+    const onExpand = vi.fn();
+
+    render(
+      <EntityRow
+        to="/accounts/$accountId"
+        params={{ accountId: "acct-1" }}
+        name="Example Account"
+        showBorder
+        selection={{
+          selected: false,
+          label: "Select Example Account",
+          onChange: onSelect,
+        }}
+        controls={(
+          <button type="button" onClick={onExpand}>
+            Expand
+          </button>
+        )}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select Example Account" });
+    const link = screen.getByRole("link", { name: "Example Account" });
+    const expand = screen.getByRole("button", { name: "Expand" });
+
+    expect(link).not.toContainElement(checkbox);
+    expect(link).not.toContainElement(expand);
+
+    fireEvent.click(checkbox);
+    expect(onSelect).toHaveBeenCalledWith({ shiftKey: false });
+    expect(onExpand).not.toHaveBeenCalled();
+
+    fireEvent.click(expand);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes shift-key checkbox interaction to the selection handler", () => {
+    const onSelect = vi.fn();
+
+    render(
+      <EntityRow
+        to="/people/$personId"
+        params={{ personId: "person-1" }}
+        name="Example Person"
+        showBorder={false}
+        selection={{
+          selected: true,
+          label: "Select Example Person",
+          onChange: onSelect,
+        }}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select Example Person" });
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox, { shiftKey: true });
+    expect(onSelect).toHaveBeenCalledWith({ shiftKey: true });
+  });
+});

--- a/src/components/entity/EntityRow.tsx
+++ b/src/components/entity/EntityRow.tsx
@@ -1,6 +1,12 @@
-import { type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import s from "./EntityRow.module.css";
+
+interface EntityRowSelection {
+  selected: boolean;
+  label?: string;
+  onChange: (options: { shiftKey: boolean }) => void;
+}
 
 interface EntityRowProps {
   to?: string;
@@ -18,6 +24,10 @@ interface EntityRowProps {
   children?: ReactNode;
   /** Optional avatar element to replace the accent dot */
   avatar?: ReactNode;
+  /** Optional row-level selection control */
+  selection?: EntityRowSelection;
+  /** Interactive row controls rendered outside the entity link */
+  controls?: ReactNode;
 }
 
 export function EntityRow({
@@ -32,9 +42,15 @@ export function EntityRow({
   subtitle,
   children,
   avatar,
+  selection,
+  controls,
 }: EntityRowProps) {
-  const className = `${s.row} ${showBorder ? s.rowBorder : ""}`;
-  const rowStyle = { paddingLeft };
+  const className = [
+    s.row,
+    showBorder ? s.rowBorder : "",
+    selection?.selected ? s.rowSelected : "",
+  ].filter(Boolean).join(" ");
+  const rowStyle: CSSProperties = { paddingLeft };
   const content = (
     <>
       {/* Avatar or accent dot */}
@@ -72,37 +88,54 @@ export function EntityRow({
     </>
   );
 
+  const bodyClassName = to || href ? s.rowLink : s.rowBody;
+
+  let body: ReactNode;
   if (href) {
-    return (
+    body = (
       <a
         href={href}
         target="_blank"
         rel="noreferrer"
-        className={className}
-        style={rowStyle}
+        className={bodyClassName}
       >
         {content}
       </a>
     );
-  }
-
-  if (to) {
-    return (
+  } else if (to) {
+    body = (
       <Link
         to={to}
         params={params ?? {}}
-        className={className}
-        // Runtime hierarchy controls nested row indentation.
-        style={rowStyle}
+        className={bodyClassName}
       >
         {content}
       </Link>
     );
+  } else {
+    body = <div className={bodyClassName}>{content}</div>;
   }
 
   return (
     <div className={className} style={rowStyle}>
-      {content}
+      {selection && (
+        <input
+          type="checkbox"
+          className={s.checkbox}
+          checked={selection.selected}
+          aria-label={selection.label ?? `Select ${name}`}
+          onChange={(event) => {
+            const nativeEvent = event.nativeEvent as Event & { shiftKey?: boolean };
+            selection.onChange({ shiftKey: Boolean(nativeEvent.shiftKey) });
+          }}
+        />
+      )}
+      {body}
+      {controls && (
+        <div className={s.controls}>
+          {controls}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/entity/useEntityListSelection.test.tsx
+++ b/src/components/entity/useEntityListSelection.test.tsx
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+} from "./useEntityListSelection";
+
+function SelectionHarness({
+  visibleIds,
+  activeIds = visibleIds,
+}: {
+  visibleIds: string[];
+  activeIds?: string[];
+}) {
+  const selection = useEntityListSelection({ visibleIds, activeIds });
+
+  return (
+    <div>
+      <output data-testid="selected">{selection.selectedIds.join(",")}</output>
+      {activeIds.map((id) => (
+        <button
+          key={id}
+          type="button"
+          onClick={(event) => selection.toggle(id, { shiftKey: event.shiftKey })}
+        >
+          Toggle {id}
+        </button>
+      ))}
+      <button type="button" onClick={selection.selectVisible}>
+        Select visible
+      </button>
+      <button type="button" onClick={selection.clear}>
+        Clear
+      </button>
+      <button type="button" onClick={() => selection.pruneTo(["a", "b"])}>
+        Prune to a-b
+      </button>
+    </div>
+  );
+}
+
+describe("useEntityListSelection", () => {
+  it("toggles individual ids, selects visible ids, and clears", () => {
+    render(<SelectionHarness visibleIds={["a", "b"]} activeIds={["a", "b", "c"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle c" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select visible" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("a,b,c");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("");
+  });
+
+  it("uses visible row order for shift range selection", () => {
+    render(<SelectionHarness visibleIds={["a", "b", "c", "d"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle b" }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle d" }), { shiftKey: true });
+
+    expect(screen.getByTestId("selected")).toHaveTextContent("b,c,d");
+  });
+
+  it("prunes stale ids against the active list without clearing hidden active selections", () => {
+    const { rerender } = render(
+      <SelectionHarness visibleIds={["a", "b"]} activeIds={["a", "b", "c"]} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle c" }));
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    rerender(<SelectionHarness visibleIds={["a"]} activeIds={["a", "b", "c"]} />);
+    expect(screen.getByTestId("selected")).toHaveTextContent("c");
+
+    rerender(<SelectionHarness visibleIds={["a"]} activeIds={["a", "b"]} />);
+    expect(screen.getByTestId("selected")).toHaveTextContent("");
+  });
+
+  it("flattens entity trees in rendered visual order", () => {
+    const roots = [
+      { id: "parent", isParent: true },
+      { id: "peer" },
+    ];
+    const children = {
+      parent: [{ id: "child" }],
+    };
+
+    expect(flattenEntityTreeIds(roots, children, {
+      expandedOnly: true,
+      expandedParents: new Set(["parent"]),
+    })).toEqual(["parent", "child", "peer"]);
+
+    expect(flattenEntityTreeIds(roots, children, {
+      expandedOnly: true,
+      expandedParents: new Set(),
+    })).toEqual(["parent", "peer"]);
+  });
+});

--- a/src/components/entity/useEntityListSelection.ts
+++ b/src/components/entity/useEntityListSelection.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+interface UseEntityListSelectionOptions {
+  visibleIds: readonly string[];
+  activeIds?: readonly string[];
+}
+
+export interface EntityListSelectionToggleOptions {
+  shiftKey?: boolean;
+}
+
+export interface EntityListSelectionApi {
+  selectedIds: string[];
+  selectedCount: number;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string, options?: EntityListSelectionToggleOptions) => void;
+  selectVisible: () => void;
+  clear: () => void;
+  pruneTo: (ids: readonly string[]) => void;
+}
+
+interface EntityTreeNode {
+  id: string;
+  isParent?: boolean;
+}
+
+interface FlattenEntityTreeOptions {
+  expandedParents?: ReadonlySet<string>;
+  expandedOnly?: boolean;
+}
+
+function orderSelection(ids: Iterable<string>, order: readonly string[]): string[] {
+  const selected = new Set(ids);
+  const ordered = order.filter((id) => selected.has(id));
+  for (const id of selected) {
+    if (!order.includes(id)) ordered.push(id);
+  }
+  return ordered;
+}
+
+function sameIds(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((id, index) => id === b[index]);
+}
+
+export function flattenEntityTreeIds<T extends EntityTreeNode>(
+  roots: readonly T[],
+  childrenByParent: Record<string, readonly T[]>,
+  options: FlattenEntityTreeOptions = {},
+): string[] {
+  const result: string[] = [];
+  const expandedParents = options.expandedParents;
+
+  function walk(items: readonly T[]) {
+    for (const item of items) {
+      result.push(item.id);
+      const children = childrenByParent[item.id] ?? [];
+      if (children.length === 0) continue;
+      if (options.expandedOnly && !expandedParents?.has(item.id)) continue;
+      walk(children);
+    }
+  }
+
+  walk(roots);
+  return result;
+}
+
+export function useEntityListSelection({
+  visibleIds,
+  activeIds = visibleIds,
+}: UseEntityListSelectionOptions): EntityListSelectionApi {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const pruneTo = useCallback((ids: readonly string[]) => {
+    const active = new Set(ids);
+    setSelectedIds((current) => {
+      const next = current.filter((id) => active.has(id));
+      return sameIds(current, next) ? current : next;
+    });
+    setLastSelectedId((current) => current && active.has(current) ? current : null);
+  }, []);
+
+  useEffect(() => {
+    pruneTo(activeIds);
+  }, [activeIds, pruneTo]);
+
+  const clear = useCallback(() => {
+    setSelectedIds([]);
+    setLastSelectedId(null);
+  }, []);
+
+  const toggle = useCallback((id: string, options: EntityListSelectionToggleOptions = {}) => {
+    setSelectedIds((current) => {
+      if (options.shiftKey && lastSelectedId) {
+        const start = visibleIds.indexOf(lastSelectedId);
+        const end = visibleIds.indexOf(id);
+        if (start !== -1 && end !== -1) {
+          const [from, to] = start < end ? [start, end] : [end, start];
+          const range = visibleIds.slice(from, to + 1);
+          return orderSelection([...current, ...range], activeIds);
+        }
+      }
+
+      if (current.includes(id)) {
+        return current.filter((selectedId) => selectedId !== id);
+      }
+      return orderSelection([...current, id], activeIds);
+    });
+    setLastSelectedId(id);
+  }, [activeIds, lastSelectedId, visibleIds]);
+
+  const selectVisible = useCallback(() => {
+    setSelectedIds((current) => orderSelection([...current, ...visibleIds], activeIds));
+    if (visibleIds.length > 0) {
+      setLastSelectedId(visibleIds[visibleIds.length - 1]);
+    }
+  }, [activeIds, visibleIds]);
+
+  const isSelected = useCallback((id: string) => selectedSet.has(id), [selectedSet]);
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.length,
+    isSelected,
+    toggle,
+    selectVisible,
+    clear,
+    pruneTo,
+  };
+}

--- a/src/features/settings-ui/DiagnosticsSection.tsx
+++ b/src/features/settings-ui/DiagnosticsSection.tsx
@@ -9,6 +9,7 @@ import {
   HardDrive,
 } from "lucide-react";
 import type { EntityMode } from "@/types";
+import { warnOnPartialArchiveResult, type ArchiveEntityCommandResult } from "@/lib/archive-command-result";
 import {
   SettingsRule,
   SettingsSectionLabel,
@@ -739,7 +740,8 @@ function ArchivedAccountsSection() {
   async function handleRestoreAccount(accountId: string) {
     setRestoringId(accountId);
     try {
-      await invoke("restore_account", { accountId, restoreChildren: true });
+      const result = await invoke<ArchiveEntityCommandResult>("restore_account", { accountId, restoreChildren: true });
+      warnOnPartialArchiveResult(result, "restored");
       await loadArchivedAccounts();
     } catch (e) {
       console.error("Failed to restore account:", e);

--- a/src/hooks/useAccountDetail.ts
+++ b/src/hooks/useAccountDetail.ts
@@ -23,6 +23,7 @@ import type {
 } from "@/types";
 import type { RolePreset } from "@/types/preset";
 import { mergeEntityDetailIntelligence } from "@/services/entity-intelligence/entity-detail-mapper";
+import { warnOnPartialArchiveResult, type ArchiveEntityCommandResult } from "@/lib/archive-command-result";
 import { useAccountFields } from "./useAccountFields";
 import { useAccountWorkData } from "./useAccountWorkData";
 import { useEnrichmentProgress } from "./useEnrichmentProgress";
@@ -448,7 +449,8 @@ export function useAccountDetail(accountId: string | undefined) {
   async function handleArchive() {
     if (!detail) return;
     try {
-      await invoke("archive_account", { id: detail.id, archived: true });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_account", { id: detail.id, archived: true });
+      warnOnPartialArchiveResult(result, "archived");
       navigate({ to: "/accounts" });
     } catch (e) {
       setError(String(e));
@@ -458,7 +460,8 @@ export function useAccountDetail(accountId: string | undefined) {
   async function handleUnarchive() {
     if (!detail) return;
     try {
-      await invoke("archive_account", { id: detail.id, archived: false });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_account", { id: detail.id, archived: false });
+      warnOnPartialArchiveResult(result, "restored");
       await load();
     } catch (e) {
       setError(String(e));

--- a/src/hooks/usePersonDetail.ts
+++ b/src/hooks/usePersonDetail.ts
@@ -8,6 +8,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useNavigate } from "@tanstack/react-router";
 import type { Person, PersonDetail, DuplicateCandidate, ContentFile } from "@/types";
 import { mergeEntityDetailIntelligence } from "@/services/entity-intelligence/entity-detail-mapper";
+import { warnOnPartialArchiveResult, type ArchiveEntityCommandResult } from "@/lib/archive-command-result";
 import { useEntityDetailIntelligence } from "./useEntityDetailIntelligence";
 import { useTauriEvent } from "./useTauriEvent";
 
@@ -300,7 +301,8 @@ export function usePersonDetail(personId: string | undefined) {
   async function handleArchive() {
     if (!detail) return;
     try {
-      await invoke("archive_person", { id: detail.id, archived: true });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_person", { id: detail.id, archived: true });
+      warnOnPartialArchiveResult(result, "archived");
       navigate({ to: "/people" });
     } catch (e) {
       setError(String(e));
@@ -310,7 +312,8 @@ export function usePersonDetail(personId: string | undefined) {
   async function handleUnarchive() {
     if (!detail) return;
     try {
-      await invoke("archive_person", { id: detail.id, archived: false });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_person", { id: detail.id, archived: false });
+      warnOnPartialArchiveResult(result, "restored");
       await load();
     } catch (e) {
       setError(String(e));

--- a/src/hooks/useProjectDetail.ts
+++ b/src/hooks/useProjectDetail.ts
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useNavigate } from "@tanstack/react-router";
 import type { ProjectDetail, ContentFile } from "@/types";
 import { mergeEntityDetailIntelligence } from "@/services/entity-intelligence/entity-detail-mapper";
+import { warnOnPartialArchiveResult, type ArchiveEntityCommandResult } from "@/lib/archive-command-result";
 import { useEntityDetailIntelligence } from "./useEntityDetailIntelligence";
 import { useTauriEvent } from "./useTauriEvent";
 
@@ -172,7 +173,8 @@ export function useProjectDetail(projectId: string | undefined) {
   async function handleArchive() {
     if (!detail) return;
     try {
-      await invoke("archive_project", { id: detail.id, archived: true });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_project", { id: detail.id, archived: true });
+      warnOnPartialArchiveResult(result, "archived");
       navigate({ to: "/projects" });
     } catch (e) {
       setError(String(e));
@@ -182,7 +184,8 @@ export function useProjectDetail(projectId: string | undefined) {
   async function handleUnarchive() {
     if (!detail) return;
     try {
-      await invoke("archive_project", { id: detail.id, archived: false });
+      const result = await invoke<ArchiveEntityCommandResult>("archive_project", { id: detail.id, archived: false });
+      warnOnPartialArchiveResult(result, "restored");
       await load();
     } catch (e) {
       setError(String(e));

--- a/src/lib/archive-command-result.test.ts
+++ b/src/lib/archive-command-result.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { archiveResultNeedsAttention, type ArchiveEntityCommandResult } from "./archive-command-result";
+
+function result(
+  status: ArchiveEntityCommandResult["status"],
+  folderStatus = "succeeded",
+): ArchiveEntityCommandResult {
+  return {
+    status,
+    changedIds: ["entity-1"],
+    childrenRestored: 0,
+    itemResults: [{ folderStatus }],
+  };
+}
+
+describe("archiveResultNeedsAttention", () => {
+  it("flags partial single-entity archive command results", () => {
+    expect(archiveResultNeedsAttention(result("partial", "succeeded"))).toBe(true);
+  });
+
+  it("flags folder statuses that need repair even when status is not partial", () => {
+    expect(archiveResultNeedsAttention(result("succeeded", "missing_source"))).toBe(true);
+  });
+
+  it("does not flag clean archive command results", () => {
+    expect(archiveResultNeedsAttention(result("succeeded"))).toBe(false);
+  });
+});

--- a/src/lib/archive-command-result.ts
+++ b/src/lib/archive-command-result.ts
@@ -1,0 +1,43 @@
+import { toast } from "sonner";
+
+export interface ArchiveCommandItemResult {
+  folderStatus: string;
+}
+
+export interface ArchiveEntityCommandResult {
+  status: "succeeded" | "partial" | string;
+  changedIds: string[];
+  childrenRestored: number;
+  itemResults: ArchiveCommandItemResult[];
+}
+
+const ATTENTION_STATUSES = new Set([
+  "folder_failed",
+  "metadata_failed",
+  "metadata_pending",
+  "missing_source",
+  "folder_missing",
+  "restore_conflict",
+]);
+
+export function archiveResultNeedsAttention(result: ArchiveEntityCommandResult): boolean {
+  if (result.status === "partial") return true;
+  return result.itemResults.some((item) => ATTENTION_STATUSES.has(item.folderStatus));
+}
+
+export function warnOnPartialArchiveResult(
+  result: ArchiveEntityCommandResult,
+  actionLabel: "archived" | "restored",
+): void {
+  if (!archiveResultNeedsAttention(result)) return;
+
+  const folderCount = result.itemResults.filter((item) =>
+    ATTENTION_STATUSES.has(item.folderStatus)
+  ).length;
+
+  toast.warning(`Record ${actionLabel}, but workspace folders need attention`, {
+    description: folderCount > 0
+      ? `${folderCount} folder ${folderCount === 1 ? "result needs" : "results need"} review.`
+      : "Review the workspace folder repair plan in diagnostics.",
+  });
+}

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -23,6 +23,7 @@ import {
   useEntityListSelection,
   type EntityListSelectionApi,
 } from "@/components/entity/useEntityListSelection";
+import { BulkArchiveSelectionAction } from "@/components/entity/BulkArchiveSelectionAction";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { EphemeralBriefing } from "@/components/editorial/EphemeralBriefing";
@@ -452,6 +453,10 @@ export default function AccountsPage() {
     if (isArchived) clearAccountSelection();
   }, [clearAccountSelection, isArchived]);
 
+  const refreshAccountArchiveLists = useCallback(async () => {
+    await Promise.all([loadAccounts(), loadArchivedAccounts()]);
+  }, [loadAccounts, loadArchivedAccounts]);
+
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -589,7 +594,17 @@ export default function AccountsPage() {
           visibleCount={visibleAccountIds.length}
           onSelectVisible={accountSelection.selectVisible}
           onClear={accountSelection.clear}
-        />
+        >
+          <BulkArchiveSelectionAction
+            selectedIds={accountSelection.selectedIds}
+            entityLabel="account"
+            entityPluralLabel="accounts"
+            previewCommand="preview_bulk_archive_accounts"
+            executeCommand="bulk_archive_accounts"
+            onArchived={refreshAccountArchiveLists}
+            onClearSelection={accountSelection.clear}
+          />
+        </EntitySelectionBar>
       )}
 
       {/* Discovery panel */}

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -15,8 +15,14 @@ import {
   EntityListHeader,
   EntityListEndMark,
   FilterTabs,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { EphemeralBriefing } from "@/components/editorial/EphemeralBriefing";
@@ -421,6 +427,30 @@ export default function AccountsPage() {
   const isArchived = archiveTab === "archived";
   const displayList = isArchived ? filteredArchived : filtered;
   const activeCount = accounts.filter((a) => !a.archived).length;
+  const activeAccountIds = useMemo(
+    () => flattenEntityTreeIds(accounts.filter((a) => !a.archived), childrenCache),
+    [accounts, childrenCache],
+  );
+  const visibleAccountIds = useMemo(() => {
+    if (isArchived) return [];
+    const ids: string[] = [];
+    for (const { type } of ACCOUNT_SECTIONS) {
+      ids.push(...flattenEntityTreeIds(groupedAccounts[type] ?? [], childrenCache, {
+        expandedOnly: true,
+        expandedParents,
+      }));
+    }
+    return ids;
+  }, [childrenCache, expandedParents, groupedAccounts, isArchived]);
+  const accountSelection = useEntityListSelection({
+    visibleIds: visibleAccountIds,
+    activeIds: activeAccountIds,
+  });
+  const { clear: clearAccountSelection } = accountSelection;
+
+  useEffect(() => {
+    if (isArchived) clearAccountSelection();
+  }, [clearAccountSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -552,6 +582,15 @@ export default function AccountsPage() {
           />
         )}
       </EntityListHeader>
+
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={accountSelection.selectedCount}
+          visibleCount={visibleAccountIds.length}
+          onSelectVisible={accountSelection.selectVisible}
+          onClear={accountSelection.clear}
+        />
+      )}
 
       {/* Discovery panel */}
       {discoveryOpen && !isArchived && (
@@ -801,6 +840,7 @@ export default function AccountsPage() {
                     childrenCache={childrenCache}
                     toggleExpand={toggleExpand}
                     isLastSibling={i === sectionAccounts.length - 1}
+                    selection={accountSelection}
                   />
                 ))}
               </div>
@@ -823,6 +863,7 @@ function AccountTreeNode({
   childrenCache,
   toggleExpand,
   isLastSibling,
+  selection,
 }: {
   account: AccountListItem;
   depth: number;
@@ -830,6 +871,7 @@ function AccountTreeNode({
   childrenCache: Record<string, AccountListItem[]>;
   toggleExpand: (id: string) => void;
   isLastSibling: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const isExpanded = expandedParents.has(account.id);
   const children = childrenCache[account.id] ?? [];
@@ -844,6 +886,7 @@ function AccountTreeNode({
         isExpanded={isExpanded}
         onToggleExpand={account.isParent ? () => toggleExpand(account.id) : undefined}
         showBorder={!isLastSibling || hasExpandedChildren}
+        selection={selection}
       />
       {hasExpandedChildren &&
         children.map((child, ci) => (
@@ -855,6 +898,7 @@ function AccountTreeNode({
             childrenCache={childrenCache}
             toggleExpand={toggleExpand}
             isLastSibling={ci === children.length - 1 && isLastSibling}
+            selection={selection}
           />
         ))}
     </div>
@@ -869,6 +913,7 @@ function AccountRow({
   onToggleExpand,
   depth = 0,
   showBorder,
+  selection,
 }: {
   account: AccountListItem;
   isExpanded?: boolean;
@@ -876,6 +921,7 @@ function AccountRow({
   isChild?: boolean; // kept for call-site compat
   depth?: number;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const nameSuffix = (
     <>
@@ -884,20 +930,17 @@ function AccountRow({
           {account.accountType === "partner" ? "Partner" : "Internal"}
         </span>
       )}
-      {onToggleExpand && (
-        <button
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          className={styles.expandToggle}
-        >
-          {isExpanded ? "\u25BE" : "\u25B8"} {account.childCount} BU{account.childCount !== 1 ? "s" : ""}
-        </button>
-      )}
     </>
   );
+  const controls = onToggleExpand ? (
+    <button
+      onClick={onToggleExpand}
+      className={styles.expandToggle}
+      type="button"
+    >
+      {isExpanded ? "\u25BE" : "\u25B8"} {account.childCount} BU{account.childCount !== 1 ? "s" : ""}
+    </button>
+  ) : undefined;
 
   const ih = account.intelligenceHealth;
   const healthAvatar = ih ? (
@@ -915,6 +958,12 @@ function AccountRow({
       nameSuffix={nameSuffix}
       subtitle={undefined}
       avatar={healthAvatar}
+      controls={controls}
+      selection={{
+        selected: selection.isSelected(account.id),
+        label: `Select ${account.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(account.id, { shiftKey }),
+      }}
     >
       {account.arr != null && (
         <span className={styles.archivedArrLabel}>

--- a/src/pages/PeoplePage.selection.test.tsx
+++ b/src/pages/PeoplePage.selection.test.tsx
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PeoplePage from "./PeoplePage";
+import type { PersonListItem } from "@/types";
+
+const invokeMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => navigateMock,
+  useSearch: () => ({}),
+}));
+
+const externalPerson: PersonListItem = {
+  id: "external-person",
+  email: "external@example.com",
+  name: "External Person",
+  organization: "Example Account",
+  role: "Champion",
+  relationship: "external",
+  meetingCount: 3,
+  updatedAt: "2026-06-01T00:00:00Z",
+  archived: false,
+  temperature: "hot",
+  trend: "steady",
+};
+
+const internalPerson: PersonListItem = {
+  id: "internal-person",
+  email: "internal@example.com",
+  name: "Internal Person",
+  organization: "DailyOS",
+  role: "CSM",
+  relationship: "internal",
+  meetingCount: 4,
+  updatedAt: "2026-06-01T00:00:00Z",
+  archived: false,
+  temperature: "warm",
+  trend: "steady",
+};
+
+describe("PeoplePage selection", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "get_people") return Promise.resolve([externalPerson, internalPerson]);
+      if (command === "get_archived_people") return Promise.resolve([]);
+      if (command === "get_duplicate_people") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+  });
+
+  it("preserves selected active people when relationship tabs hide them", async () => {
+    render(<PeoplePage />);
+
+    const internalCheckbox = await screen.findByRole("checkbox", { name: "Select Internal Person" });
+    expect(screen.getByRole("checkbox", { name: "Select External Person" })).toBeInTheDocument();
+
+    fireEvent.click(internalCheckbox);
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: "external" }));
+
+    expect(screen.queryByRole("checkbox", { name: "Select Internal Person" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select External Person" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+  });
+});

--- a/src/pages/PeoplePage.tsx
+++ b/src/pages/PeoplePage.tsx
@@ -35,6 +35,7 @@ import {
   useEntityListSelection,
   type EntityListSelectionApi,
 } from "@/components/entity/useEntityListSelection";
+import { BulkArchiveSelectionAction } from "@/components/entity/BulkArchiveSelectionAction";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { Avatar } from "@/components/ui/Avatar";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
@@ -251,6 +252,10 @@ export default function PeoplePage() {
     if (isArchived) clearPersonSelection();
   }, [clearPersonSelection, isArchived]);
 
+  const refreshPeopleArchiveLists = useCallback(async () => {
+    await Promise.all([loadPeople(), loadArchivedPeople()]);
+  }, [loadArchivedPeople, loadPeople]);
+
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -354,7 +359,17 @@ export default function PeoplePage() {
           visibleCount={visiblePersonIds.length}
           onSelectVisible={personSelection.selectVisible}
           onClear={personSelection.clear}
-        />
+        >
+          <BulkArchiveSelectionAction
+            selectedIds={personSelection.selectedIds}
+            entityLabel="person"
+            entityPluralLabel="people"
+            previewCommand="preview_bulk_archive_people"
+            executeCommand="bulk_archive_people"
+            onArchived={refreshPeopleArchiveLists}
+            onClearSelection={personSelection.clear}
+          />
+        </EntitySelectionBar>
       )}
 
       {/* Add person form */}

--- a/src/pages/PeoplePage.tsx
+++ b/src/pages/PeoplePage.tsx
@@ -25,11 +25,16 @@ import {
   EntityListEndMark,
   ArchiveToggle,
   FilterTabs,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import shellStyles from "@/components/entity/EntityListShell.module.css";
 import s from "./PeoplePage.module.css";
 import { EditorialPageHeader } from "@/components/editorial/EditorialPageHeader";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { Avatar } from "@/components/ui/Avatar";
 import { ChapterHeading } from "@/components/editorial/ChapterHeading";
@@ -41,6 +46,11 @@ type RelationshipTab = "all" | "external" | "internal" | "unknown";
 type HygieneFilter = "unnamed" | "duplicates";
 
 const relationshipTabs: readonly RelationshipTab[] = ["all", "external", "internal", "unknown"];
+const PEOPLE_SECTIONS: { type: string; title: string }[] = [
+  { type: "external", title: "Your Contacts" },
+  { type: "internal", title: "Your Team" },
+  { type: "unknown", title: "Unclassified" },
+];
 
 const tempOrder: Record<string, number> = {
   hot: 0,
@@ -126,9 +136,8 @@ export default function PeoplePage() {
     try {
       setLoading(true);
       setError(null);
-      const filter = tab === "all" ? undefined : tab;
       const result = await invoke<PersonListItem[]>("get_people", {
-        relationship: filter ?? null,
+        relationship: null,
       });
       setPeople(result);
     } catch (e) {
@@ -136,7 +145,7 @@ export default function PeoplePage() {
     } finally {
       setLoading(false);
     }
-  }, [tab]);
+  }, []);
 
   const loadArchivedPeople = useCallback(async () => {
     try {
@@ -169,15 +178,20 @@ export default function PeoplePage() {
   useTauriEvent("people-updated", onPeopleUpdated);
 
   // Filters
+  const relationshipFiltered = useMemo(
+    () => tab === "all" ? people : people.filter((p) => p.relationship === tab),
+    [people, tab],
+  );
+
   const filtered = searchQuery
-    ? people.filter(
+    ? relationshipFiltered.filter(
         (p) =>
           p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
           p.email.toLowerCase().includes(searchQuery.toLowerCase()) ||
           (p.organization ?? "").toLowerCase().includes(searchQuery.toLowerCase()) ||
           (p.role ?? "").toLowerCase().includes(searchQuery.toLowerCase())
       )
-    : people;
+    : relationshipFiltered;
 
   const hygieneFiltered =
     activeHygieneFilter === "unnamed"
@@ -207,13 +221,6 @@ export default function PeoplePage() {
   const isArchived = archiveTab === "archived";
   const showRelationship = tab === "all";
 
-  // Group people by relationship when showing "all" tab
-  const PEOPLE_SECTIONS: { type: string; title: string }[] = [
-    { type: "external", title: "Your Contacts" },
-    { type: "internal", title: "Your Team" },
-    { type: "unknown", title: "Unclassified" },
-  ];
-
   const groupedPeople = useMemo(() => {
     if (!showRelationship) return null; // flat list when filtered to one tab
     const groups: Record<string, PersonListItem[]> = {
@@ -226,6 +233,23 @@ export default function PeoplePage() {
     }
     return groups;
   }, [sorted, showRelationship]);
+  const activePersonIds = useMemo(() => people.map((person) => person.id), [people]);
+  const visiblePersonIds = useMemo(() => {
+    if (isArchived) return [];
+    if (!groupedPeople) return sorted.map((person) => person.id);
+    return PEOPLE_SECTIONS.flatMap(({ type }) => (
+      groupedPeople[type] ?? []
+    ).map((person) => person.id));
+  }, [groupedPeople, isArchived, sorted]);
+  const personSelection = useEntityListSelection({
+    visibleIds: visiblePersonIds,
+    activeIds: activePersonIds,
+  });
+  const { clear: clearPersonSelection } = personSelection;
+
+  useEffect(() => {
+    if (isArchived) clearPersonSelection();
+  }, [clearPersonSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -323,6 +347,15 @@ export default function PeoplePage() {
           />
         )}
       </EntityListHeader>
+
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={personSelection.selectedCount}
+          visibleCount={visiblePersonIds.length}
+          onSelectVisible={personSelection.selectVisible}
+          onClear={personSelection.clear}
+        />
+      )}
 
       {/* Add person form */}
       {!isArchived && showAddForm && (
@@ -505,7 +538,13 @@ export default function PeoplePage() {
                 <div key={type}>
                   <ChapterHeading title={title} />
                   {sectionPeople.map((person, i) => (
-                    <PersonRow key={person.id} person={person} showRelationship={false} showBorder={i < sectionPeople.length - 1} />
+                    <PersonRow
+                      key={person.id}
+                      person={person}
+                      showRelationship={false}
+                      showBorder={i < sectionPeople.length - 1}
+                      selection={personSelection}
+                    />
                   ))}
                 </div>
               );
@@ -515,7 +554,13 @@ export default function PeoplePage() {
           /* Flat view: single relationship tab selected */
           <div className={s.personList}>
             {sorted.map((person, i) => (
-              <PersonRow key={person.id} person={person} showRelationship={false} showBorder={i < sorted.length - 1} />
+              <PersonRow
+                key={person.id}
+                person={person}
+                showRelationship={false}
+                showBorder={i < sorted.length - 1}
+                selection={personSelection}
+              />
             ))}
           </div>
         )}
@@ -541,10 +586,12 @@ function PersonRow({
   person,
   showRelationship,
   showBorder,
+  selection,
 }: {
   person: PersonListItem;
   showRelationship: boolean;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const nameSuffix = showRelationship && person.relationship !== "unknown" ? (
     <span
@@ -583,6 +630,11 @@ function PersonRow({
       nameSuffix={nameSuffix}
       subtitle={subtitle}
       avatar={avatar}
+      selection={{
+        selected: selection.isSelected(person.id),
+        label: `Select ${person.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(person.id, { shiftKey }),
+      }}
     />
   );
 }

--- a/src/pages/ProjectsPage.selection.test.tsx
+++ b/src/pages/ProjectsPage.selection.test.tsx
@@ -1,0 +1,95 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectsPage from "./ProjectsPage";
+import type { ProjectListItem } from "@/types";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const parentProject: ProjectListItem = {
+  id: "parent-project",
+  name: "Parent Project",
+  status: "active",
+  openActionCount: 0,
+  archived: false,
+  childCount: 1,
+  isParent: true,
+};
+
+const childProject: ProjectListItem = {
+  id: "child-project",
+  name: "Child Project",
+  status: "on_hold",
+  openActionCount: 0,
+  archived: false,
+  parentId: "parent-project",
+  parentName: "Parent Project",
+  childCount: 0,
+  isParent: false,
+};
+
+const peerProject: ProjectListItem = {
+  id: "peer-project",
+  name: "Peer Project",
+  status: "completed",
+  openActionCount: 2,
+  archived: false,
+  childCount: 0,
+  isParent: false,
+};
+
+describe("ProjectsPage selection", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string, args?: Record<string, unknown>) => {
+      if (command === "get_projects_list") {
+        return Promise.resolve([parentProject, peerProject]);
+      }
+      if (command === "get_child_projects_list" && args?.parentId === "parent-project") {
+        return Promise.resolve([childProject]);
+      }
+      if (command === "get_archived_projects") {
+        return Promise.resolve([
+          {
+            id: "archived-project",
+            name: "Archived Project",
+            status: "completed",
+            openActionCount: 0,
+            archived: true,
+            childCount: 0,
+            isParent: false,
+          },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("selects active tree rows and clears selection in archived mode", async () => {
+    render(<ProjectsPage />);
+
+    const parentCheckbox = await screen.findByRole("checkbox", { name: "Select Parent Project" });
+    expect(await screen.findByRole("checkbox", { name: "Select Child Project" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select Peer Project" })).toBeInTheDocument();
+
+    fireEvent.click(parentCheckbox);
+    expect(screen.getByRole("status")).toHaveTextContent("1 selected");
+
+    fireEvent.click(screen.getByRole("button", { name: /archived/i }));
+    expect(await screen.findByText("Archived Project")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Select Archived Project" })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -13,10 +13,16 @@ import {
   EntityListHeader,
   EntityListEndMark,
   ArchiveToggle,
+  EntitySelectionBar,
 } from "@/components/entity/EntityListShell";
 import shellStyles from "@/components/entity/EntityListShell.module.css";
 import { EditorialPageHeader } from "@/components/editorial/EditorialPageHeader";
 import { EntityRow } from "@/components/entity/EntityRow";
+import {
+  flattenEntityTreeIds,
+  useEntityListSelection,
+  type EntityListSelectionApi,
+} from "@/components/entity/useEntityListSelection";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { usePersonality } from "@/hooks/usePersonality";
 import { getPersonalityCopy } from "@/lib/personality";
@@ -171,7 +177,7 @@ export default function ProjectsPage() {
   }
 
   // Filters — archived/active split handled by archiveTab; no status sub-filter
-  const activeProjects = projects.filter((p) => !p.archived);
+  const activeProjects = useMemo(() => projects.filter((p) => !p.archived), [projects]);
 
   const filtered = useMemo(() => {
     if (!searchQuery) return activeProjects;
@@ -199,6 +205,28 @@ export default function ProjectsPage() {
   const isArchived = archiveTab === "archived";
   const displayList = isArchived ? filteredArchived : filtered;
   const activeCount = activeProjects.length;
+  const activeProjectIds = useMemo(
+    () => flattenEntityTreeIds(activeProjects, childrenCache),
+    [activeProjects, childrenCache],
+  );
+  const visibleProjectIds = useMemo(
+    () => isArchived
+      ? []
+      : flattenEntityTreeIds(filtered, childrenCache, {
+        expandedOnly: true,
+        expandedParents,
+      }),
+    [childrenCache, expandedParents, filtered, isArchived],
+  );
+  const projectSelection = useEntityListSelection({
+    visibleIds: visibleProjectIds,
+    activeIds: activeProjectIds,
+  });
+  const { clear: clearProjectSelection } = projectSelection;
+
+  useEffect(() => {
+    if (isArchived) clearProjectSelection();
+  }, [clearProjectSelection, isArchived]);
 
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
@@ -304,6 +332,15 @@ export default function ProjectsPage() {
         <ArchiveToggle archiveTab={archiveTab} onTabChange={setArchiveTab} />
       </EntityListHeader>
 
+      {!isArchived && (
+        <EntitySelectionBar
+          selectedCount={projectSelection.selectedCount}
+          visibleCount={visibleProjectIds.length}
+          onSelectVisible={projectSelection.selectVisible}
+          onClear={projectSelection.clear}
+        />
+      )}
+
       {/* Create form */}
       {creating && !isArchived && (
         <div style={{ marginBottom: 16 }}>
@@ -376,6 +413,7 @@ export default function ProjectsPage() {
                     childrenCache={childrenCache}
                     toggleExpand={toggleExpand}
                     isLastSibling={i === filtered.length - 1}
+                    selection={projectSelection}
                   />
                 ))}
           </div>
@@ -396,6 +434,7 @@ function ProjectTreeNode({
   childrenCache,
   toggleExpand,
   isLastSibling,
+  selection,
 }: {
   project: ProjectListItem;
   depth: number;
@@ -403,6 +442,7 @@ function ProjectTreeNode({
   childrenCache: Record<string, ProjectListItem[]>;
   toggleExpand: (id: string) => void;
   isLastSibling: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const isExpanded = expandedParents.has(project.id);
   const children = childrenCache[project.id] ?? [];
@@ -416,6 +456,7 @@ function ProjectTreeNode({
         isExpanded={isExpanded}
         onToggleExpand={project.isParent ? () => toggleExpand(project.id) : undefined}
         showBorder={!isLastSibling || hasExpandedChildren}
+        selection={selection}
       />
       {hasExpandedChildren &&
         children.map((child, ci) => (
@@ -427,6 +468,7 @@ function ProjectTreeNode({
             childrenCache={childrenCache}
             toggleExpand={toggleExpand}
             isLastSibling={ci === children.length - 1 && isLastSibling}
+            selection={selection}
           />
         ))}
     </div>
@@ -441,12 +483,14 @@ function ProjectRow({
   isExpanded,
   onToggleExpand,
   showBorder,
+  selection,
 }: {
   project: ProjectListItem;
   depth?: number;
   isExpanded?: boolean;
   onToggleExpand?: () => void;
   showBorder: boolean;
+  selection: EntityListSelectionApi;
 }) {
   const subtitle = [
     project.owner,
@@ -471,28 +515,25 @@ function ProjectRow({
       >
         {statusLabel[project.status] ?? project.status}
       </span>
-      {onToggleExpand && (
-        <button
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onToggleExpand();
-          }}
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: 11,
-            color: "var(--color-text-tertiary)",
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            padding: 0,
-          }}
-        >
-          {isExpanded ? "\u25BE" : "\u25B8"} {project.childCount} sub{project.childCount !== 1 ? "s" : ""}
-        </button>
-      )}
     </>
   );
+  const controls = onToggleExpand ? (
+    <button
+      onClick={onToggleExpand}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        color: "var(--color-text-tertiary)",
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        padding: 0,
+      }}
+      type="button"
+    >
+      {isExpanded ? "\u25BE" : "\u25B8"} {project.childCount} sub{project.childCount !== 1 ? "s" : ""}
+    </button>
+  ) : undefined;
 
   return (
     <EntityRow
@@ -504,6 +545,12 @@ function ProjectRow({
       paddingLeft={depth > 0 ? depth * 28 : 0}
       nameSuffix={nameSuffix}
       subtitle={subtitle || undefined}
+      controls={controls}
+      selection={{
+        selected: selection.isSelected(project.id),
+        label: `Select ${project.name}`,
+        onChange: ({ shiftKey }) => selection.toggle(project.id, { shiftKey }),
+      }}
     >
       {project.targetDate && (
         <span style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--color-text-tertiary)" }}>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -23,6 +23,7 @@ import {
   useEntityListSelection,
   type EntityListSelectionApi,
 } from "@/components/entity/useEntityListSelection";
+import { BulkArchiveSelectionAction } from "@/components/entity/BulkArchiveSelectionAction";
 import { EmptyState } from "@/components/editorial/EmptyState";
 import { usePersonality } from "@/hooks/usePersonality";
 import { getPersonalityCopy } from "@/lib/personality";
@@ -228,6 +229,10 @@ export default function ProjectsPage() {
     if (isArchived) clearProjectSelection();
   }, [clearProjectSelection, isArchived]);
 
+  const refreshProjectArchiveLists = useCallback(async () => {
+    await Promise.all([loadProjects(), loadArchivedProjects()]);
+  }, [loadArchivedProjects, loadProjects]);
+
   const formattedDate = new Date().toLocaleDateString("en-US", {
     weekday: "long",
     month: "long",
@@ -338,7 +343,17 @@ export default function ProjectsPage() {
           visibleCount={visibleProjectIds.length}
           onSelectVisible={projectSelection.selectVisible}
           onClear={projectSelection.clear}
-        />
+        >
+          <BulkArchiveSelectionAction
+            selectedIds={projectSelection.selectedIds}
+            entityLabel="project"
+            entityPluralLabel="projects"
+            previewCommand="preview_bulk_archive_projects"
+            executeCommand="bulk_archive_projects"
+            onArchived={refreshProjectArchiveLists}
+            onClearSelection={projectSelection.clear}
+          />
+        </EntitySelectionBar>
       )}
 
       {/* Create form */}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,6 @@
 # Lessons
 
+- 2026-06-02: Replica and mock dev builds must scope both database and workspace paths before any scaffolding or managed-folder writes run. Validate the effective mode-scoped path first, then initialize; otherwise a replica-safe DB can still mutate production workspace folders.
 - 2026-05-26: Granola cache detection must treat filename versioning and storage mechanism as separate contracts. `cache-v*.json` catches version bumps, but not the newer encrypted cache path; prefer Granola's companion IPC/MCP access and make stale plaintext cache fallback explicit.
 - 2026-05-26: Treat "lock storm resolved" as unproven until a normal app startup with background workers runs cleanly. Deferring a corrupting backfill fixes storage safety, but independent writable `ActionDb` handles and long `db_write` finalization closures can still starve the SQLite writer.
 - 2026-05-25: Do not edit Rust backend files while `pnpm tauri dev` is writing to the production SQLCipher database. Tauri dev hot-restarts can terminate active WAL writers during runtime backfills or enrichment, producing real btree corruption even when earlier `quick_check` passes. Stop the app, patch and test, then restart once.


### PR DESCRIPTION
## Linear ticket

DOS-830, DOS-828

## Summary

Adds bulk archive flows for Account, Project, and Person list surfaces and reconciles archive/restore with workspace folders through service-owned metadata and repair paths.

## What changed

- Added backend bulk archive preview/execute commands with stale-plan protection and cascaded child reporting.
- Added `entity_archive_folders` migration and service-owned folder archive, restore, delete, and repair planning/apply behavior.
- Routed existing single-entity archive/restore through the same folder reconciliation path and normalized fail-loud restore/archive signals.
- Added list-surface bulk archive UI, result handling, diagnostics repair affordance, and focused tests.
- Added mock seed coverage for archive-folder metadata and test isolation for write-fence rollback fixtures.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` passes (if frontend changes)
- [x] Manual verification: `DAILYOS_DB_MODE=replica RUST_LOG=warn pnpm tauri dev` launched the Tauri backend and local frontend; stopped cleanly after startup.

Additional checks run:

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::entity_archive_folders::tests -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib disk_db_atomicity_under_rollback -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib compose_enrichment_full_path_rollback_atomicity -- --nocapture`
- [x] `pnpm exec vitest run src/components/entity/BulkArchiveSelectionAction.test.tsx src/lib/archive-command-result.test.ts`
- [x] `pnpm lint`
- [x] `bash scripts/check_signal_policy_registry.sh`
- [x] `bash src-tauri/scripts/check_workspace_mutation_allowlist.sh`

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field above is set false): _none_

**Exemption rationale**:

N/A

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- None.

## Notes for review

- L0 passed for DOS-830/DOS-828 and reserved registered migration version 274.
- The repair commands are Tauri/user-invoked only; no MCP or scheduled maintenance ability is added.
