### PR TITLE
feat(doctor): refresh replica database from live snapshot

### DIFF
--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -34,6 +34,9 @@ use sha2::{Digest, Sha256};
 /// (resolves to the fail-closed default in `db_mode()`).
 static DB_MODE: AtomicU8 = AtomicU8::new(0);
 
+#[cfg(test)]
+pub(crate) static DB_MODE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Which database a process operates against. Process-wide, set once at bootstrap.
 /// Orthogonal to ADR-0104 `ExecutionMode` (request-scoped mutation-gating) — this
 /// is process-wide path-selection. Do not merge the two.
@@ -135,21 +138,33 @@ pub fn set_db_mode(mode: DbMode) {
     DB_MODE.store(mode.as_u8(), Ordering::Release);
 }
 
+fn explicit_db_mode_from_inputs<I, S>(args: I, env_value: Option<&str>) -> Option<DbMode>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .find_map(|arg| DbMode::from_process_arg(arg.as_ref()))
+        .or_else(|| env_value.and_then(DbMode::from_env_value))
+}
+
+pub(crate) fn explicit_db_mode_from_process() -> Option<DbMode> {
+    let env_value = std::env::var("DAILYOS_DB_MODE").ok();
+    explicit_db_mode_from_inputs(std::env::args(), env_value.as_deref())
+}
+
+pub(crate) fn live_db_mode_explicitly_requested() -> bool {
+    explicit_db_mode_from_process() == Some(DbMode::Live)
+}
+
 /// Resolve DB mode from process inputs and set it when explicitly provided.
 ///
 /// CLI flags (`--live`, `--replica`, `--mock`) take precedence over
 /// `DAILYOS_DB_MODE=live|replica|mock`. If neither is present, leave DB_MODE
 /// unset so `db_mode()` keeps its fail-closed default.
 pub fn resolve_and_set_db_mode_from_process() {
-    if let Some(mode) = std::env::args().find_map(|arg| DbMode::from_process_arg(&arg)) {
+    if let Some(mode) = explicit_db_mode_from_process() {
         set_db_mode(mode);
-        return;
-    }
-
-    if let Ok(value) = std::env::var("DAILYOS_DB_MODE") {
-        if let Some(mode) = DbMode::from_env_value(&value) {
-            set_db_mode(mode);
-        }
     }
 }
 
@@ -471,11 +486,7 @@ impl ActionDb {
         // budget_violations counter surfaces routine contention. The 250 ms
         // AC threshold is captured by the separate `_over_250ms` rollup below.
         let gate_wait_ms = gate_started.elapsed().as_millis();
-        crate::latency::record_latency(
-            "action_db.write_transaction_gate_wait",
-            gate_wait_ms,
-            100,
-        );
+        crate::latency::record_latency("action_db.write_transaction_gate_wait", gate_wait_ms, 100);
         // Dedicated rollup for the AC4 threshold (zero gate-waits > 250 ms at
         // user-active times). Records only when above the threshold so the
         // rollup's sample count IS the violation count.
@@ -1157,8 +1168,6 @@ pub mod test_utils {
 mod db_mode_tests {
     use super::*;
 
-    static DB_MODE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     struct ResetDbMode;
 
     impl Drop for ResetDbMode {
@@ -1195,6 +1204,20 @@ mod db_mode_tests {
             Err(err) => panic!("expected ProdOpenDenied, got {err:?}"),
             Ok(_) => panic!("non-Live mode must deny production DB read path"),
         }
+    }
+
+    #[test]
+    fn explicit_db_mode_inputs_prefer_cli_over_env() {
+        assert_eq!(
+            explicit_db_mode_from_inputs(["dailyos", "--replica"], Some("live")),
+            Some(DbMode::Replica)
+        );
+        assert_eq!(
+            explicit_db_mode_from_inputs(["dailyos"], Some("live")),
+            Some(DbMode::Live)
+        );
+        assert_eq!(explicit_db_mode_from_inputs(["dailyos"], Some("bad")), None);
+        assert_eq!(explicit_db_mode_from_inputs(["dailyos"], None), None);
     }
 
     fn create_encrypted_prod_db(path: &Path) {

--- a/src-tauri/src/db_backup.rs
+++ b/src-tauri/src/db_backup.rs
@@ -10,6 +10,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use chrono::Utc;
 
@@ -249,7 +250,7 @@ const BACKUP_MAX_BUSY_RETRIES: u32 = 600;
 /// Drive a `rusqlite::backup::Backup` to completion using chunked stepping
 /// with Busy/Locked retry. Shared shape with `migrations.rs::create_backup_via_api`
 /// so both startup-time and live-time backups go through the same proven path.
-fn run_chunked_backup(
+pub(crate) fn run_chunked_backup(
     source: &rusqlite::Connection,
     destination: &mut rusqlite::Connection,
 ) -> Result<(), String> {
@@ -293,6 +294,191 @@ fn run_chunked_backup(
             }
             Err(e) => return Err(format!("Database backup step failed: {e}")),
         }
+    }
+}
+
+pub(crate) fn clone_database_to_path(
+    source_db_path: &Path,
+    destination_db_path: &Path,
+) -> Result<(), String> {
+    guard_database_clone_destination(destination_db_path)?;
+    let staged_path = database_refresh_temp_path(destination_db_path);
+    clone_database_to_staged_path(source_db_path, destination_db_path, &staged_path)?;
+    activate_staged_database_clone(&staged_path, destination_db_path)?.commit();
+    Ok(())
+}
+
+pub(crate) fn clone_database_to_staged_path(
+    source_db_path: &Path,
+    destination_db_path: &Path,
+    staged_db_path: &Path,
+) -> Result<(), String> {
+    guard_database_clone_destination(destination_db_path)?;
+    let provider = Arc::new(crate::db::LocalKeychain::new());
+    let source_db =
+        ActionDb::open_readonly_at(source_db_path, provider.clone()).map_err(|e| e.to_string())?;
+
+    let parent = staged_db_path
+        .parent()
+        .ok_or_else(|| "Database clone staged path has no parent directory".to_string())?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create database clone destination directory: {e}"))?;
+
+    if staged_db_path == destination_db_path {
+        return Err("Database clone staged path must differ from destination path".to_string());
+    }
+    remove_file_if_exists(staged_db_path)?;
+
+    let mut destination_conn = rusqlite::Connection::open(staged_db_path)
+        .map_err(|e| format!("Failed to open database clone staged file: {e}"))?;
+    let destination_key = crate::db::DbKeyProvider::get_or_create_key(
+        provider.as_ref(),
+        &crate::db::UserIdentity::local(destination_db_path.to_path_buf()),
+    )
+    .map_err(|e| format!("Failed to resolve database clone key: {e}"))?;
+    destination_conn
+        .execute_batch(&destination_key.to_pragma())
+        .map_err(|e| format!("Failed to key database clone staged file: {e}"))?;
+
+    run_chunked_backup(source_db.conn_ref(), &mut destination_conn)?;
+    drop(destination_conn);
+    drop(source_db);
+
+    crate::db::hardening::set_file_permissions(staged_db_path);
+
+    Ok(())
+}
+
+pub(crate) fn database_refresh_temp_path(destination_db_path: &Path) -> PathBuf {
+    destination_db_path.with_file_name(format!(
+        "{}.refresh.tmp",
+        destination_db_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("dailyos-replica.db")
+    ))
+}
+
+#[derive(Debug)]
+pub(crate) struct ActivatedDatabaseClone {
+    backups: Vec<(PathBuf, PathBuf)>,
+}
+
+impl ActivatedDatabaseClone {
+    pub(crate) fn rollback(self) {
+        for (backup, destination) in self.backups.into_iter().rev() {
+            if let Err(error) = remove_file_if_exists(&destination) {
+                log::warn!(
+                    "database clone rollback could not remove activated file {}: {error}",
+                    destination.display()
+                );
+            }
+            if backup.exists() {
+                if let Err(error) = fs::rename(&backup, &destination) {
+                    log::warn!(
+                        "database clone rollback could not restore {} from {}: {error}",
+                        destination.display(),
+                        backup.display()
+                    );
+                }
+            }
+        }
+    }
+
+    pub(crate) fn commit(self) {
+        for (backup, _) in self.backups {
+            if let Err(error) = remove_file_if_exists(&backup) {
+                log::warn!(
+                    "database clone cleanup could not remove backup {}: {error}",
+                    backup.display()
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn activate_staged_database_clone(
+    staged_db_path: &Path,
+    destination_db_path: &Path,
+) -> Result<ActivatedDatabaseClone, String> {
+    guard_database_clone_destination(destination_db_path)?;
+    if staged_db_path == destination_db_path {
+        return Err("Database clone staged path must differ from destination path".to_string());
+    }
+    if !staged_db_path.exists() {
+        return Err(format!(
+            "Database clone staged file does not exist: {}",
+            staged_db_path.display()
+        ));
+    }
+
+    let mut backups = Vec::new();
+    for destination in [
+        destination_db_path.to_path_buf(),
+        wal_path(destination_db_path),
+        shm_path(destination_db_path),
+    ] {
+        let backup = refresh_previous_path(&destination);
+        if let Err(error) = remove_file_if_exists(&backup) {
+            let activated = ActivatedDatabaseClone { backups };
+            activated.rollback();
+            return Err(error);
+        }
+        if destination.exists() {
+            if let Err(error) = fs::rename(&destination, &backup) {
+                let activated = ActivatedDatabaseClone { backups };
+                activated.rollback();
+                return Err(format!(
+                    "Failed to move existing database file {} aside to {}: {e}",
+                    destination.display(),
+                    backup.display(),
+                    e = error
+                ));
+            }
+            backups.push((backup, destination));
+        }
+    }
+
+    match fs::rename(staged_db_path, destination_db_path) {
+        Ok(()) => {}
+        Err(error) => {
+            let activated = ActivatedDatabaseClone { backups };
+            activated.rollback();
+            return Err(format!(
+                "Failed to activate database clone {} from {}: {error}",
+                destination_db_path.display(),
+                staged_db_path.display()
+            ));
+        }
+    }
+    crate::db::hardening::set_file_permissions(destination_db_path);
+
+    Ok(ActivatedDatabaseClone { backups })
+}
+
+fn guard_database_clone_destination(destination_db_path: &Path) -> Result<(), String> {
+    crate::db::guard_path_for_mode(destination_db_path).map_err(|e| {
+        format!(
+            "Refusing to activate database clone for destination {} in current DB mode: {e}",
+            destination_db_path.display()
+        )
+    })
+}
+
+fn refresh_previous_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        "{}.refresh.previous",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("dailyos-replica.db")
+    ))
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<(), String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("Failed to remove {}: {e}", path.display())),
     }
 }
 
@@ -348,6 +534,13 @@ pub fn restore_database_from_backup(backup_path: &Path) -> Result<(), String> {
 }
 
 fn restore_database_from_backup_for_path(db_path: &Path, backup_path: &Path) -> Result<(), String> {
+    crate::db::guard_path_for_mode(db_path).map_err(|e| {
+        format!(
+            "Refusing database restore for active DB path {} in current DB mode: {e}",
+            db_path.display()
+        )
+    })?;
+
     let backup_path = backup_path
         .canonicalize()
         .map_err(|e| format!("Failed to resolve backup path: {e}"))?;
@@ -495,7 +688,17 @@ pub fn validate_backup(path: &Path) -> Result<(), String> {
 /// Delete the active database and all associated WAL/SHM files.
 pub fn start_fresh_database() -> Result<(), String> {
     let db_path = active_db_path()?;
-    for path in [&db_path, &wal_path(&db_path), &shm_path(&db_path)] {
+    start_fresh_database_for_path(&db_path)
+}
+
+fn start_fresh_database_for_path(db_path: &Path) -> Result<(), String> {
+    crate::db::guard_path_for_mode(db_path).map_err(|e| {
+        format!(
+            "Refusing to start fresh database for active DB path {} in current DB mode: {e}",
+            db_path.display()
+        )
+    })?;
+    for path in [db_path, &wal_path(db_path), &shm_path(db_path)] {
         match fs::remove_file(path) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -569,6 +772,14 @@ pub fn rebuild_from_filesystem(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct ResetDbMode;
+
+    impl Drop for ResetDbMode {
+        fn drop(&mut self) {
+            crate::db::set_db_mode(crate::db::DbMode::Live);
+        }
+    }
 
     #[test]
     fn test_backup_creates_file() {
@@ -695,6 +906,204 @@ mod tests {
     }
 
     #[test]
+    fn restore_database_from_backup_for_path_refuses_prod_path_in_replica_mode() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        crate::db::set_db_mode(crate::db::DbMode::Replica);
+
+        let dailyos_dir = crate::db::dailyos_data_dir().expect("data dir");
+        let prod_path = dailyos_dir.join("dailyos.db");
+        let backup_path = tempfile::NamedTempFile::new()
+            .expect("backup temp")
+            .into_temp_path();
+
+        let error = restore_database_from_backup_for_path(&prod_path, &backup_path)
+            .expect_err("replica mode must not restore the production DB");
+        assert!(error.contains("Refused to open production database"));
+    }
+
+    #[test]
+    fn start_fresh_database_for_path_refuses_prod_path_in_replica_mode() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        crate::db::set_db_mode(crate::db::DbMode::Replica);
+
+        let dailyos_dir = crate::db::dailyos_data_dir().expect("data dir");
+        let prod_path = dailyos_dir.join("dailyos.db");
+
+        let error = start_fresh_database_for_path(&prod_path)
+            .expect_err("replica mode must not start fresh against the production DB");
+        assert!(error.contains("Refused to open production database"));
+    }
+
+    #[test]
+    fn start_fresh_database_for_path_removes_target_wal_and_shm() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("dailyos-replica.db");
+        let wal = wal_path(&db_path);
+        let shm = shm_path(&db_path);
+        std::fs::write(&db_path, b"db").expect("db");
+        std::fs::write(&wal, b"wal").expect("wal");
+        std::fs::write(&shm, b"shm").expect("shm");
+
+        start_fresh_database_for_path(&db_path).expect("fresh database");
+
+        assert!(!db_path.exists(), "target DB should be removed");
+        assert!(!wal.exists(), "target WAL should be removed");
+        assert!(!shm.exists(), "target SHM should be removed");
+    }
+
+    #[test]
+    fn clone_database_to_staged_path_refuses_prod_destination_in_replica_mode() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        crate::db::set_db_mode(crate::db::DbMode::Replica);
+
+        let dailyos_dir = crate::db::dailyos_data_dir().expect("data dir");
+        let prod_path = dailyos_dir.join("dailyos.db");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let staged_path = dir.path().join("dailyos.db.refresh.tmp");
+
+        let error = clone_database_to_staged_path(
+            &dir.path().join("missing-source.db"),
+            &prod_path,
+            &staged_path,
+        )
+        .expect_err("replica mode must not stage a clone for the production DB");
+        assert!(error.contains("Refused to open production database"));
+        assert!(
+            !staged_path.exists(),
+            "destination guard must fire before writing a staged DB"
+        );
+    }
+
+    #[test]
+    fn activate_staged_database_clone_refuses_prod_destination_in_replica_mode() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        crate::db::set_db_mode(crate::db::DbMode::Replica);
+
+        let dailyos_dir = crate::db::dailyos_data_dir().expect("data dir");
+        let prod_path = dailyos_dir.join("dailyos.db");
+        let staged = tempfile::NamedTempFile::new().expect("staged db");
+
+        let error = activate_staged_database_clone(staged.path(), &prod_path)
+            .expect_err("replica mode must not activate a clone over the production DB");
+        assert!(error.contains("Refused to open production database"));
+        assert!(
+            staged.path().exists(),
+            "destination guard must fire before consuming the staged DB"
+        );
+    }
+
+    #[test]
+    fn activate_staged_database_clone_rolls_back_db_when_sidecar_cleanup_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let destination_path = dir.path().join("dailyos-replica.db");
+        let staged_path = dir.path().join("dailyos-replica.db.refresh.tmp");
+        std::fs::write(&destination_path, b"old db").expect("old db");
+        std::fs::write(&staged_path, b"new db").expect("staged db");
+
+        let wal_backup = refresh_previous_path(&wal_path(&destination_path));
+        std::fs::create_dir(&wal_backup).expect("stale wal backup directory");
+
+        let error = activate_staged_database_clone(&staged_path, &destination_path)
+            .expect_err("sidecar cleanup failure must abort activation");
+        assert!(
+            error.contains("Failed to remove"),
+            "unexpected activation error: {error}"
+        );
+        assert_eq!(
+            std::fs::read(&destination_path).expect("restored db"),
+            b"old db",
+            "old destination DB must be restored after mid-loop failure"
+        );
+        assert!(
+            !refresh_previous_path(&destination_path).exists(),
+            "rollback should not strand the old DB at the previous path"
+        );
+        assert!(
+            staged_path.exists(),
+            "staged DB should remain for the caller cleanup path"
+        );
+    }
+
+    #[test]
+    fn clone_database_to_path_produces_readable_encrypted_clone_and_clears_stale_sidecars() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_path = dir.path().join("source.db");
+        let destination_path = dir.path().join("dailyos-replica.db");
+        let provider = Arc::new(crate::db::LocalKeychain::new());
+
+        let source_db =
+            ActionDb::open_at(source_path.clone(), provider).expect("open encrypted source");
+        source_db
+            .conn_ref()
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS replica_clone_marker (label TEXT);
+                 DELETE FROM replica_clone_marker;",
+            )
+            .expect("marker schema");
+        source_db
+            .conn_ref()
+            .execute(
+                "INSERT INTO replica_clone_marker (label) VALUES (?1)",
+                ["cloned"],
+            )
+            .expect("marker insert");
+        source_db
+            .conn_ref()
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .expect("checkpoint source");
+        drop(source_db);
+
+        let old_destination = ActionDb::open_at(
+            destination_path.clone(),
+            Arc::new(crate::db::LocalKeychain::new()),
+        )
+        .expect("open old encrypted destination");
+        old_destination
+            .conn_ref()
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS replica_clone_marker (label TEXT);
+                 DELETE FROM replica_clone_marker;
+                 INSERT INTO replica_clone_marker (label) VALUES ('old');",
+            )
+            .expect("old marker");
+        old_destination
+            .conn_ref()
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .expect("checkpoint old destination");
+        drop(old_destination);
+        std::fs::write(wal_path(&destination_path), b"old wal").expect("old wal");
+        std::fs::write(shm_path(&destination_path), b"old shm").expect("old shm");
+
+        clone_database_to_path(&source_path, &destination_path).expect("clone database");
+
+        assert!(
+            !wal_path(&destination_path).exists(),
+            "stale destination WAL should be removed during activation"
+        );
+        assert!(
+            !shm_path(&destination_path).exists(),
+            "stale destination SHM should be removed during activation"
+        );
+
+        let cloned = ActionDb::open_readonly_at(
+            &destination_path,
+            Arc::new(crate::db::LocalKeychain::new()),
+        )
+        .expect("open encrypted clone");
+        let label: String = cloned
+            .conn_ref()
+            .query_row("SELECT label FROM replica_clone_marker", [], |row| {
+                row.get(0)
+            })
+            .expect("read clone marker");
+        assert_eq!(label, "cloned");
+    }
+
+    #[test]
     fn test_list_database_backups_for_path_includes_known_backup_kinds() {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("dailyos.db");
@@ -738,7 +1147,9 @@ mod tests {
         // 1024 pages * 4 KB = 4 MB; seed with 8 MB worth of payload so the copy
         // requires at least two chunked-step iterations.
         let payload = vec![0xA5_u8; 8192];
-        let mut stmt = src.prepare("INSERT INTO rows (payload) VALUES (?1)").expect("prep");
+        let mut stmt = src
+            .prepare("INSERT INTO rows (payload) VALUES (?1)")
+            .expect("prep");
         for _ in 0..1024 {
             stmt.execute([&payload]).expect("insert");
         }

--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -39,6 +39,7 @@ where
     match subcommand {
         "watermarks" => Some(run_watermarks_cli()),
         "pairing" => Some(run_pairing_cli()),
+        "replica-refresh" => Some(run_replica_refresh_cli()),
         "all" => {
             let watermarks = run_watermarks_cli();
             println!();
@@ -48,7 +49,7 @@ where
         }
         other => {
             eprintln!(
-                "unknown doctor subcommand `{other}`; expected `watermarks`, `pairing`, or `all`"
+                "unknown doctor subcommand `{other}`; expected `watermarks`, `pairing`, `replica-refresh`, or `all`"
             );
             Some(2)
         }
@@ -102,6 +103,54 @@ fn run_pairing_cli() -> i32 {
         }
         1
     }
+}
+
+fn run_replica_refresh_cli() -> i32 {
+    match replica_refresh_for_doctor() {
+        Ok(report) => {
+            println!("dailyos doctor replica-refresh: ok");
+            println!("source_db={}", report.source_db_path.display());
+            println!("replica_db={}", report.replica_db_path.display());
+            println!(
+                "source_workspace={}",
+                report.source_workspace_path.display()
+            );
+            println!(
+                "replica_workspace={}",
+                report.replica_workspace_path.display()
+            );
+            println!("files_copied={}", report.files_copied);
+            println!("directories_created={}", report.directories_created);
+            0
+        }
+        Err(error) => {
+            eprintln!("dailyos doctor replica-refresh failed: {error}");
+            1
+        }
+    }
+}
+
+#[cfg(not(test))]
+fn replica_refresh_for_doctor(
+) -> Result<crate::services::replica_refresh::ReplicaRefreshReport, String> {
+    crate::services::replica_refresh::refresh_replica_from_live()
+}
+
+#[cfg(test)]
+static REPLICA_REFRESH_DOCTOR_TEST_RUNNER: std::sync::Mutex<
+    Option<fn() -> Result<crate::services::replica_refresh::ReplicaRefreshReport, String>>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn replica_refresh_for_doctor(
+) -> Result<crate::services::replica_refresh::ReplicaRefreshReport, String> {
+    if let Some(runner) = *REPLICA_REFRESH_DOCTOR_TEST_RUNNER
+        .lock()
+        .expect("replica refresh doctor test runner lock")
+    {
+        return runner();
+    }
+    crate::services::replica_refresh::refresh_replica_from_live()
 }
 
 pub fn run_watermark_doctor() -> Result<WatermarkDoctorReport, String> {
@@ -341,9 +390,38 @@ pub fn inspect_pairing() -> PairingDoctorReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     static HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+    static REPLICA_REFRESH_DISPATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct ReplicaRefreshRunnerGuard;
+
+    impl ReplicaRefreshRunnerGuard {
+        fn install() -> Self {
+            REPLICA_REFRESH_DISPATCH_COUNT.store(0, Ordering::SeqCst);
+            *REPLICA_REFRESH_DOCTOR_TEST_RUNNER
+                .lock()
+                .expect("replica refresh test runner lock") = Some(failing_replica_refresh_runner);
+            Self
+        }
+    }
+
+    impl Drop for ReplicaRefreshRunnerGuard {
+        fn drop(&mut self) {
+            *REPLICA_REFRESH_DOCTOR_TEST_RUNNER
+                .lock()
+                .expect("replica refresh test runner lock") = None;
+            REPLICA_REFRESH_DISPATCH_COUNT.store(0, Ordering::SeqCst);
+        }
+    }
+
+    fn failing_replica_refresh_runner(
+    ) -> Result<crate::services::replica_refresh::ReplicaRefreshReport, String> {
+        REPLICA_REFRESH_DISPATCH_COUNT.fetch_add(1, Ordering::SeqCst);
+        Err("replica-refresh dispatch sentinel".to_string())
+    }
 
     #[test]
     fn clean_empty_watermark_schema_passes() {
@@ -351,6 +429,42 @@ mod tests {
         let db = ActionDb::open_at_unencrypted(dir.path().join("doctor.sqlite")).expect("db");
         let report = inspect_watermarks(&db).expect("inspect");
         assert!(report.is_clean(), "unexpected report: {report:?}");
+    }
+
+    #[test]
+    fn run_from_args_routes_replica_refresh_subcommand() {
+        let _runner = ReplicaRefreshRunnerGuard::install();
+
+        let code = run_from_args(
+            ["dailyos", "doctor", "replica-refresh"]
+                .into_iter()
+                .map(String::from),
+        );
+
+        assert_eq!(
+            code,
+            Some(1),
+            "dispatcher should return the replica-refresh runner failure"
+        );
+        assert_eq!(
+            REPLICA_REFRESH_DISPATCH_COUNT.load(Ordering::SeqCst),
+            1,
+            "dispatcher should invoke the replica-refresh runner exactly once"
+        );
+        assert_eq!(
+            run_from_args(
+                ["dailyos", "doctor", "replica-refresh-typo"]
+                    .into_iter()
+                    .map(String::from)
+            ),
+            Some(2),
+            "unknown subcommands should still use the unknown-command exit"
+        );
+        assert_eq!(
+            REPLICA_REFRESH_DISPATCH_COUNT.load(Ordering::SeqCst),
+            1,
+            "unknown subcommands must not invoke the replica-refresh runner"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -48,6 +48,7 @@ pub mod people;
 pub mod projection_signing;
 pub mod projects;
 pub mod recommendations;
+pub mod replica_refresh;
 pub mod reports;
 pub mod runtime_evidence_backfill;
 pub mod sensitivity;

--- a/src-tauri/src/services/replica_refresh.rs
+++ b/src-tauri/src/services/replica_refresh.rs
@@ -1,0 +1,1114 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+use crate::db::DbMode;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplicaRefreshReport {
+    pub source_db_path: PathBuf,
+    pub replica_db_path: PathBuf,
+    pub source_workspace_path: PathBuf,
+    pub replica_workspace_path: PathBuf,
+    pub files_copied: usize,
+    pub directories_created: usize,
+}
+
+pub fn refresh_replica_from_live() -> Result<ReplicaRefreshReport, String> {
+    refresh_replica_from_live_with_path_loader(ReplicaRefreshPaths::from_runtime)
+}
+
+fn refresh_replica_from_live_with_path_loader(
+    load_paths: impl FnOnce() -> Result<ReplicaRefreshPaths, String>,
+) -> Result<ReplicaRefreshReport, String> {
+    if crate::db::db_mode() != DbMode::Live || !crate::db::live_db_mode_explicitly_requested() {
+        return Err(
+            "doctor replica-refresh requires explicit Live DB mode for its read-only production source; rerun with --live or DAILYOS_DB_MODE=live"
+                .to_string(),
+        );
+    }
+
+    let paths = load_paths()?;
+    refresh_replica_from_live_paths(paths)
+}
+
+#[derive(Debug, Clone)]
+struct ReplicaRefreshPaths {
+    source_db_path: PathBuf,
+    replica_db_path: PathBuf,
+    source_workspace_path: PathBuf,
+    replica_workspace_path: PathBuf,
+    replica_config_path: PathBuf,
+    live_config: crate::types::Config,
+}
+
+impl ReplicaRefreshPaths {
+    fn from_runtime() -> Result<Self, String> {
+        let dailyos_dir = crate::db::dailyos_data_dir().map_err(|e| e.to_string())?;
+        let source_db_path = dailyos_dir.join("dailyos.db");
+        let replica_db_path = dailyos_dir.join("dailyos-replica.db");
+        let live_config = read_live_config()?;
+        let configured_workspace = Some(live_config.workspace_path.as_str());
+        let source_workspace_path =
+            crate::state::workspace_path_for_mode(DbMode::Live, configured_workspace)?;
+        let replica_workspace_path = crate::state::workspace_path_for_mode(DbMode::Replica, None)?;
+        let replica_config_path = crate::state::replica_config_path()?;
+
+        Ok(Self {
+            source_db_path,
+            replica_db_path,
+            source_workspace_path,
+            replica_workspace_path,
+            replica_config_path,
+            live_config,
+        })
+    }
+}
+
+fn read_live_config() -> Result<crate::types::Config, String> {
+    let live_config_path = crate::state::live_config_path()?;
+    let content = fs::read_to_string(&live_config_path)
+        .map_err(|e| format!("Failed to read live config: {e}"))?;
+    let mut config: crate::types::Config =
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse live config: {e}"))?;
+    config.normalize();
+    Ok(config)
+}
+
+fn refresh_replica_from_live_paths(
+    paths: ReplicaRefreshPaths,
+) -> Result<ReplicaRefreshReport, String> {
+    let staged_paths = StagedReplicaPaths::from_paths(&paths);
+    reject_workspace_refresh_path_overlap(
+        &paths.source_workspace_path,
+        &paths.replica_workspace_path,
+        &staged_paths.workspace_path,
+    )?;
+    ensure_source_ready(&paths.source_db_path)?;
+    let stage_result = stage_replica_refresh(&paths, &staged_paths);
+    let (files_copied, directories_created) = match stage_result {
+        Ok(counts) => counts,
+        Err(error) => {
+            cleanup_staged_replica(&staged_paths);
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = activate_staged_replica(&paths, &staged_paths) {
+        cleanup_staged_replica(&staged_paths);
+        return Err(error);
+    }
+
+    Ok(ReplicaRefreshReport {
+        source_db_path: paths.source_db_path,
+        replica_db_path: paths.replica_db_path,
+        source_workspace_path: paths.source_workspace_path,
+        replica_workspace_path: paths.replica_workspace_path,
+        files_copied,
+        directories_created,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct StagedReplicaPaths {
+    db_path: PathBuf,
+    workspace_path: PathBuf,
+    config_path: PathBuf,
+}
+
+impl StagedReplicaPaths {
+    fn from_paths(paths: &ReplicaRefreshPaths) -> Self {
+        Self {
+            db_path: crate::db_backup::database_refresh_temp_path(&paths.replica_db_path),
+            workspace_path: workspace_temp_path(&paths.replica_workspace_path),
+            config_path: refresh_temp_path(&paths.replica_config_path),
+        }
+    }
+}
+
+fn stage_replica_refresh(
+    paths: &ReplicaRefreshPaths,
+    staged_paths: &StagedReplicaPaths,
+) -> Result<(usize, usize), String> {
+    clone_database(
+        &paths.source_db_path,
+        &paths.replica_db_path,
+        &staged_paths.db_path,
+    )?;
+    let counts = stage_workspace(&paths.source_workspace_path, &staged_paths.workspace_path)?;
+    write_replica_config(paths, &staged_paths.config_path)?;
+    Ok(counts)
+}
+
+fn activate_staged_replica(
+    paths: &ReplicaRefreshPaths,
+    staged_paths: &StagedReplicaPaths,
+) -> Result<(), String> {
+    let workspace_activation = activate_staged_path(
+        &staged_paths.workspace_path,
+        &paths.replica_workspace_path,
+        StagedPathKind::Directory,
+    )?;
+
+    let config_activation = match activate_staged_path(
+        &staged_paths.config_path,
+        &paths.replica_config_path,
+        StagedPathKind::File,
+    ) {
+        Ok(activation) => activation,
+        Err(error) => {
+            workspace_activation.rollback();
+            return Err(error);
+        }
+    };
+
+    let db_activation = match crate::db_backup::activate_staged_database_clone(
+        &staged_paths.db_path,
+        &paths.replica_db_path,
+    ) {
+        Ok(activation) => activation,
+        Err(error) => {
+            config_activation.rollback();
+            workspace_activation.rollback();
+            return Err(error);
+        }
+    };
+
+    db_activation.commit();
+    config_activation.commit();
+    workspace_activation.commit();
+    Ok(())
+}
+
+fn cleanup_staged_replica(staged_paths: &StagedReplicaPaths) {
+    cleanup_path(
+        &staged_paths.db_path,
+        StagedPathKind::File,
+        "staged replica DB",
+    );
+    cleanup_path(
+        &staged_paths.workspace_path,
+        StagedPathKind::Directory,
+        "staged replica workspace",
+    );
+    cleanup_path(
+        &staged_paths.config_path,
+        StagedPathKind::File,
+        "staged replica config",
+    );
+}
+
+fn ensure_source_ready(source_db_path: &Path) -> Result<(), String> {
+    if !source_db_path.exists() {
+        return Err(format!(
+            "Production DB source does not exist: {}",
+            source_db_path.display()
+        ));
+    }
+
+    let wal = wal_path(source_db_path);
+    if wal.exists() {
+        let wal_len = fs::metadata(&wal)
+            .map_err(|e| format!("Failed to inspect production WAL {}: {e}", wal.display()))?
+            .len();
+        if wal_len > 0 {
+            return Err(format!(
+                "Production WAL has live frames ({} bytes at {}). Close DailyOS or checkpoint before replica-refresh.",
+                wal_len,
+                wal.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn clone_database(
+    source_db_path: &Path,
+    replica_db_path: &Path,
+    staged_db_path: &Path,
+) -> Result<(), String> {
+    crate::db_backup::clone_database_to_staged_path(source_db_path, replica_db_path, staged_db_path)
+}
+
+fn refresh_workspace(source: &Path, destination: &Path) -> Result<(usize, usize), String> {
+    let staged_destination = workspace_temp_path(destination);
+    reject_workspace_refresh_path_overlap(source, destination, &staged_destination)?;
+    let counts = match stage_workspace(source, &staged_destination) {
+        Ok(counts) => counts,
+        Err(error) => {
+            cleanup_path(
+                &staged_destination,
+                StagedPathKind::Directory,
+                "staged replica workspace",
+            );
+            return Err(error);
+        }
+    };
+    match activate_staged_path(&staged_destination, destination, StagedPathKind::Directory) {
+        Ok(activation) => {
+            activation.commit();
+            Ok(counts)
+        }
+        Err(error) => {
+            cleanup_path(
+                &staged_destination,
+                StagedPathKind::Directory,
+                "staged replica workspace",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn stage_workspace(source: &Path, staged_destination: &Path) -> Result<(usize, usize), String> {
+    if !source.exists() {
+        return Err(format!(
+            "Live workspace source does not exist: {}",
+            source.display()
+        ));
+    }
+    let source_metadata = fs::symlink_metadata(source)
+        .map_err(|e| format!("Failed to inspect live workspace source: {e}"))?;
+    if source_metadata.file_type().is_symlink() {
+        return Err(format!(
+            "Refusing to clone symlink live workspace root: {}",
+            source.display()
+        ));
+    }
+    if !source_metadata.is_dir() {
+        return Err(format!(
+            "Live workspace source is not a directory: {}",
+            source.display()
+        ));
+    }
+    if staged_destination.exists() {
+        fs::remove_dir_all(staged_destination).map_err(|e| {
+            format!(
+                "Failed to remove existing replica workspace temp directory {}: {e}",
+                staged_destination.display()
+            )
+        })?;
+    }
+    fs::create_dir_all(staged_destination).map_err(|e| {
+        format!(
+            "Failed to create replica workspace temp directory {}: {e}",
+            staged_destination.display()
+        )
+    })?;
+
+    match copy_workspace_tree(source, staged_destination) {
+        Ok(counts) => Ok(counts),
+        Err(error) => {
+            cleanup_path(
+                staged_destination,
+                StagedPathKind::Directory,
+                "staged replica workspace",
+            );
+            Err(error)
+        }
+    }
+}
+
+fn workspace_temp_path(destination: &Path) -> PathBuf {
+    refresh_temp_path(destination)
+}
+
+fn refresh_temp_path(destination: &Path) -> PathBuf {
+    destination.with_file_name(format!(
+        "{}.refresh.tmp",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("dailyos-replica-workspace")
+    ))
+}
+
+fn refresh_previous_path(destination: &Path) -> PathBuf {
+    destination.with_file_name(format!(
+        "{}.refresh.previous",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("dailyos-replica-workspace")
+    ))
+}
+
+fn reject_workspace_refresh_path_overlap(
+    source: &Path,
+    destination: &Path,
+    staged_destination: &Path,
+) -> Result<(), String> {
+    let source_canonical = source
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve live workspace source: {e}"))?;
+
+    for (label, path) in [
+        ("replica workspace destination", destination),
+        ("staged replica workspace", staged_destination),
+        (
+            "previous replica workspace backup",
+            &refresh_previous_path(destination),
+        ),
+    ] {
+        let managed_candidate = canonical_candidate(path)?;
+        if managed_candidate == source_canonical
+            || managed_candidate.starts_with(&source_canonical)
+            || source_canonical.starts_with(&managed_candidate)
+        {
+            return Err(format!(
+                "Live workspace source must not overlap {label}: {}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn canonical_candidate(path: &Path) -> Result<PathBuf, String> {
+    if path.exists() {
+        return path
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve {}: {e}", path.display()));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("Path has no parent: {}", path.display()))?;
+    if parent.exists() {
+        let mut candidate = parent
+            .canonicalize()
+            .map_err(|e| format!("Failed to resolve {}: {e}", parent.display()))?;
+        if let Some(name) = path.file_name() {
+            candidate.push(name);
+        }
+        return Ok(candidate);
+    }
+    Ok(path.to_path_buf())
+}
+
+fn copy_workspace_tree(source: &Path, destination: &Path) -> Result<(usize, usize), String> {
+    let mut files_copied = 0_usize;
+    let mut directories_created = 1_usize;
+    for entry in WalkDir::new(source).follow_links(false) {
+        let entry = entry.map_err(|e| format!("Failed to walk live workspace: {e}"))?;
+        let path = entry.path();
+        let relative = path.strip_prefix(source).map_err(|e| {
+            format!(
+                "Failed to compute workspace relative path for {}: {e}",
+                path.display()
+            )
+        })?;
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let target = destination.join(relative);
+        let file_type = entry.file_type();
+        if file_type.is_symlink() {
+            return Err(format!(
+                "Refusing to clone symlink in live workspace: {}",
+                path.display()
+            ));
+        }
+        if file_type.is_dir() {
+            fs::create_dir_all(&target)
+                .map_err(|e| format!("Failed to create workspace directory: {e}"))?;
+            directories_created += 1;
+            continue;
+        }
+        if file_type.is_file() {
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| format!("Failed to create workspace parent: {e}"))?;
+            }
+            fs::copy(path, &target).map_err(|e| {
+                format!(
+                    "Failed to copy workspace file {} -> {}: {e}",
+                    path.display(),
+                    target.display()
+                )
+            })?;
+            files_copied += 1;
+        }
+    }
+
+    Ok((files_copied, directories_created))
+}
+
+fn write_replica_config(
+    paths: &ReplicaRefreshPaths,
+    staged_config_path: &Path,
+) -> Result<(), String> {
+    let config = replica_config_from_live(paths.live_config.clone(), &paths.replica_workspace_path);
+    let serialized =
+        serde_json::to_string_pretty(&config).map_err(|e| format!("Serialize config: {e}"))?;
+    crate::util::atomic_write_str(staged_config_path, &serialized)
+        .map_err(|e| format!("Failed to write replica config: {e}"))?;
+    harden_replica_config_permissions(staged_config_path)
+}
+
+fn harden_replica_config_permissions(config_path: &Path) -> Result<(), String> {
+    if let Some(parent) = config_path.parent() {
+        set_owner_only_directory_permissions(parent)?;
+    }
+    set_owner_only_file_permissions(config_path)
+}
+
+#[cfg(unix)]
+fn set_owner_only_directory_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(|e| {
+        format!(
+            "Failed to set owner-only permissions on replica config directory {}: {e}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_directory_permissions(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_file_permissions(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|e| {
+        format!(
+            "Failed to set owner-only permissions on replica config {}: {e}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_file_permissions(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn replica_config_from_live(
+    mut config: crate::types::Config,
+    replica_workspace_path: &Path,
+) -> crate::types::Config {
+    config.workspace_path = replica_workspace_path.to_string_lossy().to_string();
+    config.google = crate::types::GoogleConfig::default();
+    config.drive = crate::types::DriveConfig::default();
+    config.linear = crate::linear::LinearConfig::default();
+    config.clay = crate::clay::ClayConfig::default();
+    config.quill = crate::quill::QuillConfig::default();
+    config.granola = crate::granola::GranolaConfig::default();
+    config.gravatar = crate::gravatar::GravatarConfig::default();
+    config
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StagedPathKind {
+    File,
+    Directory,
+}
+
+struct ActivatedPath {
+    destination: PathBuf,
+    backup: Option<PathBuf>,
+    kind: StagedPathKind,
+}
+
+impl ActivatedPath {
+    fn rollback(self) {
+        cleanup_path(&self.destination, self.kind, "activated replica path");
+        if let Some(backup) = self.backup {
+            if backup.exists() {
+                if let Err(error) = fs::rename(&backup, &self.destination) {
+                    log::warn!(
+                        "replica-refresh rollback failed restoring {} from {}: {error}",
+                        self.destination.display(),
+                        backup.display()
+                    );
+                }
+            }
+        }
+    }
+
+    fn commit(self) {
+        if let Some(backup) = self.backup {
+            cleanup_path(&backup, self.kind, "previous replica path");
+        }
+    }
+}
+
+fn activate_staged_path(
+    staged: &Path,
+    destination: &Path,
+    kind: StagedPathKind,
+) -> Result<ActivatedPath, String> {
+    if staged == destination {
+        return Err("Staged path must differ from destination path".to_string());
+    }
+    if !staged.exists() {
+        return Err(format!("Staged path does not exist: {}", staged.display()));
+    }
+
+    let backup = refresh_previous_path(destination);
+    cleanup_path(&backup, kind, "stale previous replica path");
+    let backup = if destination.exists() {
+        fs::rename(destination, &backup).map_err(|e| {
+            format!(
+                "Failed to move existing replica path {} aside to {}: {e}",
+                destination.display(),
+                backup.display()
+            )
+        })?;
+        Some(backup)
+    } else {
+        None
+    };
+
+    match fs::rename(staged, destination) {
+        Ok(()) => Ok(ActivatedPath {
+            destination: destination.to_path_buf(),
+            backup,
+            kind,
+        }),
+        Err(error) => {
+            if let Some(backup) = backup.as_ref() {
+                if backup.exists() {
+                    if let Err(rollback_error) = fs::rename(backup, destination) {
+                        log::warn!(
+                            "replica-refresh activation rollback failed restoring {} from {}: {rollback_error}",
+                            destination.display(),
+                            backup.display()
+                        );
+                    }
+                }
+            }
+            Err(format!(
+                "Failed to activate replica path {} from {}: {error}",
+                destination.display(),
+                staged.display()
+            ))
+        }
+    }
+}
+
+fn cleanup_path(path: &Path, kind: StagedPathKind, label: &str) {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            log::warn!(
+                "{label} cleanup could not inspect {}: {error}",
+                path.display()
+            );
+            return;
+        }
+    };
+    let result = match kind {
+        StagedPathKind::File => fs::remove_file(path),
+        StagedPathKind::Directory if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            fs::remove_dir_all(path)
+        }
+        StagedPathKind::Directory => fs::remove_file(path),
+    };
+    if let Err(error) = result {
+        log::warn!("{label} cleanup failed for {}: {error}", path.display());
+    }
+}
+
+fn wal_path(db_path: &Path) -> PathBuf {
+    db_path.with_file_name(format!(
+        "{}-wal",
+        db_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("dailyos.db")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    struct ResetDbMode;
+
+    impl Drop for ResetDbMode {
+        fn drop(&mut self) {
+            crate::db::set_db_mode(DbMode::Live);
+        }
+    }
+
+    struct EnvGuard {
+        name: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn remove(name: &'static str) -> Self {
+            let previous = std::env::var(name).ok();
+            std::env::remove_var(name);
+            Self { name, previous }
+        }
+
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var(name).ok();
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
+    fn test_config(workspace_path: &Path) -> crate::types::Config {
+        let mut config: crate::types::Config = serde_json::from_value(serde_json::json!({
+            "workspacePath": workspace_path.to_string_lossy(),
+        }))
+        .expect("test config");
+        config.normalize();
+        config
+    }
+
+    fn write_marker_db(path: &Path, label: &str) {
+        let db = crate::db::ActionDb::open_at(
+            path.to_path_buf(),
+            Arc::new(crate::db::LocalKeychain::new()),
+        )
+        .expect("open marker db");
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS replica_refresh_marker (label TEXT);
+                 DELETE FROM replica_refresh_marker;",
+            )
+            .expect("marker schema");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO replica_refresh_marker (label) VALUES (?1)",
+                [label],
+            )
+            .expect("marker insert");
+        db.conn_ref()
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .expect("checkpoint marker db");
+    }
+
+    fn read_marker_db(path: &Path) -> String {
+        let db =
+            crate::db::ActionDb::open_readonly_at(path, Arc::new(crate::db::LocalKeychain::new()))
+                .expect("open cloned marker db");
+        db.conn_ref()
+            .query_row("SELECT label FROM replica_refresh_marker", [], |row| {
+                row.get(0)
+            })
+            .expect("read marker")
+    }
+
+    #[test]
+    fn refresh_replica_from_live_requires_explicit_live_mode() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        let _env = EnvGuard::remove("DAILYOS_DB_MODE");
+        crate::db::set_db_mode(DbMode::Live);
+
+        let error =
+            refresh_replica_from_live().expect_err("implicit release Live mode must be refused");
+        assert!(error.contains("requires explicit Live DB mode"));
+    }
+
+    #[test]
+    fn refresh_replica_from_live_accepts_explicit_live_mode_before_loading_paths() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        let _env = EnvGuard::set("DAILYOS_DB_MODE", "live");
+        crate::db::set_db_mode(DbMode::Live);
+
+        let error = refresh_replica_from_live_with_path_loader(|| {
+            Err("explicit live accepted; path loader reached".to_string())
+        })
+        .expect_err("path loader should provide the terminal test error");
+        assert_eq!(error, "explicit live accepted; path loader reached");
+    }
+
+    #[test]
+    fn ensure_source_ready_rejects_live_wal_frames() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("dailyos.db");
+        fs::write(&db_path, b"not a real db").expect("db");
+        fs::write(wal_path(&db_path), b"live frames").expect("wal");
+
+        let error = ensure_source_ready(&db_path).expect_err("live WAL frames must fail");
+        assert!(error.contains("Production WAL has live frames"));
+    }
+
+    #[test]
+    fn refresh_workspace_copies_files_and_rejects_symlinks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = dir.path().join("live");
+        let destination = dir.path().join("replica");
+        fs::create_dir_all(source.join("Accounts/Example")).expect("source dirs");
+        fs::write(source.join("Accounts/Example/dashboard.json"), "{}").expect("file");
+
+        let (files, dirs) = refresh_workspace(&source, &destination).expect("refresh workspace");
+        assert_eq!(files, 1);
+        assert!(dirs >= 2);
+        assert!(destination.join("Accounts/Example/dashboard.json").exists());
+
+        #[cfg(unix)]
+        {
+            let symlink_source = dir.path().join("with-symlink");
+            let symlink_destination = dir.path().join("replica-symlink");
+            fs::create_dir_all(&symlink_source).expect("symlink source");
+            fs::create_dir_all(&symlink_destination).expect("existing symlink destination");
+            fs::write(symlink_destination.join("previous.txt"), "keep").expect("previous copy");
+            std::os::unix::fs::symlink("/tmp", symlink_source.join("outside")).expect("symlink");
+            let error =
+                refresh_workspace(&symlink_source, &symlink_destination).expect_err("symlink");
+            assert!(error.contains("Refusing to clone symlink"));
+            assert!(
+                symlink_destination.join("previous.txt").exists(),
+                "failed refresh should preserve existing replica workspace"
+            );
+
+            let real_source_root = dir.path().join("real-root");
+            let symlink_root = dir.path().join("symlink-root");
+            let symlink_root_destination = dir.path().join("replica-symlink-root");
+            fs::create_dir_all(&real_source_root).expect("real source root");
+            fs::write(real_source_root.join("dashboard.json"), "{}").expect("real source file");
+            fs::create_dir_all(&symlink_root_destination)
+                .expect("existing symlink root destination");
+            fs::write(symlink_root_destination.join("previous.txt"), "keep")
+                .expect("previous symlink root copy");
+            std::os::unix::fs::symlink(&real_source_root, &symlink_root)
+                .expect("workspace root symlink");
+            let error = refresh_workspace(&symlink_root, &symlink_root_destination)
+                .expect_err("root symlink");
+            assert!(error.contains("Refusing to clone symlink live workspace root"));
+            assert!(
+                symlink_root_destination.join("previous.txt").exists(),
+                "root symlink failure should preserve existing replica workspace"
+            );
+        }
+    }
+
+    #[test]
+    fn refresh_workspace_rejects_live_source_overlap_with_managed_replica_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let destination = dir.path().join("replica-workspace");
+        let source_inside_destination = destination.join("live-source");
+        fs::create_dir_all(&source_inside_destination).expect("nested source");
+        fs::write(destination.join("previous.txt"), "keep").expect("destination marker");
+        fs::write(source_inside_destination.join("source.txt"), "keep").expect("source marker");
+
+        let error = refresh_workspace(&source_inside_destination, &destination)
+            .expect_err("source inside destination must be rejected");
+        assert!(error.contains("must not overlap replica workspace destination"));
+        assert!(
+            source_inside_destination.join("source.txt").exists(),
+            "overlap rejection must not clean the live source"
+        );
+        assert!(
+            destination.join("previous.txt").exists(),
+            "overlap rejection must not clean the existing replica workspace"
+        );
+
+        let staged_destination = dir.path().join("replica-workspace-staged");
+        let staged_source = workspace_temp_path(&staged_destination);
+        fs::create_dir_all(&staged_source).expect("staged source");
+        fs::write(staged_source.join("source.txt"), "keep").expect("staged source marker");
+        let error = refresh_workspace(&staged_source, &staged_destination)
+            .expect_err("source equal to staged path must be rejected");
+        assert!(error.contains("must not overlap staged replica workspace"));
+        assert!(
+            staged_source.join("source.txt").exists(),
+            "staged-overlap rejection must happen before generic staged cleanup"
+        );
+
+        let previous_destination = dir.path().join("replica-workspace-previous");
+        let previous_source = refresh_previous_path(&previous_destination);
+        fs::create_dir_all(&previous_source).expect("previous source");
+        fs::write(previous_source.join("source.txt"), "keep").expect("previous source marker");
+        let error = refresh_workspace(&previous_source, &previous_destination)
+            .expect_err("source equal to previous path must be rejected");
+        assert!(error.contains("must not overlap previous replica workspace backup"));
+        assert!(
+            previous_source.join("source.txt").exists(),
+            "previous-overlap rejection must happen before stale backup cleanup"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_failure_after_db_stage_preserves_existing_replica_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_db_path = dir.path().join("dailyos.db");
+        let replica_db_path = dir.path().join("dailyos-replica.db");
+        write_marker_db(&source_db_path, "new-live");
+        write_marker_db(&replica_db_path, "old-replica");
+
+        let source_workspace_path = dir.path().join("live-workspace");
+        let replica_workspace_path = dir.path().join("replica-workspace");
+        fs::create_dir_all(&source_workspace_path).expect("source workspace");
+        fs::create_dir_all(&replica_workspace_path).expect("replica workspace");
+        fs::write(replica_workspace_path.join("previous.txt"), "keep")
+            .expect("previous replica workspace");
+        std::os::unix::fs::symlink("/tmp", source_workspace_path.join("outside"))
+            .expect("nested symlink");
+
+        let replica_config_path = dir.path().join("config-replica.json");
+        let paths = ReplicaRefreshPaths {
+            source_db_path: source_db_path.clone(),
+            replica_db_path: replica_db_path.clone(),
+            source_workspace_path,
+            replica_workspace_path: replica_workspace_path.clone(),
+            replica_config_path,
+            live_config: test_config(dir.path()),
+        };
+
+        let error = refresh_replica_from_live_paths(paths).expect_err("workspace symlink failure");
+        assert!(error.contains("Refusing to clone symlink"));
+        assert_eq!(read_marker_db(&replica_db_path), "old-replica");
+        assert!(
+            replica_workspace_path.join("previous.txt").exists(),
+            "failed refresh must preserve previous replica workspace"
+        );
+        assert!(
+            !crate::db_backup::database_refresh_temp_path(&replica_db_path).exists(),
+            "failed refresh should clean staged DB"
+        );
+    }
+
+    #[test]
+    fn activation_db_failure_rolls_back_workspace_and_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let replica_db_path = dir.path().join("dailyos-replica.db");
+        write_marker_db(&replica_db_path, "old-replica");
+
+        let replica_workspace_path = dir.path().join("replica-workspace");
+        fs::create_dir_all(&replica_workspace_path).expect("old replica workspace");
+        fs::write(replica_workspace_path.join("previous.txt"), "keep")
+            .expect("old workspace marker");
+
+        let replica_config_path = dir.path().join("config-replica.json");
+        fs::write(&replica_config_path, "old config").expect("old config");
+
+        let paths = ReplicaRefreshPaths {
+            source_db_path: dir.path().join("dailyos.db"),
+            replica_db_path: replica_db_path.clone(),
+            source_workspace_path: dir.path().join("live-workspace"),
+            replica_workspace_path: replica_workspace_path.clone(),
+            replica_config_path: replica_config_path.clone(),
+            live_config: test_config(dir.path()),
+        };
+        let staged_paths = StagedReplicaPaths::from_paths(&paths);
+        fs::create_dir_all(&staged_paths.workspace_path).expect("staged workspace");
+        fs::write(staged_paths.workspace_path.join("new.txt"), "new")
+            .expect("staged workspace marker");
+        fs::write(&staged_paths.config_path, "new config").expect("staged config");
+        assert!(
+            !staged_paths.db_path.exists(),
+            "missing staged DB should force activation failure after workspace/config activation"
+        );
+
+        let error = activate_staged_replica(&paths, &staged_paths)
+            .expect_err("missing staged DB should fail activation");
+        assert!(error.contains("Database clone staged file does not exist"));
+
+        assert_eq!(read_marker_db(&replica_db_path), "old-replica");
+        assert!(
+            replica_workspace_path.join("previous.txt").exists(),
+            "old workspace must be restored after DB activation failure"
+        );
+        assert!(
+            !replica_workspace_path.join("new.txt").exists(),
+            "staged workspace must not remain active after rollback"
+        );
+        assert_eq!(
+            fs::read_to_string(&replica_config_path).expect("restored config"),
+            "old config"
+        );
+    }
+
+    #[test]
+    fn refresh_replica_from_live_paths_clones_db_workspace_and_redacted_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_db_path = dir.path().join("dailyos.db");
+        let replica_db_path = dir.path().join("dailyos-replica.db");
+        write_marker_db(&source_db_path, "new-live");
+
+        let source_workspace_path = dir.path().join("live-workspace");
+        let replica_workspace_path = dir.path().join("replica-workspace");
+        fs::create_dir_all(source_workspace_path.join("Accounts/Example")).expect("source dirs");
+        fs::write(
+            source_workspace_path.join("Accounts/Example/dashboard.json"),
+            "{}",
+        )
+        .expect("source workspace file");
+
+        let live_config: crate::types::Config = serde_json::from_value(serde_json::json!({
+            "workspacePath": source_workspace_path.to_string_lossy(),
+            "google": {
+                "enabled": true,
+                "tokenPath": "/live/token.json"
+            },
+            "linear": {
+                "enabled": true,
+                "apiKey": "lin-secret"
+            }
+        }))
+        .expect("live config");
+        let replica_config_path = dir.path().join("config-replica.json");
+        let paths = ReplicaRefreshPaths {
+            source_db_path: source_db_path.clone(),
+            replica_db_path: replica_db_path.clone(),
+            source_workspace_path: source_workspace_path.clone(),
+            replica_workspace_path: replica_workspace_path.clone(),
+            replica_config_path: replica_config_path.clone(),
+            live_config,
+        };
+
+        let report = refresh_replica_from_live_paths(paths).expect("refresh replica");
+
+        assert_eq!(report.source_db_path, source_db_path);
+        assert_eq!(report.replica_db_path, replica_db_path);
+        assert_eq!(report.source_workspace_path, source_workspace_path);
+        assert_eq!(report.replica_workspace_path, replica_workspace_path);
+        assert_eq!(report.files_copied, 1);
+        assert!(report.directories_created >= 2);
+        assert_eq!(read_marker_db(&report.replica_db_path), "new-live");
+        assert!(
+            report
+                .replica_workspace_path
+                .join("Accounts/Example/dashboard.json")
+                .exists(),
+            "workspace file should be copied into the replica workspace"
+        );
+
+        let replica_config: crate::types::Config = serde_json::from_str(
+            &fs::read_to_string(&replica_config_path).expect("replica config"),
+        )
+        .expect("parse replica config");
+        assert_eq!(
+            replica_config.workspace_path,
+            report.replica_workspace_path.to_string_lossy()
+        );
+        assert!(!replica_config.google.enabled);
+        assert!(replica_config.google.token_path.is_none());
+        assert!(!replica_config.linear.enabled);
+        assert!(replica_config.linear.api_key.is_none());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let parent = replica_config_path.parent().expect("replica config parent");
+            assert_eq!(
+                fs::metadata(parent)
+                    .expect("replica config parent mode")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700,
+                "replica config parent should be owner-only for the doctor path"
+            );
+            assert_eq!(
+                fs::metadata(&replica_config_path)
+                    .expect("replica config mode")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600,
+                "replica config should be owner-only after activation"
+            );
+        }
+        assert!(
+            !StagedReplicaPaths::from_paths(&ReplicaRefreshPaths {
+                source_db_path: report.source_db_path,
+                replica_db_path: report.replica_db_path,
+                source_workspace_path: report.source_workspace_path,
+                replica_workspace_path: report.replica_workspace_path,
+                replica_config_path,
+                live_config: test_config(dir.path()),
+            })
+            .db_path
+            .exists(),
+            "staged DB should be cleaned after a successful refresh"
+        );
+    }
+
+    #[test]
+    fn replica_config_redacts_live_connector_credentials() {
+        let live_config: crate::types::Config = serde_json::from_value(serde_json::json!({
+            "workspacePath": "/live",
+            "google": {
+                "enabled": true,
+                "tokenPath": "/live/token.json"
+            },
+            "drive": {
+                "enabled": true
+            },
+            "linear": {
+                "enabled": true,
+                "apiKey": "lin-secret"
+            },
+            "clay": {
+                "enabled": true,
+                "apiKey": "clay-secret",
+                "smitheryNamespace": "namespace",
+                "smitheryConnectionId": "connection"
+            },
+            "quill": {
+                "enabled": true,
+                "bridgePath": "/live/quill-bridge.js"
+            },
+            "granola": {
+                "enabled": true,
+                "cachePath": "/live/granola-cache.json"
+            },
+            "gravatar": {
+                "enabled": true,
+                "apiKey": "legacy-gravatar-secret"
+            }
+        }))
+        .expect("live config");
+        let replica = replica_config_from_live(live_config, Path::new("/replica-workspace"));
+
+        assert_eq!(replica.workspace_path, "/replica-workspace");
+        assert!(!replica.google.enabled);
+        assert!(replica.google.token_path.is_none());
+        assert!(!replica.drive.enabled);
+        assert!(!replica.linear.enabled);
+        assert!(replica.linear.api_key.is_none());
+        assert!(!replica.clay.enabled);
+        assert!(replica.clay.api_key.is_none());
+        assert!(replica.clay.smithery_namespace.is_none());
+        assert!(replica.clay.smithery_connection_id.is_none());
+        assert!(!replica.quill.enabled);
+        assert!(!replica.granola.enabled);
+        assert!(replica.granola.cache_path.is_empty());
+        assert!(!replica.gravatar.enabled);
+        assert!(replica.gravatar.api_key.is_none());
+    }
+
+    #[test]
+    fn clone_database_rejects_non_live_mode_prod_source() {
+        let _lock = crate::db::DB_MODE_TEST_LOCK.lock().expect("db mode lock");
+        let _reset = ResetDbMode;
+        crate::db::set_db_mode(DbMode::Replica);
+        let dailyos_dir = crate::db::dailyos_data_dir().expect("data dir");
+        let source = dailyos_dir.join("dailyos.db");
+        fs::create_dir_all(source.parent().expect("parent")).expect("parent");
+        fs::write(&source, b"placeholder").expect("source");
+        let replica = dailyos_dir.join("dailyos-replica.db");
+
+        let staged = crate::db_backup::database_refresh_temp_path(&replica);
+        let error = clone_database(&source, &replica, &staged).expect_err("non-Live source denied");
+        assert!(error.contains("Refused to open production database"));
+    }
+}


### PR DESCRIPTION
## Linear ticket

DOS-823

## Summary

Replica refresh is now an explicit doctor operation that can rebuild a replica environment from a live snapshot without allowing accidental production writes. The command requires explicitly requested Live mode, stages the database, workspace, and config separately, and activates each artifact with rollback so failures preserve the previous replica state.

## What changed

- Added `doctor replica-refresh` for read-only live-to-replica refresh through the SQLite backup API.
- Staged DB, workspace, and config activation with rollback for partial failures.
- Added destructive-command guards for production DB restore/start-fresh/clone destinations.
- Redacted connector configuration before writing replica config.
- Hardened refresh safety after L2 security review: live workspace paths cannot overlap replica destination/temp/previous paths, and replica config is written owner-only.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib db_backup::tests`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::replica_refresh::tests`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib doctor::tests::run_from_args_routes_replica_refresh_subcommand`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] `pnpm tsc --noEmit`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] Local L2 data-integrity, testing, and security review agents passed after follow-up fixes.

## Definition of Done

- [x] Acceptance criteria from DOS-823 are validated with real data paths and clone fixtures.
- [x] End-to-end doctor refresh path is covered through DB, workspace, config, rollback, and guard tests.
- [x] No stubs, TODOs, or follow-up deferrals introduced.
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field above is set false): _none_

**Exemption rationale**: Not exempt. This PR touches `src-tauri/src/services/**`, DB clone/restore guard code, and a doctor command that can replace replica storage. Local security L2 found two issues, both fixed and re-reviewed to PASS.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [ ] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [ ] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [ ] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- None.

## Notes for review

- No CLI demo is attached because a real refresh is intentionally guarded around local database state.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
