### PR TITLE
v1.5.0 W3 detail composition surfaces

### DIFF
--- a/.docs/design/_audits/reference-fidelity.md
+++ b/.docs/design/_audits/reference-fidelity.md
@@ -76,6 +76,10 @@ vs `src/pages/ProjectDetailEditorial.tsx`
 
 **Invented classes** (41): `ProjectDetailEditorial_actionAccent`, `ProjectDetailEditorial_actionAccentTerracotta`, `ProjectDetailEditorial_actionAccentTurmeric`, `ProjectDetailEditorial_actionDate`, `ProjectDetailEditorial_actionDateTerracotta`, `ProjectDetailEditorial_actionLink`, `ProjectDetailEditorial_actionMeta`, `ProjectDetailEditorial_actionSource`, `ProjectDetailEditorial_actionTitle`, `ProjectDetailEditorial_actionTitleBold`, `ProjectDetailEditorial_appendixDate`, `ProjectDetailEditorial_appendixDescription`, `ProjectDetailEditorial_appendixFrame`, `ProjectDetailEditorial_appendixMilestoneGrid`, `ProjectDetailEditorial_appendixName` … +26 more
 
+**Text deltas** (2 strings in TSX absent from HTML):
+- “Empty section”
+- “Project controls unavailable”
+
 ---
 
 ## Major (3)
@@ -84,6 +88,11 @@ vs `src/pages/ProjectDetailEditorial.tsx`
 vs `src/pages/PersonDetailEditorial.tsx`
 
 **Invented classes** (14): `PersonDetailEditorial_appendixFrame`, `PersonDetailEditorial_appendixGrid`, `PersonDetailEditorial_appendixLabel`, `PersonDetailEditorial_appendixRule`, `PersonDetailEditorial_appendixSection`, `PersonDetailEditorial_cadenceSeparator`, `PersonDetailEditorial_cadenceStrip`, `PersonDetailEditorial_cadenceTrendIncreasing`, `PersonDetailEditorial_fieldLabel`, `PersonDetailEditorial_fieldValue`, `PersonDetailEditorial_fieldValueCapitalize`, `PersonDetailEditorial_finisDate`, `PersonDetailEditorial_insightSection`, `PersonDetailEditorial_refreshButton`
+
+**Text deltas** (3 strings in TSX absent from HTML):
+- “Archive Person”
+- “Empty section”
+- “Person controls unavailable”
 
 ---
 

--- a/.docs/design/reference/surfaces/action-detail.html
+++ b/.docs/design/reference/surfaces/action-detail.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="../_shared/styles/MagazinePageLayout.module.css">
 
   <link rel="stylesheet" href="../_shared/styles/ActionDetailPage.module.css">
+  <link rel="stylesheet" href="../_shared/styles/FinisMarker.module.css">
   <link rel="stylesheet" href="../_shared/styles/EditableText.module.css">
   <link rel="stylesheet" href="../_shared/styles/editable-date.module.css">
   <link rel="stylesheet" href="../_shared/styles/editable-inline.module.css">
@@ -164,13 +165,17 @@
 
   <template data-state="error-and-completed">
     <div class="ActionDetailPage_errorState">
-      <p class="ActionDetailPage_errorTitle">Something went wrong</p>
+      <p class="ActionDetailPage_errorTitle">Action controls unavailable</p>
       <p class="ActionDetailPage_errorMessage">Action not found</p>
       <button class="ActionDetailPage_retryButton" type="button">Try again</button>
     </div>
     <span class="ActionDetailPage_titleEditable ActionDetailPage_titleCompleted">Completed action title</span>
     <input class="ActionDetailPage_titleInput" value="Editing title" aria-label="Action title" />
   </template>
+
+  <div class="FinisMarker_root" data-ds-tier="pattern" data-ds-name="FinisMarker" data-ds-spec="patterns/FinisMarker.md">
+    <div class="FinisMarker_marks" aria-hidden="true"><span>*</span><span>*</span><span>*</span></div>
+  </div>
 </div>
 
 </main>

--- a/.docs/plans/v1.5.0-w3-l0-packet.md
+++ b/.docs/plans/v1.5.0-w3-l0-packet.md
@@ -1,0 +1,231 @@
+# v1.5.0 W3 — L0 Plan Packet · Forward Detail Surfaces
+
+> **Status:** L0 passed in cycle 2. Wave W3 of the v1.5.0 Composable Surfaces program (`.docs/plans/v1.5.0-waves.html`).
+> **Prerequisites:** W1 and W2 merged to `dev`; W1 established the Tauri React `ReactBlockRenderer`, sectioned `ProjectedComposition`, first-party composition command, and `dailyos/account-overview`; W2 established account layout overlays without changing composition authorship.
+
+---
+
+## §0 — Origination & scope
+
+- **Origination class:** Extension. W3 carries the Account vertical slice forward to Project, Person, and Action Detail.
+- **Scope tier:** Wave. The wave plan names Project / Person / Actions as the next producer + surface group and requires the producer resolver and composition-id parser to move from account-hardcoded to composition-subject-keyed. Account, Project, and Person are entity subjects; Action Detail is a first-class non-entity action subject.
+- **Trust topology:** `local-to-local single-user`, with Amendment 3 paths. The work touches composition-producing abilities, claim/provenance/trust output, service-owned reads, first-party Tauri IPC, and rendered user-facing surfaces.
+- **Review posture:** AC-scoped. Blockers are acceptance-criteria misses, ADR-named contract violations, or PR-introduced regressions. Path-alpha issues route to Codebase Maintenance unless they directly invalidate this packet.
+- **Proof obligation:** Project Detail, Person Detail, and Action Detail each render end-to-end from substrate-authored `Composition` output through the W1 renderer, with provenance/trust treatment and safe fallback. No frontend-authored composition fallback, and no direct command data assembly masquerading as composition.
+
+---
+
+## §1 — Why W3 exists
+
+W1 proved the Account Detail composition vertical. W3 validates that Account was not a one-off by making the composition transport and producer routing composition-subject-keyed, then shipping three more detail surfaces through the same substrate-owned composition model.
+
+The existing Project and Person routed pages are React templates that call surface-specific detail commands, assemble chapter navigation in the frontend, and render imported chapter components. Action Detail is a canonical editing surface that loads one action via `get_action_detail`. W3 moves their primary read surface to substrate-authored compositions while preserving their expected editing affordances.
+
+The wave plan says "Actions" in W3 and list-surface work is a separate lane. W3 therefore interprets Actions as **Action Detail**, not the Actions list. If L0 review rejects that interpretation, W3 blocks before L1 rather than coding both a detail and list surface.
+
+---
+
+## §2 — K-in citations and constraints
+
+- **ADR-0130 Surface-Independent Composition Contract:** substrate owns composition; abilities return `AbilityOutput<Composition>`; renderers project blocks and never author composition; `ProvenanceRef` points into the single canonical envelope; unknown block fallback is schema-bounded and trust-capped.
+- **ADR-0045 Entity Abstraction:** `EntityType` already includes Account, Project, Person, and Other. W3 consumes that first-class entity model for Account/Project/Person and must not add `EntityType::Action`; Action Detail is modeled as an action subject, not a new entity type.
+- **ADR-0101 Service Boundary Enforcement:** commands do not perform domain mutations or bypass service-owned behavior. W3 producer inputs must enter through ability service handles or existing services, not direct command reads.
+- **W1 L0 packet:** W1 deliberately kept `resolve_producer_ability_name()` account-only for shipped behavior, but required a small producer registry shape so W3 can add Project/Person without rewriting transport. It also requires block components to be pure renderers over projected payload, not independent frontend query fanout.
+- **W1 proof bundle:** the accepted renderer path is Tauri `invoke("get_projected_composition")` → shared `CompositionRenderOrchestrator` → ability output → fallback projection → `ReactBlockRenderer`.
+- **Wave plan W3 row:** per surface, add a Composition producer mirroring `account-overview` plus the surface's variant-D block set; reuse cross-surface blocks built on Account; net-new block types are pattern-first.
+- **Wave plan carried item:** forward surfaces must generalize `resolve_producer_ability_name` and composition-id parsing from account-hardcoded to subject-keyed routing, and pre-allocate disjoint block-type registry + `patterns/` slots like SQL slot reservations.
+- **Surface references:** Project and Person target `.docs/design/reference/surfaces/project.html` and `.docs/design/reference/surfaces/person.html`; Action Detail target is `.docs/design/surfaces/ActionDetailPage.md` plus `.docs/design/reference/surfaces/action-detail.html`.
+
+No cited prior solution under `docs/solutions/` replaces these W3 requirements. The relevant prior substrate is ADR-0130 plus W1/W2.
+
+---
+
+## §3 — Binding decisions
+
+### Decision A — W3 uses one composition-subject-keyed producer registry
+
+W3 replaces the account-only producer resolver with a typed registry that maps a composition id to:
+
+- ability name
+- producer subject kind
+- subject id
+- schema version
+- required producer input key
+
+The parsed subject is explicit:
+
+- `ProducerSubject::Entity { entity_type: EntityType::Account | EntityType::Project | EntityType::Person, entity_id }`
+- `ProducerSubject::Action { action_id }`
+
+`action` in the composition id grammar is a subject key for Action Detail only. It is not `EntityType::Action`, does not create Action layout settings, and does not create a generic entity registry.
+
+Accepted composition id shapes:
+
+| Surface | Ability | Subject kind | Composition id |
+|---|---|---|---|
+| Account Detail | `dailyos/account-overview` | Entity(Account) | `dailyos/account-overview:account:{account_id}` |
+| Project Detail | `dailyos/project-overview` | Entity(Project) | `dailyos/project-overview:project:{project_id}` |
+| Person Detail | `dailyos/person-overview` | Entity(Person) | `dailyos/person-overview:person:{person_id}` |
+| Action Detail | `dailyos/action-detail` | Action | `dailyos/action-detail:action:{action_id}` |
+
+The parser rejects empty ids, malformed or extra delimiters, control characters, unknown ability prefixes, and ability/subject mismatches such as `dailyos/project-overview:person:{id}`. It returns an owned parsed input rather than `&str` account-only state.
+
+### Decision B — Project and Person mirror Account's claim-first producer architecture
+
+Project and Person producers use `read_entity_context_claims(entity_type, entity_id, TauriEntityDetail, depth)` for claim-backed sections, plus a narrow snapshot handle only for non-claim detail facts already loaded by existing Project/Person detail services.
+
+Snapshot fields follow the W1 wrapper discipline:
+
+- `value`
+- sensitivity
+- source label/ref when known
+- `source_asof` when known
+- trust band/status
+- provenance kind
+
+Explicit non-sensitive identity fields may be classified as `non_sensitive_identity`. Everything else must be claim-backed or wrapped. Empty/degraded blocks are producer output, not frontend omissions.
+
+### Decision C — Action Detail composition is a read surface with retained editing affordances
+
+Action Detail remains an editing workflow. W3 moves the page's primary rendered content into a substrate composition, while preserving service-owned mutation controls for title, status, priority, due date, context, account, source, and Linear push.
+
+The producer reads the action detail through a service/ability handle, emits an `ActionDetail` composition, and exposes edit routes only where the existing feedback or mutation path can safely handle the action field. UI controls still call existing commands/services for mutations; the composition is the read model and provenance/trust carrier.
+
+W3 adds first-class action subject support for this surface instead of falling back to global, user, or unknown subjects:
+
+- extend provenance subject modeling with `SubjectRef::Action(String)`
+- extend ownership target parsing for `action_id` and `{ entity_type: "action", entity_id }`
+- use `SubjectRef::Action(action_id)` for the Action Detail envelope and action field provenance
+- add `ClaimSubjectRef::Action` only if W3 emits claim-backed action claims
+
+`SubjectRef::Global`, `SubjectRef::User`, and `SubjectRef::Unknown` are not acceptable substitutes for Action Detail provenance.
+
+### Decision D — New block types are last resort, pattern-first
+
+W3 starts with existing W1 block types:
+
+- `account_overview` as a generic masthead-shaped block only if payload remains semantically neutral enough
+- `claim_summary`
+- `evidence_list`
+- `health_snapshot`
+- `relationship_map`
+- `risk_callout`
+- `action_list`
+- `markdown_document`
+- W1 primitives including `dailyos/score-band`
+
+The wave plan names meter cluster, relationship arc, and who's-waiting owed-grid as possible W3 net-new patterns. W3 treats them as follows:
+
+| Candidate | W3 default | Reason |
+|---|---|---|
+| meter cluster | reuse `health_snapshot` + `dailyos/score-band` unless tests show required payload cannot fit |
+| relationship arc | reuse `relationship_map`; rename/spec update only if the concept is the same |
+| who's-waiting owed-grid | add only if Action/Project/Person acceptance requires a grid that cannot be represented by `action_list` |
+
+Any net-new type ships in this order: `.docs/design/patterns/` spec, reference render slot, Rust `BlockType`/schema/fallback tests, TypeScript known type, React renderer tests.
+
+### Decision E — W3 is one wave PR with internal surface milestones
+
+The user's protocol requires one PR per wave. W3 will land as one PR, with implementation grouped internally:
+
+1. producer registry/parser generalization
+2. Project producer + page integration
+3. Person producer + page integration
+4. Action Detail producer + page integration
+5. proof/L2 remediation
+
+---
+
+## §4 — Work plan and acceptance criteria
+
+### W3-A — Subject-keyed composition producer routing
+
+- **Do:** Replace `ProducerProjectionInput { account_id, ... }` with a subject-keyed input that carries parsed ability name, `ProducerSubject`, composition id, schema version, and expected composition version.
+- **Do:** Replace `resolve_producer_ability_name()` and `extract_account_id_from_composition_id()` with one parser/registry that supports Account, Project, Person, and Action Detail.
+- **Do:** Keep cache identity scoped by composition id, current composition version, `SurfaceKind`, fallback policy version, and actor scope identity.
+- **Do:** Preserve W1 behavior for Account without changing its composition id.
+- **Do:** Extend the frontend projected-composition hook from account-only to subject keyed, while retaining account call sites through a thin wrapper or compatibility helper if needed.
+- **AC:** tests prove valid ids resolve to the correct ability/input, malformed ids fail closed, empty ids fail closed, extra delimiters/control characters fail closed, cross-subject mismatches fail closed, cache behavior is unchanged, and Account Detail still loads through the same command response shape.
+
+### W3-B — Project Detail composition producer and surface
+
+- **Do:** Add `dailyos/project-overview` returning `AbilityOutput<Composition>`.
+- **Do:** Use `SubjectRef::Project(project_id)` and claim eligibility for project-subject active claims; exclude dismissed, superseded, retracted, non-renderable, or sensitivity-disallowed claims.
+- **Do:** Add a service-owned Project composition snapshot reader for existing non-claim detail fields only where claims do not already carry the information.
+- **Do:** Emit variant-D Project sections from the reference surface: `headline`, optional `portfolio`, `trajectory`, `the-horizon`, `the-landscape`, `the-room`, `whats-next`, `the-record`, `the-work`, plus any existing `linear-issues` section only if backed by service-owned data.
+- **Do:** Render `ProjectDetailEditorial` from `useProjectedComposition({ entityType: "project", entityId })` and `ReactBlockRenderer`; derive magazine shell chapters from projected sections.
+- **Do:** Preserve user actions such as field edits, archive, project hierarchy navigation, and Linear issue controls through existing service-backed commands where still present.
+- **Do:** Declare and wire invalidation for project-subject claim version/lifecycle/dismissal/source freshness changes and service-owned Project field edits that affect emitted blocks. If an expected signal is missing, adding that signal emission is W3 scope.
+- **AC:** Project Detail renders from `dailyos/project-overview` with no old-template chapter assembly as the primary read path; producer tests cover claims, snapshot wrappers, empty sections, provenance validation, trust bands, sensitivity exclusion, and invalidation/refresh after claim and service-owned project field changes; frontend tests cover projected-section navigation and fallback/error states.
+
+### W3-C — Person Detail composition producer and surface
+
+- **Do:** Add `dailyos/person-overview` returning `AbilityOutput<Composition>`.
+- **Do:** Use `SubjectRef::Person(person_id)` and claim eligibility for person-subject active claims.
+- **Do:** Add a service-owned Person composition snapshot reader for display identity, relationship, organization/role, relationship signals, linked entities, upcoming/recent meetings, and open actions only where those are already safe for Tauri Detail render policy and wrapped with trust/provenance classification.
+- **Do:** Emit variant-D Person sections from the reference surface: `headline`, `the-dynamic` or `the-rhythm`, `their-orbit`, `their-network`, `the-landscape`, `open-threads`, `the-record`, `the-work`.
+- **Do:** Render `PersonDetailEditorial` from the projected composition and derive shell chapters from projected sections.
+- **Do:** Preserve person mutation controls such as field edits, merge/archive/delete, and relationship management through existing service-backed commands where still present.
+- **Do:** Declare and wire invalidation for person-subject claim version/lifecycle/dismissal/source freshness changes and service-owned Person field edits or relationship changes that affect emitted blocks. If an expected signal is missing, adding that signal emission is W3 scope.
+- **AC:** Person Detail renders from `dailyos/person-overview`; producer tests cover person claims, relationship/network blocks, snapshot wrappers, provenance validation, trust bands, sensitivity exclusion, empty sections, and invalidation/refresh after claim and service-owned person field changes; frontend tests cover projected-section navigation and fallback/error states.
+
+### W3-D — Action Detail composition producer and surface
+
+- **Do:** Add `dailyos/action-detail` returning `AbilityOutput<Composition>`.
+- **Do:** Use `SubjectRef::Action(action_id)` for action subject attribution; add the first-class action subject support described in Decision C before emitting Action Detail compositions. Do not use global, user, or unknown subjects as fallback.
+- **Do:** Add a service-owned Action composition snapshot reader over existing action detail data: title, status, priority, due date, context, linked account, source meeting, Linear state, created/completed dates, and auto-generated/source metadata.
+- **Do:** Emit Action Detail sections matching `.docs/design/surfaces/ActionDetailPage.md`: `headline`, `status`, `priority`, `context`, `reference`, `linear`, `action-bar` or equivalent section ids that derive the shell/navigation correctly without adding fake chapters.
+- **Do:** Preserve existing editable controls and mutation commands, including title, status, priority, context, due date, linked account, source, and Linear push. The producer is the read authority; mutation paths remain service-owned.
+- **Do:** Declare and wire invalidation for action title/status/priority/due date/context/account/source/Linear mutations that affect emitted blocks. If an expected signal is missing, adding that signal emission is W3 scope.
+- **AC:** Action Detail renders its primary data from `dailyos/action-detail`; editing title/status/priority/context/due date/account/source/Linear still works through existing command/service paths and re-renders the projected composition; producer tests cover standalone actions without source/account, missing Linear states, completed/open states, action-subject provenance validation, subject mismatch rejection, ownership parser rejection, trust classification, and empty/degraded source metadata; frontend tests cover loading, projected data, editing controls, and fallback/error states.
+
+### W3-E — Cross-surface block reuse and optional net-new patterns
+
+- **Do:** Map each W3 section to existing known block types first.
+- **Do:** If `dailyos/owed-grid` or another new type is genuinely required, pre-allocate its registry slot and pattern doc before adding code.
+- **Do:** Reconcile "relationship arc" with existing `relationship_map`; do not add a duplicate concept under a new type.
+- **AC:** known-block exhaustiveness tests pass; any new block has pattern docs, reference render, schema/fallback tests, TypeScript contract entry, and renderer tests. If no new block ships, the proof bundle states which existing blocks absorbed the named W3 concepts.
+
+### W3-F — Proof, verification, and L4 visual review
+
+- **Do:** Add `.docs/proofs/v1.5.0/W3-proof-bundle.md`.
+- **Do:** Run focused Rust producer/parser tests, frontend renderer/page tests, `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`, full relevant Rust tests, `pnpm test`, and `pnpm tsc --noEmit`.
+- **Do:** Run a replica smoke before PR: `DAILYOS_DB_MODE=replica cargo run --manifest-path src-tauri/Cargo.toml --bin workspace_graph_audit -- --format human --fail-on-gaps=false`, verifying no unintended production migration/write path is used.
+- **Do:** Capture L4 visual evidence for Project, Person, and Action Detail against `.docs/design/reference/surfaces/project.html`, `.docs/design/reference/surfaces/person.html`, and `.docs/design/reference/surfaces/action-detail.html` before L2 review begins.
+- **AC:** proof bundle records command/test output summaries, visual artifacts, fallback/provenance evidence, and any path-alpha maintenance items separated from blockers.
+
+---
+
+## §5 — Intelligence Loop integration check
+
+1. **Claim model:** W3 producers use existing active `IntelligenceClaim` records for claim-backed blocks. Non-claim identity/detail fields enter only through snapshot wrappers with sensitivity and provenance classification. W3 does not introduce ad-hoc frontend-only intelligence fields.
+2. **Provenance + trust:** Blocks carry `claim_refs`, `ProvenanceRef`, trust bands, source labels, and `source_asof` for each field where the backing source is known. Missing provenance degrades visibly per ADR-0130/W1.
+3. **Signals + invalidation:** Producers declare output-change signal policies for claim version/lifecycle/dismissal/source freshness plus relevant project/person/action field signals. Missing signal emission for W3-mutated fields is implemented in W3. Composition commits use existing composition versioning.
+4. **Runtime + surfaces:** Tauri Detail consumes `ProjectedComposition` through the shared command/orchestrator. External surfaces keep using the same projection substrate; W3 does not fork MCP/SurfaceClient behavior.
+5. **Feedback loop:** Existing correction/dismissal/edit routes remain service-owned. Claim-backed block feedback routes point to claims/field paths; action/project/person direct edits remain routed through current mutation commands/services.
+
+---
+
+## §6 — Out of scope
+
+- Briefing and Meeting composition producers (W4).
+- Settings layout controls for Project and Person (W5 unless W3 explicitly needs a minimal compatibility reset).
+- Actions list, bulk selection, bulk archive, and list-surface premise work.
+- A generic user-defined entity-type composition registry.
+- `EntityType::Action`, Action layout settings rows, or W5-style per-type layout configuration for Action.
+- A full ability runtime sweep beyond the producer routing needed for these four detail composition ids.
+- New lifecycle or claim-state schema unless a W3 producer cannot satisfy existing claim contracts without it.
+
+---
+
+## §7 — L0 review routing
+
+W3 L0 should include:
+
+- `/codex challenge` for plan coherence and wave-plan fit.
+- `ce-feasibility-reviewer` for the producer registry, service handle, and ability/runtime fit.
+- `ce-product-lens-reviewer` for the Action Detail interpretation and surface-retirement scope.
+- `ce-security-lens-reviewer` because W3 touches claim/provenance, render policy, and first-party IPC.
+- K-in citation check against `.docs/decisions/` and `docs/solutions/` as included in §2.
+
+Unanimous approval is required before L1. If a reviewer rejects the Action Detail interpretation, patch this packet and rerun W3 L0 before coding.

--- a/.docs/proofs/v1.5.0/W3-proof-bundle.md
+++ b/.docs/proofs/v1.5.0/W3-proof-bundle.md
@@ -1,0 +1,105 @@
+# v1.5.0 Wave 3 - Proof Bundle
+
+**Wave:** W3 - Forward detail surfaces
+**Date:** 2026-06-02
+**Branch:** `codex/v1.5.0-w3`
+**Base:** `public/dev` after W2 merge
+
+## Issue Map
+
+| Issue | Scope | Evidence |
+|---|---|---|
+| W3-0 | L0 plan packet and review | `.docs/plans/v1.5.0-w3-l0-packet.md`, `.docs/reviews/v1.5.0-w3-l0-cycle-1.md`, `.docs/reviews/v1.5.0-w3-l0-cycle-2.md` |
+| W3-A | Subject-keyed producer registry | `src-tauri/src/services/composition_render_orchestrator.rs` |
+| W3-B | Project overview producer | `src-tauri/abilities-runtime/src/abilities/project_overview.rs`, `src-tauri/src/services/context.rs` |
+| W3-C | Person overview producer | `src-tauri/abilities-runtime/src/abilities/person_overview.rs`, `src-tauri/src/services/context.rs` |
+| W3-D | Action detail producer | `src-tauri/abilities-runtime/src/abilities/action_detail.rs`, `src-tauri/src/services/context.rs` |
+| W3-E | Action claim subject support | `src-tauri/abilities-runtime/src/types.rs`, `src-tauri/abilities-runtime/src/abilities/provenance/subject.rs`, `src-tauri/src/services/claims.rs`, `src-tauri/src/db/claim_invalidation.rs`, `src-tauri/src/migrations/276_action_claim_version.sql` |
+| W3-F | Detail page projection routing | `src/hooks/useProjectedComposition.ts`, `src/hooks/useChapterLayout.ts`, `src/pages/ProjectDetailEditorial.tsx`, `src/pages/PersonDetailEditorial.tsx`, `src/pages/ActionDetailPage.tsx` |
+| W3-G | Signal invalidation | `src-tauri/src/services/projects.rs`, `src-tauri/src/services/people.rs`, `src-tauri/src/services/actions.rs`, `src-tauri/src/services/linear.rs` |
+| W3-H | Renderer/action feedback contract | `src/components/composition/ReactBlockRenderer.tsx`, `src/components/composition/blocks/BlockComponents.tsx`, `src/components/composition/CompositionInlineEdit.tsx`, `src/services/composition/contracts.ts` |
+
+## Acceptance Evidence
+
+- The composition orchestrator now resolves producers by subject identity rather than account-only routing. Project, person, and action composition ids map to `dailyos/project-overview:project:{id}`, `dailyos/person-overview:person:{id}`, and `dailyos/action-detail:action:{id}`.
+- The composition id parser rejects malformed ids, empty parts, extra delimiters, unknown producers, and producer/subject mismatches before execution.
+- Project and person overview producers accept orchestrator identity inputs while preserving subject validation, fallback projection, trust/provenance metadata, and renderable section/block output.
+- Action Detail is modeled as `ProducerSubject::Action`, not as a generic entity kind. Action provenance uses `SubjectRef::Action(action_id)`.
+- Action claims can be read through the claim service and invalidation version checks. Migration 276 adds action `claim_version` storage so action subject claim reads participate in the same invalidation discipline as account/project/person/meeting subjects.
+- Legacy entity-intelligence projection stays fail-closed for action subjects; Action Detail reads claim-backed context through the W3 action producer instead of adding an unsupported generic canonical action subject.
+- Project, person, action, and Linear mutation paths emit detail-surface invalidation signals when W3-visible fields change.
+- Project Detail and Person Detail render projected compositions first and keep their existing controls, hierarchy/network/appendix sections, and Linear chapter below the projected surface.
+- Action Detail renders the projected action composition first and preserves the existing editable action controls below it.
+- `useChapterLayout` supports action as a non-persisted layout subject, so W2 account/project/person overlays do not create action overlay writes.
+
+## Validation Log
+
+| Check | Command | Result |
+|---|---|---|
+| Diff whitespace | `git diff --check` | Pass |
+| Action producer tests | `cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml action_detail -- --nocapture` | Pass: 6 tests |
+| Project/person overview tests | `cargo test --manifest-path src-tauri/abilities-runtime/Cargo.toml overview -- --nocapture` | Pass: 24 unit tests plus 3 fallback projection tests |
+| App-side project composition tests | `cargo test --manifest-path src-tauri/Cargo.toml project_composition -- --nocapture` | Pass: 4 tests |
+| Claim version entity mapping | `cargo test --manifest-path src-tauri/Cargo.toml bump_each_entity_kind_targets_correct_table -- --nocapture` | Pass |
+| Action claim read regression | `cargo test --manifest-path src-tauri/Cargo.toml load_claims_active_accepts_action_subjects -- --nocapture` | Pass |
+| Mock data schema validator | `cargo test --manifest-path src-tauri/Cargo.toml test_mock_data_insert_statements_match_current_schema -- --nocapture` | Pass |
+| Reference fidelity audit | `python3 .docs/design/_audits/audit-reference.py` | Pass: Action Detail reference returned to `clean`; unrelated existing reference debt unchanged |
+| Rust clippy | `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` | Pass |
+| Full Rust tests | `cargo test --manifest-path src-tauri/Cargo.toml` | Pass: main lib `3134 passed; 0 failed; 11 ignored`; integration and doc tests completed cleanly |
+| Frontend typecheck | `pnpm tsc --noEmit` | Pass |
+| Detail mutation projection refresh regressions | `pnpm vitest run src/hooks/useProjectedComposition.test.tsx src/pages/ActionDetailPage.test.tsx src/pages/ProjectDetailEditorial.test.tsx src/pages/PersonDetailEditorial.test.tsx` | Pass: 4 files, 30 tests |
+| Frontend tests | `pnpm test` | Pass: 62 files, 345 tests |
+| Pre-commit hook | `.githooks/pre-commit` | Pass |
+
+Note: the full Rust test run emits pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; they do not fail clippy or tests.
+
+## Replica Smoke
+
+Replica smoke used `DAILYOS_DB_MODE=replica` and the replica database path `~/.dailyos/dailyos-replica.db`. The command exercised the live W3 projection path with a temporary local helper that was removed before this proof bundle.
+
+| Surface | Result | Sections | Root blocks | Rendered provenance | Unknown blocks | Served from cache |
+|---|---:|---:|---:|---:|---:|---:|
+| Project overview | Pass | 8 | 8 | present | 0 | false |
+| Person overview | Pass | 8 | 8 | present | 0 | false |
+| Action detail | Pass | 7 | 7 | present | 0 | false |
+
+No live replica content is included in this proof bundle. Only structural counts from the smoke are recorded.
+
+## L4 Surface Evidence
+
+Browser evidence used the local Vite dev server at `http://localhost:1420/` with sanitized synthetic Tauri responses. Live replica data was not copied into screenshots.
+
+| Surface | Composition id asserted | Sections asserted | Controls asserted | Screenshot |
+|---|---|---|---|---|
+| Project Detail | `dailyos/project-overview:project:project-l4` | `headline`, `portfolio`, `trajectory`, `the-horizon`, `the-landscape`, `the-room`, `whats-next`, `the-record` | `Project controls` with `Save` | `/private/tmp/dailyos-v150-w3-l4/project-main.png` |
+| Person Detail | `dailyos/person-overview:person:person-l4` | `headline`, `the-dynamic`, `their-orbit`, `their-network`, `the-landscape`, `open-threads`, `the-record`, `the-work` | `Person controls` with `Save` | `/private/tmp/dailyos-v150-w3-l4/person-main.png` |
+| Action Detail | `dailyos/action-detail:action:action-l4` | `headline`, `status`, `priority`, `context`, `reference`, `linear`, `action-bar` | `Action controls` with `Mark Complete` | `/private/tmp/dailyos-v150-w3-l4/action-main.png` |
+
+Additional L4 assertions:
+
+- `main[data-composition-id]` was visible for each route.
+- No `No project/person/action composition` empty fallback rendered.
+- No `No renderable blocks are available`, `controls unavailable`, `composition failed`, or error-boundary text rendered.
+- Onboarding/update/telemetry splash chrome was suppressed in the fixture state and did not appear in the screenshots.
+- Page errors were empty after the Tauri event lifecycle shim included listener cleanup.
+- Shell-only unhandled-command warnings from the browser harness were filtered as non-actionable; actionable console findings were empty.
+
+## Intelligence Loop Check
+
+| Question | W3 answer |
+|---|---|
+| Claim model | Project/person/action detail surfaces consume claim-backed producer outputs. Action is represented as an action subject for read/provenance/invalidation paths rather than display-only frontend data. |
+| Provenance + trust | Producers emit rendered provenance and trust-band-aware projected blocks. Action provenance uses `SubjectRef::Action(action_id)` instead of global/user/unknown attribution. |
+| Signals + invalidation | Project, person, action, and Linear mutation paths emit W3-visible invalidation signals. Action subjects now have claim-version state for invalidation jobs. |
+| Runtime + surfaces | Tauri detail routes consume subject-keyed projected compositions through `useProjectedComposition` and `useChapterLayout`. Generic legacy action entity-intelligence projection remains fail-closed. |
+| Feedback loop | Renderer feedback/inline edit contracts include action entity type support so claim-backed projected blocks can send corrections with the right surface subject. Presentation controls remain separate from claim mutation. |
+
+## L2 Readiness
+
+| Gate | Status | Notes |
+|---|---|---|
+| L0 review cycles | Passed | Cycle 2 accepted the W3 plan with action-as-subject, parser rejection, W3 signal emissions, and pre-L2 L4 requirements. |
+| Validation suite | Passed | Rust, clippy, frontend typecheck, frontend tests, focused producer/claim tests, and diff whitespace all passed. |
+| Replica smoke | Passed | Structural projection smoke passed against replica mode; no live data is included here. |
+| L4 surface proof | Passed | Sanitized browser assertions and screenshots captured for project, person, and action detail surfaces. |
+| L2 review | Passed | Cycle 3 passed with no blockers after stale projection refresh was remediated across Action, Project, Person, and Person relationship mutations. One nonblocking path-alpha test-depth item was routed to maintenance as `DOS-849`. |

--- a/.docs/reviews/v1.5.0-w3-l0-cycle-1.md
+++ b/.docs/reviews/v1.5.0-w3-l0-cycle-1.md
@@ -1,0 +1,39 @@
+# v1.5.0 W3 L0 Review — Cycle 1
+
+> **Verdict:** Blocked. Packet patched before L1.
+> **Scope:** AC-scoped W3 plan review for Project Detail, Person Detail, and Action Detail composable surfaces.
+
+## Reviewers
+
+- `/codex challenge`
+- `ce-feasibility-reviewer`
+- `ce-product-lens-reviewer`
+- `ce-security-lens-reviewer`
+- K-in citation check against `.docs/decisions/` and `docs/solutions/`
+
+## Blockers
+
+1. **Action subject/provenance contract was ambiguous.** The original packet used entity-keyed language and allowed an Action Detail fallback to an unspecified existing subject contract. That conflicted with ADR-0045 because Action is not an `EntityType`, and it left provenance ownership validation under-specified.
+   - **Remediation:** The packet now defines `ProducerSubject::Entity(...)` for Account/Project/Person and `ProducerSubject::Action { action_id }` for Action Detail. It explicitly forbids `EntityType::Action`, Action layout settings, and generic entity registry expansion. It requires `SubjectRef::Action(action_id)`, ownership parsing for action targets, and forbids global/user/unknown provenance fallback.
+
+2. **Invalidation proof was too soft.** The original packet said field signals were used "where available," which allowed stale projected compositions after claim or field changes.
+   - **Remediation:** W3-B/C/D now require invalidation and refresh proof for claim version/lifecycle/dismissal/source freshness changes plus service-owned Project, Person, and Action mutations that affect emitted blocks. Missing signal emission for W3-mutated fields is now W3 scope.
+
+3. **Action Detail edit preservation omitted title.** The Action Detail spec includes title editing, but the packet did not name it.
+   - **Remediation:** Decision C and W3-D now require preserving title editing along with status, priority, context, due date, account, source, and Linear controls.
+
+4. **L4 visual review ordering was under-specified.** The original packet required visual evidence but did not force it before L2.
+   - **Remediation:** W3-F now requires Project, Person, and Action Detail visual evidence against the reference surfaces before L2 review begins.
+
+## Path-alpha Items
+
+These were not W3 blockers unless they become acceptance-criteria misses during implementation:
+
+- Broader generic entity registry work beyond the four W3 composition ids.
+- Action list or bulk action surface work.
+- Optional new owed-grid or relationship-arc block types unless the W3 surfaces cannot satisfy acceptance criteria with existing blocks.
+- External SurfaceClient scope expansion beyond preserving the shared projection substrate.
+
+## Cycle 2 Focus
+
+Cycle 2 should verify only the remediated blockers above and avoid reopening path-alpha concerns unless they invalidate the W3 acceptance criteria or an ADR-named contract.

--- a/.docs/reviews/v1.5.0-w3-l0-cycle-2.md
+++ b/.docs/reviews/v1.5.0-w3-l0-cycle-2.md
@@ -1,0 +1,44 @@
+# v1.5.0 W3 L0 Review — Cycle 2
+
+> **Verdict:** Pass. No AC-scoped blockers remain.
+> **Scope:** Targeted re-review of cycle-1 blockers only. Path-alpha findings remain nonblocking unless they become acceptance-criteria misses or ADR-named contract violations during L1.
+
+## Reviewer Verdicts
+
+| Reviewer | Verdict | Blockers |
+|---|---:|---:|
+| `/codex challenge` | Pass | 0 |
+| `ce-feasibility-reviewer` | Pass | 0 |
+| `ce-product-lens-reviewer` | Pass | 0 |
+| `ce-security-lens-reviewer` | Pass | 0 |
+
+## Accepted Remediation
+
+- W3 now uses a subject-keyed producer registry bounded to Account, Project, Person, and Action Detail.
+- Action Detail uses `ProducerSubject::Action { action_id }` and explicitly does not add `EntityType::Action`.
+- Action Detail provenance requires `SubjectRef::Action(action_id)` and ownership parsing for `action_id` / `{ entity_type: "action", entity_id }`.
+- `SubjectRef::Global`, `SubjectRef::User`, and `SubjectRef::Unknown` are forbidden as Action Detail substitutes.
+- Composition-id parsing must fail closed for malformed ids, empty ids, extra delimiters, control characters, unknown ability prefixes, and ability/subject mismatches.
+- Invalidation and refresh proof is mandatory for claim lifecycle/source freshness and service-owned Project, Person, and Action mutations. Missing signal emission for W3-mutated fields is W3 scope.
+- Action title editing and existing mutation controls are preserved.
+- L4 visual evidence for Project, Person, and Action Detail is required before L2 review begins.
+
+## Path-alpha Items
+
+These remain nonblocking for W3:
+
+- Broader generic entity registry work beyond the four W3 composition ids.
+- Action list, bulk selection, bulk archive, and other list-surface work.
+- Optional owed-grid or relationship-arc block additions unless existing blocks cannot satisfy W3 acceptance criteria.
+- External SurfaceClient expansion beyond preserving the shared projection substrate.
+- Design polish beyond the named reference-surface visual proof.
+
+## L1 Entry
+
+W3 may enter implementation in this order:
+
+1. subject-keyed registry and parser
+2. Project producer + page integration
+3. Person producer + page integration
+4. Action Detail producer + page integration
+5. proof bundle, replica smoke, L4 visual evidence, and L2

--- a/.docs/reviews/v1.5.0-w3-l2-cycle-1.md
+++ b/.docs/reviews/v1.5.0-w3-l2-cycle-1.md
@@ -1,0 +1,19 @@
+# v1.5.0 W3 L2 Review - Cycle 1
+
+> **Verdict:** Fail.
+> **Scope:** Bounded W3 diff review against W3 acceptance criteria. Path-alpha findings are nonblocking and belong in Codebase Maintenance.
+
+## Blocking Finding
+
+Action Detail mutations reloaded only the legacy action detail state after status, field, and Linear mutations. They did not refetch the projected composition, so the visible projected surface could remain stale after edits. This violated W3-D acceptance criteria requiring title/status/priority/context/due date/account/source/Linear edits to keep working through existing service paths and re-render the projected composition.
+
+## Remediation
+
+- Added an explicit force-refresh option to the projected composition command and orchestrator cache path.
+- Updated `useProjectedComposition().refetch()` to accept `{ forceRefresh: true }`.
+- Updated Action Detail mutation paths to reload the legacy controls state and force-refresh the projected action composition after each existing service mutation.
+- Added frontend regression coverage for explicit force-refresh requests and Action Detail mutation refresh behavior.
+
+## Path-alpha Items
+
+None.

--- a/.docs/reviews/v1.5.0-w3-l2-cycle-2.md
+++ b/.docs/reviews/v1.5.0-w3-l2-cycle-2.md
@@ -1,0 +1,21 @@
+# v1.5.0 W3 L2 Review - Cycle 2
+
+> **Verdict:** Fail.
+> **Scope:** Bounded re-review after cycle-1 Action Detail remediation. Path-alpha findings are nonblocking and belong in Codebase Maintenance.
+
+## Blocking Finding
+
+Project and Person detail surfaces could still leave projected compositions stale after service-owned changes. Project and Person rendered projected composition data independently from their legacy detail hooks, but save flows only reloaded the legacy detail state. Person relationship link/unlink/change callbacks had the same stale-projection shape.
+
+This violated W3-B and W3-C refresh-after-service-owned-change acceptance criteria.
+
+## Remediation
+
+- Project controls now force-refresh the projected composition after existing save, refresh, restore, and action-create mutations that remain on the current detail surface.
+- Person controls now force-refresh the projected composition after existing save, refresh, restore, and action-create mutations that remain on the current detail surface.
+- Person relationship link/unlink callbacks and relationship-change callbacks now force-refresh the projected composition after the existing relationship mutation path.
+- Added Project and Person page regression tests for post-mutation `forceRefresh` behavior.
+
+## Path-alpha Items
+
+None.

--- a/.docs/reviews/v1.5.0-w3-l2-cycle-3.md
+++ b/.docs/reviews/v1.5.0-w3-l2-cycle-3.md
@@ -1,0 +1,19 @@
+# v1.5.0 W3 L2 Review - Cycle 3
+
+> **Verdict:** Pass.
+> **Scope:** Bounded re-review after cycle-2 Project/Person refresh remediation. Path-alpha findings are nonblocking and belong in Codebase Maintenance.
+
+## Blocking Findings
+
+None.
+
+## Accepted Remediation
+
+- Action Detail post-mutation projection refresh remains force-refresh backed.
+- Project controls force-refresh projected composition after existing service mutations that keep the user on the current detail surface.
+- Person controls and relationship mutations force-refresh projected composition after existing service mutations that keep the user on the current detail surface.
+- Focused regression tests cover Action, Project, Person, and hook-level explicit `forceRefresh` behavior.
+
+## Path-alpha Items
+
+- `DOS-849`: Add separate regression tests for the other already-wrapped Project and Person mutation controls: enrich, restore, and action-create. These are nonblocking because the implementation routes them through the same force-refresh wrapper verified by the save-path tests.

--- a/src-tauri/abilities-runtime/src/abilities/action_detail.rs
+++ b/src-tauri/abilities-runtime/src/abilities/action_detail.rs
@@ -1,0 +1,2176 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use dailyos_abilities_macro::ability;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::abilities::claims::{metadata_for_name, ClaimType, FreshnessDecayClass};
+use crate::abilities::composition::{
+    AbilityRef, BindingRole, Block, BlockId, BlockType, ClaimRef, Composition, CompositionDocId,
+    CompositionKind, CompositionMetadata, CompositionVersion, EntityRef, FieldBinding,
+    ProvenanceRef, Salience, SalienceBand, Section, SectionId, SectionLayout,
+};
+use crate::abilities::provenance::source_time::{parse_source_timestamp, SourceTimestampStatus};
+use crate::abilities::provenance::trust::{claim_trust_band_from_score, most_cautious_trust_band};
+use crate::abilities::provenance::{
+    AbilityExecutionMode, AbilityVersion, Confidence, DataSource, EntityId, FieldAttribution,
+    FieldPath, GleanDownstream, InputsSnapshot, InvocationId, ProvenanceBuilder,
+    ProvenanceBuilderConfig, SchemaVersion, SourceAttribution, SourceIdentifier, SourceName,
+    SourceRef, SubjectAttribution, SubjectRef,
+};
+use crate::abilities::trust::TrustBand;
+use crate::abilities::{
+    AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
+};
+use crate::services::context::{
+    ActionCompositionProvenanceKind, ActionCompositionSnapshot, ActionCompositionSnapshotField,
+    ActionCompositionSnapshotReadError, CompositionCommitError, CompositionProposal,
+};
+use crate::types::{
+    prompt_input_sensitivity_allowed, subject_ref_from_json, ClaimState, ClaimSubjectRef,
+    IntelligenceClaim, SurfacingState,
+};
+
+const ABILITY_NAME: &str = "dailyos/action-detail";
+const ABILITY_SCHEMA_VERSION: u32 = 1;
+const ACTION_CLAIM_DEPTH: usize = 1;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct ActionDetailInput {
+    pub schema_version: u32,
+    pub action_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_ref: Option<Value>,
+    #[serde(default)]
+    pub expected_composition_version: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composition_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedInput {
+    action_id: String,
+    expected_composition_version: u64,
+    composition_id: CompositionDocId,
+}
+
+struct PreparedActionDetail {
+    proposal: CompositionProposal,
+    provenance_builder: ProvenanceBuilder,
+}
+
+#[derive(Debug, Clone)]
+struct ClaimProjection {
+    claim: IntelligenceClaim,
+    claim_type: ClaimType,
+    placement: ClaimPlacement,
+    source_index: crate::abilities::provenance::SourceIndex,
+    trust_band: TrustBand,
+    rendered_text: String,
+    parsed_source_asof: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+struct SnapshotReadOutcome {
+    snapshot: Option<ActionCompositionSnapshot>,
+    degraded_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimPlacement {
+    Status,
+    Context,
+    Reference,
+    Work,
+    Risk,
+    Ignored,
+}
+
+#[ability(
+    name = "dailyos/action-detail",
+    category = Read,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [User, SurfaceClient],
+    allowed_modes = [Live],
+    requires_confirmation = false,
+    may_publish = false,
+    required_scopes = ["read.action_detail"],
+    mcp_exposure = Invocable,
+    client_side_executable = false,
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [
+        "claim.version",
+        "action_subject.claim_changed",
+        "claim.lifecycle",
+        "claim.dismissal",
+        "source.freshness",
+        "source.revocation",
+        "action.field_changed",
+        "action_completed",
+        "action_reopened",
+        "action_pushed_to_linear"
+    ], coalesce = true }
+)]
+pub async fn action_detail(
+    ctx: &AbilityContext<'_>,
+    input: ActionDetailInput,
+) -> AbilityResult<Composition> {
+    let input = normalize_input(input)?;
+    let prepared = prepare_action_detail(ctx, &input).await?;
+    let committed = ctx
+        .services()
+        .commit_composition(prepared.proposal)
+        .await
+        .map_err(composition_commit_error)?;
+    let output = prepared
+        .provenance_builder
+        .finalize(committed.composition)
+        .map_err(provenance_error)?;
+    validate_block_provenance(output.data(), output.provenance())?;
+    Ok(output)
+}
+
+fn normalize_input(input: ActionDetailInput) -> Result<NormalizedInput, AbilityError> {
+    if input.schema_version != ABILITY_SCHEMA_VERSION {
+        return Err(validation_error(format!(
+            "unsupported schema_version `{}` for `{ABILITY_NAME}`",
+            input.schema_version
+        )));
+    }
+    let action_id = input.action_id.trim();
+    if action_id.is_empty() {
+        return Err(validation_error("action_id must be non-empty"));
+    }
+    validate_subject_ref(action_id, input.subject_ref.as_ref())?;
+    let composition_id = input
+        .composition_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("dailyos/action-detail:action:{action_id}"));
+    validate_composition_id(action_id, &composition_id)?;
+
+    Ok(NormalizedInput {
+        action_id: action_id.to_string(),
+        expected_composition_version: input.expected_composition_version,
+        composition_id: CompositionDocId::new(composition_id),
+    })
+}
+
+fn validate_subject_ref(action_id: &str, subject_ref: Option<&Value>) -> Result<(), AbilityError> {
+    let Some(subject_ref) = subject_ref else {
+        return Ok(());
+    };
+    let Some(action_ref) = subject_ref.get("action").and_then(Value::as_str) else {
+        return Err(validation_error("subject_ref must contain action"));
+    };
+    if action_ref.trim() != action_id {
+        return Err(validation_error("subject_ref action must match action_id"));
+    }
+    Ok(())
+}
+
+fn validate_composition_id(action_id: &str, composition_id: &str) -> Result<(), AbilityError> {
+    let parts = composition_id.split(':').collect::<Vec<_>>();
+    if parts.len() != 3 || parts[0] != ABILITY_NAME || parts[1] != "action" || parts[2] != action_id
+    {
+        return Err(validation_error(format!(
+            "composition_id must be `{ABILITY_NAME}:action:{action_id}`"
+        )));
+    }
+    if composition_id.chars().any(char::is_control) {
+        return Err(validation_error(
+            "composition_id must not contain control characters",
+        ));
+    }
+    Ok(())
+}
+
+async fn prepare_action_detail(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+) -> Result<PreparedActionDetail, AbilityError> {
+    let snapshot = read_action_snapshot(ctx, input).await?;
+    let claims = ctx
+        .services()
+        .read_entity_context_claims(
+            "action".to_string(),
+            input.action_id.clone(),
+            ctx.entity_context_claim_surface(),
+            ACTION_CLAIM_DEPTH,
+        )
+        .await
+        .map_err(|error| hard_error("action_detail_claim_read", error))?;
+
+    let subject_ref = SubjectRef::Action(input.action_id.clone());
+    let subject = SubjectAttribution::direct_confident(subject_ref);
+    let provenance_config = provenance_config(ctx);
+    let invocation_id = provenance_config.invocation_id;
+    let mut provenance_builder = ProvenanceBuilder::new(provenance_config);
+    provenance_builder.set_subject(subject.clone());
+
+    let mut projections = Vec::new();
+    for claim in claims {
+        let Some(projection) = action_claim(ctx, &input.action_id, claim, &mut provenance_builder)?
+        else {
+            continue;
+        };
+        projections.push(projection);
+    }
+    projections.sort_by(compare_claim_projection);
+
+    let composition = build_composition(
+        ctx,
+        input,
+        &projections,
+        &snapshot,
+        &subject,
+        invocation_id,
+        &mut provenance_builder,
+    )?;
+
+    Ok(PreparedActionDetail {
+        proposal: CompositionProposal {
+            composition_id: input.composition_id.clone(),
+            expected_composition_version: input.expected_composition_version,
+            composition,
+        },
+        provenance_builder,
+    })
+}
+
+async fn read_action_snapshot(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+) -> Result<SnapshotReadOutcome, AbilityError> {
+    match ctx
+        .services()
+        .read_action_composition_snapshot(
+            input.action_id.clone(),
+            ctx.entity_context_claim_surface(),
+        )
+        .await
+    {
+        Ok(snapshot) => Ok(SnapshotReadOutcome {
+            snapshot: Some(snapshot),
+            degraded_reason: None,
+        }),
+        Err(ActionCompositionSnapshotReadError::ActionNotFound(action_id)) => Err(
+            validation_error(format!("action `{action_id}` was not found")),
+        ),
+        Err(ActionCompositionSnapshotReadError::ReadFailed(_)) => Ok(SnapshotReadOutcome {
+            snapshot: None,
+            degraded_reason: Some("action_snapshot_unavailable".to_string()),
+        }),
+    }
+}
+
+fn action_claim(
+    ctx: &AbilityContext<'_>,
+    action_id: &str,
+    claim: IntelligenceClaim,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Option<ClaimProjection>, AbilityError> {
+    if !claim_is_eligible_for_action_detail(&claim, action_id)? {
+        return Ok(None);
+    }
+    let Some(metadata) = metadata_for_name(&claim.claim_type) else {
+        return Err(validation_error(format!(
+            "unknown claim_type `{}` in action detail input",
+            claim.claim_type
+        )));
+    };
+    let placement = placement_for_claim_type(metadata.kind);
+    if placement == ClaimPlacement::Ignored {
+        return Ok(None);
+    }
+    let rendered_text = claim.text.trim().to_string();
+    if rendered_text.is_empty() {
+        return Ok(None);
+    }
+
+    let source = source_for_claim(ctx, action_id, &claim)?;
+    let parsed_source_asof = source.source_asof;
+    let source_index = provenance_builder.add_source(source);
+    let trust_band = resolved_claim_trust_band(&claim, metadata.kind, ctx.services().clock.now());
+    provenance_builder.set_source_trust_band(source_index, trust_band);
+
+    Ok(Some(ClaimProjection {
+        claim,
+        claim_type: metadata.kind,
+        placement,
+        source_index,
+        trust_band,
+        rendered_text,
+        parsed_source_asof,
+    }))
+}
+
+fn claim_is_eligible_for_action_detail(
+    claim: &IntelligenceClaim,
+    action_id: &str,
+) -> Result<bool, AbilityError> {
+    if claim.claim_state != ClaimState::Active || claim.surfacing_state != SurfacingState::Active {
+        return Ok(false);
+    }
+    if claim.superseded_by.is_some()
+        || claim.retraction_reason.is_some()
+        || claim
+            .demotion_reason
+            .as_deref()
+            .is_some_and(|reason| reason.eq_ignore_ascii_case("dismissed"))
+    {
+        return Ok(false);
+    }
+    if !prompt_input_sensitivity_allowed(&claim.sensitivity) {
+        return Ok(false);
+    }
+
+    let value: Value = serde_json::from_str(&claim.subject_ref)
+        .map_err(|error| validation_error(format!("invalid claim subject_ref JSON: {error}")))?;
+    match subject_ref_from_json(&value)
+        .map_err(|error| validation_error(format!("invalid claim subject_ref: {error}")))?
+    {
+        ClaimSubjectRef::Action { id } => Ok(id == action_id),
+        ClaimSubjectRef::Account { .. }
+        | ClaimSubjectRef::Person { .. }
+        | ClaimSubjectRef::Project { .. }
+        | ClaimSubjectRef::Meeting { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => Ok(false),
+    }
+}
+
+fn placement_for_claim_type(kind: ClaimType) -> ClaimPlacement {
+    match kind {
+        ClaimType::Risk | ClaimType::EntityRisk => ClaimPlacement::Risk,
+        ClaimType::Commitment | ClaimType::OpenLoop | ClaimType::Recommendation => {
+            ClaimPlacement::Work
+        }
+        ClaimType::EntityCurrentState | ClaimType::EntitySummary => ClaimPlacement::Status,
+        ClaimType::UserNote | ClaimType::CompanyContext | ClaimType::AccountFact => {
+            ClaimPlacement::Context
+        }
+        ClaimType::EntityIdentity | ClaimType::ValueDelivered | ClaimType::EntityWin => {
+            ClaimPlacement::Reference
+        }
+        ClaimType::Win
+        | ClaimType::StakeholderEngagement
+        | ClaimType::StakeholderAssessment
+        | ClaimType::StakeholderRole
+        | ClaimType::LinkingDismissed
+        | ClaimType::EmailDismissed
+        | ClaimType::IntelligenceFieldDismissed
+        | ClaimType::FeedbackFieldDismissed
+        | ClaimType::TriageSnooze
+        | ClaimType::MeetingEntityDismissed
+        | ClaimType::AccountFieldCorrection
+        | ClaimType::DismissedItem
+        | ClaimType::BriefingCalloutDismissed
+        | ClaimType::NudgeDismissed
+        | ClaimType::MeetingReadiness
+        | ClaimType::MeetingTopic
+        | ClaimType::MeetingEventNote
+        | ClaimType::AttendeeContext
+        | ClaimType::MeetingChangeMarker
+        | ClaimType::SuggestedOutcome => ClaimPlacement::Ignored,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_composition(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    projections: &[ClaimProjection],
+    snapshot_outcome: &SnapshotReadOutcome,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Composition, AbilityError> {
+    let snapshot = snapshot_outcome.snapshot.as_ref();
+    let mut sections = Vec::new();
+    sections.push(section(
+        "headline",
+        "Headline",
+        vec![build_overview_block(
+            ctx,
+            input,
+            projections,
+            snapshot_outcome,
+            "/sections/0/blocks/0",
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?],
+        SectionLayout::Stacked,
+        salience(0.96, SalienceBand::Critical, "action masthead"),
+    ));
+
+    for (section_index, (section_id, label, layout, band, reason)) in [
+        (
+            "status",
+            "Status",
+            SectionLayout::Stacked,
+            SalienceBand::Important,
+            "action status",
+        ),
+        (
+            "priority",
+            "Priority",
+            SectionLayout::Inline,
+            SalienceBand::Important,
+            "action priority",
+        ),
+        (
+            "context",
+            "Context",
+            SectionLayout::Stacked,
+            SalienceBand::Important,
+            "action context",
+        ),
+        (
+            "reference",
+            "Reference",
+            SectionLayout::Grid,
+            SalienceBand::Contextual,
+            "action reference",
+        ),
+        (
+            "linear",
+            "Linear",
+            SectionLayout::Stacked,
+            SalienceBand::Contextual,
+            "action linear state",
+        ),
+        (
+            "action-bar",
+            "Action bar",
+            SectionLayout::Inline,
+            SalienceBand::Background,
+            "action controls",
+        ),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let index = section_index + 1;
+        let claims = projections
+            .iter()
+            .filter(|projection| claim_belongs_to_section(projection.placement, section_id))
+            .collect::<Vec<_>>();
+        let fields = snapshot_fields_for_section(snapshot, section_id);
+        let blocks = build_claim_or_snapshot_blocks(
+            ctx,
+            input,
+            section_id,
+            index,
+            claims,
+            fields,
+            EmptySectionCopy {
+                title: empty_title(section_id),
+                body: empty_body(section_id),
+                status: "empty",
+            },
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?;
+        sections.push(section(
+            section_id,
+            label,
+            blocks,
+            layout,
+            salience(0.74, band, reason),
+        ));
+    }
+
+    let section_count = sections.len();
+    let generated_at = ctx.services().clock.now();
+    let composition = Composition::new(
+        input.composition_id.clone(),
+        CompositionKind::Custom {
+            type_id: "action_detail".to_string(),
+        },
+        Some(EntityRef::new(format!("action:{}", input.action_id))),
+        sections,
+        salience(0.9, SalienceBand::Important, "action detail"),
+        generated_at,
+        AbilityRef::new(ABILITY_NAME),
+        CompositionMetadata {
+            schema_version: SchemaVersion(ABILITY_SCHEMA_VERSION),
+            generated_at,
+            composition_version: CompositionVersion::new(0),
+            generated_by: ABILITY_NAME.to_string(),
+        },
+    );
+
+    attribute_static_composition_fields(provenance_builder, subject, section_count)?;
+    Ok(composition)
+}
+
+fn claim_belongs_to_section(placement: ClaimPlacement, section_id: &str) -> bool {
+    matches!(
+        (placement, section_id),
+        (ClaimPlacement::Status, "status")
+            | (ClaimPlacement::Context, "context")
+            | (ClaimPlacement::Reference, "reference")
+            | (ClaimPlacement::Work, "action-bar")
+            | (ClaimPlacement::Risk, "status")
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EmptySectionCopy {
+    title: &'static str,
+    body: &'static str,
+    status: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SectionBlockPosition<'a> {
+    section_id: &'a str,
+    section_index: usize,
+    block_index: usize,
+}
+
+impl SectionBlockPosition<'_> {
+    fn composition_path(&self) -> String {
+        format!(
+            "/sections/{}/blocks/{}",
+            self.section_index, self.block_index
+        )
+    }
+}
+
+fn section(
+    id: &str,
+    label: &str,
+    blocks: Vec<Block>,
+    layout: SectionLayout,
+    salience: Salience,
+) -> Section {
+    let mut section = Section::new(SectionId::new(id), blocks);
+    section.label = Some(label.to_string());
+    section.layout = layout;
+    section.salience = salience;
+    section
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_claim_or_snapshot_blocks(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    section_id: &str,
+    section_index: usize,
+    projections: Vec<&ClaimProjection>,
+    snapshot_fields: Vec<&ActionCompositionSnapshotField>,
+    empty_copy: EmptySectionCopy,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Vec<Block>, AbilityError> {
+    let mut blocks = Vec::new();
+    for projection in projections {
+        let block_index = blocks.len();
+        blocks.push(build_claim_block(
+            input,
+            section_id,
+            projection,
+            subject,
+            invocation_id,
+            &format!("/sections/{section_index}/blocks/{block_index}"),
+            provenance_builder,
+        )?);
+    }
+    if !snapshot_fields.is_empty() {
+        let block_index = blocks.len();
+        blocks.push(build_snapshot_fields_block(
+            ctx,
+            input,
+            section_id,
+            section_index,
+            block_index,
+            snapshot_fields,
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?);
+    }
+    if blocks.is_empty() {
+        blocks.push(build_section_state_block(
+            input,
+            SectionBlockPosition {
+                section_id,
+                section_index,
+                block_index: 0,
+            },
+            empty_copy,
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?);
+    }
+    Ok(blocks)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_overview_block(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    projections: &[ClaimProjection],
+    snapshot_outcome: &SnapshotReadOutcome,
+    composition_block_path: &str,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Block, AbilityError> {
+    let snapshot = snapshot_outcome.snapshot.as_ref();
+    let headline_fields = snapshot_fields_for_section(snapshot, "headline");
+    let mut source_indexes = projections
+        .iter()
+        .map(|projection| projection.source_index)
+        .collect::<Vec<_>>();
+    source_indexes.extend(snapshot_source_indexes(
+        ctx,
+        input,
+        &headline_fields,
+        provenance_builder,
+    )?);
+
+    let all_refs = projections
+        .iter()
+        .map(claim_ref_for_projection)
+        .collect::<Result<Vec<_>, _>>()?;
+    let trust_band = block_trust_band(projections.iter().map(|projection| projection.trust_band));
+    let counts_by_band = trust_band_counts(projections);
+    let title = snapshot
+        .map(|snapshot| snapshot_value_text(&snapshot.title.value))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| input.action_id.clone());
+    let status = snapshot
+        .and_then(|snapshot| snapshot.status.as_ref())
+        .map(|field| snapshot_value_text(&field.value));
+    let priority = snapshot
+        .and_then(|snapshot| snapshot.priority.as_ref())
+        .map(|field| snapshot_value_text(&field.value));
+    let vitals = headline_fields
+        .iter()
+        .map(|field| {
+            json!({
+                "label": field.label,
+                "value": snapshot_value_text(&field.value),
+                "source_label": field.source_label,
+                "source_asof": field.source_asof,
+                "trust_band": trust_band_label(field.trust_band),
+            })
+        })
+        .collect::<Vec<_>>();
+    let context = projections
+        .iter()
+        .map(|projection| {
+            json!({
+                "claim_id": projection.claim.id,
+                "text": projection.rendered_text,
+                "trust_band": trust_band_label(projection.trust_band),
+                "source_asof": projection.claim.source_asof,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let vitals_len = vitals.len();
+    let attributes = json!({
+        "entity_type": "action",
+        "action_id": input.action_id,
+        "account": {
+            "id": input.action_id,
+            "display_name": title,
+            "type": "Action",
+        },
+        "action": {
+            "id": input.action_id,
+            "title": title,
+            "status": status,
+            "priority": priority,
+        },
+        "title": "Action detail",
+        "summary": context
+            .first()
+            .and_then(|value| value.get("text"))
+            .and_then(Value::as_str)
+            .unwrap_or("Action detail is grounded in the current action record and any action-local claims."),
+        "claim_count": projections.len(),
+        "trust_band": trust_band_label(trust_band),
+        "counts_by_trust_band": counts_by_band,
+        "context": context,
+        "vitals": vitals,
+        "snapshot_degraded": snapshot_outcome.degraded_reason.as_deref().unwrap_or(""),
+    });
+    let mut block = Block::new(
+        BlockId::new(block_id(input, "headline", "account_overview", "summary")),
+        BlockType::AccountOverview,
+        attributes,
+        all_refs,
+        ProvenanceRef::new(
+            invocation_id,
+            FieldPath::new(composition_block_path).map_err(field_error)?,
+        ),
+        None,
+    )
+    .map_err(block_error)?;
+    block.salience = salience(0.96, SalienceBand::Critical, "summary");
+
+    let mut bindings = vec![
+        display_only_binding("/title")?,
+        display_only_binding("/account/id")?,
+        display_only_binding("/account/display_name")?,
+        display_only_binding("/account/type")?,
+        display_only_binding("/action/id")?,
+        display_only_binding("/action/title")?,
+        display_only_binding("/action/status")?,
+        display_only_binding("/action/priority")?,
+        display_only_binding("/snapshot_degraded")?,
+    ];
+    bindings.extend(vitals_display_bindings(vitals_len)?);
+    if !projections.is_empty() {
+        bindings.push(computed_binding("/claim_count", 0..projections.len())?);
+        bindings.extend(trust_band_count_computed_bindings(projections.len())?);
+        bindings.extend(context_computed_bindings(projections.len())?);
+    }
+    block.field_bindings = bindings;
+    attribute_block(
+        provenance_builder,
+        composition_block_path,
+        subject,
+        source_indexes,
+    )?;
+    Ok(block)
+}
+
+fn build_claim_block(
+    input: &NormalizedInput,
+    section_id: &str,
+    projection: &ClaimProjection,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    composition_block_path: &str,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Block, AbilityError> {
+    let claim_ref = claim_ref_for_projection(projection)?;
+    let trust_band = trust_band_label(projection.trust_band);
+    let (block_type, attributes, bindings, weight, band, reason) = match projection.placement {
+        ClaimPlacement::Risk => (
+            BlockType::RiskCallout,
+            json!({
+                "claim_id": projection.claim.id,
+                "text": projection.rendered_text,
+                "claim_type": projection.claim.claim_type,
+                "trust_band": trust_band,
+                "source_asof": projection.claim.source_asof,
+            }),
+            source_feedback_computed_bindings("/text", "/trust_band")?,
+            0.9,
+            SalienceBand::Critical,
+            "action risk claim",
+        ),
+        ClaimPlacement::Work => (
+            BlockType::ActionList,
+            json!({
+                "title": "Related work",
+                "items": [{
+                    "claim_id": projection.claim.id,
+                    "text": projection.rendered_text,
+                    "status": "action-local",
+                    "trust_band": trust_band,
+                    "source_asof": projection.claim.source_asof,
+                }],
+                "trust_band": trust_band,
+            }),
+            source_feedback_computed_bindings("/items/0/text", "/items/0/trust_band")?,
+            0.72,
+            SalienceBand::Important,
+            "action work claim",
+        ),
+        ClaimPlacement::Status | ClaimPlacement::Context | ClaimPlacement::Reference => (
+            BlockType::ClaimSummary,
+            json!({
+                "title": section_title(section_id),
+                "claim_id": projection.claim.id,
+                "text": projection.rendered_text,
+                "claim_type": projection.claim.claim_type,
+                "trust_band": trust_band,
+                "source_asof": projection.claim.source_asof,
+            }),
+            source_feedback_computed_bindings("/text", "/trust_band")?,
+            0.66,
+            SalienceBand::Important,
+            "action claim",
+        ),
+        ClaimPlacement::Ignored => {
+            return Err(validation_error("unexpected action detail block placement"));
+        }
+    };
+
+    let mut block = Block::new(
+        BlockId::new(block_id(
+            input,
+            section_id,
+            block_type.type_id(),
+            &projection.claim.id,
+        )),
+        block_type,
+        attributes,
+        vec![claim_ref],
+        ProvenanceRef::new(
+            invocation_id,
+            FieldPath::new(composition_block_path).map_err(field_error)?,
+        ),
+        None,
+    )
+    .map_err(block_error)?;
+    block.field_bindings = bindings;
+    block.salience = salience(weight, band, reason);
+    attribute_block(
+        provenance_builder,
+        composition_block_path,
+        subject,
+        vec![projection.source_index],
+    )?;
+    Ok(block)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_snapshot_fields_block(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    section_id: &str,
+    section_index: usize,
+    block_index: usize,
+    fields: Vec<&ActionCompositionSnapshotField>,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Block, AbilityError> {
+    let source_indexes = snapshot_source_indexes(ctx, input, &fields, provenance_builder)?;
+    let items = fields
+        .iter()
+        .flat_map(|field| snapshot_field_evidence_items(field))
+        .collect::<Vec<_>>();
+    let composition_block_path = format!("/sections/{section_index}/blocks/{block_index}");
+    let item_count = items.len();
+    let mut block = Block::new(
+        BlockId::new(block_id(input, section_id, "evidence_list", "snapshot")),
+        BlockType::EvidenceList,
+        json!({ "title": section_title(section_id), "items": items }),
+        Vec::new(),
+        ProvenanceRef::new(
+            invocation_id,
+            FieldPath::new(&composition_block_path).map_err(field_error)?,
+        ),
+        None,
+    )
+    .map_err(block_error)?;
+    block.field_bindings = evidence_list_display_bindings(item_count)?;
+    block.salience = salience(0.58, SalienceBand::Contextual, "action snapshot fields");
+    attribute_block(
+        provenance_builder,
+        &composition_block_path,
+        subject,
+        source_indexes,
+    )?;
+    Ok(block)
+}
+
+fn build_section_state_block(
+    input: &NormalizedInput,
+    position: SectionBlockPosition<'_>,
+    copy: EmptySectionCopy,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Block, AbilityError> {
+    let composition_block_path = position.composition_path();
+    let mut block = Block::new(
+        BlockId::new(block_id(
+            input,
+            position.section_id,
+            "empty_state",
+            copy.status,
+        )),
+        BlockType::ClaimSummary,
+        json!({
+            "title": copy.title,
+            "body": copy.body,
+            "status": copy.status,
+            "empty_state": true,
+            "trust_band": "needs_verification",
+        }),
+        Vec::new(),
+        ProvenanceRef::new(
+            invocation_id,
+            FieldPath::new(&composition_block_path).map_err(field_error)?,
+        ),
+        None,
+    )
+    .map_err(block_error)?;
+    block.field_bindings = vec![
+        display_only_binding("/title")?,
+        display_only_binding("/body")?,
+        display_only_binding("/status")?,
+        display_only_binding("/empty_state")?,
+    ];
+    block.salience = salience(0.24, SalienceBand::Background, copy.status);
+    attribute_block(
+        provenance_builder,
+        &composition_block_path,
+        subject,
+        Vec::new(),
+    )?;
+    Ok(block)
+}
+
+fn snapshot_fields_for_section<'a>(
+    snapshot: Option<&'a ActionCompositionSnapshot>,
+    section_id: &str,
+) -> Vec<&'a ActionCompositionSnapshotField> {
+    let Some(snapshot) = snapshot else {
+        return Vec::new();
+    };
+    snapshot
+        .fields
+        .iter()
+        .filter(|field| field.sensitivity.is_render_safe())
+        .filter(|field| snapshot_field_belongs_to_section(&field.field_path, section_id))
+        .collect()
+}
+
+fn snapshot_field_belongs_to_section(field_path: &str, section_id: &str) -> bool {
+    match section_id {
+        "headline" => field_path.starts_with("/headline/"),
+        "status" => field_path.starts_with("/status/"),
+        "priority" => field_path.starts_with("/priority/"),
+        "context" => field_path.starts_with("/context/"),
+        "reference" => field_path.starts_with("/reference/"),
+        "linear" => field_path.starts_with("/linear/"),
+        "action-bar" => field_path.starts_with("/action-bar/"),
+        _ => false,
+    }
+}
+
+fn snapshot_source_indexes(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    fields: &[&ActionCompositionSnapshotField],
+    provenance_builder: &mut ProvenanceBuilder,
+) -> Result<Vec<crate::abilities::provenance::SourceIndex>, AbilityError> {
+    let mut indexes = Vec::new();
+    for field in fields {
+        let Some(source) = source_for_snapshot_field(ctx, input, field)? else {
+            continue;
+        };
+        let index = provenance_builder.add_source(source);
+        provenance_builder.set_source_trust_band(index, visible_trust_band(field.trust_band));
+        indexes.push(index);
+    }
+    Ok(indexes)
+}
+
+fn source_for_snapshot_field(
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
+    field: &ActionCompositionSnapshotField,
+) -> Result<Option<SourceAttribution>, AbilityError> {
+    if matches!(
+        field.provenance_kind,
+        ActionCompositionProvenanceKind::NonSensitiveIdentity
+            | ActionCompositionProvenanceKind::Unavailable
+    ) && field.source_label.is_none()
+        && field.source_ref.is_none()
+        && field.source_asof.is_none()
+    {
+        return Ok(None);
+    }
+
+    let now = ctx.services().clock.now();
+    let observed_at = match parse_source_timestamp(field.source_asof.as_deref(), now, None) {
+        SourceTimestampStatus::Accepted(parsed)
+        | SourceTimestampStatus::Implausible { parsed, .. } => parsed,
+        SourceTimestampStatus::Malformed(_) | SourceTimestampStatus::Missing => now,
+    };
+    let source_asof = match parse_source_timestamp(field.source_asof.as_deref(), now, None) {
+        SourceTimestampStatus::Accepted(parsed)
+        | SourceTimestampStatus::Implausible { parsed, .. } => Some(parsed),
+        SourceTimestampStatus::Malformed(_) | SourceTimestampStatus::Missing => None,
+    };
+    SourceAttribution::new(
+        data_source_for_snapshot_field(field),
+        vec![SourceIdentifier::Entity {
+            entity_id: EntityId::new(input.action_id.clone()),
+            field: Some(field.field_path.clone()),
+        }],
+        observed_at,
+        source_asof,
+        1.0,
+        None,
+    )
+    .map(Some)
+    .map_err(|error| validation_error(format!("invalid snapshot source attribution: {error}")))
+}
+
+fn data_source_for_snapshot_field(field: &ActionCompositionSnapshotField) -> DataSource {
+    match field.provenance_kind {
+        ActionCompositionProvenanceKind::ManualUser => DataSource::User,
+        ActionCompositionProvenanceKind::SystemConfig => DataSource::LocalEnrichment,
+        _ => field
+            .source_label
+            .as_deref()
+            .map(data_source_for_claim)
+            .unwrap_or_else(|| DataSource::Other(SourceName::new("action_snapshot"))),
+    }
+}
+
+fn snapshot_field_evidence_items(field: &ActionCompositionSnapshotField) -> Vec<Value> {
+    let source_label = field
+        .source_label
+        .as_deref()
+        .unwrap_or(match field.provenance_kind {
+            ActionCompositionProvenanceKind::NonSensitiveIdentity => "identity",
+            ActionCompositionProvenanceKind::ManualUser => "user",
+            ActionCompositionProvenanceKind::SourceField => "source",
+            ActionCompositionProvenanceKind::SystemConfig => "system_config",
+            ActionCompositionProvenanceKind::Derived => "derived",
+            ActionCompositionProvenanceKind::Unavailable => "unavailable",
+        });
+    match &field.value {
+        Value::Array(items) => items
+            .iter()
+            .take(12)
+            .map(|item| {
+                json!({
+                    "label": format!("{}: {}", field.label, compact_item_label(item)),
+                    "source_label": source_label,
+                    "source_asof": field.source_asof,
+                })
+            })
+            .collect(),
+        Value::Object(_) => vec![json!({
+            "label": format!("{}: {}", field.label, compact_item_label(&field.value)),
+            "source_label": source_label,
+            "source_asof": field.source_asof,
+        })],
+        _ => vec![json!({
+            "label": format!("{}: {}", field.label, snapshot_value_text(&field.value)),
+            "source_label": source_label,
+            "source_asof": field.source_asof,
+        })],
+    }
+}
+
+fn compact_item_label(value: &Value) -> String {
+    let Some(object) = value.as_object() else {
+        return snapshot_value_text(value);
+    };
+    for key in ["title", "name", "label", "identifier", "status", "value"] {
+        if let Some(label) = object.get(key).and_then(Value::as_str) {
+            if !label.trim().is_empty() {
+                return label.to_string();
+            }
+        }
+    }
+    snapshot_value_text(value)
+}
+
+fn snapshot_value_text(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.clone(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::Array(_) | Value::Object(_) => value.to_string(),
+    }
+}
+
+fn section_title(section_id: &str) -> &'static str {
+    match section_id {
+        "status" => "Status",
+        "priority" => "Priority",
+        "context" => "Context",
+        "reference" => "Reference",
+        "linear" => "Linear",
+        "action-bar" => "Action bar",
+        _ => "Action detail",
+    }
+}
+
+fn empty_title(section_id: &str) -> &'static str {
+    match section_id {
+        "context" => "No context",
+        "linear" => "No Linear issue",
+        "reference" => "No reference metadata",
+        _ => "No action details",
+    }
+}
+
+fn empty_body(section_id: &str) -> &'static str {
+    match section_id {
+        "context" => "No source-backed context is currently attached to this action.",
+        "linear" => "This action has not been pushed to Linear.",
+        "reference" => "No account, source, or due-date reference is currently attached.",
+        _ => "No renderable action fields are currently available for this section.",
+    }
+}
+
+fn attribute_static_composition_fields(
+    builder: &mut ProvenanceBuilder,
+    subject: &SubjectAttribution,
+    section_count: usize,
+) -> Result<(), AbilityError> {
+    for path in [
+        "",
+        "/id",
+        "/kind/kind",
+        "/subject",
+        "/generated_at",
+        "/generated_by",
+        "/metadata",
+        "/salience",
+    ] {
+        builder
+            .attribute(
+                FieldPath::new(path).map_err(field_error)?,
+                FieldAttribution::constant(subject.clone()),
+            )
+            .map_err(provenance_error)?;
+    }
+    for section_index in 0..section_count {
+        for suffix in ["id", "label", "layout", "salience"] {
+            builder
+                .attribute(
+                    FieldPath::new(format!("/sections/{section_index}/{suffix}"))
+                        .map_err(field_error)?,
+                    FieldAttribution::constant(subject.clone()),
+                )
+                .map_err(provenance_error)?;
+        }
+    }
+    builder
+        .attribute(
+            FieldPath::root(),
+            FieldAttribution::constant(subject.clone()),
+        )
+        .map_err(provenance_error)?;
+    builder
+        .attribute(
+            FieldPath::new("/metadata").map_err(field_error)?,
+            FieldAttribution::constant(subject.clone()),
+        )
+        .map_err(provenance_error)?;
+    Ok(())
+}
+
+fn attribute_block(
+    builder: &mut ProvenanceBuilder,
+    composition_block_path: &str,
+    subject: &SubjectAttribution,
+    source_indexes: Vec<crate::abilities::provenance::SourceIndex>,
+) -> Result<(), AbilityError> {
+    let path = FieldPath::new(composition_block_path).map_err(field_error)?;
+    let attribution = if source_indexes.is_empty() {
+        FieldAttribution::constant(subject.clone())
+    } else if source_indexes.len() == 1 {
+        FieldAttribution::direct(subject.clone(), source_indexes[0])
+    } else {
+        FieldAttribution::computed(
+            subject.clone(),
+            "dailyos.action_detail.v1",
+            source_indexes
+                .into_iter()
+                .map(|source_index| SourceRef::Source { source_index })
+                .collect(),
+            Confidence::computed(1.0).map_err(field_error)?,
+        )
+        .map_err(field_error)?
+    };
+    builder
+        .attribute(path, attribution)
+        .map_err(provenance_error)?;
+    Ok(())
+}
+
+fn source_feedback_computed_bindings(
+    source_path: &str,
+    computed_path: &str,
+) -> Result<Vec<FieldBinding>, AbilityError> {
+    Ok(vec![
+        binding(source_path, BindingRole::Source, vec![0])?,
+        binding(source_path, BindingRole::FeedbackTarget, vec![0])?,
+        binding(computed_path, BindingRole::ComputedFrom, vec![0])?,
+    ])
+}
+
+fn computed_binding(
+    field_path: &str,
+    indexes: std::ops::Range<usize>,
+) -> Result<FieldBinding, AbilityError> {
+    binding(field_path, BindingRole::ComputedFrom, indexes.collect())
+}
+
+fn computed_binding_for_indexes(
+    field_path: &str,
+    indexes: Vec<usize>,
+) -> Result<FieldBinding, AbilityError> {
+    binding(field_path, BindingRole::ComputedFrom, indexes)
+}
+
+fn display_only_binding(field_path: &str) -> Result<FieldBinding, AbilityError> {
+    binding(field_path, BindingRole::DisplayOnly, Vec::new())
+}
+
+fn trust_band_count_computed_bindings(
+    projection_count: usize,
+) -> Result<Vec<FieldBinding>, AbilityError> {
+    let indexes = (0..projection_count).collect::<Vec<_>>();
+    let mut bindings = Vec::with_capacity(3);
+    for field in [
+        "/counts_by_trust_band/likely_current",
+        "/counts_by_trust_band/use_with_caution",
+        "/counts_by_trust_band/needs_verification",
+    ] {
+        bindings.push(computed_binding_for_indexes(field, indexes.clone())?);
+    }
+    Ok(bindings)
+}
+
+fn context_computed_bindings(projection_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
+    let mut bindings = Vec::with_capacity(projection_count * 4);
+    for index in 0..projection_count {
+        for field in ["claim_id", "text", "trust_band", "source_asof"] {
+            bindings.push(computed_binding_for_indexes(
+                &format!("/context/{index}/{field}"),
+                vec![index],
+            )?);
+        }
+    }
+    Ok(bindings)
+}
+
+fn vitals_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
+    let mut bindings = Vec::with_capacity(item_count * 5);
+    for index in 0..item_count {
+        for field in [
+            "label",
+            "value",
+            "source_label",
+            "source_asof",
+            "trust_band",
+        ] {
+            bindings.push(display_only_binding(&format!("/vitals/{index}/{field}"))?);
+        }
+    }
+    Ok(bindings)
+}
+
+fn evidence_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
+    let mut bindings = Vec::with_capacity(item_count * 3 + 1);
+    bindings.push(display_only_binding("/title")?);
+    for index in 0..item_count {
+        bindings.push(display_only_binding(&format!("/items/{index}/label"))?);
+        bindings.push(display_only_binding(&format!(
+            "/items/{index}/source_label"
+        ))?);
+        bindings.push(display_only_binding(&format!(
+            "/items/{index}/source_asof"
+        ))?);
+    }
+    Ok(bindings)
+}
+
+fn binding(
+    field_path: &str,
+    role: BindingRole,
+    indexes: Vec<usize>,
+) -> Result<FieldBinding, AbilityError> {
+    Ok(FieldBinding {
+        field_path: FieldPath::new(field_path).map_err(field_error)?,
+        role,
+        claim_refs: indexes
+            .into_iter()
+            .map(crate::abilities::composition::ClaimRefIndex)
+            .collect(),
+    })
+}
+
+fn claim_ref_for_projection(projection: &ClaimProjection) -> Result<ClaimRef, AbilityError> {
+    Ok(ClaimRef::with_field(
+        projection.claim.id.clone(),
+        projection.claim.claim_version,
+        claim_field_path(&projection.claim)?,
+    ))
+}
+
+fn claim_field_path(claim: &IntelligenceClaim) -> Result<FieldPath, AbilityError> {
+    let raw = claim
+        .field_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("/text");
+    let pointer = if raw.starts_with('/') {
+        raw.to_string()
+    } else {
+        format!("/{raw}")
+    };
+    FieldPath::new(pointer).map_err(field_error)
+}
+
+fn resolved_claim_trust_band(
+    claim: &IntelligenceClaim,
+    claim_type: ClaimType,
+    now: DateTime<Utc>,
+) -> TrustBand {
+    if claim.trust_score.is_none() {
+        return TrustBand::NeedsVerification;
+    }
+
+    let score_band = visible_trust_band(claim_trust_band_from_score(claim.trust_score));
+    if !freshness_cap_applies(claim_type) {
+        return score_band;
+    }
+
+    let Some(source_asof) = parse_claim_source_asof(claim, now) else {
+        return TrustBand::NeedsVerification;
+    };
+    let age_days = now.signed_duration_since(source_asof).num_days();
+    if age_days < 7 {
+        score_band
+    } else if age_days <= 30 {
+        block_trust_band([score_band, TrustBand::UseWithCaution])
+    } else {
+        TrustBand::NeedsVerification
+    }
+}
+
+fn freshness_cap_applies(claim_type: ClaimType) -> bool {
+    let metadata = crate::abilities::claims::metadata_for_claim_type(claim_type);
+    !matches!(
+        (claim_type, metadata.freshness_decay_class),
+        (ClaimType::CompanyContext, _) | (_, FreshnessDecayClass::Static)
+    )
+}
+
+fn visible_trust_band(band: TrustBand) -> TrustBand {
+    match band {
+        TrustBand::Unscored => TrustBand::NeedsVerification,
+        other => other,
+    }
+}
+
+fn block_trust_band(bands: impl IntoIterator<Item = TrustBand>) -> TrustBand {
+    most_cautious_trust_band(bands.into_iter().map(visible_trust_band))
+        .map(visible_trust_band)
+        .unwrap_or(TrustBand::NeedsVerification)
+}
+
+fn trust_band_label(band: TrustBand) -> &'static str {
+    match visible_trust_band(band) {
+        TrustBand::LikelyCurrent => "likely_current",
+        TrustBand::UseWithCaution => "use_with_caution",
+        TrustBand::NeedsVerification | TrustBand::Unscored => "needs_verification",
+    }
+}
+
+fn trust_band_counts(projections: &[ClaimProjection]) -> BTreeMap<&'static str, usize> {
+    let mut counts = BTreeMap::from([
+        ("likely_current", 0),
+        ("use_with_caution", 0),
+        ("needs_verification", 0),
+    ]);
+    for projection in projections {
+        let key = trust_band_label(projection.trust_band);
+        counts.entry(key).and_modify(|value| *value += 1);
+    }
+    counts
+}
+
+fn compare_claim_projection(left: &ClaimProjection, right: &ClaimProjection) -> Ordering {
+    placement_rank(left.placement)
+        .cmp(&placement_rank(right.placement))
+        .then_with(|| trust_rank(right.trust_band).cmp(&trust_rank(left.trust_band)))
+        .then_with(|| {
+            right
+                .parsed_source_asof
+                .cmp(&left.parsed_source_asof)
+                .then_with(|| {
+                    if left.parsed_source_asof.is_none() == right.parsed_source_asof.is_none() {
+                        Ordering::Equal
+                    } else if left.parsed_source_asof.is_none() {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Less
+                    }
+                })
+        })
+        .then_with(|| left.claim_type.as_str().cmp(right.claim_type.as_str()))
+        .then_with(|| left.claim.id.cmp(&right.claim.id))
+}
+
+fn placement_rank(placement: ClaimPlacement) -> u8 {
+    match placement {
+        ClaimPlacement::Risk => 0,
+        ClaimPlacement::Status => 1,
+        ClaimPlacement::Work => 2,
+        ClaimPlacement::Context => 3,
+        ClaimPlacement::Reference => 4,
+        ClaimPlacement::Ignored => 5,
+    }
+}
+
+fn trust_rank(band: TrustBand) -> u8 {
+    match visible_trust_band(band) {
+        TrustBand::LikelyCurrent => 3,
+        TrustBand::UseWithCaution => 2,
+        TrustBand::NeedsVerification | TrustBand::Unscored => 1,
+    }
+}
+
+fn source_for_claim(
+    ctx: &AbilityContext<'_>,
+    action_id: &str,
+    claim: &IntelligenceClaim,
+) -> Result<SourceAttribution, AbilityError> {
+    let now = ctx.services().clock.now();
+    let observed_at = parse_observed_at(claim, now);
+    let source_asof = parse_claim_source_asof(claim, now);
+    SourceAttribution::new(
+        data_source_for_claim(&claim.data_source),
+        vec![SourceIdentifier::Entity {
+            entity_id: EntityId::new(action_id.to_string()),
+            field: Some(
+                claim
+                    .field_path
+                    .clone()
+                    .unwrap_or_else(|| claim.claim_type.clone()),
+            ),
+        }],
+        observed_at,
+        source_asof,
+        1.0,
+        None,
+    )
+    .map_err(|error| validation_error(format!("invalid source attribution: {error}")))
+}
+
+fn parse_observed_at(claim: &IntelligenceClaim, now: DateTime<Utc>) -> DateTime<Utc> {
+    for candidate in [claim.observed_at.as_str(), claim.created_at.as_str()] {
+        match parse_source_timestamp(Some(candidate), now, None) {
+            SourceTimestampStatus::Accepted(parsed)
+            | SourceTimestampStatus::Implausible { parsed, .. } => return parsed,
+            SourceTimestampStatus::Malformed(_) | SourceTimestampStatus::Missing => {}
+        }
+    }
+    now
+}
+
+fn parse_claim_source_asof(claim: &IntelligenceClaim, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    match parse_source_timestamp(claim.source_asof.as_deref(), now, None) {
+        SourceTimestampStatus::Accepted(parsed)
+        | SourceTimestampStatus::Implausible { parsed, .. } => Some(parsed),
+        SourceTimestampStatus::Malformed(_) | SourceTimestampStatus::Missing => None,
+    }
+}
+
+fn data_source_for_claim(value: &str) -> DataSource {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "user" | "human" | "manual" => DataSource::User,
+        "google" => DataSource::Google,
+        "glean" => DataSource::Glean {
+            downstream: GleanDownstream::Documents,
+        },
+        "ai" | "agent" => DataSource::Ai,
+        "local_enrichment" => DataSource::LocalEnrichment,
+        "legacy_unattributed" => DataSource::LegacyUnattributed,
+        other => DataSource::Other(SourceName::new(other)),
+    }
+}
+
+fn block_id(input: &NormalizedInput, section: &str, kind: &str, source: &str) -> String {
+    let raw = format!(
+        "{}:{section}:{kind}:{source}",
+        input.composition_id.as_str()
+    );
+    raw.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, ':' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn salience(weight: f32, band: SalienceBand, reason: &str) -> Salience {
+    Salience {
+        weight,
+        band,
+        reason: reason.to_string(),
+    }
+}
+
+fn provenance_config(ctx: &AbilityContext<'_>) -> ProvenanceBuilderConfig {
+    let mut config = ProvenanceBuilderConfig::new(ABILITY_NAME, ctx.services().clock.now());
+    config.ability_version = AbilityVersion::new(1, 0);
+    config.ability_schema_version = SchemaVersion(ABILITY_SCHEMA_VERSION);
+    config.actor = provenance_actor(ctx.actor.clone());
+    config.mode = AbilityExecutionMode::from(ctx.mode());
+    config.category = AbilityCategory::Read;
+    config.inputs_snapshot = InputsSnapshot::default();
+    config
+}
+
+fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Actor {
+    match actor {
+        Actor::User => crate::abilities::provenance::Actor::User,
+        Actor::Agent => crate::abilities::provenance::Actor::Agent {
+            name: "agent".to_string(),
+            version: "unknown".to_string(),
+        },
+        Actor::Admin => crate::abilities::provenance::Actor::Human {
+            role: "admin".to_string(),
+            id: "admin".to_string(),
+        },
+        Actor::System => crate::abilities::provenance::Actor::System {
+            component: "dailyos".to_string(),
+        },
+        Actor::SurfaceClient { instance, .. } => crate::abilities::provenance::Actor::External {
+            source: format!("surface_client:{}", instance.as_str()),
+        },
+        Actor::McpClient { client_id, .. } => crate::abilities::provenance::Actor::External {
+            source: format!("mcp_client:{}", client_id.as_str()),
+        },
+    }
+}
+
+fn validate_block_provenance(
+    composition: &Composition,
+    provenance: &crate::abilities::provenance::Provenance,
+) -> Result<(), AbilityError> {
+    for block in composition.blocks() {
+        block.validate_against(provenance).map_err(block_error)?;
+        for binding in &block.field_bindings {
+            if matches!(
+                binding.role,
+                BindingRole::Source | BindingRole::FeedbackTarget
+            ) {
+                for index in &binding.claim_refs {
+                    let Some(claim_ref) = block.claim_refs.get(index.0) else {
+                        return Err(validation_error(
+                            "field binding claim_ref index out of range",
+                        ));
+                    };
+                    if claim_ref.field_path.is_none() {
+                        return Err(validation_error(
+                            "Source and FeedbackTarget bindings require field-aware ClaimRef",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn composition_commit_error(error: CompositionCommitError) -> AbilityError {
+    let message = error.to_string();
+    match error {
+        CompositionCommitError::StaleVersion {
+            composition_id,
+            expected,
+            current,
+        }
+        | CompositionCommitError::InflatedVersion {
+            composition_id,
+            expected,
+            current,
+        } => AbilityError {
+            kind: AbilityErrorKind::StaleComposition {
+                composition_id,
+                expected,
+                current,
+            },
+            message,
+        },
+        CompositionCommitError::Overflow { composition_id } => AbilityError {
+            kind: AbilityErrorKind::CompositionVersionOverflow { composition_id },
+            message,
+        },
+        CompositionCommitError::EmptyCompositionId
+        | CompositionCommitError::Transaction(_)
+        | CompositionCommitError::Mode(_)
+        | CompositionCommitError::Unavailable(_) => hard_error("composition_commit", error),
+    }
+}
+
+fn validation_error(message: impl Into<String>) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Validation,
+        message: message.into(),
+    }
+}
+
+fn hard_error(code: impl Into<String>, message: impl std::fmt::Display) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::HardError(code.into()),
+        message: message.to_string(),
+    }
+}
+
+fn field_error(error: impl std::fmt::Display) -> AbilityError {
+    validation_error(format!("field path construction failed: {error}"))
+}
+
+fn block_error(error: impl std::fmt::Display) -> AbilityError {
+    validation_error(format!("composition block construction failed: {error}"))
+}
+
+fn provenance_error(error: impl std::fmt::Display) -> AbilityError {
+    validation_error(format!("provenance construction failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+
+    use super::*;
+    use crate::abilities::registry::{AbilityRegistry, ActorKind, McpExposure, ScopeSet};
+    use crate::abilities::NOOP_ABILITY_TRACER;
+    use crate::intelligence::provider::{
+        Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
+        ProviderError, ProviderKind,
+    };
+    use crate::sensitivity::{ClaimDismissalSurface, ClaimVerificationState};
+    use crate::services::context::{
+        ActionCompositionSnapshotReadFuture, ActionCompositionSnapshotReadHandle,
+        ActionCompositionSnapshotSensitivity, CompositionCommitFuture, CompositionCommitHandle,
+        CompositionCommitRequest, EntityContextClaimReadFuture, EntityContextClaimReadHandle,
+        ExternalClients, FixedClock, SeedableRng, ServiceContext,
+    };
+    use crate::types::{ClaimSensitivity, TemporalScope};
+
+    #[derive(Default)]
+    struct SpyClaimReader {
+        claims: Mutex<Vec<IntelligenceClaim>>,
+        calls: AtomicUsize,
+    }
+
+    impl SpyClaimReader {
+        fn new(claims: Vec<IntelligenceClaim>) -> Self {
+            Self {
+                claims: Mutex::new(claims),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl EntityContextClaimReadHandle for SpyClaimReader {
+        fn read_entity_context_claims<'a>(
+            &'a self,
+            entity_type: String,
+            entity_id: String,
+            _surface: ClaimDismissalSurface,
+            _depth: usize,
+        ) -> EntityContextClaimReadFuture<'a> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(entity_type, "action");
+                assert_eq!(entity_id, "action-fixture-1");
+                Ok(self.claims.lock().expect("claim lock").clone())
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingCommitter {
+        calls: AtomicUsize,
+    }
+
+    impl CompositionCommitHandle for RecordingCommitter {
+        fn commit_composition<'a>(
+            &'a self,
+            request: CompositionCommitRequest,
+        ) -> CompositionCommitFuture<'a> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let composition = Composition {
+                    id: request.proposal.composition_id.clone(),
+                    metadata: CompositionMetadata {
+                        composition_version: CompositionVersion::new(1),
+                        ..request.proposal.composition.metadata
+                    },
+                    ..request.proposal.composition
+                };
+                Ok(crate::services::context::CommittedComposition {
+                    composition_id: request.proposal.composition_id,
+                    composition_version: 1,
+                    composition,
+                })
+            })
+        }
+    }
+
+    struct SpySnapshotReader {
+        result: Mutex<Result<ActionCompositionSnapshot, ActionCompositionSnapshotReadError>>,
+        calls: AtomicUsize,
+    }
+
+    impl SpySnapshotReader {
+        fn new(
+            result: Result<ActionCompositionSnapshot, ActionCompositionSnapshotReadError>,
+        ) -> Self {
+            Self {
+                result: Mutex::new(result),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl ActionCompositionSnapshotReadHandle for SpySnapshotReader {
+        fn read_action_composition_snapshot<'a>(
+            &'a self,
+            action_id: String,
+            _surface: ClaimDismissalSurface,
+        ) -> ActionCompositionSnapshotReadFuture<'a> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(action_id, "action-fixture-1");
+                self.result.lock().expect("snapshot result lock").clone()
+            })
+        }
+    }
+
+    struct StaticProvider;
+
+    #[async_trait]
+    impl IntelligenceProvider for StaticProvider {
+        async fn complete(
+            &self,
+            _prompt: PromptInput,
+            _tier: ModelTier,
+        ) -> Result<Completion, ProviderError> {
+            Ok(Completion {
+                text: String::new(),
+                fingerprint_metadata: FingerprintMetadata {
+                    provider: ProviderKind::Other("test"),
+                    model: ModelName::new("unused"),
+                    temperature: 0.0,
+                    top_p: None,
+                    seed: None,
+                    tokens_input: None,
+                    tokens_output: None,
+                    provider_completion_id: None,
+                },
+            })
+        }
+
+        fn provider_kind(&self) -> ProviderKind {
+            ProviderKind::Other("test")
+        }
+
+        fn current_model(&self, _tier: ModelTier) -> ModelName {
+            ModelName::new("unused")
+        }
+    }
+
+    fn fixture_parts(
+        claims: Vec<IntelligenceClaim>,
+    ) -> (
+        FixedClock,
+        SeedableRng,
+        ExternalClients,
+        Arc<SpyClaimReader>,
+        Arc<RecordingCommitter>,
+        StaticProvider,
+    ) {
+        (
+            FixedClock::new(Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap()),
+            SeedableRng::new(42),
+            ExternalClients::default(),
+            Arc::new(SpyClaimReader::new(claims)),
+            Arc::new(RecordingCommitter::default()),
+            StaticProvider,
+        )
+    }
+
+    fn services<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+        reader: Arc<SpyClaimReader>,
+        committer: Arc<RecordingCommitter>,
+        snapshot_reader: Arc<SpySnapshotReader>,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external)
+            .with_actor("surface_client")
+            .with_ability_id(ABILITY_NAME)
+            .with_entity_context_claim_reader(reader)
+            .with_action_composition_snapshot_reader(snapshot_reader)
+            .with_composition_commit_handle(committer)
+    }
+
+    fn ability_ctx<'a>(
+        services: &'a ServiceContext<'a>,
+        provider: &'a StaticProvider,
+    ) -> AbilityContext<'a> {
+        AbilityContext::new(
+            services,
+            provider,
+            &NOOP_ABILITY_TRACER,
+            Actor::SurfaceClient {
+                instance: crate::abilities::registry::SurfaceClientId::new("sc_action_fixture"),
+                scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
+                    "read.action_detail",
+                )])
+                .expect("scope set"),
+            },
+            None,
+            ClaimDismissalSurface::LogStructured,
+        )
+    }
+
+    fn input() -> ActionDetailInput {
+        ActionDetailInput {
+            schema_version: ABILITY_SCHEMA_VERSION,
+            action_id: "action-fixture-1".to_string(),
+            subject_ref: None,
+            expected_composition_version: 0,
+            composition_id: Some("dailyos/action-detail:action:action-fixture-1".to_string()),
+        }
+    }
+
+    fn claim(id: &str, subject_ref: Value, text: &str) -> IntelligenceClaim {
+        IntelligenceClaim {
+            id: id.to_string(),
+            claim_version: 2,
+            subject_ref: subject_ref.to_string(),
+            claim_type: "user_note".to_string(),
+            field_path: Some("/text".to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            dedup_key: format!("dedup-{id}"),
+            item_hash: None,
+            actor: "agent:test".to_string(),
+            data_source: "google".to_string(),
+            source_ref: Some(format!("source-{id}")),
+            source_asof: Some("2026-05-15T10:00:00Z".to_string()),
+            observed_at: "2026-05-15T10:00:00Z".to_string(),
+            created_at: "2026-05-15T10:00:00Z".to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            claim_state: ClaimState::Active,
+            surfacing_state: SurfacingState::Active,
+            demotion_reason: None,
+            reactivated_at: None,
+            retraction_reason: None,
+            expires_at: None,
+            superseded_by: None,
+            trust_score: Some(0.92),
+            trust_computed_at: None,
+            trust_version: Some(1),
+            thread_id: None,
+            temporal_scope: TemporalScope::State,
+            sensitivity: ClaimSensitivity::Internal,
+            verification_state: ClaimVerificationState::Active,
+            verification_reason: None,
+            needs_user_decision_at: None,
+        }
+    }
+
+    fn action_claim(id: &str, text: &str) -> IntelligenceClaim {
+        claim(
+            id,
+            json!({"kind": "action", "id": "action-fixture-1"}),
+            text,
+        )
+    }
+
+    fn snapshot_field(
+        field_path: &str,
+        label: &str,
+        value: Value,
+    ) -> ActionCompositionSnapshotField {
+        ActionCompositionSnapshotField {
+            field_path: field_path.to_string(),
+            label: label.to_string(),
+            value,
+            sensitivity: ActionCompositionSnapshotSensitivity::Internal,
+            source_label: Some("action".to_string()),
+            source_ref: Some("action:fixture".to_string()),
+            source_asof: Some("2026-05-15T10:00:00Z".to_string()),
+            trust_band: TrustBand::UseWithCaution,
+            trust_status: "use_with_caution".to_string(),
+            provenance_kind: ActionCompositionProvenanceKind::SourceField,
+        }
+    }
+
+    fn snapshot_fixture(fields: Vec<ActionCompositionSnapshotField>) -> ActionCompositionSnapshot {
+        let title = snapshot_field(
+            "/headline/title",
+            "Title",
+            Value::String("Review renewal plan".to_string()),
+        );
+        let status = snapshot_field(
+            "/headline/status",
+            "Status",
+            Value::String("unstarted".to_string()),
+        );
+        let priority = snapshot_field(
+            "/headline/priority",
+            "Priority",
+            json!({"value": 1, "label": "Urgent"}),
+        );
+        let mut all_fields = vec![title.clone(), status.clone(), priority.clone()];
+        all_fields.extend(fields);
+        ActionCompositionSnapshot {
+            action_id: "action-fixture-1".to_string(),
+            title,
+            status: Some(status),
+            priority: Some(priority),
+            fields: all_fields,
+        }
+    }
+
+    fn output_json(output: &crate::abilities::provenance::AbilityOutput<Composition>) -> Value {
+        serde_json::to_value(output).expect("output serializes")
+    }
+
+    #[test]
+    fn registry_declaration_pins_action_policy_and_invalidation_signals() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let descriptor = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == ABILITY_NAME)
+            .expect("action detail ability registered");
+
+        assert_eq!(descriptor.category, AbilityCategory::Read);
+        assert_eq!(
+            descriptor.policy.allowed_actors,
+            &[ActorKind::User, ActorKind::SurfaceClient]
+        );
+        assert_eq!(descriptor.policy.required_scopes, &["read.action_detail"]);
+        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::Invocable);
+        assert!(!descriptor.policy.client_side_executable);
+        assert!(descriptor.mutates.is_empty());
+        assert!(descriptor.signal_policy.coalesce);
+        for signal in [
+            "claim.version",
+            "action_subject.claim_changed",
+            "claim.lifecycle",
+            "claim.dismissal",
+            "source.freshness",
+            "source.revocation",
+            "action.field_changed",
+            "action_completed",
+            "action_reopened",
+            "action_pushed_to_linear",
+        ] {
+            assert!(
+                descriptor
+                    .signal_policy
+                    .emits_on_output_change
+                    .contains(&signal),
+                "action detail declares invalidation signal {signal}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_action_rejects_before_claim_read_or_commit() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
+            ActionCompositionSnapshotReadError::ActionNotFound("action-fixture-1".to_string()),
+        )));
+        let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader.clone(),
+            committer.clone(),
+            snapshot_reader.clone(),
+        );
+        let ctx = ability_ctx(&services, &provider);
+
+        let err = match action_detail(&ctx, input()).await {
+            Ok(_) => panic!("missing action rejects"),
+            Err(error) => error,
+        };
+
+        assert_eq!(err.kind, AbilityErrorKind::Validation);
+        assert!(err.message.contains("action-fixture-1"));
+        assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(reader.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(committer.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn committed_output_filters_action_claims_and_emits_expected_sections() {
+        let claims = vec![
+            action_claim("claim-action", "Action-local context"),
+            claim(
+                "claim-account",
+                json!({"kind": "account", "id": "acct-1"}),
+                "Wrong subject context",
+            ),
+        ];
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
+            snapshot_field(
+                "/context/body",
+                "Context",
+                Value::String("Existing action context".to_string()),
+            ),
+            snapshot_field(
+                "/reference/source",
+                "Source",
+                json!({"type": "manual", "label": "User"}),
+            ),
+            snapshot_field(
+                "/linear/issue",
+                "Linear issue",
+                json!({"identifier": "DOS-123", "url": "https://linear.example/DOS-123"}),
+            ),
+            snapshot_field(
+                "/action-bar/status_toggle",
+                "Action bar",
+                json!({"can_complete": true, "status": "unstarted"}),
+            ),
+        ]))));
+        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader.clone(),
+            committer.clone(),
+            snapshot_reader,
+        );
+        let ctx = ability_ctx(&services, &provider);
+
+        let output = action_detail(&ctx, input()).await.expect("action detail");
+        let output_value = output_json(&output);
+        let rendered = output_value.to_string();
+
+        assert!(rendered.contains("Action-local context"));
+        assert!(!rendered.contains("Wrong subject context"));
+        let sections = output
+            .data()
+            .sections
+            .iter()
+            .map(|section| section.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            sections,
+            vec![
+                "headline",
+                "status",
+                "priority",
+                "context",
+                "reference",
+                "linear",
+                "action-bar"
+            ]
+        );
+        assert!(matches!(
+            output.provenance().subject.subject,
+            SubjectRef::Action(ref id) if id == "action-fixture-1"
+        ));
+        assert_eq!(reader.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn snapshot_read_failure_degrades_without_blocking_claim_render() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
+            ActionCompositionSnapshotReadError::ReadFailed("boom".to_string()),
+        )));
+        let (clock, rng, external, reader, committer, provider) =
+            fixture_parts(vec![action_claim(
+                "claim-action",
+                "Claim survives degradation",
+            )]);
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader,
+            committer.clone(),
+            snapshot_reader,
+        );
+        let ctx = ability_ctx(&services, &provider);
+
+        let output = action_detail(&ctx, input())
+            .await
+            .expect("degraded action detail");
+        let rendered = output_json(&output).to_string();
+
+        assert!(rendered.contains("Claim survives degradation"));
+        assert!(rendered.contains("action_snapshot_unavailable"));
+        assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn composition_id_rejects_subject_mismatch_and_extra_segments() {
+        let mismatch = ActionDetailInput {
+            composition_id: Some("dailyos/action-detail:action:other-action".to_string()),
+            ..input()
+        };
+        let err = normalize_input(mismatch).expect_err("mismatch rejects");
+        assert_eq!(err.kind, AbilityErrorKind::Validation);
+
+        let extra = ActionDetailInput {
+            composition_id: Some("dailyos/action-detail:action:action-fixture-1:extra".to_string()),
+            ..input()
+        };
+        let err = normalize_input(extra).expect_err("extra segment rejects");
+        assert_eq!(err.kind, AbilityErrorKind::Validation);
+    }
+
+    #[test]
+    fn subject_ref_accepts_matching_action_and_rejects_mismatch() {
+        let ok = ActionDetailInput {
+            subject_ref: Some(json!({ "action": "action-fixture-1" })),
+            ..input()
+        };
+        normalize_input(ok).expect("matching action subject ref is accepted");
+
+        let missing = ActionDetailInput {
+            subject_ref: Some(json!({ "person": "action-fixture-1" })),
+            ..input()
+        };
+        assert_eq!(
+            normalize_input(missing)
+                .expect_err("missing action rejects")
+                .kind,
+            AbilityErrorKind::Validation
+        );
+
+        let mismatch = ActionDetailInput {
+            subject_ref: Some(json!({ "action": "other-action" })),
+            ..input()
+        };
+        assert_eq!(
+            normalize_input(mismatch)
+                .expect_err("action mismatch rejects")
+                .kind,
+            AbilityErrorKind::Validation
+        );
+    }
+}

--- a/src-tauri/abilities-runtime/src/abilities/detect_risk_shift/synthesis.rs
+++ b/src-tauri/abilities-runtime/src/abilities/detect_risk_shift/synthesis.rs
@@ -1084,12 +1084,13 @@ fn risk_subject_from_claim(claim: &IntelligenceClaim) -> Result<RiskShiftSubject
         ClaimSubjectRef::Meeting { id } => Ok(RiskShiftSubjectRef::new("meeting", id)),
         ClaimSubjectRef::Person { id } => Ok(RiskShiftSubjectRef::new("person", id)),
         ClaimSubjectRef::Project { id } => Ok(RiskShiftSubjectRef::new("project", id)),
-        ClaimSubjectRef::Email { .. } | ClaimSubjectRef::Multi(_) | ClaimSubjectRef::Global => {
-            Err(validation_error(format!(
-                "detect_risk_shift claim `{}` has unsupported subject_ref",
-                claim.id
-            )))
-        }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => Err(validation_error(format!(
+            "detect_risk_shift claim `{}` has unsupported subject_ref",
+            claim.id
+        ))),
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
+++ b/src-tauri/abilities-runtime/src/abilities/fallback_projection.rs
@@ -3,7 +3,7 @@ use std::sync::{OnceLock, RwLock};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use thiserror::Error;
 
 use crate::abilities::composition::{
@@ -14,7 +14,7 @@ use crate::abilities::provenance::{CompositionId, FieldPath};
 use crate::abilities::registry::{Actor, ActorKind, SurfaceScope};
 use crate::abilities::trust::TrustBand;
 use crate::sensitivity::{
-    ClaimVerificationState, RenderActor, RenderDecision, RenderSurface, render_policy_for_surface,
+    render_policy_for_surface, ClaimVerificationState, RenderActor, RenderDecision, RenderSurface,
 };
 use crate::types::{
     ClaimSensitivity, ClaimState, IntelligenceClaim, SurfacingState, TemporalScope,
@@ -1384,6 +1384,18 @@ const ACCOUNT_OVERVIEW_FIELDS: &[FieldPolicy] = &[
     text_field("/account/id", ClaimSensitivity::Internal),
     text_field("/account/display_name", ClaimSensitivity::Internal),
     text_field("/account/type", ClaimSensitivity::Internal),
+    text_field("/project/id", ClaimSensitivity::Internal),
+    text_field("/project/display_name", ClaimSensitivity::Internal),
+    text_field("/project/status", ClaimSensitivity::Internal),
+    text_field("/person/id", ClaimSensitivity::Internal),
+    text_field("/person/display_name", ClaimSensitivity::Internal),
+    text_field("/person/relationship", ClaimSensitivity::Internal),
+    text_field("/person/organization", ClaimSensitivity::Internal),
+    text_field("/person/role", ClaimSensitivity::Internal),
+    text_field("/action/id", ClaimSensitivity::Internal),
+    text_field("/action/title", ClaimSensitivity::Internal),
+    text_field("/action/status", ClaimSensitivity::Internal),
+    text_field("/action/priority", ClaimSensitivity::Internal),
     text_field("/summary", ClaimSensitivity::Internal),
     text_field("/health/band", ClaimSensitivity::Internal),
     number_field("/health/score", ClaimSensitivity::Internal),
@@ -1432,6 +1444,7 @@ const CLAIM_SUMMARY_FIELDS: &[FieldPolicy] = &[
     bool_field("/empty_state", ClaimSensitivity::Internal),
 ];
 const EVIDENCE_LIST_FIELDS: &[FieldPolicy] = &[
+    text_field("/title", ClaimSensitivity::Internal),
     text_field("/items/*/label", ClaimSensitivity::Internal),
     text_field("/items/*/source_label", ClaimSensitivity::Internal),
     text_field("/items/*/source_asof", ClaimSensitivity::Internal),

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/contracts.rs
@@ -110,7 +110,11 @@ pub struct BriefingState {
 
 /// Overall presence of a briefing for the requested date.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum BriefingAvailability {
     Available,
     Empty { reason: BriefingEmptyReason },
@@ -128,7 +132,11 @@ pub enum BriefingEmptyReason {
 /// Freshness posture across the briefing's underlying prep + claim inputs.
 /// Independent of integrity — a Fresh briefing can have HasCorrections.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum BriefingFreshness {
     Fresh,
     Stale { reason: BriefingStaleReason },
@@ -146,7 +154,11 @@ pub enum BriefingStaleReason {
 /// Claim-store integrity — corrections / ambiguity that consumers should
 /// surface even when the briefing is otherwise fresh.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum BriefingIntegrity {
     Clean,
     HasCorrections { superseded_claim_ids: Vec<String> },
@@ -163,7 +175,11 @@ pub struct AmbiguityPair {
 
 /// Typed non-blocking advisory surfaced alongside the briefing state.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum BriefingAdvisory {
     /// A watch proposal is available for review. Pairs with the
     /// `watch_proposals` envelope field.

--- a/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_daily_briefing/producer.rs
@@ -1529,11 +1529,10 @@ mod state_matrix_fixtures {
             meeting_brief_unlinked("m-internal-1"),
             meeting_brief_unlinked("m-internal-2"),
         ];
-        let non_customer: std::collections::HashSet<String> =
-            ["m-internal-1", "m-internal-2"]
-                .iter()
-                .map(|s| s.to_string())
-                .collect();
+        let non_customer: std::collections::HashSet<String> = ["m-internal-1", "m-internal-2"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         let advisories = derive_advisories(&readiness, &meetings, &non_customer, &[], &[]);
 

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_context.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_context.rs
@@ -505,12 +505,13 @@ fn claim_subject_identity(claim: &IntelligenceClaim) -> Result<(String, String),
         ClaimSubjectRef::Meeting { id } => Ok(("meeting".to_string(), id)),
         ClaimSubjectRef::Person { id } => Ok(("person".to_string(), id)),
         ClaimSubjectRef::Project { id } => Ok(("project".to_string(), id)),
-        ClaimSubjectRef::Email { .. } | ClaimSubjectRef::Multi(_) | ClaimSubjectRef::Global => {
-            Err(validation_error(format!(
-                "claim `{}` has unsupported entity context subject",
-                claim.id
-            )))
-        }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => Err(validation_error(format!(
+            "claim `{}` has unsupported entity context subject",
+            claim.id
+        ))),
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/get_entity_intelligence/producer.rs
@@ -549,6 +549,7 @@ fn subject_ref_from_claim(claim: &IntelligenceClaim) -> SubjectRef {
         Ok(crate::types::ClaimSubjectRef::Project { id }) => SubjectRef::Project(id),
         Ok(crate::types::ClaimSubjectRef::Person { id }) => SubjectRef::Person(id),
         Ok(crate::types::ClaimSubjectRef::Meeting { id }) => SubjectRef::Meeting(id),
+        Ok(crate::types::ClaimSubjectRef::Action { id }) => SubjectRef::Action(id),
         _ => SubjectRef::Unknown,
     }
 }

--- a/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/list_open_loops/mod.rs
@@ -371,12 +371,13 @@ fn claim_subject_identity(claim: &IntelligenceClaim) -> Result<(String, String),
         ClaimSubjectRef::Meeting { id } => Ok(("meeting".to_string(), id)),
         ClaimSubjectRef::Person { id } => Ok(("person".to_string(), id)),
         ClaimSubjectRef::Project { id } => Ok(("project".to_string(), id)),
-        ClaimSubjectRef::Email { .. } | ClaimSubjectRef::Multi(_) | ClaimSubjectRef::Global => {
-            Err(validation_error(format!(
-                "claim `{}` has unsupported open loop subject",
-                claim.id
-            )))
-        }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => Err(validation_error(format!(
+            "claim `{}` has unsupported open loop subject",
+            claim.id
+        ))),
     }
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/markdown_preview/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/markdown_preview/mod.rs
@@ -57,7 +57,10 @@ mod tests {
             .expect("markdown preview ability is registered");
 
         assert_eq!(descriptor.category, AbilityCategory::Read);
-        assert_eq!(descriptor.policy.allowed_actors, &[ActorKind::SurfaceClient]);
+        assert_eq!(
+            descriptor.policy.allowed_actors,
+            &[ActorKind::SurfaceClient]
+        );
         assert_eq!(descriptor.policy.required_scopes, &[MARKDOWN_PREVIEW_SCOPE]);
         assert_eq!(descriptor.policy.mcp_exposure, McpExposure::None);
         assert!(!descriptor.policy.may_publish);
@@ -72,8 +75,8 @@ mod tests {
             SurfaceScope::new("read.composition"),
             SurfaceScope::new("submit.feedback"),
         ]);
-        let scopes = ScopeSet::new([SurfaceScope::new("read.account_overview")])
-            .expect("scope set");
+        let scopes =
+            ScopeSet::new([SurfaceScope::new("read.account_overview")]).expect("scope set");
         let registry = AbilityRegistry::global_checked().expect("registry");
         let clock = FixedClock::new(chrono::Utc::now());
         let rng = SeedableRng::new(7);

--- a/src-tauri/abilities-runtime/src/abilities/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/mod.rs
@@ -1,6 +1,7 @@
 //! Ability runtime modules.
 
 pub mod account_overview;
+pub mod action_detail;
 pub mod claim_receipt;
 pub mod claims;
 pub mod composition;
@@ -19,7 +20,9 @@ pub mod list_pagination;
 pub mod list_people;
 pub mod list_projects;
 pub mod markdown_preview;
+pub mod person_overview;
 pub mod prepare_meeting;
+pub mod project_overview;
 pub mod provenance;
 pub mod recommendations;
 pub mod registry;

--- a/src-tauri/abilities-runtime/src/abilities/person_overview.rs
+++ b/src-tauri/abilities-runtime/src/abilities/person_overview.rs
@@ -26,36 +26,22 @@ use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
 };
 use crate::services::context::{
-    AccountCompositionProvenanceKind, AccountCompositionSnapshot, AccountCompositionSnapshotField,
-    AccountCompositionSnapshotReadError, CompositionCommitError, CompositionProposal,
+    CompositionCommitError, CompositionProposal, PersonCompositionProvenanceKind,
+    PersonCompositionSnapshot, PersonCompositionSnapshotField, PersonCompositionSnapshotReadError,
 };
 use crate::types::{
     prompt_input_sensitivity_allowed, subject_ref_from_json, ClaimState, ClaimSubjectRef,
     IntelligenceClaim, SurfacingState,
 };
 
-const ABILITY_NAME: &str = "dailyos/account-overview";
+const ABILITY_NAME: &str = "dailyos/person-overview";
 const ABILITY_SCHEMA_VERSION: u32 = 1;
-const ACCOUNT_CLAIM_DEPTH: usize = 3;
-
-const VARIANT_D_SECTIONS: [(&str, &str); 11] = [
-    ("headline", "Headline"),
-    ("outlook", "Outlook"),
-    ("state-of-play", "State of play"),
-    ("the-room", "The room"),
-    ("whats-next", "What's next"),
-    ("watch-list", "Watch list"),
-    ("value-commitments", "Value commitments"),
-    ("strategic-landscape", "Strategic landscape"),
-    ("the-record", "The record"),
-    ("the-work", "The work"),
-    ("reports", "Reports"),
-];
+const PERSON_CLAIM_DEPTH: usize = 3;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct AccountOverviewInput {
+pub struct PersonOverviewInput {
     pub schema_version: u32,
-    pub account_id: String,
+    pub person_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entity_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -68,12 +54,12 @@ pub struct AccountOverviewInput {
 
 #[derive(Debug, Clone)]
 struct NormalizedInput {
-    account_id: String,
+    person_id: String,
     expected_composition_version: u64,
     composition_id: CompositionDocId,
 }
 
-struct PreparedAccountOverview {
+struct PreparedPersonOverview {
     proposal: CompositionProposal,
     provenance_builder: ProvenanceBuilder,
 }
@@ -91,24 +77,22 @@ struct ClaimProjection {
 
 #[derive(Debug, Clone)]
 struct SnapshotReadOutcome {
-    snapshot: Option<AccountCompositionSnapshot>,
+    snapshot: Option<PersonCompositionSnapshot>,
     degraded_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClaimPlacement {
-    Overview,
+    Momentum,
     Risk,
-    Win,
-    Value,
     Commitment,
     Relationship,
-    Health,
+    Context,
     Ignored,
 }
 
 #[ability(
-    name = "dailyos/account-overview",
+    name = "dailyos/person-overview",
     category = Read,
     version = "1.0.0",
     schema_version = 1,
@@ -116,26 +100,28 @@ enum ClaimPlacement {
     allowed_modes = [Live],
     requires_confirmation = false,
     may_publish = false,
-    required_scopes = ["read.account_overview"],
+    required_scopes = ["read.person_overview"],
     mcp_exposure = Invocable,
     client_side_executable = false,
     composes = [],
     experimental = false,
     signal_policy = { emits_on_output_change = [
         "claim.version",
-        "account_subject.claim_changed",
+        "person_subject.claim_changed",
         "claim.lifecycle",
         "claim.dismissal",
         "source.freshness",
-        "source.revocation"
+        "source.revocation",
+        "person.field_changed",
+        "relationship_graph_changed"
     ], coalesce = true }
 )]
-pub async fn account_overview(
+pub async fn person_overview(
     ctx: &AbilityContext<'_>,
-    input: AccountOverviewInput,
+    input: PersonOverviewInput,
 ) -> AbilityResult<Composition> {
     let input = normalize_input(input)?;
-    let prepared = prepare_account_overview(ctx, &input).await?;
+    let prepared = prepare_person_overview(ctx, &input).await?;
     let committed = ctx
         .services()
         .commit_composition(prepared.proposal)
@@ -149,20 +135,20 @@ pub async fn account_overview(
     Ok(output)
 }
 
-fn normalize_input(input: AccountOverviewInput) -> Result<NormalizedInput, AbilityError> {
+fn normalize_input(input: PersonOverviewInput) -> Result<NormalizedInput, AbilityError> {
     if input.schema_version != ABILITY_SCHEMA_VERSION {
         return Err(validation_error(format!(
             "unsupported schema_version `{}` for `{ABILITY_NAME}`",
             input.schema_version
         )));
     }
-    let account_id = input.account_id.trim();
-    if account_id.is_empty() {
-        return Err(validation_error("account_id must be non-empty"));
+    let person_id = input.person_id.trim();
+    if person_id.is_empty() {
+        return Err(validation_error("person_id must be non-empty"));
     }
     validate_entity_envelope(
-        "account",
-        account_id,
+        "person",
+        person_id,
         input.entity_type.as_deref(),
         input.entity_id.as_deref(),
     )?;
@@ -172,10 +158,10 @@ fn normalize_input(input: AccountOverviewInput) -> Result<NormalizedInput, Abili
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
-        .unwrap_or_else(|| format!("dailyos/account-overview:account:{account_id}"));
+        .unwrap_or_else(|| format!("dailyos/person-overview:person:{person_id}"));
 
     Ok(NormalizedInput {
-        account_id: account_id.to_string(),
+        person_id: person_id.to_string(),
         expected_composition_version: input.expected_composition_version,
         composition_id: CompositionDocId::new(composition_id),
     })
@@ -206,30 +192,22 @@ fn validate_entity_envelope(
     Ok(())
 }
 
-async fn prepare_account_overview(
+async fn prepare_person_overview(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-) -> Result<PreparedAccountOverview, AbilityError> {
-    // The reader currently takes (entity_type, entity_id, surface, depth)
-    // without an actor/scope discriminator. The substrate-side SurfaceClient
-    // scope contract (W4-B §16) calls for SQL-layer projection keyed on
-    // Actor::SurfaceClient { scopes }; until that lands, scope filtering is
-    // enforced one layer up by prompt_input_sensitivity_allowed, which gates
-    // Confidential+ before any block, ClaimRef, or count flows into the
-    // composition. Behavior is preserved; the longer-term tightening is
-    // tracked in the maintenance project.
+) -> Result<PreparedPersonOverview, AbilityError> {
     let claims = ctx
         .services()
         .read_entity_context_claims(
-            "account".to_string(),
-            input.account_id.clone(),
+            "person".to_string(),
+            input.person_id.clone(),
             ctx.entity_context_claim_surface(),
-            ACCOUNT_CLAIM_DEPTH,
+            PERSON_CLAIM_DEPTH,
         )
         .await
-        .map_err(|error| hard_error("account_overview_claim_read", error))?;
+        .map_err(|error| hard_error("person_overview_claim_read", error))?;
 
-    let subject_ref = SubjectRef::Account(input.account_id.clone());
+    let subject_ref = SubjectRef::Person(input.person_id.clone());
     let subject = SubjectAttribution::direct_confident(subject_ref);
     let provenance_config = provenance_config(ctx);
     let invocation_id = provenance_config.invocation_id;
@@ -238,8 +216,7 @@ async fn prepare_account_overview(
 
     let mut projections = Vec::new();
     for claim in claims {
-        let Some(projection) =
-            project_claim(ctx, &input.account_id, claim, &mut provenance_builder)?
+        let Some(projection) = person_claim(ctx, &input.person_id, claim, &mut provenance_builder)?
         else {
             continue;
         };
@@ -247,7 +224,7 @@ async fn prepare_account_overview(
     }
     projections.sort_by(compare_claim_projection);
 
-    let snapshot = read_account_snapshot(ctx, input).await?;
+    let snapshot = read_person_snapshot(ctx, input).await?;
     let composition = build_composition(
         ctx,
         input,
@@ -258,7 +235,7 @@ async fn prepare_account_overview(
         &mut provenance_builder,
     )?;
 
-    Ok(PreparedAccountOverview {
+    Ok(PreparedPersonOverview {
         proposal: CompositionProposal {
             composition_id: input.composition_id.clone(),
             expected_composition_version: input.expected_composition_version,
@@ -268,14 +245,14 @@ async fn prepare_account_overview(
     })
 }
 
-async fn read_account_snapshot(
+async fn read_person_snapshot(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
 ) -> Result<SnapshotReadOutcome, AbilityError> {
     match ctx
         .services()
-        .read_account_composition_snapshot(
-            input.account_id.clone(),
+        .read_person_composition_snapshot(
+            input.person_id.clone(),
             ctx.entity_context_claim_surface(),
         )
         .await
@@ -284,28 +261,28 @@ async fn read_account_snapshot(
             snapshot: Some(snapshot),
             degraded_reason: None,
         }),
-        Err(AccountCompositionSnapshotReadError::AccountNotFound(account_id)) => Err(
-            validation_error(format!("account `{account_id}` was not found")),
+        Err(PersonCompositionSnapshotReadError::PersonNotFound(person_id)) => Err(
+            validation_error(format!("person `{person_id}` was not found")),
         ),
-        Err(AccountCompositionSnapshotReadError::ReadFailed(_)) => Ok(SnapshotReadOutcome {
+        Err(PersonCompositionSnapshotReadError::ReadFailed(_)) => Ok(SnapshotReadOutcome {
             snapshot: None,
-            degraded_reason: Some("account_snapshot_unavailable".to_string()),
+            degraded_reason: Some("person_snapshot_unavailable".to_string()),
         }),
     }
 }
 
-fn project_claim(
+fn person_claim(
     ctx: &AbilityContext<'_>,
-    account_id: &str,
+    person_id: &str,
     claim: IntelligenceClaim,
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Option<ClaimProjection>, AbilityError> {
-    if !claim_is_eligible_for_account_overview(&claim, account_id)? {
+    if !claim_is_eligible_for_person_overview(&claim, person_id)? {
         return Ok(None);
     }
     let Some(metadata) = metadata_for_name(&claim.claim_type) else {
         return Err(validation_error(format!(
-            "unknown claim_type `{}` in account overview input",
+            "unknown claim_type `{}` in person overview input",
             claim.claim_type
         )));
     };
@@ -318,7 +295,7 @@ fn project_claim(
         return Ok(None);
     }
 
-    let source = source_for_claim(ctx, account_id, &claim)?;
+    let source = source_for_claim(ctx, person_id, &claim)?;
     let parsed_source_asof = source.source_asof;
     let source_index = provenance_builder.add_source(source);
     let trust_band = resolved_claim_trust_band(&claim, metadata.kind, ctx.services().clock.now());
@@ -335,9 +312,9 @@ fn project_claim(
     }))
 }
 
-fn claim_is_eligible_for_account_overview(
+fn claim_is_eligible_for_person_overview(
     claim: &IntelligenceClaim,
-    account_id: &str,
+    person_id: &str,
 ) -> Result<bool, AbilityError> {
     if claim.claim_state != ClaimState::Active || claim.surfacing_state != SurfacingState::Active {
         return Ok(false);
@@ -360,9 +337,9 @@ fn claim_is_eligible_for_account_overview(
     match subject_ref_from_json(&value)
         .map_err(|error| validation_error(format!("invalid claim subject_ref: {error}")))?
     {
-        ClaimSubjectRef::Account { id } => Ok(id == account_id),
-        ClaimSubjectRef::Action { .. }
-        | ClaimSubjectRef::Person { .. }
+        ClaimSubjectRef::Person { id } => Ok(id == person_id),
+        ClaimSubjectRef::Account { .. }
+        | ClaimSubjectRef::Action { .. }
         | ClaimSubjectRef::Project { .. }
         | ClaimSubjectRef::Meeting { .. }
         | ClaimSubjectRef::Email { .. }
@@ -374,20 +351,21 @@ fn claim_is_eligible_for_account_overview(
 fn placement_for_claim_type(kind: ClaimType) -> ClaimPlacement {
     match kind {
         ClaimType::Risk | ClaimType::EntityRisk => ClaimPlacement::Risk,
-        ClaimType::Win | ClaimType::EntityWin => ClaimPlacement::Win,
-        ClaimType::ValueDelivered => ClaimPlacement::Value,
+        ClaimType::Win
+        | ClaimType::EntityWin
+        | ClaimType::ValueDelivered
+        | ClaimType::EntityCurrentState
+        | ClaimType::EntitySummary => ClaimPlacement::Momentum,
         ClaimType::Commitment | ClaimType::OpenLoop | ClaimType::Recommendation => {
             ClaimPlacement::Commitment
         }
         ClaimType::StakeholderEngagement
         | ClaimType::StakeholderAssessment
         | ClaimType::StakeholderRole => ClaimPlacement::Relationship,
-        ClaimType::EntityCurrentState => ClaimPlacement::Health,
         ClaimType::CompanyContext
         | ClaimType::AccountFact
         | ClaimType::EntityIdentity
-        | ClaimType::EntitySummary
-        | ClaimType::UserNote => ClaimPlacement::Overview,
+        | ClaimType::UserNote => ClaimPlacement::Context,
         ClaimType::LinkingDismissed
         | ClaimType::EmailDismissed
         | ClaimType::IntelligenceFieldDismissed
@@ -417,82 +395,53 @@ fn build_composition(
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Composition, AbilityError> {
     let snapshot = snapshot_outcome.snapshot.as_ref();
-    let mut sections = Vec::with_capacity(VARIANT_D_SECTIONS.len());
-    let block_context = AccountBlockBuildContext {
-        ctx,
-        input,
-        subject,
-        invocation_id,
-    };
+    let mut sections = Vec::new();
 
-    let headline_block = build_overview_block(
-        &block_context,
-        projections,
-        snapshot_outcome,
-        "/sections/0/blocks/0",
-        provenance_builder,
-    )?;
     sections.push(variant_section(
         "headline",
         "Headline",
-        vec![headline_block],
-        SectionLayout::Stacked,
-        salience(0.95, SalienceBand::Critical, "account masthead"),
-    ));
-
-    let outlook_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Health)
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "outlook",
-        "Outlook",
-        build_claim_or_snapshot_section_blocks(
+        vec![build_overview_block(
             ctx,
             input,
-            "outlook",
-            1,
-            outlook_claims,
-            snapshot_fields_for_section(snapshot, "outlook"),
-            EmptySectionCopy {
-                title: "No current outlook signals",
-                body: "DailyOS has not found current account-health signals with renderable provenance.",
-                status: "source_gap",
-            },
+            projections,
+            snapshot_outcome,
+            "/sections/0/blocks/0",
             subject,
             invocation_id,
             provenance_builder,
-        )?,
+        )?],
         SectionLayout::Stacked,
-        salience(0.86, SalienceBand::Important, "account outlook"),
+        salience(0.95, SalienceBand::Critical, "person masthead"),
     ));
 
-    let state_claims = projections
+    let mut next_section_index = 1;
+    let relationship = snapshot
+        .and_then(|snapshot| snapshot.relationship.as_ref())
+        .map(|field| snapshot_value_text(&field.value))
+        .unwrap_or_else(|| "unknown".to_string());
+    let (dynamic_section_id, dynamic_label, dynamic_reason) = if relationship == "internal" {
+        ("the-rhythm", "The rhythm", "person rhythm")
+    } else {
+        ("the-dynamic", "The dynamic", "person dynamic")
+    };
+
+    let dynamic_claims = projections
         .iter()
-        .filter(|projection| {
-            matches!(
-                projection.placement,
-                ClaimPlacement::Health
-                    | ClaimPlacement::Risk
-                    | ClaimPlacement::Win
-                    | ClaimPlacement::Value
-                    | ClaimPlacement::Overview
-            )
-        })
+        .filter(|projection| projection.placement == ClaimPlacement::Momentum)
         .collect::<Vec<_>>();
     sections.push(variant_section(
-        "state-of-play",
-        "State of play",
+        dynamic_section_id,
+        dynamic_label,
         build_claim_or_snapshot_section_blocks(
             ctx,
             input,
-            "state-of-play",
-            2,
-            state_claims,
-            snapshot_fields_for_section(snapshot, "state-of-play"),
+            dynamic_section_id,
+            next_section_index,
+            dynamic_claims,
+            snapshot_fields_for_section(snapshot, dynamic_section_id),
             EmptySectionCopy {
-                title: "No active state-of-play signals",
-                body: "No active account claims are currently eligible for this surface.",
+                title: "No relationship signals",
+                body: "No active relationship dynamic claims are eligible for this surface.",
                 status: "empty",
             },
             subject,
@@ -500,26 +449,23 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.82, SalienceBand::Important, "current account state"),
+        salience(0.86, SalienceBand::Important, dynamic_reason),
     ));
+    next_section_index += 1;
 
-    let room_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Relationship)
-        .collect::<Vec<_>>();
     sections.push(variant_section(
-        "the-room",
-        "The room",
+        "their-orbit",
+        "Their orbit",
         build_claim_or_snapshot_section_blocks(
             ctx,
             input,
-            "the-room",
-            3,
-            room_claims,
-            snapshot_fields_for_section(snapshot, "the-room"),
+            "their-orbit",
+            next_section_index,
+            Vec::new(),
+            snapshot_fields_for_section(snapshot, "their-orbit"),
             EmptySectionCopy {
-                title: "No room signals",
-                body: "Stakeholder and relationship inputs are not yet grounded for this account.",
+                title: "No linked entities",
+                body: "No source-backed account or project context is currently linked to this person.",
                 status: "empty",
             },
             subject,
@@ -527,121 +473,60 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Grid,
-        salience(0.72, SalienceBand::Contextual, "account relationships"),
+        salience(0.8, SalienceBand::Important, "person orbit"),
     ));
+    next_section_index += 1;
 
-    let next_claims = projections
+    let network_claims = projections
         .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Commitment)
+        .filter(|projection| projection.placement == ClaimPlacement::Relationship)
         .collect::<Vec<_>>();
     sections.push(variant_section(
-        "whats-next",
-        "What's next",
+        "their-network",
+        "Their network",
         build_claim_or_snapshot_section_blocks(
             ctx,
             input,
-            "whats-next",
-            4,
-            next_claims,
-            snapshot_fields_for_section(snapshot, "whats-next"),
+            "their-network",
+            next_section_index,
+            network_claims,
+            snapshot_fields_for_section(snapshot, "their-network"),
             EmptySectionCopy {
-                title: "No open next steps",
-                body: "There are no renderable commitments or next-step records for this account.",
+                title: "No relationship graph",
+                body: "Relationship graph inputs are not yet grounded for this person.",
                 status: "empty",
             },
             subject,
             invocation_id,
             provenance_builder,
         )?,
-        SectionLayout::Stacked,
-        salience(0.8, SalienceBand::Important, "next account work"),
+        SectionLayout::Grid,
+        salience(0.72, SalienceBand::Contextual, "person network"),
     ));
+    next_section_index += 1;
 
-    let watch_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Risk)
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "watch-list",
-        "Watch list",
-        build_claim_or_snapshot_section_blocks(
-            ctx,
-            input,
-            "watch-list",
-            5,
-            watch_claims,
-            snapshot_fields_for_section(snapshot, "watch-list"),
-            EmptySectionCopy {
-                title: "No active watch-list signals",
-                body: "No active risk or watch-list claims are eligible for this account.",
-                status: "empty",
-            },
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Stacked,
-        salience(0.76, SalienceBand::Important, "watch-list signals"),
-    ));
-
-    let value_claims = projections
+    let landscape_claims = projections
         .iter()
         .filter(|projection| {
             matches!(
                 projection.placement,
-                ClaimPlacement::Value | ClaimPlacement::Win | ClaimPlacement::Commitment
+                ClaimPlacement::Risk | ClaimPlacement::Context
             )
         })
         .collect::<Vec<_>>();
     sections.push(variant_section(
-        "value-commitments",
-        "Value commitments",
+        "the-landscape",
+        "The landscape",
         build_claim_or_snapshot_section_blocks(
             ctx,
             input,
-            "value-commitments",
-            6,
-            value_claims,
-            snapshot_fields_for_section(snapshot, "value-commitments"),
+            "the-landscape",
+            next_section_index,
+            landscape_claims,
+            snapshot_fields_for_section(snapshot, "the-landscape"),
             EmptySectionCopy {
-                title: "No commitments with current evidence",
-                body: "DailyOS has not found value or commitment claims with current evidence.",
-                status: "source_gap",
-            },
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Stacked,
-        salience(0.72, SalienceBand::Important, "value and commitments"),
-    ));
-
-    let strategic_claims = projections
-        .iter()
-        .filter(|projection| {
-            matches!(
-                projection.claim_type,
-                ClaimType::CompanyContext
-                    | ClaimType::AccountFact
-                    | ClaimType::EntityIdentity
-                    | ClaimType::EntitySummary
-                    | ClaimType::UserNote
-            )
-        })
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "strategic-landscape",
-        "Strategic landscape",
-        build_claim_or_snapshot_section_blocks(
-            ctx,
-            input,
-            "strategic-landscape",
-            7,
-            strategic_claims,
-            snapshot_fields_for_section(snapshot, "strategic-landscape"),
-            EmptySectionCopy {
-                title: "Strategic context not yet grounded",
-                body: "No source-backed strategic context is available for this account.",
+                title: "Landscape not yet grounded",
+                body: "No renderable person context or risk claims are available.",
                 status: "needs_grounding",
             },
             subject,
@@ -649,8 +534,37 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.62, SalienceBand::Contextual, "strategic account context"),
+        salience(0.76, SalienceBand::Important, "person landscape"),
     ));
+    next_section_index += 1;
+
+    let next_claims = projections
+        .iter()
+        .filter(|projection| projection.placement == ClaimPlacement::Commitment)
+        .collect::<Vec<_>>();
+    sections.push(variant_section(
+        "open-threads",
+        "Open threads",
+        build_claim_or_snapshot_section_blocks(
+            ctx,
+            input,
+            "open-threads",
+            next_section_index,
+            next_claims.clone(),
+            snapshot_fields_for_section(snapshot, "open-threads"),
+            EmptySectionCopy {
+                title: "No open threads",
+                body: "There are no renderable commitments or open-thread records for this person.",
+                status: "empty",
+            },
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?,
+        SectionLayout::Stacked,
+        salience(0.78, SalienceBand::Important, "person open threads"),
+    ));
+    next_section_index += 1;
 
     sections.push(variant_section(
         "the-record",
@@ -660,19 +574,16 @@ fn build_composition(
             input,
             projections,
             snapshot_fields_for_section(snapshot, "the-record"),
-            8,
+            next_section_index,
             subject,
             invocation_id,
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.58, SalienceBand::Contextual, "account evidence record"),
+        salience(0.58, SalienceBand::Contextual, "person evidence record"),
     ));
+    next_section_index += 1;
 
-    let work_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Commitment)
-        .collect::<Vec<_>>();
     sections.push(variant_section(
         "the-work",
         "The work",
@@ -680,12 +591,12 @@ fn build_composition(
             ctx,
             input,
             "the-work",
-            9,
-            work_claims,
+            next_section_index,
+            next_claims,
             snapshot_fields_for_section(snapshot, "the-work"),
             EmptySectionCopy {
                 title: "No active work items",
-                body: "No active work records are currently grounded for this account.",
+                body: "No active person work records are currently grounded.",
                 status: "empty",
             },
             subject,
@@ -693,23 +604,7 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.46, SalienceBand::Background, "account work"),
-    ));
-
-    sections.push(variant_section(
-        "reports",
-        "Reports",
-        build_reports_section_blocks(
-            ctx,
-            input,
-            snapshot_fields_for_section(snapshot, "reports"),
-            10,
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Grid,
-        salience(0.38, SalienceBand::Background, "account reports"),
+        salience(0.5, SalienceBand::Background, "person work"),
     ));
 
     let section_count = sections.len();
@@ -717,9 +612,9 @@ fn build_composition(
     let composition = Composition::new(
         input.composition_id.clone(),
         CompositionKind::EntityPage,
-        Some(EntityRef::new(format!("account:{}", input.account_id))),
+        Some(EntityRef::new(format!("person:{}", input.person_id))),
         sections,
-        salience(0.9, SalienceBand::Important, "account overview"),
+        salience(0.9, SalienceBand::Important, "person overview"),
         generated_at,
         AbilityRef::new(ABILITY_NAME),
         CompositionMetadata {
@@ -739,14 +634,6 @@ struct EmptySectionCopy {
     title: &'static str,
     body: &'static str,
     status: &'static str,
-}
-
-#[derive(Clone, Copy)]
-struct AccountBlockBuildContext<'a, 'ctx> {
-    ctx: &'a AbilityContext<'ctx>,
-    input: &'a NormalizedInput,
-    subject: &'a SubjectAttribution,
-    invocation_id: InvocationId,
 }
 
 fn variant_section(
@@ -770,7 +657,7 @@ fn build_claim_or_snapshot_section_blocks(
     section_id: &str,
     section_index: usize,
     projections: Vec<&ClaimProjection>,
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
+    snapshot_fields: Vec<&PersonCompositionSnapshotField>,
     empty_copy: EmptySectionCopy,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
@@ -862,7 +749,7 @@ fn build_record_section_blocks(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
     projections: &[ClaimProjection],
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
+    snapshot_fields: Vec<&PersonCompositionSnapshotField>,
     section_index: usize,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
@@ -873,8 +760,8 @@ fn build_record_section_blocks(
             input,
             "the-record",
             EmptySectionCopy {
-                title: "No account record yet",
-                body: "No source-backed account events are available for this record.",
+                title: "No person record yet",
+                body: "No source-backed person events are available for this record.",
                 status: "empty",
             },
             section_index,
@@ -904,14 +791,15 @@ fn build_record_section_blocks(
         provenance_builder,
     )?);
     for field in snapshot_fields {
-        items.push(snapshot_field_evidence_item(field));
+        items.extend(snapshot_field_evidence_items(field));
     }
 
     let composition_block_path = format!("/sections/{section_index}/blocks/0");
+    let item_count = items.len();
     let mut block = Block::new(
         BlockId::new(block_id(input, "the-record", "evidence_list", "sources")),
         BlockType::EvidenceList,
-        json!({ "items": items }),
+        json!({ "title": "Evidence", "items": items }),
         claim_refs,
         ProvenanceRef::new(
             invocation_id,
@@ -920,7 +808,7 @@ fn build_record_section_blocks(
         None,
     )
     .map_err(block_error)?;
-    block.field_bindings = evidence_list_display_bindings(items.len())?;
+    block.field_bindings = evidence_list_display_bindings(item_count)?;
     block.salience = salience(0.58, SalienceBand::Contextual, "source record");
     attribute_block(
         provenance_builder,
@@ -932,68 +820,13 @@ fn build_record_section_blocks(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn build_reports_section_blocks(
-    ctx: &AbilityContext<'_>,
-    input: &NormalizedInput,
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
-    section_index: usize,
-    subject: &SubjectAttribution,
-    invocation_id: InvocationId,
-    provenance_builder: &mut ProvenanceBuilder,
-) -> Result<Vec<Block>, AbilityError> {
-    if snapshot_fields.is_empty() {
-        let composition_block_path = format!("/sections/{section_index}/blocks/0");
-        let mut block = Block::new(
-            BlockId::new(block_id(input, "reports", "action_list", "system_config")),
-            BlockType::ActionList,
-            json!({
-                "claim_type": "system_config",
-                "items": [{
-                    "title": "Account report",
-                    "status": "unavailable",
-                    "text": "No generated account report is currently available."
-                }]
-            }),
-            Vec::new(),
-            ProvenanceRef::new(
-                invocation_id,
-                FieldPath::new(&composition_block_path).map_err(field_error)?,
-            ),
-            None,
-        )
-        .map_err(block_error)?;
-        block.field_bindings = action_list_display_bindings(1)?;
-        block.salience = salience(0.32, SalienceBand::Background, "report availability");
-        attribute_block(
-            provenance_builder,
-            &composition_block_path,
-            subject,
-            Vec::new(),
-        )?;
-        return Ok(vec![block]);
-    }
-
-    Ok(vec![build_snapshot_fields_block(
-        ctx,
-        input,
-        "reports",
-        section_index,
-        0,
-        snapshot_fields,
-        subject,
-        invocation_id,
-        provenance_builder,
-    )?])
-}
-
-#[allow(clippy::too_many_arguments)]
 fn build_snapshot_fields_block(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
     section_id: &str,
     section_index: usize,
     block_index: usize,
-    fields: Vec<&AccountCompositionSnapshotField>,
+    fields: Vec<&PersonCompositionSnapshotField>,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
     provenance_builder: &mut ProvenanceBuilder,
@@ -1001,13 +834,14 @@ fn build_snapshot_fields_block(
     let source_indexes = snapshot_source_indexes(ctx, input, &fields, provenance_builder)?;
     let items = fields
         .iter()
-        .map(|field| snapshot_field_evidence_item(field))
+        .flat_map(|field| snapshot_field_evidence_items(field))
         .collect::<Vec<_>>();
     let composition_block_path = format!("/sections/{section_index}/blocks/{block_index}");
+    let item_count = items.len();
     let mut block = Block::new(
         BlockId::new(block_id(input, section_id, "evidence_list", "snapshot")),
         BlockType::EvidenceList,
-        json!({ "items": items }),
+        json!({ "title": section_title(section_id), "items": items }),
         Vec::new(),
         ProvenanceRef::new(
             invocation_id,
@@ -1016,7 +850,7 @@ fn build_snapshot_fields_block(
         None,
     )
     .map_err(block_error)?;
-    block.field_bindings = evidence_list_display_bindings(items.len())?;
+    block.field_bindings = evidence_list_display_bindings(item_count)?;
     block.salience = salience(0.54, SalienceBand::Contextual, "snapshot fields");
     attribute_block(
         provenance_builder,
@@ -1027,19 +861,64 @@ fn build_snapshot_fields_block(
     Ok(block)
 }
 
-fn snapshot_field_evidence_item(field: &AccountCompositionSnapshotField) -> Value {
-    json!({
-        "label": format!("{}: {}", field.label, snapshot_value_text(&field.value)),
-        "source_label": field.source_label.as_deref().unwrap_or(match field.provenance_kind {
-            AccountCompositionProvenanceKind::NonSensitiveIdentity => "identity",
-            AccountCompositionProvenanceKind::ManualUser => "user",
-            AccountCompositionProvenanceKind::SourceField => "source",
-            AccountCompositionProvenanceKind::SystemConfig => "system_config",
-            AccountCompositionProvenanceKind::Derived => "derived",
-            AccountCompositionProvenanceKind::Unavailable => "unavailable",
-        }),
-        "source_asof": field.source_asof,
-    })
+fn section_title(section_id: &str) -> &'static str {
+    match section_id {
+        "the-dynamic" => "The dynamic",
+        "the-rhythm" => "The rhythm",
+        "their-orbit" => "Their orbit",
+        "their-network" => "Their network",
+        "the-landscape" => "Landscape",
+        "open-threads" => "Open threads",
+        "the-record" => "Record",
+        "the-work" => "Work",
+        _ => "Evidence",
+    }
+}
+
+fn snapshot_field_evidence_items(field: &PersonCompositionSnapshotField) -> Vec<Value> {
+    let source_label = field
+        .source_label
+        .as_deref()
+        .unwrap_or(match field.provenance_kind {
+            PersonCompositionProvenanceKind::NonSensitiveIdentity => "identity",
+            PersonCompositionProvenanceKind::ManualUser => "user",
+            PersonCompositionProvenanceKind::SourceField => "source",
+            PersonCompositionProvenanceKind::SystemConfig => "system_config",
+            PersonCompositionProvenanceKind::Derived => "derived",
+            PersonCompositionProvenanceKind::Unavailable => "unavailable",
+        });
+    match &field.value {
+        Value::Array(items) => items
+            .iter()
+            .take(12)
+            .map(|item| {
+                json!({
+                    "label": format!("{}: {}", field.label, compact_item_label(item)),
+                    "source_label": source_label,
+                    "source_asof": field.source_asof,
+                })
+            })
+            .collect(),
+        _ => vec![json!({
+            "label": format!("{}: {}", field.label, snapshot_value_text(&field.value)),
+            "source_label": source_label,
+            "source_asof": field.source_asof,
+        })],
+    }
+}
+
+fn compact_item_label(value: &Value) -> String {
+    let Some(object) = value.as_object() else {
+        return snapshot_value_text(value);
+    };
+    for key in ["title", "name", "signal_text", "content"] {
+        if let Some(label) = object.get(key).and_then(Value::as_str) {
+            if !label.trim().is_empty() {
+                return label.to_string();
+            }
+        }
+    }
+    snapshot_value_text(value)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1088,11 +967,15 @@ fn build_section_state_block(
     Ok(block)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_overview_block(
-    build_context: &AccountBlockBuildContext<'_, '_>,
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
     projections: &[ClaimProjection],
     snapshot_outcome: &SnapshotReadOutcome,
     composition_block_path: &str,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Block, AbilityError> {
     let snapshot = snapshot_outcome.snapshot.as_ref();
@@ -1102,15 +985,20 @@ fn build_overview_block(
         .map(|projection| projection.source_index)
         .collect::<Vec<_>>();
     source_indexes.extend(snapshot_source_indexes(
-        build_context.ctx,
-        build_context.input,
+        ctx,
+        input,
         &headline_fields,
         provenance_builder,
     )?);
     let overview_claims = projections
         .iter()
         .enumerate()
-        .filter(|(_, projection)| projection.placement == ClaimPlacement::Overview)
+        .filter(|(_, projection)| {
+            matches!(
+                projection.placement,
+                ClaimPlacement::Momentum | ClaimPlacement::Context
+            )
+        })
         .collect::<Vec<_>>();
     let all_refs = projections
         .iter()
@@ -1133,12 +1021,20 @@ fn build_overview_block(
         .collect::<Vec<_>>();
     let trust_band = block_trust_band(projections.iter().map(|projection| projection.trust_band));
     let counts_by_band = trust_band_counts(projections);
-    let account_display_name = snapshot
+    let person_display_name = snapshot
         .map(|snapshot| snapshot_value_text(&snapshot.display_name.value))
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| build_context.input.account_id.clone());
-    let account_type = snapshot
-        .and_then(|snapshot| snapshot.account_type.as_ref())
+        .unwrap_or_else(|| input.person_id.clone());
+    let relationship = snapshot
+        .and_then(|snapshot| snapshot.relationship.as_ref())
+        .filter(|field| field.sensitivity.is_render_safe())
+        .map(|field| snapshot_value_text(&field.value));
+    let organization = snapshot
+        .and_then(|snapshot| snapshot.organization.as_ref())
+        .filter(|field| field.sensitivity.is_render_safe())
+        .map(|field| snapshot_value_text(&field.value));
+    let role = snapshot
+        .and_then(|snapshot| snapshot.role.as_ref())
         .filter(|field| field.sensitivity.is_render_safe())
         .map(|field| snapshot_value_text(&field.value));
     let vitals = headline_fields
@@ -1155,17 +1051,25 @@ fn build_overview_block(
         .collect::<Vec<_>>();
     let vitals_len = vitals.len();
     let attributes = json!({
-        "account_id": build_context.input.account_id,
+        "entity_type": "person",
+        "person_id": input.person_id,
         "account": {
-            "id": build_context.input.account_id,
-            "display_name": account_display_name,
-            "type": account_type,
+            "id": input.person_id,
+            "display_name": person_display_name,
+            "type": "Person",
         },
-        "title": "Account overview",
+        "person": {
+            "id": input.person_id,
+            "display_name": person_display_name,
+            "relationship": relationship,
+            "organization": organization,
+            "role": role,
+        },
+        "title": "Person overview",
         "summary": overview_claims
             .first()
             .map(|(_, projection)| projection.rendered_text.as_str())
-            .unwrap_or("Account composition is grounded in current renderable claims and source-backed account fields."),
+            .unwrap_or("Person composition is grounded in current renderable claims and source-backed person fields."),
         "claim_count": projections.len(),
         "trust_band": trust_band_label(trust_band),
         "counts_by_trust_band": counts_by_band,
@@ -1174,17 +1078,12 @@ fn build_overview_block(
         "snapshot_degraded": snapshot_outcome.degraded_reason.as_deref().unwrap_or(""),
     });
     let mut block = Block::new(
-        BlockId::new(block_id(
-            build_context.input,
-            "headline",
-            "account_overview",
-            "summary",
-        )),
+        BlockId::new(block_id(input, "headline", "account_overview", "summary")),
         BlockType::AccountOverview,
         attributes,
         all_refs,
         ProvenanceRef::new(
-            build_context.invocation_id,
+            invocation_id,
             FieldPath::new(composition_block_path).map_err(field_error)?,
         ),
         None,
@@ -1197,31 +1096,30 @@ fn build_overview_block(
         display_only_binding("/account/id")?,
         display_only_binding("/account/display_name")?,
         display_only_binding("/account/type")?,
+        display_only_binding("/person/id")?,
+        display_only_binding("/person/display_name")?,
+        display_only_binding("/person/relationship")?,
+        display_only_binding("/person/organization")?,
+        display_only_binding("/person/role")?,
         display_only_binding("/snapshot_degraded")?,
     ];
     display_bindings.extend(vitals_display_bindings(vitals_len)?);
 
     if projections.is_empty() {
         block.field_bindings = display_bindings;
-        attribute_block(
-            provenance_builder,
-            composition_block_path,
-            build_context.subject,
-            source_indexes,
-        )?;
     } else {
         let mut bindings = vec![computed_binding("/claim_count", 0..projections.len())?];
         bindings.extend(trust_band_count_computed_bindings(projections.len())?);
         bindings.extend(context_computed_bindings(&overview_claim_indexes)?);
         bindings.extend(display_bindings);
         block.field_bindings = bindings;
-        attribute_block(
-            provenance_builder,
-            composition_block_path,
-            build_context.subject,
-            source_indexes,
-        )?;
     }
+    attribute_block(
+        provenance_builder,
+        composition_block_path,
+        subject,
+        source_indexes,
+    )?;
     Ok(block)
 }
 
@@ -1252,39 +1150,10 @@ fn build_claim_block(
                 SalienceBand::Critical,
                 "risk claim",
             ),
-            ClaimPlacement::Win => (
-                BlockType::ClaimSummary,
-                json!({
-                    "intent": "win",
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.72,
-                SalienceBand::Important,
-                "win claim",
-            ),
-            ClaimPlacement::Value => (
-                BlockType::ClaimSummary,
-                json!({
-                    "intent": "value",
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.72,
-                SalienceBand::Important,
-                "value claim",
-            ),
             ClaimPlacement::Commitment => (
                 BlockType::ActionList,
                 json!({
+                    "title": "Actions",
                     "items": [{
                         "claim_id": projection.claim.id,
                         "text": projection.rendered_text,
@@ -1316,24 +1185,10 @@ fn build_claim_block(
                 SalienceBand::Contextual,
                 "relationship claim",
             ),
-            ClaimPlacement::Health => (
-                BlockType::HealthSnapshot,
-                json!({
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.82,
-                SalienceBand::Important,
-                "health claim",
-            ),
-            ClaimPlacement::Overview => (
+            ClaimPlacement::Momentum | ClaimPlacement::Context => (
                 BlockType::ClaimSummary,
                 json!({
-                    "intent": "context",
+                    "intent": if projection.placement == ClaimPlacement::Momentum { "relationship_dynamic" } else { "context" },
                     "claim_id": projection.claim.id,
                     "text": projection.rendered_text,
                     "claim_type": projection.claim.claim_type,
@@ -1341,13 +1196,13 @@ fn build_claim_block(
                     "source_asof": projection.claim.source_asof,
                 }),
                 source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.58,
-                SalienceBand::Contextual,
-                "account context claim",
+                0.66,
+                SalienceBand::Important,
+                "person claim",
             ),
             ClaimPlacement::Ignored => {
                 return Err(validation_error(
-                    "unexpected account overview block placement",
+                    "unexpected person overview block placement",
                 ));
             }
         };
@@ -1381,9 +1236,9 @@ fn build_claim_block(
 }
 
 fn snapshot_fields_for_section<'a>(
-    snapshot: Option<&'a AccountCompositionSnapshot>,
+    snapshot: Option<&'a PersonCompositionSnapshot>,
     section_id: &str,
-) -> Vec<&'a AccountCompositionSnapshotField> {
+) -> Vec<&'a PersonCompositionSnapshotField> {
     let Some(snapshot) = snapshot else {
         return Vec::new();
     };
@@ -1397,34 +1252,14 @@ fn snapshot_fields_for_section<'a>(
 
 fn snapshot_field_belongs_to_section(field_path: &str, section_id: &str) -> bool {
     match section_id {
-        "headline" => {
-            field_path.starts_with("/vitals/")
-                || field_path.starts_with("/identity/")
-                || field_path == "/health/band"
-        }
-        "outlook" => {
-            field_path.starts_with("/outlook/")
-                || field_path.starts_with("/renewal/")
-                || field_path == "/vitals/contract_end"
-                || field_path == "/health/band"
-        }
-        "state-of-play" => field_path.starts_with("/state/"),
-        "the-room" => field_path.starts_with("/stakeholders/"),
-        "whats-next" => field_path.starts_with("/work/next_steps/"),
-        "watch-list" => field_path.starts_with("/watch_list/"),
-        "value-commitments" => {
-            field_path.starts_with("/value/")
-                || field_path.starts_with("/work/commitments/")
-                || field_path == "/vitals/arr"
-        }
-        "strategic-landscape" => {
-            field_path.starts_with("/strategy/")
-                || field_path.starts_with("/technical/")
-                || field_path.starts_with("/company/")
-        }
-        "the-record" => field_path.starts_with("/record/") || field_path.starts_with("/sources/"),
-        "the-work" => field_path.starts_with("/work/"),
-        "reports" => field_path.starts_with("/reports/"),
+        "headline" => field_path.starts_with("/vitals/") || field_path.starts_with("/identity/"),
+        "the-dynamic" | "the-rhythm" => field_path.starts_with("/relationship/"),
+        "their-orbit" => field_path.starts_with("/their-orbit/"),
+        "their-network" => field_path.starts_with("/their-network/"),
+        "the-landscape" => field_path.starts_with("/state/"),
+        "open-threads" => field_path.starts_with("/open-threads/"),
+        "the-record" => field_path.starts_with("/the-record/"),
+        "the-work" => field_path.starts_with("/the-work/"),
         _ => false,
     }
 }
@@ -1432,7 +1267,7 @@ fn snapshot_field_belongs_to_section(field_path: &str, section_id: &str) -> bool
 fn snapshot_source_indexes(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-    fields: &[&AccountCompositionSnapshotField],
+    fields: &[&PersonCompositionSnapshotField],
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Vec<crate::abilities::provenance::SourceIndex>, AbilityError> {
     let mut indexes = Vec::new();
@@ -1450,12 +1285,12 @@ fn snapshot_source_indexes(
 fn source_for_snapshot_field(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-    field: &AccountCompositionSnapshotField,
+    field: &PersonCompositionSnapshotField,
 ) -> Result<Option<SourceAttribution>, AbilityError> {
     if matches!(
         field.provenance_kind,
-        AccountCompositionProvenanceKind::NonSensitiveIdentity
-            | AccountCompositionProvenanceKind::Unavailable
+        PersonCompositionProvenanceKind::NonSensitiveIdentity
+            | PersonCompositionProvenanceKind::Unavailable
     ) && field.source_label.is_none()
         && field.source_ref.is_none()
         && field.source_asof.is_none()
@@ -1477,7 +1312,7 @@ fn source_for_snapshot_field(
     SourceAttribution::new(
         data_source_for_snapshot_field(field),
         vec![SourceIdentifier::Entity {
-            entity_id: EntityId::new(input.account_id.clone()),
+            entity_id: EntityId::new(input.person_id.clone()),
             field: Some(field.field_path.clone()),
         }],
         observed_at,
@@ -1489,15 +1324,15 @@ fn source_for_snapshot_field(
     .map_err(|error| validation_error(format!("invalid snapshot source attribution: {error}")))
 }
 
-fn data_source_for_snapshot_field(field: &AccountCompositionSnapshotField) -> DataSource {
+fn data_source_for_snapshot_field(field: &PersonCompositionSnapshotField) -> DataSource {
     match field.provenance_kind {
-        AccountCompositionProvenanceKind::ManualUser => DataSource::User,
-        AccountCompositionProvenanceKind::SystemConfig => DataSource::LocalEnrichment,
+        PersonCompositionProvenanceKind::ManualUser => DataSource::User,
+        PersonCompositionProvenanceKind::SystemConfig => DataSource::LocalEnrichment,
         _ => field
             .source_label
             .as_deref()
             .map(data_source_for_claim)
-            .unwrap_or_else(|| DataSource::Other(SourceName::new("account_snapshot"))),
+            .unwrap_or_else(|| DataSource::Other(SourceName::new("person_snapshot"))),
     }
 }
 
@@ -1573,7 +1408,7 @@ fn attribute_block(
     } else {
         FieldAttribution::computed(
             subject.clone(),
-            "dailyos.account_overview.v1",
+            "dailyos.person_overview.v1",
             source_indexes
                 .into_iter()
                 .map(|source_index| SourceRef::Source { source_index })
@@ -1583,7 +1418,7 @@ fn attribute_block(
         .map_err(field_error)?
     };
     builder
-        .attribute(path.clone(), attribution.clone())
+        .attribute(path, attribution)
         .map_err(provenance_error)?;
     Ok(())
 }
@@ -1664,7 +1499,8 @@ fn vitals_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, Abili
 }
 
 fn evidence_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
-    let mut bindings = Vec::with_capacity(item_count * 3);
+    let mut bindings = Vec::with_capacity(item_count * 3 + 1);
+    bindings.push(display_only_binding("/title")?);
     for index in 0..item_count {
         bindings.push(display_only_binding(&format!("/items/{index}/label"))?);
         bindings.push(display_only_binding(&format!(
@@ -1673,16 +1509,6 @@ fn evidence_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>
         bindings.push(display_only_binding(&format!(
             "/items/{index}/source_asof"
         ))?);
-    }
-    Ok(bindings)
-}
-
-fn action_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
-    let mut bindings = Vec::with_capacity(item_count * 3);
-    for index in 0..item_count {
-        bindings.push(display_only_binding(&format!("/items/{index}/title"))?);
-        bindings.push(display_only_binding(&format!("/items/{index}/status"))?);
-        bindings.push(display_only_binding(&format!("/items/{index}/text"))?);
     }
     Ok(bindings)
 }
@@ -1819,13 +1645,11 @@ fn compare_claim_projection(left: &ClaimProjection, right: &ClaimProjection) -> 
 fn placement_rank(placement: ClaimPlacement) -> u8 {
     match placement {
         ClaimPlacement::Risk => 0,
-        ClaimPlacement::Health => 1,
+        ClaimPlacement::Momentum => 1,
         ClaimPlacement::Commitment => 2,
-        ClaimPlacement::Value => 3,
-        ClaimPlacement::Win => 4,
-        ClaimPlacement::Relationship => 5,
-        ClaimPlacement::Overview => 6,
-        ClaimPlacement::Ignored => 7,
+        ClaimPlacement::Relationship => 3,
+        ClaimPlacement::Context => 4,
+        ClaimPlacement::Ignored => 5,
     }
 }
 
@@ -1839,7 +1663,7 @@ fn trust_rank(band: TrustBand) -> u8 {
 
 fn source_for_claim(
     ctx: &AbilityContext<'_>,
-    account_id: &str,
+    person_id: &str,
     claim: &IntelligenceClaim,
 ) -> Result<SourceAttribution, AbilityError> {
     let now = ctx.services().clock.now();
@@ -1848,7 +1672,7 @@ fn source_for_claim(
     SourceAttribution::new(
         data_source_for_claim(&claim.data_source),
         vec![SourceIdentifier::Entity {
-            entity_id: EntityId::new(account_id.to_string()),
+            entity_id: EntityId::new(person_id.to_string()),
             field: Some(
                 claim
                     .field_path
@@ -2050,22 +1874,18 @@ mod tests {
     use chrono::TimeZone;
 
     use super::*;
-    use crate::abilities::provenance::ProvenanceWarning;
     use crate::abilities::registry::{AbilityRegistry, ActorKind, McpExposure, ScopeSet};
-    use crate::abilities::{
-        project_composition_for_surface, Actor, FallbackProjectionContext, SurfaceKind,
-        NOOP_ABILITY_TRACER,
-    };
+    use crate::abilities::NOOP_ABILITY_TRACER;
     use crate::intelligence::provider::{
         Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
         ProviderError, ProviderKind,
     };
     use crate::sensitivity::{ClaimDismissalSurface, ClaimVerificationState};
     use crate::services::context::{
-        AccountCompositionSnapshotReadFuture, AccountCompositionSnapshotReadHandle,
-        AccountCompositionSnapshotSensitivity, CompositionCommitFuture, CompositionCommitHandle,
-        CompositionCommitRequest, EntityContextClaimReadFuture, EntityContextClaimReadHandle,
-        ExternalClients, FixedClock, SeedableRng, ServiceContext,
+        CompositionCommitFuture, CompositionCommitHandle, CompositionCommitRequest,
+        EntityContextClaimReadFuture, EntityContextClaimReadHandle, ExternalClients, FixedClock,
+        PersonCompositionSnapshotReadFuture, PersonCompositionSnapshotReadHandle,
+        PersonCompositionSnapshotSensitivity, SeedableRng, ServiceContext,
     };
     use crate::types::{ClaimSensitivity, TemporalScope};
 
@@ -2096,9 +1916,9 @@ mod tests {
         ) -> EntityContextClaimReadFuture<'a> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                *self.last_surface.lock().expect("surface lock") = Some(surface);
-                assert_eq!(entity_type, "account");
-                assert_eq!(entity_id, "acct-fixture-1");
+                *self.last_surface.lock().expect("claim surface lock") = Some(surface);
+                assert_eq!(entity_type, "person");
+                assert_eq!(entity_id, "person-fixture-1");
                 Ok(self.claims.lock().expect("claim lock").clone())
             })
         }
@@ -2139,14 +1959,14 @@ mod tests {
     }
 
     struct SpySnapshotReader {
-        result: Mutex<Result<AccountCompositionSnapshot, AccountCompositionSnapshotReadError>>,
+        result: Mutex<Result<PersonCompositionSnapshot, PersonCompositionSnapshotReadError>>,
         calls: AtomicUsize,
         last_surface: Mutex<Option<ClaimDismissalSurface>>,
     }
 
     impl SpySnapshotReader {
         fn new(
-            result: Result<AccountCompositionSnapshot, AccountCompositionSnapshotReadError>,
+            result: Result<PersonCompositionSnapshot, PersonCompositionSnapshotReadError>,
         ) -> Self {
             Self {
                 result: Mutex::new(result),
@@ -2156,16 +1976,16 @@ mod tests {
         }
     }
 
-    impl AccountCompositionSnapshotReadHandle for SpySnapshotReader {
-        fn read_account_composition_snapshot<'a>(
+    impl PersonCompositionSnapshotReadHandle for SpySnapshotReader {
+        fn read_person_composition_snapshot<'a>(
             &'a self,
-            account_id: String,
+            person_id: String,
             surface: ClaimDismissalSurface,
-        ) -> AccountCompositionSnapshotReadFuture<'a> {
+        ) -> PersonCompositionSnapshotReadFuture<'a> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 *self.last_surface.lock().expect("snapshot surface lock") = Some(surface);
-                assert_eq!(account_id, "acct-fixture-1");
+                assert_eq!(person_id, "person-fixture-1");
                 self.result.lock().expect("snapshot result lock").clone()
             })
         }
@@ -2230,24 +2050,14 @@ mod tests {
         external: &'a ExternalClients,
         reader: Arc<SpyClaimReader>,
         committer: Arc<RecordingCommitter>,
+        snapshot_reader: Arc<SpySnapshotReader>,
     ) -> ServiceContext<'a> {
         ServiceContext::test_live(clock, rng, external)
             .with_actor("surface_client")
             .with_ability_id(ABILITY_NAME)
             .with_entity_context_claim_reader(reader)
+            .with_person_composition_snapshot_reader(snapshot_reader)
             .with_composition_commit_handle(committer)
-    }
-
-    fn services_with_snapshot<'a>(
-        clock: &'a FixedClock,
-        rng: &'a SeedableRng,
-        external: &'a ExternalClients,
-        reader: Arc<SpyClaimReader>,
-        committer: Arc<RecordingCommitter>,
-        snapshot_reader: Arc<SpySnapshotReader>,
-    ) -> ServiceContext<'a> {
-        services(clock, rng, external, reader, committer)
-            .with_account_composition_snapshot_reader(snapshot_reader)
     }
 
     fn ability_ctx<'a>(
@@ -2259,9 +2069,9 @@ mod tests {
             provider,
             &NOOP_ABILITY_TRACER,
             Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
+                instance: crate::abilities::registry::SurfaceClientId::new("sc_person_fixture"),
                 scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
+                    "read.person_overview",
                 )])
                 .expect("scope set"),
             },
@@ -2270,19 +2080,20 @@ mod tests {
         )
     }
 
-    fn input() -> AccountOverviewInput {
-        AccountOverviewInput {
+    fn input() -> PersonOverviewInput {
+        PersonOverviewInput {
             schema_version: ABILITY_SCHEMA_VERSION,
-            account_id: "acct-fixture-1".to_string(),
+            person_id: "person-fixture-1".to_string(),
             entity_type: None,
             entity_id: None,
             expected_composition_version: 0,
-            composition_id: Some("acct-overview-fixture".to_string()),
+            composition_id: Some("person-overview-fixture".to_string()),
         }
     }
 
     fn claim(
         id: &str,
+        subject_ref: Value,
         claim_type: &str,
         field_path: &str,
         text: &str,
@@ -2293,7 +2104,7 @@ mod tests {
         IntelligenceClaim {
             id: id.to_string(),
             claim_version: 2,
-            subject_ref: json!({"kind": "account", "id": "acct-fixture-1"}).to_string(),
+            subject_ref: subject_ref.to_string(),
             claim_type: claim_type.to_string(),
             field_path: Some(field_path.to_string()),
             topic_key: None,
@@ -2327,15 +2138,36 @@ mod tests {
         }
     }
 
+    fn person_claim(
+        id: &str,
+        claim_type: &str,
+        field_path: &str,
+        text: &str,
+        trust_score: Option<f64>,
+        source_asof: Option<&str>,
+        sensitivity: ClaimSensitivity,
+    ) -> IntelligenceClaim {
+        claim(
+            id,
+            json!({"kind": "person", "id": "person-fixture-1"}),
+            claim_type,
+            field_path,
+            text,
+            trust_score,
+            source_asof,
+            sensitivity,
+        )
+    }
+
     fn snapshot_field(
         field_path: &str,
         label: &str,
         value: Value,
-        sensitivity: AccountCompositionSnapshotSensitivity,
+        sensitivity: PersonCompositionSnapshotSensitivity,
         source_label: Option<&str>,
         source_asof: Option<&str>,
-    ) -> AccountCompositionSnapshotField {
-        AccountCompositionSnapshotField {
+    ) -> PersonCompositionSnapshotField {
+        PersonCompositionSnapshotField {
             field_path: field_path.to_string(),
             label: label.to_string(),
             value,
@@ -2345,7 +2177,7 @@ mod tests {
             source_asof: source_asof.map(ToString::to_string),
             trust_band: TrustBand::UseWithCaution,
             trust_status: "use_with_caution".to_string(),
-            provenance_kind: AccountCompositionProvenanceKind::SourceField,
+            provenance_kind: PersonCompositionProvenanceKind::SourceField,
         }
     }
 
@@ -2353,35 +2185,43 @@ mod tests {
         field_path: &str,
         label: &str,
         value: &str,
-    ) -> AccountCompositionSnapshotField {
-        AccountCompositionSnapshotField {
+    ) -> PersonCompositionSnapshotField {
+        PersonCompositionSnapshotField {
             field_path: field_path.to_string(),
             label: label.to_string(),
             value: Value::String(value.to_string()),
-            sensitivity: AccountCompositionSnapshotSensitivity::NonSensitiveIdentity,
+            sensitivity: PersonCompositionSnapshotSensitivity::NonSensitiveIdentity,
             source_label: None,
             source_ref: None,
             source_asof: None,
             trust_band: TrustBand::LikelyCurrent,
             trust_status: "likely_current".to_string(),
-            provenance_kind: AccountCompositionProvenanceKind::NonSensitiveIdentity,
+            provenance_kind: PersonCompositionProvenanceKind::NonSensitiveIdentity,
         }
     }
 
-    fn snapshot_fixture(
-        fields: Vec<AccountCompositionSnapshotField>,
-    ) -> AccountCompositionSnapshot {
-        AccountCompositionSnapshot {
-            account_id: "acct-fixture-1".to_string(),
+    fn snapshot_fixture(fields: Vec<PersonCompositionSnapshotField>) -> PersonCompositionSnapshot {
+        PersonCompositionSnapshot {
+            person_id: "person-fixture-1".to_string(),
             display_name: identity_snapshot_field(
                 "/identity/display_name",
-                "Account",
-                "Example Account",
+                "Person",
+                "Example Person",
             ),
-            account_type: Some(identity_snapshot_field(
-                "/identity/account_type",
-                "Account type",
-                "customer",
+            relationship: Some(identity_snapshot_field(
+                "/identity/relationship",
+                "Relationship",
+                "external",
+            )),
+            organization: Some(identity_snapshot_field(
+                "/identity/organization",
+                "Organization",
+                "Example Organization",
+            )),
+            role: Some(identity_snapshot_field(
+                "/identity/role",
+                "Role",
+                "Champion",
             )),
             fields,
         }
@@ -2392,41 +2232,17 @@ mod tests {
     }
 
     #[test]
-    fn registry_declaration_pins_policy() {
-        let registry = AbilityRegistry::global_checked().expect("registry builds");
-        let descriptor = registry
-            .iter_all()
-            .find(|descriptor| descriptor.name == ABILITY_NAME)
-            .expect("account overview ability registered");
-
-        assert_eq!(descriptor.name, ABILITY_NAME);
-        assert_eq!(descriptor.category, AbilityCategory::Read);
-        assert_eq!(
-            descriptor.policy.allowed_actors,
-            &[ActorKind::User, ActorKind::SurfaceClient]
-        );
-        assert_eq!(
-            descriptor.policy.required_scopes,
-            &["read.account_overview"]
-        );
-        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::Invocable);
-        assert!(!descriptor.policy.client_side_executable);
-        assert!(descriptor.mutates.is_empty());
-        assert!(descriptor.composes.is_empty());
-    }
-
-    #[test]
-    fn entity_envelope_accepts_matching_account_and_rejects_mismatch() {
-        let ok = AccountOverviewInput {
-            entity_type: Some("account".to_string()),
-            entity_id: Some("acct-fixture-1".to_string()),
+    fn entity_envelope_accepts_matching_person_and_rejects_mismatch() {
+        let ok = PersonOverviewInput {
+            entity_type: Some("person".to_string()),
+            entity_id: Some("person-fixture-1".to_string()),
             ..input()
         };
         normalize_input(ok).expect("matching envelope is accepted");
 
-        let wrong_type = AccountOverviewInput {
-            entity_type: Some("project".to_string()),
-            entity_id: Some("acct-fixture-1".to_string()),
+        let wrong_type = PersonOverviewInput {
+            entity_type: Some("account".to_string()),
+            entity_id: Some("person-fixture-1".to_string()),
             ..input()
         };
         assert_eq!(
@@ -2436,9 +2252,9 @@ mod tests {
             AbilityErrorKind::Validation
         );
 
-        let wrong_id = AccountOverviewInput {
-            entity_type: Some("account".to_string()),
-            entity_id: Some("other-account".to_string()),
+        let wrong_id = PersonOverviewInput {
+            entity_type: Some("person".to_string()),
+            entity_id: Some("other-person".to_string()),
             ..input()
         };
         assert_eq!(
@@ -2449,37 +2265,53 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn missing_account_id_rejects_before_claim_read_or_commit() {
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services(&clock, &rng, &external, reader.clone(), committer.clone());
-        let ctx = ability_ctx(&services, &provider);
+    #[test]
+    fn registry_declaration_pins_person_policy_and_invalidation_signals() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let descriptor = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == ABILITY_NAME)
+            .expect("person overview ability registered");
 
-        let err = match account_overview(
-            &ctx,
-            AccountOverviewInput {
-                account_id: " ".to_string(),
-                ..input()
-            },
-        )
-        .await
-        {
-            Ok(_) => panic!("missing account id rejects"),
-            Err(error) => error,
-        };
-
-        assert_eq!(err.kind, AbilityErrorKind::Validation);
-        assert_eq!(reader.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(committer.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(descriptor.name, ABILITY_NAME);
+        assert_eq!(descriptor.category, AbilityCategory::Read);
+        assert_eq!(
+            descriptor.policy.allowed_actors,
+            &[ActorKind::User, ActorKind::SurfaceClient]
+        );
+        assert_eq!(descriptor.policy.required_scopes, &["read.person_overview"]);
+        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::Invocable);
+        assert!(!descriptor.policy.client_side_executable);
+        assert!(descriptor.mutates.is_empty());
+        assert!(descriptor.composes.is_empty());
+        assert!(descriptor.signal_policy.coalesce);
+        for signal in [
+            "claim.version",
+            "person_subject.claim_changed",
+            "claim.lifecycle",
+            "claim.dismissal",
+            "source.freshness",
+            "source.revocation",
+            "person.field_changed",
+            "relationship_graph_changed",
+        ] {
+            assert!(
+                descriptor
+                    .signal_policy
+                    .emits_on_output_change
+                    .contains(&signal),
+                "person overview declares invalidation signal {signal}"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn missing_account_snapshot_rejects_before_composition_commit() {
+    async fn missing_person_rejects_before_composition_commit() {
         let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
-            AccountCompositionSnapshotReadError::AccountNotFound("acct-fixture-1".to_string()),
+            PersonCompositionSnapshotReadError::PersonNotFound("person-fixture-1".to_string()),
         )));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services_with_snapshot(
+        let services = services(
             &clock,
             &rng,
             &external,
@@ -2489,104 +2321,166 @@ mod tests {
         );
         let ctx = ability_ctx(&services, &provider);
 
-        let err = match account_overview(&ctx, input()).await {
-            Ok(_) => panic!("missing account rejects"),
+        let err = match person_overview(&ctx, input()).await {
+            Ok(_) => panic!("missing person rejects"),
             Err(error) => error,
         };
 
         assert_eq!(err.kind, AbilityErrorKind::Validation);
-        assert!(err.message.contains("acct-fixture-1"));
+        assert!(err.message.contains("person-fixture-1"));
         assert_eq!(reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(committer.calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
-    async fn committed_output_has_field_bindings_provenance_and_degraded_trust() {
-        let mut hidden = claim(
-            "claim-hidden",
+    async fn committed_output_filters_person_claims_and_wraps_snapshot_fields() {
+        let mut dismissed = person_claim(
+            "claim-dismissed",
             "entity_risk",
             "/risk/hidden",
-            "Hidden risk",
+            "Dismissed risk should not render",
             Some(0.99),
             Some("2026-05-15T09:00:00Z"),
-            ClaimSensitivity::Confidential,
+            ClaimSensitivity::Internal,
         );
-        hidden.surfacing_state = SurfacingState::Active;
+        dismissed.demotion_reason = Some("dismissed".to_string());
         let claims = vec![
-            claim(
+            person_claim(
                 "claim-risk",
                 "entity_risk",
                 "/risk/current",
                 "Implementation risk is rising",
                 Some(0.97),
-                None,
+                Some("2026-05-15T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            claim(
+            person_claim(
                 "claim-win",
                 "entity_win",
                 "/wins/latest",
-                "Renewal path is clearer",
+                "Launch path is clearer",
                 Some(0.92),
                 Some("2026-05-14T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            claim(
-                "claim-value",
-                "value_delivered",
-                "/value/latest",
-                "Team shipped adoption milestone",
-                None,
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
+            person_claim(
                 "claim-commitment",
                 "commitment",
                 "/commitments/next",
-                "Follow up on launch checklist",
-                Some(0.85),
-                Some("2026-05-01T09:00:00Z"),
+                "Review the rollout plan",
+                Some(0.86),
+                Some("2026-04-01T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
             claim(
-                "claim-context",
-                "company_context",
-                "/company/industry",
-                "Fixture Account operates in software",
-                Some(0.96),
-                Some("2026-03-01T09:00:00Z"),
+                "claim-account-scope",
+                json!({"kind": "account", "id": "acct-fixture"}),
+                "entity_win",
+                "/wins/account",
+                "Account-scoped claim should not render",
+                Some(0.92),
+                Some("2026-05-14T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            hidden,
+            person_claim(
+                "claim-confidential",
+                "company_context",
+                "/context/confidential",
+                "Confidential person detail should not render",
+                Some(0.9),
+                Some("2026-05-14T09:00:00Z"),
+                ClaimSensitivity::Confidential,
+            ),
+            dismissed,
         ];
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
+            snapshot_field(
+                "/vitals/role",
+                "Role",
+                Value::String("Champion".to_string()),
+                PersonCompositionSnapshotSensitivity::Internal,
+                Some("person"),
+                Some("2026-05-14T09:00:00Z"),
+            ),
+            snapshot_field(
+                "/relationship/signals",
+                "Person signals",
+                json!({"temperature": "warm", "trend": "improving"}),
+                PersonCompositionSnapshotSensitivity::Internal,
+                Some("person_signals"),
+                Some("2026-05-14T09:00:00Z"),
+            ),
+            snapshot_field(
+                "/their-network/relationships",
+                "Relationships",
+                json!([{"id": "rel-1", "relationship_type": "ally"}]),
+                PersonCompositionSnapshotSensitivity::Internal,
+                Some("person_relationships"),
+                Some("2026-05-14T09:00:00Z"),
+            ),
+            snapshot_field(
+                "/the-record/private",
+                "Private field",
+                Value::String("private snapshot value".to_string()),
+                PersonCompositionSnapshotSensitivity::Confidential,
+                Some("person"),
+                Some("2026-05-14T09:00:00Z"),
+            ),
+        ]))));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader.clone(), committer.clone());
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader.clone(),
+            committer.clone(),
+            snapshot_reader.clone(),
+        );
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = person_overview(&ctx, input())
             .await
-            .expect("account overview succeeds");
+            .expect("person overview succeeds");
         let composition = output.data();
+        let serialized = output_json(&output);
+        let serialized_text = serialized.to_string();
 
         assert_eq!(reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(
-            *reader.last_surface.lock().expect("surface lock"),
+            *reader.last_surface.lock().expect("claim surface lock"),
             Some(ClaimDismissalSurface::LogStructured)
         );
+        assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
         assert_eq!(composition.metadata.composition_version.0, 1);
         assert_eq!(composition.generated_by.as_str(), ABILITY_NAME);
         assert_eq!(composition.metadata.generated_by, ABILITY_NAME);
+        assert_eq!(
+            composition.subject.as_ref().map(|subject| subject.as_str()),
+            Some("person:person-fixture-1")
+        );
 
-        let serialized = output_json(&output);
-        assert!(serialized.to_string().contains("claim-risk"));
-        assert!(!serialized.to_string().contains("claim-hidden"));
-        assert!(serialized.to_string().contains("needs_verification"));
-        assert!(output.provenance().warnings.iter().any(|warning| {
-            matches!(warning, ProvenanceWarning::SourceTimestampUnknown { .. })
-        }));
+        let section_ids = composition
+            .sections
+            .iter()
+            .map(|section| section.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(section_ids[0], "headline");
+        assert!(section_ids.contains(&"the-dynamic"));
+        assert!(section_ids.contains(&"their-network"));
+        assert!(section_ids.contains(&"open-threads"));
+        assert!(section_ids.contains(&"the-work"));
+
+        assert!(serialized_text.contains("claim-risk"));
+        assert!(serialized_text.contains("claim-win"));
+        assert!(serialized_text.contains("claim-commitment"));
+        assert!(!serialized_text.contains("claim-account-scope"));
+        assert!(!serialized_text.contains("claim-confidential"));
+        assert!(!serialized_text.contains("claim-dismissed"));
+        assert!(!serialized_text.contains("private snapshot value"));
+        assert!(serialized_text.contains("Person signals"));
+        assert!(serialized_text.contains("needs_verification"));
 
         let blocks = composition.blocks().collect::<Vec<_>>();
         assert!(blocks
@@ -2595,6 +2489,9 @@ mod tests {
         assert!(blocks
             .iter()
             .any(|block| block.block_type == BlockType::ActionList));
+        assert!(blocks
+            .iter()
+            .any(|block| block.block_type == BlockType::EvidenceList));
         for block in blocks {
             block
                 .validate_against(output.provenance())
@@ -2618,70 +2515,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn high_cardinality_overview_claims_keep_provenance_under_hard_budget() {
-        let claims = (0..160)
-            .map(|index| {
-                claim(
-                    &format!("claim-context-{index:03}"),
-                    "company_context",
-                    &format!("/company/context/{index}"),
-                    &format!(
-                        "Context signal {index} remains relevant for the account composition proof."
-                    ),
-                    Some(0.94),
-                    Some("2026-05-14T09:00:00Z"),
-                    ClaimSensitivity::Internal,
-                )
-            })
-            .collect::<Vec<_>>();
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("large overview composition stays within provenance budget");
-        let provenance_bytes = serde_json::to_vec(output.provenance())
-            .expect("provenance serializes")
-            .len();
-
-        assert!(
-            provenance_bytes < crate::abilities::provenance::builder::HARD_PROVENANCE_BUDGET_BYTES,
-            "provenance envelope should stay under hard budget, got {provenance_bytes}"
-        );
-        for block in output.data().blocks() {
-            block
-                .validate_against(output.provenance())
-                .expect("block provenance resolves");
-        }
-    }
-
-    #[tokio::test]
-    async fn empty_claim_set_returns_display_only_empty_state() {
+    async fn empty_claim_set_returns_person_sections_without_frontend_fallback() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(Vec::new()))));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services(&clock, &rng, &external, reader, committer);
+        let services = services(&clock, &rng, &external, reader, committer, snapshot_reader);
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = person_overview(&ctx, input())
             .await
-            .expect("empty state succeeds");
+            .expect("empty person overview succeeds");
         let composition = output.data();
         let section_ids = composition
             .sections
             .iter()
             .map(|section| section.id.as_str())
             .collect::<Vec<_>>();
+
         assert_eq!(
             section_ids,
-            VARIANT_D_SECTIONS
-                .iter()
-                .map(|(id, _)| *id)
-                .collect::<Vec<_>>()
+            vec![
+                "headline",
+                "the-dynamic",
+                "their-orbit",
+                "their-network",
+                "the-landscape",
+                "open-threads",
+                "the-record",
+                "the-work",
+            ]
         );
-        assert!(!section_ids.contains(&"empty"));
-        assert!(!section_ids.contains(&"signals"));
-
-        let degraded_blocks = composition
+        let empty_blocks = composition
             .sections
             .iter()
             .flat_map(|section| section.blocks.iter())
@@ -2694,402 +2557,58 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert!(
-            degraded_blocks.len() >= 9,
-            "most non-headline sections render degraded empty blocks"
+            empty_blocks.len() >= 7,
+            "non-headline person sections render producer-authored empty blocks"
         );
-        for block in degraded_blocks {
+        for block in empty_blocks {
             assert!(block.claim_refs.is_empty());
             assert!(block.field_bindings.iter().all(|binding| {
                 binding.role == BindingRole::DisplayOnly && binding.claim_refs.is_empty()
             }));
+            block
+                .validate_against(output.provenance())
+                .expect("empty block provenance resolves");
         }
     }
 
     #[tokio::test]
-    async fn snapshot_fields_are_wrapped_sourced_and_sensitivity_filtered() {
-        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
-            snapshot_field(
-                "/vitals/lifecycle",
-                "Lifecycle",
-                Value::String("active".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("user"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-            snapshot_field(
-                "/vitals/arr",
-                "ARR",
-                Value::String("sensitive-commercial-value".to_string()),
-                AccountCompositionSnapshotSensitivity::Confidential,
-                Some("salesforce"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-            snapshot_field(
-                "/reports/account_report",
-                "Account report",
-                Value::String("unavailable".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("system_config"),
-                Some("2026-05-15T10:00:00Z"),
-            ),
-        ]))));
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services_with_snapshot(
-            &clock,
-            &rng,
-            &external,
-            reader,
-            committer,
-            snapshot_reader.clone(),
-        );
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("snapshot-backed account overview succeeds");
-        let serialized = output_json(&output);
-
-        assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *snapshot_reader
-                .last_surface
-                .lock()
-                .expect("snapshot surface lock"),
-            Some(ClaimDismissalSurface::LogStructured)
-        );
-        assert!(serialized.to_string().contains("Example Account"));
-        let headline_vitals = output.data().sections[0].blocks[0]
-            .attributes
-            .pointer("/vitals")
-            .and_then(Value::as_array)
-            .expect("headline vitals array");
-        assert!(headline_vitals.iter().any(|value| {
-            value.pointer("/label").and_then(Value::as_str) == Some("Lifecycle")
-                && value.pointer("/value").and_then(Value::as_str) == Some("active")
-        }));
-        assert!(!serialized
-            .to_string()
-            .contains("sensitive-commercial-value"));
-        assert!(output.provenance().sources.iter().any(|source| {
-            source.identifiers.iter().any(|identifier| {
-                matches!(
-                    identifier,
-                    SourceIdentifier::Entity { field: Some(field), .. }
-                        if field == "/vitals/lifecycle"
-                )
-            })
-        }));
-    }
-
-    #[tokio::test]
-    async fn mixed_claim_and_snapshot_sections_keep_both_evidence_paths() {
-        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
-            snapshot_field(
-                "/value/growth_potential",
-                "Growth potential",
-                Value::String("expansion motion active".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("salesforce"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-        ]))));
-        let claims = vec![claim(
-            "claim-value",
-            "value_delivered",
-            "/value/latest",
-            "Adoption milestone shipped",
+    async fn snapshot_read_failure_degrades_in_headline_without_blocking_claim_render() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
+            PersonCompositionSnapshotReadError::ReadFailed("fixture failure".to_string()),
+        )));
+        let claims = vec![person_claim(
+            "claim-win",
+            "entity_win",
+            "/wins/latest",
+            "Launch path is clearer",
             Some(0.92),
             Some("2026-05-14T09:00:00Z"),
             ClaimSensitivity::Internal,
         )];
         let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services =
-            services_with_snapshot(&clock, &rng, &external, reader, committer, snapshot_reader);
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader,
+            committer.clone(),
+            snapshot_reader,
+        );
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = person_overview(&ctx, input())
             .await
-            .expect("mixed claim and snapshot account overview succeeds");
-        let composition = output.data();
-        let value_section = composition
-            .sections
-            .iter()
-            .find(|section| section.id.as_str() == "value-commitments")
-            .expect("value commitments section");
+            .expect("snapshot degradation still renders claims");
+        let headline = &output.data().sections[0].blocks[0];
 
-        assert!(
-            value_section
-                .blocks
-                .iter()
-                .any(|block| block.block_type == BlockType::ClaimSummary
-                    && block.attributes.pointer("/text").and_then(Value::as_str)
-                        == Some("Adoption milestone shipped")),
-            "claim evidence remains renderable"
+        assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            headline
+                .attributes
+                .pointer("/snapshot_degraded")
+                .and_then(Value::as_str),
+            Some("person_snapshot_unavailable")
         );
-        assert!(
-            value_section
-                .blocks
-                .iter()
-                .any(|block| block.block_type == BlockType::EvidenceList
-                    && block.attributes.to_string().contains("Growth potential")),
-            "snapshot evidence remains renderable beside claims"
-        );
-    }
-
-    #[tokio::test]
-    async fn recommendation_claims_render_as_work_actions() {
-        let claims = vec![claim(
-            "claim-recommendation",
-            "recommendation",
-            "/recommendations/review",
-            "Review the launch plan with the account owner",
-            Some(0.88),
-            Some("2026-05-14T09:00:00Z"),
-            ClaimSensitivity::Internal,
-        )];
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("recommendation-backed account overview succeeds");
-        let composition = output.data();
-
-        for section_id in ["whats-next", "the-work"] {
-            let section = composition
-                .sections
-                .iter()
-                .find(|section| section.id.as_str() == section_id)
-                .expect("work section exists");
-            let block = section
-                .blocks
-                .iter()
-                .find(|block| {
-                    block.block_type == BlockType::ActionList
-                        && block
-                            .attributes
-                            .pointer("/claim_type")
-                            .and_then(Value::as_str)
-                            == Some("recommendation")
-                        && block
-                            .attributes
-                            .pointer("/items/0/text")
-                            .and_then(Value::as_str)
-                            == Some("Review the launch plan with the account owner")
-                })
-                .expect("recommendation is rendered as a work action");
-
-            assert!(block
-                .claim_refs
-                .iter()
-                .any(|claim_ref| claim_ref.claim_id == "claim-recommendation"));
-            assert!(block.field_bindings.iter().any(|binding| {
-                binding.role == BindingRole::FeedbackTarget
-                    && binding.field_path.as_str() == "/items/0/text"
-                    && !binding.claim_refs.is_empty()
-            }));
-            assert_eq!(
-                block
-                    .attributes
-                    .pointer("/trust_band")
-                    .and_then(Value::as_str),
-                Some("likely_current"),
-                "work action blocks expose block-level trust for the shell badge"
-            );
-            assert_eq!(
-                block
-                    .attributes
-                    .pointer("/source_asof")
-                    .and_then(Value::as_str),
-                Some("2026-05-14T09:00:00Z"),
-                "work action blocks expose block-level freshness for the shell"
-            );
-        }
-
-        let proj_ctx = FallbackProjectionContext::new(
-            Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
-                scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
-                )])
-                .expect("scope set"),
-            },
-            SurfaceKind::SurfaceClient,
-            3,
-        );
-        let (projected, _audits) = project_composition_for_surface(composition, &proj_ctx)
-            .expect("projected recommendation action preserves shell metadata");
-
-        for section_id in ["whats-next", "the-work"] {
-            let section = projected
-                .sections
-                .iter()
-                .find(|section| section.section_id.as_str() == section_id)
-                .expect("projected work section exists");
-            let projected_block = section
-                .block_indexes
-                .iter()
-                .filter_map(|index| projected.blocks.get(*index as usize))
-                .find(|block| {
-                    block.payload.pointer("/claim_type").and_then(Value::as_str)
-                        == Some("recommendation")
-                })
-                .expect("projected recommendation work action exists");
-
-            assert_eq!(
-                projected_block
-                    .payload
-                    .pointer("/trust_band")
-                    .and_then(Value::as_str),
-                Some("likely_current"),
-                "projection must preserve block-level trust for the renderer shell"
-            );
-            assert_eq!(
-                projected_block
-                    .payload
-                    .pointer("/source_asof")
-                    .and_then(Value::as_str),
-                Some("2026-05-14T09:00:00Z"),
-                "projection must preserve block-level freshness for the renderer shell"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn pure_builder_output_is_deterministic_without_commit() {
-        let claims = vec![
-            claim(
-                "claim-b",
-                "entity_win",
-                "/wins/latest",
-                "Stable win",
-                Some(0.91),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-a",
-                "entity_risk",
-                "/risk/current",
-                "Stable risk",
-                Some(0.91),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-        ];
-        let first = prepared_json(claims.clone()).await;
-        let second = prepared_json(claims).await;
-
-        assert_eq!(first, second);
-        assert!(!first.to_string().contains("Acme"));
-    }
-
-    async fn prepared_json(claims: Vec<IntelligenceClaim>) -> Value {
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-        let normalized = normalize_input(input()).expect("input normalizes");
-        let prepared = prepare_account_overview(&ctx, &normalized)
-            .await
-            .expect("proposal builds");
-        let output = prepared
-            .provenance_builder
-            .finalize(prepared.proposal.composition)
-            .expect("provenance finalizes");
-        output_json(&output)
-    }
-
-    // Asserts producer output passes fallback_projection's binding validator
-    // without BindingTargetsUnknownField. Covers the producer→projection
-    // contract that wasn't exercised by either side's isolated test suite.
-    #[tokio::test]
-    async fn dos670_producer_output_passes_w4d_projection() {
-        let claims = vec![
-            claim(
-                "claim-risk",
-                "entity_risk",
-                "/risk/current",
-                "Implementation risk is rising",
-                Some(0.97),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-win",
-                "entity_win",
-                "/wins/latest",
-                "Renewal path is clearer",
-                Some(0.92),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-commitment",
-                "commitment",
-                "/commitments/next",
-                "Follow up on launch checklist",
-                Some(0.85),
-                Some("2026-05-01T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-context",
-                "company_context",
-                "/company/industry",
-                "Fixture Account operates in software",
-                Some(0.96),
-                Some("2026-03-01T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-        ];
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("account overview succeeds");
-        let composition = output.data();
-
-        let proj_ctx = FallbackProjectionContext::new(
-            Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
-                scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
-                )])
-                .expect("scope set"),
-            },
-            SurfaceKind::SurfaceClient,
-            3,
-        );
-
-        let (projected, _audits) = project_composition_for_surface(composition, &proj_ctx)
-            .expect("projection must accept producer output (DOS-670 contract)");
-
-        assert!(
-            !projected.blocks.is_empty(),
-            "projected composition must contain at least one block"
-        );
-
-        let claim_text_rendered = projected.blocks.iter().any(|block| {
-            block.payload.pointer("/text").is_some()
-                || block.payload.pointer("/items/0/text").is_some()
-                || block.payload.pointer("/nodes/0/text").is_some()
-        });
-        assert!(
-            claim_text_rendered,
-            "projected payload must surface claim text from producer attributes"
-        );
-
-        let trust_band_rendered = projected.blocks.iter().any(|block| {
-            block.payload.pointer("/trust_band").is_some()
-                || block.payload.pointer("/items/0/trust_band").is_some()
-                || block.payload.pointer("/nodes/0/trust_band").is_some()
-        });
-        assert!(
-            trust_band_rendered,
-            "projected payload must surface trust_band from producer attributes"
-        );
+        assert!(output_json(&output).to_string().contains("claim-win"));
     }
 }

--- a/src-tauri/abilities-runtime/src/abilities/prepare_meeting/synthesis.rs
+++ b/src-tauri/abilities-runtime/src/abilities/prepare_meeting/synthesis.rs
@@ -688,12 +688,13 @@ fn brief_subject_from_claim(claim: &IntelligenceClaim) -> Result<BriefSubjectRef
         ClaimSubjectRef::Meeting { id } => Ok(BriefSubjectRef::meeting(&id)),
         ClaimSubjectRef::Person { id } => Ok(BriefSubjectRef::person(&id)),
         ClaimSubjectRef::Project { id } => Ok(BriefSubjectRef::project(&id)),
-        ClaimSubjectRef::Email { .. } | ClaimSubjectRef::Multi(_) | ClaimSubjectRef::Global => {
-            Err(validation_error(format!(
-                "prepare_meeting claim `{}` has unsupported subject_ref",
-                claim.id
-            )))
-        }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => Err(validation_error(format!(
+            "prepare_meeting claim `{}` has unsupported subject_ref",
+            claim.id
+        ))),
     }
 }
 
@@ -1709,7 +1710,8 @@ impl BriefSubjectRef {
             SubjectRef::Project(id) => Some(Self::project(id)),
             SubjectRef::Person(id) => Some(Self::person(id)),
             SubjectRef::Meeting(id) => Some(Self::meeting(id)),
-            SubjectRef::User(_)
+            SubjectRef::Action(_)
+            | SubjectRef::User(_)
             | SubjectRef::Global
             | SubjectRef::Multi(_)
             | SubjectRef::Unknown => None,

--- a/src-tauri/abilities-runtime/src/abilities/project_overview.rs
+++ b/src-tauri/abilities-runtime/src/abilities/project_overview.rs
@@ -26,36 +26,23 @@ use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult, Actor,
 };
 use crate::services::context::{
-    AccountCompositionProvenanceKind, AccountCompositionSnapshot, AccountCompositionSnapshotField,
-    AccountCompositionSnapshotReadError, CompositionCommitError, CompositionProposal,
+    CompositionCommitError, CompositionProposal, ProjectCompositionProvenanceKind,
+    ProjectCompositionSnapshot, ProjectCompositionSnapshotField,
+    ProjectCompositionSnapshotReadError,
 };
 use crate::types::{
     prompt_input_sensitivity_allowed, subject_ref_from_json, ClaimState, ClaimSubjectRef,
     IntelligenceClaim, SurfacingState,
 };
 
-const ABILITY_NAME: &str = "dailyos/account-overview";
+const ABILITY_NAME: &str = "dailyos/project-overview";
 const ABILITY_SCHEMA_VERSION: u32 = 1;
-const ACCOUNT_CLAIM_DEPTH: usize = 3;
-
-const VARIANT_D_SECTIONS: [(&str, &str); 11] = [
-    ("headline", "Headline"),
-    ("outlook", "Outlook"),
-    ("state-of-play", "State of play"),
-    ("the-room", "The room"),
-    ("whats-next", "What's next"),
-    ("watch-list", "Watch list"),
-    ("value-commitments", "Value commitments"),
-    ("strategic-landscape", "Strategic landscape"),
-    ("the-record", "The record"),
-    ("the-work", "The work"),
-    ("reports", "Reports"),
-];
+const PROJECT_CLAIM_DEPTH: usize = 3;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-pub struct AccountOverviewInput {
+pub struct ProjectOverviewInput {
     pub schema_version: u32,
-    pub account_id: String,
+    pub project_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entity_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -68,12 +55,12 @@ pub struct AccountOverviewInput {
 
 #[derive(Debug, Clone)]
 struct NormalizedInput {
-    account_id: String,
+    project_id: String,
     expected_composition_version: u64,
     composition_id: CompositionDocId,
 }
 
-struct PreparedAccountOverview {
+struct PreparedProjectOverview {
     proposal: CompositionProposal,
     provenance_builder: ProvenanceBuilder,
 }
@@ -91,24 +78,22 @@ struct ClaimProjection {
 
 #[derive(Debug, Clone)]
 struct SnapshotReadOutcome {
-    snapshot: Option<AccountCompositionSnapshot>,
+    snapshot: Option<ProjectCompositionSnapshot>,
     degraded_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClaimPlacement {
-    Overview,
+    Momentum,
     Risk,
-    Win,
-    Value,
     Commitment,
     Relationship,
-    Health,
+    Context,
     Ignored,
 }
 
 #[ability(
-    name = "dailyos/account-overview",
+    name = "dailyos/project-overview",
     category = Read,
     version = "1.0.0",
     schema_version = 1,
@@ -116,26 +101,27 @@ enum ClaimPlacement {
     allowed_modes = [Live],
     requires_confirmation = false,
     may_publish = false,
-    required_scopes = ["read.account_overview"],
+    required_scopes = ["read.project_overview"],
     mcp_exposure = Invocable,
     client_side_executable = false,
     composes = [],
     experimental = false,
     signal_policy = { emits_on_output_change = [
         "claim.version",
-        "account_subject.claim_changed",
+        "project_subject.claim_changed",
         "claim.lifecycle",
         "claim.dismissal",
         "source.freshness",
-        "source.revocation"
+        "source.revocation",
+        "project.field_changed"
     ], coalesce = true }
 )]
-pub async fn account_overview(
+pub async fn project_overview(
     ctx: &AbilityContext<'_>,
-    input: AccountOverviewInput,
+    input: ProjectOverviewInput,
 ) -> AbilityResult<Composition> {
     let input = normalize_input(input)?;
-    let prepared = prepare_account_overview(ctx, &input).await?;
+    let prepared = prepare_project_overview(ctx, &input).await?;
     let committed = ctx
         .services()
         .commit_composition(prepared.proposal)
@@ -149,20 +135,20 @@ pub async fn account_overview(
     Ok(output)
 }
 
-fn normalize_input(input: AccountOverviewInput) -> Result<NormalizedInput, AbilityError> {
+fn normalize_input(input: ProjectOverviewInput) -> Result<NormalizedInput, AbilityError> {
     if input.schema_version != ABILITY_SCHEMA_VERSION {
         return Err(validation_error(format!(
             "unsupported schema_version `{}` for `{ABILITY_NAME}`",
             input.schema_version
         )));
     }
-    let account_id = input.account_id.trim();
-    if account_id.is_empty() {
-        return Err(validation_error("account_id must be non-empty"));
+    let project_id = input.project_id.trim();
+    if project_id.is_empty() {
+        return Err(validation_error("project_id must be non-empty"));
     }
     validate_entity_envelope(
-        "account",
-        account_id,
+        "project",
+        project_id,
         input.entity_type.as_deref(),
         input.entity_id.as_deref(),
     )?;
@@ -172,10 +158,10 @@ fn normalize_input(input: AccountOverviewInput) -> Result<NormalizedInput, Abili
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
-        .unwrap_or_else(|| format!("dailyos/account-overview:account:{account_id}"));
+        .unwrap_or_else(|| format!("dailyos/project-overview:project:{project_id}"));
 
     Ok(NormalizedInput {
-        account_id: account_id.to_string(),
+        project_id: project_id.to_string(),
         expected_composition_version: input.expected_composition_version,
         composition_id: CompositionDocId::new(composition_id),
     })
@@ -206,30 +192,22 @@ fn validate_entity_envelope(
     Ok(())
 }
 
-async fn prepare_account_overview(
+async fn prepare_project_overview(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-) -> Result<PreparedAccountOverview, AbilityError> {
-    // The reader currently takes (entity_type, entity_id, surface, depth)
-    // without an actor/scope discriminator. The substrate-side SurfaceClient
-    // scope contract (W4-B §16) calls for SQL-layer projection keyed on
-    // Actor::SurfaceClient { scopes }; until that lands, scope filtering is
-    // enforced one layer up by prompt_input_sensitivity_allowed, which gates
-    // Confidential+ before any block, ClaimRef, or count flows into the
-    // composition. Behavior is preserved; the longer-term tightening is
-    // tracked in the maintenance project.
+) -> Result<PreparedProjectOverview, AbilityError> {
     let claims = ctx
         .services()
         .read_entity_context_claims(
-            "account".to_string(),
-            input.account_id.clone(),
+            "project".to_string(),
+            input.project_id.clone(),
             ctx.entity_context_claim_surface(),
-            ACCOUNT_CLAIM_DEPTH,
+            PROJECT_CLAIM_DEPTH,
         )
         .await
-        .map_err(|error| hard_error("account_overview_claim_read", error))?;
+        .map_err(|error| hard_error("project_overview_claim_read", error))?;
 
-    let subject_ref = SubjectRef::Account(input.account_id.clone());
+    let subject_ref = SubjectRef::Project(input.project_id.clone());
     let subject = SubjectAttribution::direct_confident(subject_ref);
     let provenance_config = provenance_config(ctx);
     let invocation_id = provenance_config.invocation_id;
@@ -239,7 +217,7 @@ async fn prepare_account_overview(
     let mut projections = Vec::new();
     for claim in claims {
         let Some(projection) =
-            project_claim(ctx, &input.account_id, claim, &mut provenance_builder)?
+            project_claim(ctx, &input.project_id, claim, &mut provenance_builder)?
         else {
             continue;
         };
@@ -247,7 +225,7 @@ async fn prepare_account_overview(
     }
     projections.sort_by(compare_claim_projection);
 
-    let snapshot = read_account_snapshot(ctx, input).await?;
+    let snapshot = read_project_snapshot(ctx, input).await?;
     let composition = build_composition(
         ctx,
         input,
@@ -258,7 +236,7 @@ async fn prepare_account_overview(
         &mut provenance_builder,
     )?;
 
-    Ok(PreparedAccountOverview {
+    Ok(PreparedProjectOverview {
         proposal: CompositionProposal {
             composition_id: input.composition_id.clone(),
             expected_composition_version: input.expected_composition_version,
@@ -268,14 +246,14 @@ async fn prepare_account_overview(
     })
 }
 
-async fn read_account_snapshot(
+async fn read_project_snapshot(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
 ) -> Result<SnapshotReadOutcome, AbilityError> {
     match ctx
         .services()
-        .read_account_composition_snapshot(
-            input.account_id.clone(),
+        .read_project_composition_snapshot(
+            input.project_id.clone(),
             ctx.entity_context_claim_surface(),
         )
         .await
@@ -284,28 +262,28 @@ async fn read_account_snapshot(
             snapshot: Some(snapshot),
             degraded_reason: None,
         }),
-        Err(AccountCompositionSnapshotReadError::AccountNotFound(account_id)) => Err(
-            validation_error(format!("account `{account_id}` was not found")),
+        Err(ProjectCompositionSnapshotReadError::ProjectNotFound(project_id)) => Err(
+            validation_error(format!("project `{project_id}` was not found")),
         ),
-        Err(AccountCompositionSnapshotReadError::ReadFailed(_)) => Ok(SnapshotReadOutcome {
+        Err(ProjectCompositionSnapshotReadError::ReadFailed(_)) => Ok(SnapshotReadOutcome {
             snapshot: None,
-            degraded_reason: Some("account_snapshot_unavailable".to_string()),
+            degraded_reason: Some("project_snapshot_unavailable".to_string()),
         }),
     }
 }
 
 fn project_claim(
     ctx: &AbilityContext<'_>,
-    account_id: &str,
+    project_id: &str,
     claim: IntelligenceClaim,
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Option<ClaimProjection>, AbilityError> {
-    if !claim_is_eligible_for_account_overview(&claim, account_id)? {
+    if !claim_is_eligible_for_project_overview(&claim, project_id)? {
         return Ok(None);
     }
     let Some(metadata) = metadata_for_name(&claim.claim_type) else {
         return Err(validation_error(format!(
-            "unknown claim_type `{}` in account overview input",
+            "unknown claim_type `{}` in project overview input",
             claim.claim_type
         )));
     };
@@ -318,7 +296,7 @@ fn project_claim(
         return Ok(None);
     }
 
-    let source = source_for_claim(ctx, account_id, &claim)?;
+    let source = source_for_claim(ctx, project_id, &claim)?;
     let parsed_source_asof = source.source_asof;
     let source_index = provenance_builder.add_source(source);
     let trust_band = resolved_claim_trust_band(&claim, metadata.kind, ctx.services().clock.now());
@@ -335,9 +313,9 @@ fn project_claim(
     }))
 }
 
-fn claim_is_eligible_for_account_overview(
+fn claim_is_eligible_for_project_overview(
     claim: &IntelligenceClaim,
-    account_id: &str,
+    project_id: &str,
 ) -> Result<bool, AbilityError> {
     if claim.claim_state != ClaimState::Active || claim.surfacing_state != SurfacingState::Active {
         return Ok(false);
@@ -360,10 +338,10 @@ fn claim_is_eligible_for_account_overview(
     match subject_ref_from_json(&value)
         .map_err(|error| validation_error(format!("invalid claim subject_ref: {error}")))?
     {
-        ClaimSubjectRef::Account { id } => Ok(id == account_id),
-        ClaimSubjectRef::Action { .. }
+        ClaimSubjectRef::Project { id } => Ok(id == project_id),
+        ClaimSubjectRef::Account { .. }
+        | ClaimSubjectRef::Action { .. }
         | ClaimSubjectRef::Person { .. }
-        | ClaimSubjectRef::Project { .. }
         | ClaimSubjectRef::Meeting { .. }
         | ClaimSubjectRef::Email { .. }
         | ClaimSubjectRef::Multi(_)
@@ -374,20 +352,21 @@ fn claim_is_eligible_for_account_overview(
 fn placement_for_claim_type(kind: ClaimType) -> ClaimPlacement {
     match kind {
         ClaimType::Risk | ClaimType::EntityRisk => ClaimPlacement::Risk,
-        ClaimType::Win | ClaimType::EntityWin => ClaimPlacement::Win,
-        ClaimType::ValueDelivered => ClaimPlacement::Value,
+        ClaimType::Win
+        | ClaimType::EntityWin
+        | ClaimType::ValueDelivered
+        | ClaimType::EntityCurrentState
+        | ClaimType::EntitySummary => ClaimPlacement::Momentum,
         ClaimType::Commitment | ClaimType::OpenLoop | ClaimType::Recommendation => {
             ClaimPlacement::Commitment
         }
         ClaimType::StakeholderEngagement
         | ClaimType::StakeholderAssessment
         | ClaimType::StakeholderRole => ClaimPlacement::Relationship,
-        ClaimType::EntityCurrentState => ClaimPlacement::Health,
         ClaimType::CompanyContext
         | ClaimType::AccountFact
         | ClaimType::EntityIdentity
-        | ClaimType::EntitySummary
-        | ClaimType::UserNote => ClaimPlacement::Overview,
+        | ClaimType::UserNote => ClaimPlacement::Context,
         ClaimType::LinkingDismissed
         | ClaimType::EmailDismissed
         | ClaimType::IntelligenceFieldDismissed
@@ -417,82 +396,70 @@ fn build_composition(
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Composition, AbilityError> {
     let snapshot = snapshot_outcome.snapshot.as_ref();
-    let mut sections = Vec::with_capacity(VARIANT_D_SECTIONS.len());
-    let block_context = AccountBlockBuildContext {
-        ctx,
-        input,
-        subject,
-        invocation_id,
-    };
+    let mut sections = Vec::new();
 
-    let headline_block = build_overview_block(
-        &block_context,
-        projections,
-        snapshot_outcome,
-        "/sections/0/blocks/0",
-        provenance_builder,
-    )?;
     sections.push(variant_section(
         "headline",
         "Headline",
-        vec![headline_block],
-        SectionLayout::Stacked,
-        salience(0.95, SalienceBand::Critical, "account masthead"),
-    ));
-
-    let outlook_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Health)
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "outlook",
-        "Outlook",
-        build_claim_or_snapshot_section_blocks(
+        vec![build_overview_block(
             ctx,
             input,
-            "outlook",
-            1,
-            outlook_claims,
-            snapshot_fields_for_section(snapshot, "outlook"),
-            EmptySectionCopy {
-                title: "No current outlook signals",
-                body: "DailyOS has not found current account-health signals with renderable provenance.",
-                status: "source_gap",
-            },
+            projections,
+            snapshot_outcome,
+            "/sections/0/blocks/0",
             subject,
             invocation_id,
             provenance_builder,
-        )?,
+        )?],
         SectionLayout::Stacked,
-        salience(0.86, SalienceBand::Important, "account outlook"),
+        salience(0.95, SalienceBand::Critical, "project masthead"),
     ));
 
-    let state_claims = projections
+    let mut next_section_index = 1;
+    let portfolio_fields = snapshot_fields_for_section(snapshot, "portfolio");
+    if snapshot.is_some_and(|snapshot| snapshot.is_parent) || !portfolio_fields.is_empty() {
+        sections.push(variant_section(
+            "portfolio",
+            "Portfolio",
+            build_claim_or_snapshot_section_blocks(
+                ctx,
+                input,
+                "portfolio",
+                next_section_index,
+                Vec::new(),
+                portfolio_fields,
+                EmptySectionCopy {
+                    title: "No portfolio signals",
+                    body: "This project has no source-backed portfolio detail yet.",
+                    status: "empty",
+                },
+                subject,
+                invocation_id,
+                provenance_builder,
+            )?,
+            SectionLayout::Grid,
+            salience(0.74, SalienceBand::Contextual, "project portfolio"),
+        ));
+        next_section_index += 1;
+    }
+
+    let trajectory_claims = projections
         .iter()
-        .filter(|projection| {
-            matches!(
-                projection.placement,
-                ClaimPlacement::Health
-                    | ClaimPlacement::Risk
-                    | ClaimPlacement::Win
-                    | ClaimPlacement::Value
-                    | ClaimPlacement::Overview
-            )
-        })
+        .filter(|projection| projection.placement == ClaimPlacement::Momentum)
         .collect::<Vec<_>>();
     sections.push(variant_section(
-        "state-of-play",
-        "State of play",
+        "trajectory",
+        "Trajectory",
         build_claim_or_snapshot_section_blocks(
             ctx,
             input,
-            "state-of-play",
-            2,
-            state_claims,
-            snapshot_fields_for_section(snapshot, "state-of-play"),
+            "trajectory",
+            next_section_index,
+            trajectory_claims,
+            snapshot_fields_for_section(snapshot, "trajectory"),
             EmptySectionCopy {
-                title: "No active state-of-play signals",
-                body: "No active account claims are currently eligible for this surface.",
+                title: "No trajectory signals",
+                body: "No active project trajectory claims are eligible for this surface.",
                 status: "empty",
             },
             subject,
@@ -500,8 +467,66 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.82, SalienceBand::Important, "current account state"),
+        salience(0.86, SalienceBand::Important, "project trajectory"),
     ));
+    next_section_index += 1;
+
+    sections.push(variant_section(
+        "the-horizon",
+        "The horizon",
+        build_claim_or_snapshot_section_blocks(
+            ctx,
+            input,
+            "the-horizon",
+            next_section_index,
+            Vec::new(),
+            snapshot_fields_for_section(snapshot, "the-horizon"),
+            EmptySectionCopy {
+                title: "No horizon signals",
+                body: "Target-date and activity signals are not yet grounded for this project.",
+                status: "source_gap",
+            },
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?,
+        SectionLayout::Stacked,
+        salience(0.8, SalienceBand::Important, "project horizon"),
+    ));
+    next_section_index += 1;
+
+    let landscape_claims = projections
+        .iter()
+        .filter(|projection| {
+            matches!(
+                projection.placement,
+                ClaimPlacement::Risk | ClaimPlacement::Context
+            )
+        })
+        .collect::<Vec<_>>();
+    sections.push(variant_section(
+        "the-landscape",
+        "The landscape",
+        build_claim_or_snapshot_section_blocks(
+            ctx,
+            input,
+            "the-landscape",
+            next_section_index,
+            landscape_claims,
+            snapshot_fields_for_section(snapshot, "the-landscape"),
+            EmptySectionCopy {
+                title: "Landscape not yet grounded",
+                body: "No renderable project context or risk claims are available.",
+                status: "needs_grounding",
+            },
+            subject,
+            invocation_id,
+            provenance_builder,
+        )?,
+        SectionLayout::Stacked,
+        salience(0.76, SalienceBand::Important, "project landscape"),
+    ));
+    next_section_index += 1;
 
     let room_claims = projections
         .iter()
@@ -514,12 +539,12 @@ fn build_composition(
             ctx,
             input,
             "the-room",
-            3,
+            next_section_index,
             room_claims,
             snapshot_fields_for_section(snapshot, "the-room"),
             EmptySectionCopy {
-                title: "No room signals",
-                body: "Stakeholder and relationship inputs are not yet grounded for this account.",
+                title: "No team signals",
+                body: "People and relationship inputs are not yet grounded for this project.",
                 status: "empty",
             },
             subject,
@@ -527,8 +552,9 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Grid,
-        salience(0.72, SalienceBand::Contextual, "account relationships"),
+        salience(0.7, SalienceBand::Contextual, "project people"),
     ));
+    next_section_index += 1;
 
     let next_claims = projections
         .iter()
@@ -541,12 +567,12 @@ fn build_composition(
             ctx,
             input,
             "whats-next",
-            4,
-            next_claims,
-            snapshot_fields_for_section(snapshot, "whats-next"),
+            next_section_index,
+            next_claims.clone(),
+            Vec::new(),
             EmptySectionCopy {
                 title: "No open next steps",
-                body: "There are no renderable commitments or next-step records for this account.",
+                body: "There are no renderable commitments or next-step records for this project.",
                 status: "empty",
             },
             subject,
@@ -554,103 +580,9 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.8, SalienceBand::Important, "next account work"),
+        salience(0.78, SalienceBand::Important, "project next steps"),
     ));
-
-    let watch_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Risk)
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "watch-list",
-        "Watch list",
-        build_claim_or_snapshot_section_blocks(
-            ctx,
-            input,
-            "watch-list",
-            5,
-            watch_claims,
-            snapshot_fields_for_section(snapshot, "watch-list"),
-            EmptySectionCopy {
-                title: "No active watch-list signals",
-                body: "No active risk or watch-list claims are eligible for this account.",
-                status: "empty",
-            },
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Stacked,
-        salience(0.76, SalienceBand::Important, "watch-list signals"),
-    ));
-
-    let value_claims = projections
-        .iter()
-        .filter(|projection| {
-            matches!(
-                projection.placement,
-                ClaimPlacement::Value | ClaimPlacement::Win | ClaimPlacement::Commitment
-            )
-        })
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "value-commitments",
-        "Value commitments",
-        build_claim_or_snapshot_section_blocks(
-            ctx,
-            input,
-            "value-commitments",
-            6,
-            value_claims,
-            snapshot_fields_for_section(snapshot, "value-commitments"),
-            EmptySectionCopy {
-                title: "No commitments with current evidence",
-                body: "DailyOS has not found value or commitment claims with current evidence.",
-                status: "source_gap",
-            },
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Stacked,
-        salience(0.72, SalienceBand::Important, "value and commitments"),
-    ));
-
-    let strategic_claims = projections
-        .iter()
-        .filter(|projection| {
-            matches!(
-                projection.claim_type,
-                ClaimType::CompanyContext
-                    | ClaimType::AccountFact
-                    | ClaimType::EntityIdentity
-                    | ClaimType::EntitySummary
-                    | ClaimType::UserNote
-            )
-        })
-        .collect::<Vec<_>>();
-    sections.push(variant_section(
-        "strategic-landscape",
-        "Strategic landscape",
-        build_claim_or_snapshot_section_blocks(
-            ctx,
-            input,
-            "strategic-landscape",
-            7,
-            strategic_claims,
-            snapshot_fields_for_section(snapshot, "strategic-landscape"),
-            EmptySectionCopy {
-                title: "Strategic context not yet grounded",
-                body: "No source-backed strategic context is available for this account.",
-                status: "needs_grounding",
-            },
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Stacked,
-        salience(0.62, SalienceBand::Contextual, "strategic account context"),
-    ));
+    next_section_index += 1;
 
     sections.push(variant_section(
         "the-record",
@@ -660,19 +592,16 @@ fn build_composition(
             input,
             projections,
             snapshot_fields_for_section(snapshot, "the-record"),
-            8,
+            next_section_index,
             subject,
             invocation_id,
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.58, SalienceBand::Contextual, "account evidence record"),
+        salience(0.58, SalienceBand::Contextual, "project evidence record"),
     ));
+    next_section_index += 1;
 
-    let work_claims = projections
-        .iter()
-        .filter(|projection| projection.placement == ClaimPlacement::Commitment)
-        .collect::<Vec<_>>();
     sections.push(variant_section(
         "the-work",
         "The work",
@@ -680,12 +609,12 @@ fn build_composition(
             ctx,
             input,
             "the-work",
-            9,
-            work_claims,
+            next_section_index,
+            next_claims,
             snapshot_fields_for_section(snapshot, "the-work"),
             EmptySectionCopy {
                 title: "No active work items",
-                body: "No active work records are currently grounded for this account.",
+                body: "No active project work records are currently grounded.",
                 status: "empty",
             },
             subject,
@@ -693,23 +622,7 @@ fn build_composition(
             provenance_builder,
         )?,
         SectionLayout::Stacked,
-        salience(0.46, SalienceBand::Background, "account work"),
-    ));
-
-    sections.push(variant_section(
-        "reports",
-        "Reports",
-        build_reports_section_blocks(
-            ctx,
-            input,
-            snapshot_fields_for_section(snapshot, "reports"),
-            10,
-            subject,
-            invocation_id,
-            provenance_builder,
-        )?,
-        SectionLayout::Grid,
-        salience(0.38, SalienceBand::Background, "account reports"),
+        salience(0.5, SalienceBand::Background, "project work"),
     ));
 
     let section_count = sections.len();
@@ -717,9 +630,9 @@ fn build_composition(
     let composition = Composition::new(
         input.composition_id.clone(),
         CompositionKind::EntityPage,
-        Some(EntityRef::new(format!("account:{}", input.account_id))),
+        Some(EntityRef::new(format!("project:{}", input.project_id))),
         sections,
-        salience(0.9, SalienceBand::Important, "account overview"),
+        salience(0.9, SalienceBand::Important, "project overview"),
         generated_at,
         AbilityRef::new(ABILITY_NAME),
         CompositionMetadata {
@@ -739,14 +652,6 @@ struct EmptySectionCopy {
     title: &'static str,
     body: &'static str,
     status: &'static str,
-}
-
-#[derive(Clone, Copy)]
-struct AccountBlockBuildContext<'a, 'ctx> {
-    ctx: &'a AbilityContext<'ctx>,
-    input: &'a NormalizedInput,
-    subject: &'a SubjectAttribution,
-    invocation_id: InvocationId,
 }
 
 fn variant_section(
@@ -770,7 +675,7 @@ fn build_claim_or_snapshot_section_blocks(
     section_id: &str,
     section_index: usize,
     projections: Vec<&ClaimProjection>,
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
+    snapshot_fields: Vec<&ProjectCompositionSnapshotField>,
     empty_copy: EmptySectionCopy,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
@@ -862,7 +767,7 @@ fn build_record_section_blocks(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
     projections: &[ClaimProjection],
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
+    snapshot_fields: Vec<&ProjectCompositionSnapshotField>,
     section_index: usize,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
@@ -873,8 +778,8 @@ fn build_record_section_blocks(
             input,
             "the-record",
             EmptySectionCopy {
-                title: "No account record yet",
-                body: "No source-backed account events are available for this record.",
+                title: "No project record yet",
+                body: "No source-backed project events are available for this record.",
                 status: "empty",
             },
             section_index,
@@ -904,14 +809,15 @@ fn build_record_section_blocks(
         provenance_builder,
     )?);
     for field in snapshot_fields {
-        items.push(snapshot_field_evidence_item(field));
+        items.extend(snapshot_field_evidence_items(field));
     }
 
     let composition_block_path = format!("/sections/{section_index}/blocks/0");
+    let item_count = items.len();
     let mut block = Block::new(
         BlockId::new(block_id(input, "the-record", "evidence_list", "sources")),
         BlockType::EvidenceList,
-        json!({ "items": items }),
+        json!({ "title": "Evidence", "items": items }),
         claim_refs,
         ProvenanceRef::new(
             invocation_id,
@@ -920,7 +826,7 @@ fn build_record_section_blocks(
         None,
     )
     .map_err(block_error)?;
-    block.field_bindings = evidence_list_display_bindings(items.len())?;
+    block.field_bindings = evidence_list_display_bindings(item_count)?;
     block.salience = salience(0.58, SalienceBand::Contextual, "source record");
     attribute_block(
         provenance_builder,
@@ -932,68 +838,13 @@ fn build_record_section_blocks(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn build_reports_section_blocks(
-    ctx: &AbilityContext<'_>,
-    input: &NormalizedInput,
-    snapshot_fields: Vec<&AccountCompositionSnapshotField>,
-    section_index: usize,
-    subject: &SubjectAttribution,
-    invocation_id: InvocationId,
-    provenance_builder: &mut ProvenanceBuilder,
-) -> Result<Vec<Block>, AbilityError> {
-    if snapshot_fields.is_empty() {
-        let composition_block_path = format!("/sections/{section_index}/blocks/0");
-        let mut block = Block::new(
-            BlockId::new(block_id(input, "reports", "action_list", "system_config")),
-            BlockType::ActionList,
-            json!({
-                "claim_type": "system_config",
-                "items": [{
-                    "title": "Account report",
-                    "status": "unavailable",
-                    "text": "No generated account report is currently available."
-                }]
-            }),
-            Vec::new(),
-            ProvenanceRef::new(
-                invocation_id,
-                FieldPath::new(&composition_block_path).map_err(field_error)?,
-            ),
-            None,
-        )
-        .map_err(block_error)?;
-        block.field_bindings = action_list_display_bindings(1)?;
-        block.salience = salience(0.32, SalienceBand::Background, "report availability");
-        attribute_block(
-            provenance_builder,
-            &composition_block_path,
-            subject,
-            Vec::new(),
-        )?;
-        return Ok(vec![block]);
-    }
-
-    Ok(vec![build_snapshot_fields_block(
-        ctx,
-        input,
-        "reports",
-        section_index,
-        0,
-        snapshot_fields,
-        subject,
-        invocation_id,
-        provenance_builder,
-    )?])
-}
-
-#[allow(clippy::too_many_arguments)]
 fn build_snapshot_fields_block(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
     section_id: &str,
     section_index: usize,
     block_index: usize,
-    fields: Vec<&AccountCompositionSnapshotField>,
+    fields: Vec<&ProjectCompositionSnapshotField>,
     subject: &SubjectAttribution,
     invocation_id: InvocationId,
     provenance_builder: &mut ProvenanceBuilder,
@@ -1001,13 +852,14 @@ fn build_snapshot_fields_block(
     let source_indexes = snapshot_source_indexes(ctx, input, &fields, provenance_builder)?;
     let items = fields
         .iter()
-        .map(|field| snapshot_field_evidence_item(field))
+        .flat_map(|field| snapshot_field_evidence_items(field))
         .collect::<Vec<_>>();
     let composition_block_path = format!("/sections/{section_index}/blocks/{block_index}");
+    let item_count = items.len();
     let mut block = Block::new(
         BlockId::new(block_id(input, section_id, "evidence_list", "snapshot")),
         BlockType::EvidenceList,
-        json!({ "items": items }),
+        json!({ "title": section_title(section_id), "items": items }),
         Vec::new(),
         ProvenanceRef::new(
             invocation_id,
@@ -1016,7 +868,7 @@ fn build_snapshot_fields_block(
         None,
     )
     .map_err(block_error)?;
-    block.field_bindings = evidence_list_display_bindings(items.len())?;
+    block.field_bindings = evidence_list_display_bindings(item_count)?;
     block.salience = salience(0.54, SalienceBand::Contextual, "snapshot fields");
     attribute_block(
         provenance_builder,
@@ -1027,19 +879,63 @@ fn build_snapshot_fields_block(
     Ok(block)
 }
 
-fn snapshot_field_evidence_item(field: &AccountCompositionSnapshotField) -> Value {
-    json!({
-        "label": format!("{}: {}", field.label, snapshot_value_text(&field.value)),
-        "source_label": field.source_label.as_deref().unwrap_or(match field.provenance_kind {
-            AccountCompositionProvenanceKind::NonSensitiveIdentity => "identity",
-            AccountCompositionProvenanceKind::ManualUser => "user",
-            AccountCompositionProvenanceKind::SourceField => "source",
-            AccountCompositionProvenanceKind::SystemConfig => "system_config",
-            AccountCompositionProvenanceKind::Derived => "derived",
-            AccountCompositionProvenanceKind::Unavailable => "unavailable",
-        }),
-        "source_asof": field.source_asof,
-    })
+fn section_title(section_id: &str) -> &'static str {
+    match section_id {
+        "portfolio" => "Portfolio",
+        "trajectory" => "Trajectory",
+        "the-horizon" => "Horizon",
+        "the-landscape" => "Landscape",
+        "the-room" => "Team",
+        "the-record" => "Record",
+        "the-work" => "Work",
+        _ => "Evidence",
+    }
+}
+
+fn snapshot_field_evidence_items(field: &ProjectCompositionSnapshotField) -> Vec<Value> {
+    let source_label = field
+        .source_label
+        .as_deref()
+        .unwrap_or(match field.provenance_kind {
+            ProjectCompositionProvenanceKind::NonSensitiveIdentity => "identity",
+            ProjectCompositionProvenanceKind::ManualUser => "user",
+            ProjectCompositionProvenanceKind::SourceField => "source",
+            ProjectCompositionProvenanceKind::SystemConfig => "system_config",
+            ProjectCompositionProvenanceKind::Derived => "derived",
+            ProjectCompositionProvenanceKind::Unavailable => "unavailable",
+        });
+    match &field.value {
+        Value::Array(items) => items
+            .iter()
+            .take(12)
+            .map(|item| {
+                json!({
+                    "label": format!("{}: {}", field.label, compact_item_label(item)),
+                    "source_label": source_label,
+                    "source_asof": field.source_asof,
+                })
+            })
+            .collect(),
+        _ => vec![json!({
+            "label": format!("{}: {}", field.label, snapshot_value_text(&field.value)),
+            "source_label": source_label,
+            "source_asof": field.source_asof,
+        })],
+    }
+}
+
+fn compact_item_label(value: &Value) -> String {
+    let Some(object) = value.as_object() else {
+        return snapshot_value_text(value);
+    };
+    for key in ["title", "name", "signal_text", "content"] {
+        if let Some(label) = object.get(key).and_then(Value::as_str) {
+            if !label.trim().is_empty() {
+                return label.to_string();
+            }
+        }
+    }
+    snapshot_value_text(value)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1088,11 +984,15 @@ fn build_section_state_block(
     Ok(block)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_overview_block(
-    build_context: &AccountBlockBuildContext<'_, '_>,
+    ctx: &AbilityContext<'_>,
+    input: &NormalizedInput,
     projections: &[ClaimProjection],
     snapshot_outcome: &SnapshotReadOutcome,
     composition_block_path: &str,
+    subject: &SubjectAttribution,
+    invocation_id: InvocationId,
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Block, AbilityError> {
     let snapshot = snapshot_outcome.snapshot.as_ref();
@@ -1102,15 +1002,20 @@ fn build_overview_block(
         .map(|projection| projection.source_index)
         .collect::<Vec<_>>();
     source_indexes.extend(snapshot_source_indexes(
-        build_context.ctx,
-        build_context.input,
+        ctx,
+        input,
         &headline_fields,
         provenance_builder,
     )?);
     let overview_claims = projections
         .iter()
         .enumerate()
-        .filter(|(_, projection)| projection.placement == ClaimPlacement::Overview)
+        .filter(|(_, projection)| {
+            matches!(
+                projection.placement,
+                ClaimPlacement::Momentum | ClaimPlacement::Context
+            )
+        })
         .collect::<Vec<_>>();
     let all_refs = projections
         .iter()
@@ -1133,12 +1038,12 @@ fn build_overview_block(
         .collect::<Vec<_>>();
     let trust_band = block_trust_band(projections.iter().map(|projection| projection.trust_band));
     let counts_by_band = trust_band_counts(projections);
-    let account_display_name = snapshot
+    let project_display_name = snapshot
         .map(|snapshot| snapshot_value_text(&snapshot.display_name.value))
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| build_context.input.account_id.clone());
-    let account_type = snapshot
-        .and_then(|snapshot| snapshot.account_type.as_ref())
+        .unwrap_or_else(|| input.project_id.clone());
+    let status = snapshot
+        .and_then(|snapshot| snapshot.status.as_ref())
         .filter(|field| field.sensitivity.is_render_safe())
         .map(|field| snapshot_value_text(&field.value));
     let vitals = headline_fields
@@ -1155,17 +1060,23 @@ fn build_overview_block(
         .collect::<Vec<_>>();
     let vitals_len = vitals.len();
     let attributes = json!({
-        "account_id": build_context.input.account_id,
+        "entity_type": "project",
+        "project_id": input.project_id,
         "account": {
-            "id": build_context.input.account_id,
-            "display_name": account_display_name,
-            "type": account_type,
+            "id": input.project_id,
+            "display_name": project_display_name,
+            "type": "Project",
         },
-        "title": "Account overview",
+        "project": {
+            "id": input.project_id,
+            "display_name": project_display_name,
+            "status": status,
+        },
+        "title": "Project overview",
         "summary": overview_claims
             .first()
             .map(|(_, projection)| projection.rendered_text.as_str())
-            .unwrap_or("Account composition is grounded in current renderable claims and source-backed account fields."),
+            .unwrap_or("Project composition is grounded in current renderable claims and source-backed project fields."),
         "claim_count": projections.len(),
         "trust_band": trust_band_label(trust_band),
         "counts_by_trust_band": counts_by_band,
@@ -1174,17 +1085,12 @@ fn build_overview_block(
         "snapshot_degraded": snapshot_outcome.degraded_reason.as_deref().unwrap_or(""),
     });
     let mut block = Block::new(
-        BlockId::new(block_id(
-            build_context.input,
-            "headline",
-            "account_overview",
-            "summary",
-        )),
+        BlockId::new(block_id(input, "headline", "account_overview", "summary")),
         BlockType::AccountOverview,
         attributes,
         all_refs,
         ProvenanceRef::new(
-            build_context.invocation_id,
+            invocation_id,
             FieldPath::new(composition_block_path).map_err(field_error)?,
         ),
         None,
@@ -1197,31 +1103,28 @@ fn build_overview_block(
         display_only_binding("/account/id")?,
         display_only_binding("/account/display_name")?,
         display_only_binding("/account/type")?,
+        display_only_binding("/project/id")?,
+        display_only_binding("/project/display_name")?,
+        display_only_binding("/project/status")?,
         display_only_binding("/snapshot_degraded")?,
     ];
     display_bindings.extend(vitals_display_bindings(vitals_len)?);
 
     if projections.is_empty() {
         block.field_bindings = display_bindings;
-        attribute_block(
-            provenance_builder,
-            composition_block_path,
-            build_context.subject,
-            source_indexes,
-        )?;
     } else {
         let mut bindings = vec![computed_binding("/claim_count", 0..projections.len())?];
         bindings.extend(trust_band_count_computed_bindings(projections.len())?);
         bindings.extend(context_computed_bindings(&overview_claim_indexes)?);
         bindings.extend(display_bindings);
         block.field_bindings = bindings;
-        attribute_block(
-            provenance_builder,
-            composition_block_path,
-            build_context.subject,
-            source_indexes,
-        )?;
     }
+    attribute_block(
+        provenance_builder,
+        composition_block_path,
+        subject,
+        source_indexes,
+    )?;
     Ok(block)
 }
 
@@ -1252,39 +1155,10 @@ fn build_claim_block(
                 SalienceBand::Critical,
                 "risk claim",
             ),
-            ClaimPlacement::Win => (
-                BlockType::ClaimSummary,
-                json!({
-                    "intent": "win",
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.72,
-                SalienceBand::Important,
-                "win claim",
-            ),
-            ClaimPlacement::Value => (
-                BlockType::ClaimSummary,
-                json!({
-                    "intent": "value",
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.72,
-                SalienceBand::Important,
-                "value claim",
-            ),
             ClaimPlacement::Commitment => (
                 BlockType::ActionList,
                 json!({
+                    "title": "Actions",
                     "items": [{
                         "claim_id": projection.claim.id,
                         "text": projection.rendered_text,
@@ -1316,24 +1190,10 @@ fn build_claim_block(
                 SalienceBand::Contextual,
                 "relationship claim",
             ),
-            ClaimPlacement::Health => (
-                BlockType::HealthSnapshot,
-                json!({
-                    "claim_id": projection.claim.id,
-                    "text": projection.rendered_text,
-                    "claim_type": projection.claim.claim_type,
-                    "trust_band": trust_band,
-                    "source_asof": projection.claim.source_asof,
-                }),
-                source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.82,
-                SalienceBand::Important,
-                "health claim",
-            ),
-            ClaimPlacement::Overview => (
+            ClaimPlacement::Momentum | ClaimPlacement::Context => (
                 BlockType::ClaimSummary,
                 json!({
-                    "intent": "context",
+                    "intent": if projection.placement == ClaimPlacement::Momentum { "trajectory" } else { "context" },
                     "claim_id": projection.claim.id,
                     "text": projection.rendered_text,
                     "claim_type": projection.claim.claim_type,
@@ -1341,13 +1201,13 @@ fn build_claim_block(
                     "source_asof": projection.claim.source_asof,
                 }),
                 source_feedback_computed_bindings("/text", "/trust_band")?,
-                0.58,
-                SalienceBand::Contextual,
-                "account context claim",
+                0.66,
+                SalienceBand::Important,
+                "project claim",
             ),
             ClaimPlacement::Ignored => {
                 return Err(validation_error(
-                    "unexpected account overview block placement",
+                    "unexpected project overview block placement",
                 ));
             }
         };
@@ -1381,9 +1241,9 @@ fn build_claim_block(
 }
 
 fn snapshot_fields_for_section<'a>(
-    snapshot: Option<&'a AccountCompositionSnapshot>,
+    snapshot: Option<&'a ProjectCompositionSnapshot>,
     section_id: &str,
-) -> Vec<&'a AccountCompositionSnapshotField> {
+) -> Vec<&'a ProjectCompositionSnapshotField> {
     let Some(snapshot) = snapshot else {
         return Vec::new();
     };
@@ -1397,34 +1257,14 @@ fn snapshot_fields_for_section<'a>(
 
 fn snapshot_field_belongs_to_section(field_path: &str, section_id: &str) -> bool {
     match section_id {
-        "headline" => {
-            field_path.starts_with("/vitals/")
-                || field_path.starts_with("/identity/")
-                || field_path == "/health/band"
-        }
-        "outlook" => {
-            field_path.starts_with("/outlook/")
-                || field_path.starts_with("/renewal/")
-                || field_path == "/vitals/contract_end"
-                || field_path == "/health/band"
-        }
-        "state-of-play" => field_path.starts_with("/state/"),
-        "the-room" => field_path.starts_with("/stakeholders/"),
-        "whats-next" => field_path.starts_with("/work/next_steps/"),
-        "watch-list" => field_path.starts_with("/watch_list/"),
-        "value-commitments" => {
-            field_path.starts_with("/value/")
-                || field_path.starts_with("/work/commitments/")
-                || field_path == "/vitals/arr"
-        }
-        "strategic-landscape" => {
-            field_path.starts_with("/strategy/")
-                || field_path.starts_with("/technical/")
-                || field_path.starts_with("/company/")
-        }
-        "the-record" => field_path.starts_with("/record/") || field_path.starts_with("/sources/"),
-        "the-work" => field_path.starts_with("/work/"),
-        "reports" => field_path.starts_with("/reports/"),
+        "headline" => field_path.starts_with("/vitals/") || field_path.starts_with("/identity/"),
+        "portfolio" => field_path.starts_with("/portfolio/"),
+        "trajectory" => field_path.starts_with("/trajectory/"),
+        "the-horizon" => field_path.starts_with("/the-horizon/"),
+        "the-landscape" => field_path.starts_with("/state/"),
+        "the-room" => field_path.starts_with("/the-room/"),
+        "the-record" => field_path.starts_with("/the-record/"),
+        "the-work" => field_path.starts_with("/the-work/"),
         _ => false,
     }
 }
@@ -1432,7 +1272,7 @@ fn snapshot_field_belongs_to_section(field_path: &str, section_id: &str) -> bool
 fn snapshot_source_indexes(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-    fields: &[&AccountCompositionSnapshotField],
+    fields: &[&ProjectCompositionSnapshotField],
     provenance_builder: &mut ProvenanceBuilder,
 ) -> Result<Vec<crate::abilities::provenance::SourceIndex>, AbilityError> {
     let mut indexes = Vec::new();
@@ -1450,12 +1290,12 @@ fn snapshot_source_indexes(
 fn source_for_snapshot_field(
     ctx: &AbilityContext<'_>,
     input: &NormalizedInput,
-    field: &AccountCompositionSnapshotField,
+    field: &ProjectCompositionSnapshotField,
 ) -> Result<Option<SourceAttribution>, AbilityError> {
     if matches!(
         field.provenance_kind,
-        AccountCompositionProvenanceKind::NonSensitiveIdentity
-            | AccountCompositionProvenanceKind::Unavailable
+        ProjectCompositionProvenanceKind::NonSensitiveIdentity
+            | ProjectCompositionProvenanceKind::Unavailable
     ) && field.source_label.is_none()
         && field.source_ref.is_none()
         && field.source_asof.is_none()
@@ -1477,7 +1317,7 @@ fn source_for_snapshot_field(
     SourceAttribution::new(
         data_source_for_snapshot_field(field),
         vec![SourceIdentifier::Entity {
-            entity_id: EntityId::new(input.account_id.clone()),
+            entity_id: EntityId::new(input.project_id.clone()),
             field: Some(field.field_path.clone()),
         }],
         observed_at,
@@ -1489,15 +1329,15 @@ fn source_for_snapshot_field(
     .map_err(|error| validation_error(format!("invalid snapshot source attribution: {error}")))
 }
 
-fn data_source_for_snapshot_field(field: &AccountCompositionSnapshotField) -> DataSource {
+fn data_source_for_snapshot_field(field: &ProjectCompositionSnapshotField) -> DataSource {
     match field.provenance_kind {
-        AccountCompositionProvenanceKind::ManualUser => DataSource::User,
-        AccountCompositionProvenanceKind::SystemConfig => DataSource::LocalEnrichment,
+        ProjectCompositionProvenanceKind::ManualUser => DataSource::User,
+        ProjectCompositionProvenanceKind::SystemConfig => DataSource::LocalEnrichment,
         _ => field
             .source_label
             .as_deref()
             .map(data_source_for_claim)
-            .unwrap_or_else(|| DataSource::Other(SourceName::new("account_snapshot"))),
+            .unwrap_or_else(|| DataSource::Other(SourceName::new("project_snapshot"))),
     }
 }
 
@@ -1573,7 +1413,7 @@ fn attribute_block(
     } else {
         FieldAttribution::computed(
             subject.clone(),
-            "dailyos.account_overview.v1",
+            "dailyos.project_overview.v1",
             source_indexes
                 .into_iter()
                 .map(|source_index| SourceRef::Source { source_index })
@@ -1583,7 +1423,7 @@ fn attribute_block(
         .map_err(field_error)?
     };
     builder
-        .attribute(path.clone(), attribution.clone())
+        .attribute(path, attribution)
         .map_err(provenance_error)?;
     Ok(())
 }
@@ -1664,7 +1504,8 @@ fn vitals_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, Abili
 }
 
 fn evidence_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
-    let mut bindings = Vec::with_capacity(item_count * 3);
+    let mut bindings = Vec::with_capacity(item_count * 3 + 1);
+    bindings.push(display_only_binding("/title")?);
     for index in 0..item_count {
         bindings.push(display_only_binding(&format!("/items/{index}/label"))?);
         bindings.push(display_only_binding(&format!(
@@ -1673,16 +1514,6 @@ fn evidence_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>
         bindings.push(display_only_binding(&format!(
             "/items/{index}/source_asof"
         ))?);
-    }
-    Ok(bindings)
-}
-
-fn action_list_display_bindings(item_count: usize) -> Result<Vec<FieldBinding>, AbilityError> {
-    let mut bindings = Vec::with_capacity(item_count * 3);
-    for index in 0..item_count {
-        bindings.push(display_only_binding(&format!("/items/{index}/title"))?);
-        bindings.push(display_only_binding(&format!("/items/{index}/status"))?);
-        bindings.push(display_only_binding(&format!("/items/{index}/text"))?);
     }
     Ok(bindings)
 }
@@ -1819,13 +1650,11 @@ fn compare_claim_projection(left: &ClaimProjection, right: &ClaimProjection) -> 
 fn placement_rank(placement: ClaimPlacement) -> u8 {
     match placement {
         ClaimPlacement::Risk => 0,
-        ClaimPlacement::Health => 1,
+        ClaimPlacement::Momentum => 1,
         ClaimPlacement::Commitment => 2,
-        ClaimPlacement::Value => 3,
-        ClaimPlacement::Win => 4,
-        ClaimPlacement::Relationship => 5,
-        ClaimPlacement::Overview => 6,
-        ClaimPlacement::Ignored => 7,
+        ClaimPlacement::Relationship => 3,
+        ClaimPlacement::Context => 4,
+        ClaimPlacement::Ignored => 5,
     }
 }
 
@@ -1839,7 +1668,7 @@ fn trust_rank(band: TrustBand) -> u8 {
 
 fn source_for_claim(
     ctx: &AbilityContext<'_>,
-    account_id: &str,
+    project_id: &str,
     claim: &IntelligenceClaim,
 ) -> Result<SourceAttribution, AbilityError> {
     let now = ctx.services().clock.now();
@@ -1848,7 +1677,7 @@ fn source_for_claim(
     SourceAttribution::new(
         data_source_for_claim(&claim.data_source),
         vec![SourceIdentifier::Entity {
-            entity_id: EntityId::new(account_id.to_string()),
+            entity_id: EntityId::new(project_id.to_string()),
             field: Some(
                 claim
                     .field_path
@@ -2050,22 +1879,18 @@ mod tests {
     use chrono::TimeZone;
 
     use super::*;
-    use crate::abilities::provenance::ProvenanceWarning;
     use crate::abilities::registry::{AbilityRegistry, ActorKind, McpExposure, ScopeSet};
-    use crate::abilities::{
-        project_composition_for_surface, Actor, FallbackProjectionContext, SurfaceKind,
-        NOOP_ABILITY_TRACER,
-    };
+    use crate::abilities::NOOP_ABILITY_TRACER;
     use crate::intelligence::provider::{
         Completion, FingerprintMetadata, IntelligenceProvider, ModelName, ModelTier, PromptInput,
         ProviderError, ProviderKind,
     };
     use crate::sensitivity::{ClaimDismissalSurface, ClaimVerificationState};
     use crate::services::context::{
-        AccountCompositionSnapshotReadFuture, AccountCompositionSnapshotReadHandle,
-        AccountCompositionSnapshotSensitivity, CompositionCommitFuture, CompositionCommitHandle,
-        CompositionCommitRequest, EntityContextClaimReadFuture, EntityContextClaimReadHandle,
-        ExternalClients, FixedClock, SeedableRng, ServiceContext,
+        CompositionCommitFuture, CompositionCommitHandle, CompositionCommitRequest,
+        EntityContextClaimReadFuture, EntityContextClaimReadHandle, ExternalClients, FixedClock,
+        ProjectCompositionSnapshotReadFuture, ProjectCompositionSnapshotReadHandle,
+        ProjectCompositionSnapshotSensitivity, SeedableRng, ServiceContext,
     };
     use crate::types::{ClaimSensitivity, TemporalScope};
 
@@ -2096,9 +1921,9 @@ mod tests {
         ) -> EntityContextClaimReadFuture<'a> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
-                *self.last_surface.lock().expect("surface lock") = Some(surface);
-                assert_eq!(entity_type, "account");
-                assert_eq!(entity_id, "acct-fixture-1");
+                *self.last_surface.lock().expect("claim surface lock") = Some(surface);
+                assert_eq!(entity_type, "project");
+                assert_eq!(entity_id, "project-fixture-1");
                 Ok(self.claims.lock().expect("claim lock").clone())
             })
         }
@@ -2139,14 +1964,14 @@ mod tests {
     }
 
     struct SpySnapshotReader {
-        result: Mutex<Result<AccountCompositionSnapshot, AccountCompositionSnapshotReadError>>,
+        result: Mutex<Result<ProjectCompositionSnapshot, ProjectCompositionSnapshotReadError>>,
         calls: AtomicUsize,
         last_surface: Mutex<Option<ClaimDismissalSurface>>,
     }
 
     impl SpySnapshotReader {
         fn new(
-            result: Result<AccountCompositionSnapshot, AccountCompositionSnapshotReadError>,
+            result: Result<ProjectCompositionSnapshot, ProjectCompositionSnapshotReadError>,
         ) -> Self {
             Self {
                 result: Mutex::new(result),
@@ -2156,16 +1981,16 @@ mod tests {
         }
     }
 
-    impl AccountCompositionSnapshotReadHandle for SpySnapshotReader {
-        fn read_account_composition_snapshot<'a>(
+    impl ProjectCompositionSnapshotReadHandle for SpySnapshotReader {
+        fn read_project_composition_snapshot<'a>(
             &'a self,
-            account_id: String,
+            project_id: String,
             surface: ClaimDismissalSurface,
-        ) -> AccountCompositionSnapshotReadFuture<'a> {
+        ) -> ProjectCompositionSnapshotReadFuture<'a> {
             Box::pin(async move {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 *self.last_surface.lock().expect("snapshot surface lock") = Some(surface);
-                assert_eq!(account_id, "acct-fixture-1");
+                assert_eq!(project_id, "project-fixture-1");
                 self.result.lock().expect("snapshot result lock").clone()
             })
         }
@@ -2230,24 +2055,14 @@ mod tests {
         external: &'a ExternalClients,
         reader: Arc<SpyClaimReader>,
         committer: Arc<RecordingCommitter>,
+        snapshot_reader: Arc<SpySnapshotReader>,
     ) -> ServiceContext<'a> {
         ServiceContext::test_live(clock, rng, external)
             .with_actor("surface_client")
             .with_ability_id(ABILITY_NAME)
             .with_entity_context_claim_reader(reader)
+            .with_project_composition_snapshot_reader(snapshot_reader)
             .with_composition_commit_handle(committer)
-    }
-
-    fn services_with_snapshot<'a>(
-        clock: &'a FixedClock,
-        rng: &'a SeedableRng,
-        external: &'a ExternalClients,
-        reader: Arc<SpyClaimReader>,
-        committer: Arc<RecordingCommitter>,
-        snapshot_reader: Arc<SpySnapshotReader>,
-    ) -> ServiceContext<'a> {
-        services(clock, rng, external, reader, committer)
-            .with_account_composition_snapshot_reader(snapshot_reader)
     }
 
     fn ability_ctx<'a>(
@@ -2259,9 +2074,9 @@ mod tests {
             provider,
             &NOOP_ABILITY_TRACER,
             Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
+                instance: crate::abilities::registry::SurfaceClientId::new("sc_project_fixture"),
                 scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
+                    "read.project_overview",
                 )])
                 .expect("scope set"),
             },
@@ -2270,19 +2085,20 @@ mod tests {
         )
     }
 
-    fn input() -> AccountOverviewInput {
-        AccountOverviewInput {
+    fn input() -> ProjectOverviewInput {
+        ProjectOverviewInput {
             schema_version: ABILITY_SCHEMA_VERSION,
-            account_id: "acct-fixture-1".to_string(),
+            project_id: "project-fixture-1".to_string(),
             entity_type: None,
             entity_id: None,
             expected_composition_version: 0,
-            composition_id: Some("acct-overview-fixture".to_string()),
+            composition_id: Some("project-overview-fixture".to_string()),
         }
     }
 
     fn claim(
         id: &str,
+        subject_ref: Value,
         claim_type: &str,
         field_path: &str,
         text: &str,
@@ -2293,7 +2109,7 @@ mod tests {
         IntelligenceClaim {
             id: id.to_string(),
             claim_version: 2,
-            subject_ref: json!({"kind": "account", "id": "acct-fixture-1"}).to_string(),
+            subject_ref: subject_ref.to_string(),
             claim_type: claim_type.to_string(),
             field_path: Some(field_path.to_string()),
             topic_key: None,
@@ -2327,15 +2143,36 @@ mod tests {
         }
     }
 
+    fn project_claim(
+        id: &str,
+        claim_type: &str,
+        field_path: &str,
+        text: &str,
+        trust_score: Option<f64>,
+        source_asof: Option<&str>,
+        sensitivity: ClaimSensitivity,
+    ) -> IntelligenceClaim {
+        claim(
+            id,
+            json!({"kind": "project", "id": "project-fixture-1"}),
+            claim_type,
+            field_path,
+            text,
+            trust_score,
+            source_asof,
+            sensitivity,
+        )
+    }
+
     fn snapshot_field(
         field_path: &str,
         label: &str,
         value: Value,
-        sensitivity: AccountCompositionSnapshotSensitivity,
+        sensitivity: ProjectCompositionSnapshotSensitivity,
         source_label: Option<&str>,
         source_asof: Option<&str>,
-    ) -> AccountCompositionSnapshotField {
-        AccountCompositionSnapshotField {
+    ) -> ProjectCompositionSnapshotField {
+        ProjectCompositionSnapshotField {
             field_path: field_path.to_string(),
             label: label.to_string(),
             value,
@@ -2345,7 +2182,7 @@ mod tests {
             source_asof: source_asof.map(ToString::to_string),
             trust_band: TrustBand::UseWithCaution,
             trust_status: "use_with_caution".to_string(),
-            provenance_kind: AccountCompositionProvenanceKind::SourceField,
+            provenance_kind: ProjectCompositionProvenanceKind::SourceField,
         }
     }
 
@@ -2353,36 +2190,38 @@ mod tests {
         field_path: &str,
         label: &str,
         value: &str,
-    ) -> AccountCompositionSnapshotField {
-        AccountCompositionSnapshotField {
+    ) -> ProjectCompositionSnapshotField {
+        ProjectCompositionSnapshotField {
             field_path: field_path.to_string(),
             label: label.to_string(),
             value: Value::String(value.to_string()),
-            sensitivity: AccountCompositionSnapshotSensitivity::NonSensitiveIdentity,
+            sensitivity: ProjectCompositionSnapshotSensitivity::NonSensitiveIdentity,
             source_label: None,
             source_ref: None,
             source_asof: None,
             trust_band: TrustBand::LikelyCurrent,
             trust_status: "likely_current".to_string(),
-            provenance_kind: AccountCompositionProvenanceKind::NonSensitiveIdentity,
+            provenance_kind: ProjectCompositionProvenanceKind::NonSensitiveIdentity,
         }
     }
 
     fn snapshot_fixture(
-        fields: Vec<AccountCompositionSnapshotField>,
-    ) -> AccountCompositionSnapshot {
-        AccountCompositionSnapshot {
-            account_id: "acct-fixture-1".to_string(),
+        is_parent: bool,
+        fields: Vec<ProjectCompositionSnapshotField>,
+    ) -> ProjectCompositionSnapshot {
+        ProjectCompositionSnapshot {
+            project_id: "project-fixture-1".to_string(),
             display_name: identity_snapshot_field(
                 "/identity/display_name",
-                "Account",
-                "Example Account",
+                "Project",
+                "Example Project",
             ),
-            account_type: Some(identity_snapshot_field(
-                "/identity/account_type",
-                "Account type",
-                "customer",
+            status: Some(identity_snapshot_field(
+                "/identity/status",
+                "Status",
+                "active",
             )),
+            is_parent,
             fields,
         }
     }
@@ -2392,41 +2231,17 @@ mod tests {
     }
 
     #[test]
-    fn registry_declaration_pins_policy() {
-        let registry = AbilityRegistry::global_checked().expect("registry builds");
-        let descriptor = registry
-            .iter_all()
-            .find(|descriptor| descriptor.name == ABILITY_NAME)
-            .expect("account overview ability registered");
-
-        assert_eq!(descriptor.name, ABILITY_NAME);
-        assert_eq!(descriptor.category, AbilityCategory::Read);
-        assert_eq!(
-            descriptor.policy.allowed_actors,
-            &[ActorKind::User, ActorKind::SurfaceClient]
-        );
-        assert_eq!(
-            descriptor.policy.required_scopes,
-            &["read.account_overview"]
-        );
-        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::Invocable);
-        assert!(!descriptor.policy.client_side_executable);
-        assert!(descriptor.mutates.is_empty());
-        assert!(descriptor.composes.is_empty());
-    }
-
-    #[test]
-    fn entity_envelope_accepts_matching_account_and_rejects_mismatch() {
-        let ok = AccountOverviewInput {
-            entity_type: Some("account".to_string()),
-            entity_id: Some("acct-fixture-1".to_string()),
+    fn entity_envelope_accepts_matching_project_and_rejects_mismatch() {
+        let ok = ProjectOverviewInput {
+            entity_type: Some("project".to_string()),
+            entity_id: Some("project-fixture-1".to_string()),
             ..input()
         };
         normalize_input(ok).expect("matching envelope is accepted");
 
-        let wrong_type = AccountOverviewInput {
-            entity_type: Some("project".to_string()),
-            entity_id: Some("acct-fixture-1".to_string()),
+        let wrong_type = ProjectOverviewInput {
+            entity_type: Some("person".to_string()),
+            entity_id: Some("project-fixture-1".to_string()),
             ..input()
         };
         assert_eq!(
@@ -2436,9 +2251,9 @@ mod tests {
             AbilityErrorKind::Validation
         );
 
-        let wrong_id = AccountOverviewInput {
-            entity_type: Some("account".to_string()),
-            entity_id: Some("other-account".to_string()),
+        let wrong_id = ProjectOverviewInput {
+            entity_type: Some("project".to_string()),
+            entity_id: Some("other-project".to_string()),
             ..input()
         };
         assert_eq!(
@@ -2449,37 +2264,55 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn missing_account_id_rejects_before_claim_read_or_commit() {
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services(&clock, &rng, &external, reader.clone(), committer.clone());
-        let ctx = ability_ctx(&services, &provider);
+    #[test]
+    fn registry_declaration_pins_project_policy_and_invalidation_signals() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let descriptor = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == ABILITY_NAME)
+            .expect("project overview ability registered");
 
-        let err = match account_overview(
-            &ctx,
-            AccountOverviewInput {
-                account_id: " ".to_string(),
-                ..input()
-            },
-        )
-        .await
-        {
-            Ok(_) => panic!("missing account id rejects"),
-            Err(error) => error,
-        };
-
-        assert_eq!(err.kind, AbilityErrorKind::Validation);
-        assert_eq!(reader.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(committer.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(descriptor.name, ABILITY_NAME);
+        assert_eq!(descriptor.category, AbilityCategory::Read);
+        assert_eq!(
+            descriptor.policy.allowed_actors,
+            &[ActorKind::User, ActorKind::SurfaceClient]
+        );
+        assert_eq!(
+            descriptor.policy.required_scopes,
+            &["read.project_overview"]
+        );
+        assert_eq!(descriptor.policy.mcp_exposure, McpExposure::Invocable);
+        assert!(!descriptor.policy.client_side_executable);
+        assert!(descriptor.mutates.is_empty());
+        assert!(descriptor.composes.is_empty());
+        assert!(descriptor.signal_policy.coalesce);
+        for signal in [
+            "claim.version",
+            "project_subject.claim_changed",
+            "claim.lifecycle",
+            "claim.dismissal",
+            "source.freshness",
+            "source.revocation",
+            "project.field_changed",
+        ] {
+            assert!(
+                descriptor
+                    .signal_policy
+                    .emits_on_output_change
+                    .contains(&signal),
+                "project overview declares invalidation signal {signal}"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn missing_account_snapshot_rejects_before_composition_commit() {
+    async fn missing_project_rejects_before_composition_commit() {
         let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
-            AccountCompositionSnapshotReadError::AccountNotFound("acct-fixture-1".to_string()),
+            ProjectCompositionSnapshotReadError::ProjectNotFound("project-fixture-1".to_string()),
         )));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services_with_snapshot(
+        let services = services(
             &clock,
             &rng,
             &external,
@@ -2489,104 +2322,168 @@ mod tests {
         );
         let ctx = ability_ctx(&services, &provider);
 
-        let err = match account_overview(&ctx, input()).await {
-            Ok(_) => panic!("missing account rejects"),
+        let err = match project_overview(&ctx, input()).await {
+            Ok(_) => panic!("missing project rejects"),
             Err(error) => error,
         };
 
         assert_eq!(err.kind, AbilityErrorKind::Validation);
-        assert!(err.message.contains("acct-fixture-1"));
+        assert!(err.message.contains("project-fixture-1"));
         assert_eq!(reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(committer.calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
-    async fn committed_output_has_field_bindings_provenance_and_degraded_trust() {
-        let mut hidden = claim(
-            "claim-hidden",
+    async fn committed_output_filters_project_claims_and_wraps_snapshot_fields() {
+        let mut dismissed = project_claim(
+            "claim-dismissed",
             "entity_risk",
             "/risk/hidden",
-            "Hidden risk",
+            "Dismissed risk should not render",
             Some(0.99),
             Some("2026-05-15T09:00:00Z"),
-            ClaimSensitivity::Confidential,
+            ClaimSensitivity::Internal,
         );
-        hidden.surfacing_state = SurfacingState::Active;
+        dismissed.demotion_reason = Some("dismissed".to_string());
         let claims = vec![
-            claim(
+            project_claim(
                 "claim-risk",
                 "entity_risk",
                 "/risk/current",
                 "Implementation risk is rising",
                 Some(0.97),
-                None,
+                Some("2026-05-15T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            claim(
+            project_claim(
                 "claim-win",
                 "entity_win",
                 "/wins/latest",
-                "Renewal path is clearer",
+                "Launch path is clearer",
                 Some(0.92),
                 Some("2026-05-14T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            claim(
-                "claim-value",
-                "value_delivered",
-                "/value/latest",
-                "Team shipped adoption milestone",
-                None,
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
+            project_claim(
                 "claim-commitment",
                 "commitment",
                 "/commitments/next",
-                "Follow up on launch checklist",
-                Some(0.85),
-                Some("2026-05-01T09:00:00Z"),
+                "Review the rollout plan",
+                Some(0.86),
+                Some("2026-04-01T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
             claim(
-                "claim-context",
-                "company_context",
-                "/company/industry",
-                "Fixture Account operates in software",
-                Some(0.96),
-                Some("2026-03-01T09:00:00Z"),
+                "claim-account-scope",
+                json!({"kind": "account", "id": "acct-fixture"}),
+                "entity_win",
+                "/wins/account",
+                "Account-scoped claim should not render",
+                Some(0.92),
+                Some("2026-05-14T09:00:00Z"),
                 ClaimSensitivity::Internal,
             ),
-            hidden,
+            project_claim(
+                "claim-confidential",
+                "company_context",
+                "/context/confidential",
+                "Confidential project detail should not render",
+                Some(0.9),
+                Some("2026-05-14T09:00:00Z"),
+                ClaimSensitivity::Confidential,
+            ),
+            dismissed,
         ];
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(
+            true,
+            vec![
+                snapshot_field(
+                    "/vitals/status",
+                    "Status",
+                    Value::String("active".to_string()),
+                    ProjectCompositionSnapshotSensitivity::Internal,
+                    Some("project"),
+                    Some("2026-05-14T09:00:00Z"),
+                ),
+                snapshot_field(
+                    "/the-horizon/signals",
+                    "Project signals",
+                    json!({"open_action_count": 3, "trend": "improving"}),
+                    ProjectCompositionSnapshotSensitivity::Internal,
+                    Some("project_signals"),
+                    Some("2026-05-14T09:00:00Z"),
+                ),
+                snapshot_field(
+                    "/portfolio/children",
+                    "Sub-projects",
+                    json!([{"id": "child-1", "name": "Child Project"}]),
+                    ProjectCompositionSnapshotSensitivity::Internal,
+                    Some("project"),
+                    Some("2026-05-14T09:00:00Z"),
+                ),
+                snapshot_field(
+                    "/the-record/private",
+                    "Private field",
+                    Value::String("private snapshot value".to_string()),
+                    ProjectCompositionSnapshotSensitivity::Confidential,
+                    Some("project"),
+                    Some("2026-05-14T09:00:00Z"),
+                ),
+            ],
+        ))));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader.clone(), committer.clone());
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader.clone(),
+            committer.clone(),
+            snapshot_reader.clone(),
+        );
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = project_overview(&ctx, input())
             .await
-            .expect("account overview succeeds");
+            .expect("project overview succeeds");
         let composition = output.data();
+        let serialized = output_json(&output);
+        let serialized_text = serialized.to_string();
 
         assert_eq!(reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(
-            *reader.last_surface.lock().expect("surface lock"),
+            *reader.last_surface.lock().expect("claim surface lock"),
             Some(ClaimDismissalSurface::LogStructured)
         );
+        assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
         assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
         assert_eq!(composition.metadata.composition_version.0, 1);
         assert_eq!(composition.generated_by.as_str(), ABILITY_NAME);
         assert_eq!(composition.metadata.generated_by, ABILITY_NAME);
+        assert_eq!(
+            composition.subject.as_ref().map(|subject| subject.as_str()),
+            Some("project:project-fixture-1")
+        );
 
-        let serialized = output_json(&output);
-        assert!(serialized.to_string().contains("claim-risk"));
-        assert!(!serialized.to_string().contains("claim-hidden"));
-        assert!(serialized.to_string().contains("needs_verification"));
-        assert!(output.provenance().warnings.iter().any(|warning| {
-            matches!(warning, ProvenanceWarning::SourceTimestampUnknown { .. })
-        }));
+        let section_ids = composition
+            .sections
+            .iter()
+            .map(|section| section.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(section_ids[0], "headline");
+        assert!(section_ids.contains(&"portfolio"));
+        assert!(section_ids.contains(&"the-horizon"));
+        assert!(section_ids.contains(&"the-work"));
+
+        assert!(serialized_text.contains("claim-risk"));
+        assert!(serialized_text.contains("claim-win"));
+        assert!(serialized_text.contains("claim-commitment"));
+        assert!(!serialized_text.contains("claim-account-scope"));
+        assert!(!serialized_text.contains("claim-confidential"));
+        assert!(!serialized_text.contains("claim-dismissed"));
+        assert!(!serialized_text.contains("private snapshot value"));
+        assert!(serialized_text.contains("Project signals"));
+        assert!(serialized_text.contains("needs_verification"));
 
         let blocks = composition.blocks().collect::<Vec<_>>();
         assert!(blocks
@@ -2595,6 +2492,9 @@ mod tests {
         assert!(blocks
             .iter()
             .any(|block| block.block_type == BlockType::ActionList));
+        assert!(blocks
+            .iter()
+            .any(|block| block.block_type == BlockType::EvidenceList));
         for block in blocks {
             block
                 .validate_against(output.provenance())
@@ -2618,70 +2518,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn high_cardinality_overview_claims_keep_provenance_under_hard_budget() {
-        let claims = (0..160)
-            .map(|index| {
-                claim(
-                    &format!("claim-context-{index:03}"),
-                    "company_context",
-                    &format!("/company/context/{index}"),
-                    &format!(
-                        "Context signal {index} remains relevant for the account composition proof."
-                    ),
-                    Some(0.94),
-                    Some("2026-05-14T09:00:00Z"),
-                    ClaimSensitivity::Internal,
-                )
-            })
-            .collect::<Vec<_>>();
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("large overview composition stays within provenance budget");
-        let provenance_bytes = serde_json::to_vec(output.provenance())
-            .expect("provenance serializes")
-            .len();
-
-        assert!(
-            provenance_bytes < crate::abilities::provenance::builder::HARD_PROVENANCE_BUDGET_BYTES,
-            "provenance envelope should stay under hard budget, got {provenance_bytes}"
-        );
-        for block in output.data().blocks() {
-            block
-                .validate_against(output.provenance())
-                .expect("block provenance resolves");
-        }
-    }
-
-    #[tokio::test]
-    async fn empty_claim_set_returns_display_only_empty_state() {
+    async fn empty_claim_set_returns_project_sections_without_frontend_fallback() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(
+            false,
+            Vec::new(),
+        ))));
         let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services(&clock, &rng, &external, reader, committer);
+        let services = services(&clock, &rng, &external, reader, committer, snapshot_reader);
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = project_overview(&ctx, input())
             .await
-            .expect("empty state succeeds");
+            .expect("empty project overview succeeds");
         let composition = output.data();
         let section_ids = composition
             .sections
             .iter()
             .map(|section| section.id.as_str())
             .collect::<Vec<_>>();
+
         assert_eq!(
             section_ids,
-            VARIANT_D_SECTIONS
-                .iter()
-                .map(|(id, _)| *id)
-                .collect::<Vec<_>>()
+            vec![
+                "headline",
+                "trajectory",
+                "the-horizon",
+                "the-landscape",
+                "the-room",
+                "whats-next",
+                "the-record",
+                "the-work",
+            ]
         );
-        assert!(!section_ids.contains(&"empty"));
-        assert!(!section_ids.contains(&"signals"));
-
-        let degraded_blocks = composition
+        assert!(!section_ids.contains(&"portfolio"));
+        let empty_blocks = composition
             .sections
             .iter()
             .flat_map(|section| section.blocks.iter())
@@ -2694,402 +2564,58 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert!(
-            degraded_blocks.len() >= 9,
-            "most non-headline sections render degraded empty blocks"
+            empty_blocks.len() >= 7,
+            "non-headline project sections render producer-authored empty blocks"
         );
-        for block in degraded_blocks {
+        for block in empty_blocks {
             assert!(block.claim_refs.is_empty());
             assert!(block.field_bindings.iter().all(|binding| {
                 binding.role == BindingRole::DisplayOnly && binding.claim_refs.is_empty()
             }));
+            block
+                .validate_against(output.provenance())
+                .expect("empty block provenance resolves");
         }
     }
 
     #[tokio::test]
-    async fn snapshot_fields_are_wrapped_sourced_and_sensitivity_filtered() {
-        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
-            snapshot_field(
-                "/vitals/lifecycle",
-                "Lifecycle",
-                Value::String("active".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("user"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-            snapshot_field(
-                "/vitals/arr",
-                "ARR",
-                Value::String("sensitive-commercial-value".to_string()),
-                AccountCompositionSnapshotSensitivity::Confidential,
-                Some("salesforce"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-            snapshot_field(
-                "/reports/account_report",
-                "Account report",
-                Value::String("unavailable".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("system_config"),
-                Some("2026-05-15T10:00:00Z"),
-            ),
-        ]))));
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(Vec::new());
-        let services = services_with_snapshot(
-            &clock,
-            &rng,
-            &external,
-            reader,
-            committer,
-            snapshot_reader.clone(),
-        );
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("snapshot-backed account overview succeeds");
-        let serialized = output_json(&output);
-
-        assert_eq!(snapshot_reader.calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            *snapshot_reader
-                .last_surface
-                .lock()
-                .expect("snapshot surface lock"),
-            Some(ClaimDismissalSurface::LogStructured)
-        );
-        assert!(serialized.to_string().contains("Example Account"));
-        let headline_vitals = output.data().sections[0].blocks[0]
-            .attributes
-            .pointer("/vitals")
-            .and_then(Value::as_array)
-            .expect("headline vitals array");
-        assert!(headline_vitals.iter().any(|value| {
-            value.pointer("/label").and_then(Value::as_str) == Some("Lifecycle")
-                && value.pointer("/value").and_then(Value::as_str) == Some("active")
-        }));
-        assert!(!serialized
-            .to_string()
-            .contains("sensitive-commercial-value"));
-        assert!(output.provenance().sources.iter().any(|source| {
-            source.identifiers.iter().any(|identifier| {
-                matches!(
-                    identifier,
-                    SourceIdentifier::Entity { field: Some(field), .. }
-                        if field == "/vitals/lifecycle"
-                )
-            })
-        }));
-    }
-
-    #[tokio::test]
-    async fn mixed_claim_and_snapshot_sections_keep_both_evidence_paths() {
-        let snapshot_reader = Arc::new(SpySnapshotReader::new(Ok(snapshot_fixture(vec![
-            snapshot_field(
-                "/value/growth_potential",
-                "Growth potential",
-                Value::String("expansion motion active".to_string()),
-                AccountCompositionSnapshotSensitivity::Internal,
-                Some("salesforce"),
-                Some("2026-05-14T09:00:00Z"),
-            ),
-        ]))));
-        let claims = vec![claim(
-            "claim-value",
-            "value_delivered",
-            "/value/latest",
-            "Adoption milestone shipped",
+    async fn snapshot_read_failure_degrades_in_headline_without_blocking_claim_render() {
+        let snapshot_reader = Arc::new(SpySnapshotReader::new(Err(
+            ProjectCompositionSnapshotReadError::ReadFailed("fixture failure".to_string()),
+        )));
+        let claims = vec![project_claim(
+            "claim-win",
+            "entity_win",
+            "/wins/latest",
+            "Launch path is clearer",
             Some(0.92),
             Some("2026-05-14T09:00:00Z"),
             ClaimSensitivity::Internal,
         )];
         let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services =
-            services_with_snapshot(&clock, &rng, &external, reader, committer, snapshot_reader);
+        let services = services(
+            &clock,
+            &rng,
+            &external,
+            reader,
+            committer.clone(),
+            snapshot_reader,
+        );
         let ctx = ability_ctx(&services, &provider);
 
-        let output = account_overview(&ctx, input())
+        let output = project_overview(&ctx, input())
             .await
-            .expect("mixed claim and snapshot account overview succeeds");
-        let composition = output.data();
-        let value_section = composition
-            .sections
-            .iter()
-            .find(|section| section.id.as_str() == "value-commitments")
-            .expect("value commitments section");
+            .expect("snapshot degradation still renders claims");
+        let headline = &output.data().sections[0].blocks[0];
 
-        assert!(
-            value_section
-                .blocks
-                .iter()
-                .any(|block| block.block_type == BlockType::ClaimSummary
-                    && block.attributes.pointer("/text").and_then(Value::as_str)
-                        == Some("Adoption milestone shipped")),
-            "claim evidence remains renderable"
+        assert_eq!(committer.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            headline
+                .attributes
+                .pointer("/snapshot_degraded")
+                .and_then(Value::as_str),
+            Some("project_snapshot_unavailable")
         );
-        assert!(
-            value_section
-                .blocks
-                .iter()
-                .any(|block| block.block_type == BlockType::EvidenceList
-                    && block.attributes.to_string().contains("Growth potential")),
-            "snapshot evidence remains renderable beside claims"
-        );
-    }
-
-    #[tokio::test]
-    async fn recommendation_claims_render_as_work_actions() {
-        let claims = vec![claim(
-            "claim-recommendation",
-            "recommendation",
-            "/recommendations/review",
-            "Review the launch plan with the account owner",
-            Some(0.88),
-            Some("2026-05-14T09:00:00Z"),
-            ClaimSensitivity::Internal,
-        )];
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("recommendation-backed account overview succeeds");
-        let composition = output.data();
-
-        for section_id in ["whats-next", "the-work"] {
-            let section = composition
-                .sections
-                .iter()
-                .find(|section| section.id.as_str() == section_id)
-                .expect("work section exists");
-            let block = section
-                .blocks
-                .iter()
-                .find(|block| {
-                    block.block_type == BlockType::ActionList
-                        && block
-                            .attributes
-                            .pointer("/claim_type")
-                            .and_then(Value::as_str)
-                            == Some("recommendation")
-                        && block
-                            .attributes
-                            .pointer("/items/0/text")
-                            .and_then(Value::as_str)
-                            == Some("Review the launch plan with the account owner")
-                })
-                .expect("recommendation is rendered as a work action");
-
-            assert!(block
-                .claim_refs
-                .iter()
-                .any(|claim_ref| claim_ref.claim_id == "claim-recommendation"));
-            assert!(block.field_bindings.iter().any(|binding| {
-                binding.role == BindingRole::FeedbackTarget
-                    && binding.field_path.as_str() == "/items/0/text"
-                    && !binding.claim_refs.is_empty()
-            }));
-            assert_eq!(
-                block
-                    .attributes
-                    .pointer("/trust_band")
-                    .and_then(Value::as_str),
-                Some("likely_current"),
-                "work action blocks expose block-level trust for the shell badge"
-            );
-            assert_eq!(
-                block
-                    .attributes
-                    .pointer("/source_asof")
-                    .and_then(Value::as_str),
-                Some("2026-05-14T09:00:00Z"),
-                "work action blocks expose block-level freshness for the shell"
-            );
-        }
-
-        let proj_ctx = FallbackProjectionContext::new(
-            Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
-                scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
-                )])
-                .expect("scope set"),
-            },
-            SurfaceKind::SurfaceClient,
-            3,
-        );
-        let (projected, _audits) = project_composition_for_surface(composition, &proj_ctx)
-            .expect("projected recommendation action preserves shell metadata");
-
-        for section_id in ["whats-next", "the-work"] {
-            let section = projected
-                .sections
-                .iter()
-                .find(|section| section.section_id.as_str() == section_id)
-                .expect("projected work section exists");
-            let projected_block = section
-                .block_indexes
-                .iter()
-                .filter_map(|index| projected.blocks.get(*index as usize))
-                .find(|block| {
-                    block.payload.pointer("/claim_type").and_then(Value::as_str)
-                        == Some("recommendation")
-                })
-                .expect("projected recommendation work action exists");
-
-            assert_eq!(
-                projected_block
-                    .payload
-                    .pointer("/trust_band")
-                    .and_then(Value::as_str),
-                Some("likely_current"),
-                "projection must preserve block-level trust for the renderer shell"
-            );
-            assert_eq!(
-                projected_block
-                    .payload
-                    .pointer("/source_asof")
-                    .and_then(Value::as_str),
-                Some("2026-05-14T09:00:00Z"),
-                "projection must preserve block-level freshness for the renderer shell"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn pure_builder_output_is_deterministic_without_commit() {
-        let claims = vec![
-            claim(
-                "claim-b",
-                "entity_win",
-                "/wins/latest",
-                "Stable win",
-                Some(0.91),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-a",
-                "entity_risk",
-                "/risk/current",
-                "Stable risk",
-                Some(0.91),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-        ];
-        let first = prepared_json(claims.clone()).await;
-        let second = prepared_json(claims).await;
-
-        assert_eq!(first, second);
-        assert!(!first.to_string().contains("Acme"));
-    }
-
-    async fn prepared_json(claims: Vec<IntelligenceClaim>) -> Value {
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-        let normalized = normalize_input(input()).expect("input normalizes");
-        let prepared = prepare_account_overview(&ctx, &normalized)
-            .await
-            .expect("proposal builds");
-        let output = prepared
-            .provenance_builder
-            .finalize(prepared.proposal.composition)
-            .expect("provenance finalizes");
-        output_json(&output)
-    }
-
-    // Asserts producer output passes fallback_projection's binding validator
-    // without BindingTargetsUnknownField. Covers the producer→projection
-    // contract that wasn't exercised by either side's isolated test suite.
-    #[tokio::test]
-    async fn dos670_producer_output_passes_w4d_projection() {
-        let claims = vec![
-            claim(
-                "claim-risk",
-                "entity_risk",
-                "/risk/current",
-                "Implementation risk is rising",
-                Some(0.97),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-win",
-                "entity_win",
-                "/wins/latest",
-                "Renewal path is clearer",
-                Some(0.92),
-                Some("2026-05-14T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-commitment",
-                "commitment",
-                "/commitments/next",
-                "Follow up on launch checklist",
-                Some(0.85),
-                Some("2026-05-01T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-            claim(
-                "claim-context",
-                "company_context",
-                "/company/industry",
-                "Fixture Account operates in software",
-                Some(0.96),
-                Some("2026-03-01T09:00:00Z"),
-                ClaimSensitivity::Internal,
-            ),
-        ];
-        let (clock, rng, external, reader, committer, provider) = fixture_parts(claims);
-        let services = services(&clock, &rng, &external, reader, committer);
-        let ctx = ability_ctx(&services, &provider);
-
-        let output = account_overview(&ctx, input())
-            .await
-            .expect("account overview succeeds");
-        let composition = output.data();
-
-        let proj_ctx = FallbackProjectionContext::new(
-            Actor::SurfaceClient {
-                instance: crate::abilities::registry::SurfaceClientId::new("sc_fixture"),
-                scopes: ScopeSet::new([crate::abilities::registry::SurfaceScope::new(
-                    "read.account_overview",
-                )])
-                .expect("scope set"),
-            },
-            SurfaceKind::SurfaceClient,
-            3,
-        );
-
-        let (projected, _audits) = project_composition_for_surface(composition, &proj_ctx)
-            .expect("projection must accept producer output (DOS-670 contract)");
-
-        assert!(
-            !projected.blocks.is_empty(),
-            "projected composition must contain at least one block"
-        );
-
-        let claim_text_rendered = projected.blocks.iter().any(|block| {
-            block.payload.pointer("/text").is_some()
-                || block.payload.pointer("/items/0/text").is_some()
-                || block.payload.pointer("/nodes/0/text").is_some()
-        });
-        assert!(
-            claim_text_rendered,
-            "projected payload must surface claim text from producer attributes"
-        );
-
-        let trust_band_rendered = projected.blocks.iter().any(|block| {
-            block.payload.pointer("/trust_band").is_some()
-                || block.payload.pointer("/items/0/trust_band").is_some()
-                || block.payload.pointer("/nodes/0/trust_band").is_some()
-        });
-        assert!(
-            trust_band_rendered,
-            "projected payload must surface trust_band from producer attributes"
-        );
+        assert!(output_json(&output).to_string().contains("claim-win"));
     }
 }

--- a/src-tauri/abilities-runtime/src/abilities/provenance/ownership.rs
+++ b/src-tauri/abilities-runtime/src/abilities/provenance/ownership.rs
@@ -664,6 +664,7 @@ fn subject_contains_id(subject: &SubjectRef, id: &str) -> bool {
         SubjectRef::Account(value)
         | SubjectRef::Project(value)
         | SubjectRef::Person(value)
+        | SubjectRef::Action(value)
         | SubjectRef::Meeting(value)
         | SubjectRef::User(value) => value == id,
         SubjectRef::Multi(subjects) => subjects
@@ -762,6 +763,7 @@ fn subject_from_input_json(input_json: &Value) -> Option<SubjectRef> {
         .or_else(|| string_field(input_json, "account_id").map(SubjectRef::Account))
         .or_else(|| string_field(input_json, "project_id").map(SubjectRef::Project))
         .or_else(|| string_field(input_json, "person_id").map(SubjectRef::Person))
+        .or_else(|| string_field(input_json, "action_id").map(SubjectRef::Action))
         .or_else(|| string_field(input_json, "meeting_id").map(SubjectRef::Meeting))
         .or_else(|| string_field(input_json, "user_id").map(SubjectRef::User))
 }
@@ -802,6 +804,7 @@ fn subject_from_kind_and_id(kind: &str, id: &str) -> Option<SubjectRef> {
         "account" | "accounts" => Some(SubjectRef::Account(id.to_string())),
         "project" | "projects" => Some(SubjectRef::Project(id.to_string())),
         "person" | "people" => Some(SubjectRef::Person(id.to_string())),
+        "action" | "actions" => Some(SubjectRef::Action(id.to_string())),
         "meeting" | "meetings" => Some(SubjectRef::Meeting(id.to_string())),
         "user" | "users" => Some(SubjectRef::User(id.to_string())),
         "global" => Some(SubjectRef::Global),
@@ -1035,4 +1038,33 @@ fn redacted_hash(value: &str) -> String {
     hasher.update(value.as_bytes());
     let digest = hasher.finalize();
     hex::encode(&digest[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn subject_from_input_json_accepts_action_id() {
+        assert_eq!(
+            subject_from_input_json(&json!({ "action_id": "action-1" })),
+            Some(SubjectRef::Action("action-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn subject_from_entity_fields_accepts_action_kind_without_entity_type_promotion() {
+        assert_eq!(
+            subject_from_input_json(
+                &json!({ "entity_type": "action", "entity_id": "action-entity-1" })
+            ),
+            Some(SubjectRef::Action("action-entity-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn subject_from_kind_and_id_rejects_empty_action_ids() {
+        assert_eq!(subject_from_kind_and_id("action", " "), None);
+    }
 }

--- a/src-tauri/abilities-runtime/src/abilities/provenance/subject.rs
+++ b/src-tauri/abilities-runtime/src/abilities/provenance/subject.rs
@@ -9,6 +9,7 @@ pub enum SubjectRef {
     Account(String),
     Project(String),
     Person(String),
+    Action(String),
     Meeting(String),
     User(String),
     Global,

--- a/src-tauri/abilities-runtime/src/abilities/source_management_ledger/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/source_management_ledger/producer.rs
@@ -46,7 +46,9 @@ pub async fn source_management_action(
     finalize_action_output(ctx, schema_version, receipt)
 }
 
-fn authorize(ctx: &AbilityContext<'_>) -> Result<SourceManagementLedgerPrivacyProfile, AbilityError> {
+fn authorize(
+    ctx: &AbilityContext<'_>,
+) -> Result<SourceManagementLedgerPrivacyProfile, AbilityError> {
     match &ctx.actor {
         Actor::SurfaceClient { scopes, .. } => {
             if !scopes.contains(&SurfaceScope::new("read.workspace_sources")) {
@@ -161,7 +163,10 @@ fn provenance_config(ctx: &AbilityContext<'_>, schema_version: u32) -> Provenanc
     config
 }
 
-fn provenance_action_config(ctx: &AbilityContext<'_>, schema_version: u32) -> ProvenanceBuilderConfig {
+fn provenance_action_config(
+    ctx: &AbilityContext<'_>,
+    schema_version: u32,
+) -> ProvenanceBuilderConfig {
     let mut config =
         ProvenanceBuilderConfig::new("source_management_action", ctx.services().clock.now());
     config.ability_version = AbilityVersion::new(1, 0);

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -868,6 +868,9 @@ pub struct ServiceContext<'a> {
     meeting_prep_status_reader: Option<Arc<dyn MeetingPrepStatusReadHandle>>,
     claim_receipt_reader: Option<Arc<dyn ClaimReceiptReadHandle>>,
     account_composition_snapshot_reader: Option<Arc<dyn AccountCompositionSnapshotReadHandle>>,
+    project_composition_snapshot_reader: Option<Arc<dyn ProjectCompositionSnapshotReadHandle>>,
+    person_composition_snapshot_reader: Option<Arc<dyn PersonCompositionSnapshotReadHandle>>,
+    action_composition_snapshot_reader: Option<Arc<dyn ActionCompositionSnapshotReadHandle>>,
     account_list_reader: Option<Arc<dyn AccountListReadHandle>>,
     person_list_reader: Option<Arc<dyn PersonListReadHandle>>,
     project_list_reader: Option<Arc<dyn ProjectListReadHandle>>,
@@ -1037,6 +1040,137 @@ pub trait AccountCompositionSnapshotReadHandle: Send + Sync {
         account_id: String,
         surface: ClaimDismissalSurface,
     ) -> AccountCompositionSnapshotReadFuture<'a>;
+}
+
+pub type ProjectCompositionSnapshotSensitivity = AccountCompositionSnapshotSensitivity;
+pub type ProjectCompositionProvenanceKind = AccountCompositionProvenanceKind;
+pub type ProjectCompositionSnapshotField = AccountCompositionSnapshotField;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProjectCompositionSnapshot {
+    pub project_id: String,
+    pub display_name: ProjectCompositionSnapshotField,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ProjectCompositionSnapshotField>,
+    pub is_parent: bool,
+    #[serde(default)]
+    pub fields: Vec<ProjectCompositionSnapshotField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProjectCompositionSnapshotReadError {
+    #[error("project not found: {0}")]
+    ProjectNotFound(String),
+    #[error("project composition snapshot read failed: {0}")]
+    ReadFailed(String),
+}
+
+pub type ProjectCompositionSnapshotReadFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ProjectCompositionSnapshot, ProjectCompositionSnapshotReadError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Service-owned Project page input bundle for non-claim display facts.
+/// Implementations must wrap every non-identity field with sensitivity,
+/// source/freshness, trust, and provenance metadata before ability code may
+/// render it.
+pub trait ProjectCompositionSnapshotReadHandle: Send + Sync {
+    fn read_project_composition_snapshot<'a>(
+        &'a self,
+        project_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> ProjectCompositionSnapshotReadFuture<'a>;
+}
+
+pub type PersonCompositionSnapshotSensitivity = AccountCompositionSnapshotSensitivity;
+pub type PersonCompositionProvenanceKind = AccountCompositionProvenanceKind;
+pub type PersonCompositionSnapshotField = AccountCompositionSnapshotField;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct PersonCompositionSnapshot {
+    pub person_id: String,
+    pub display_name: PersonCompositionSnapshotField,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relationship: Option<PersonCompositionSnapshotField>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<PersonCompositionSnapshotField>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<PersonCompositionSnapshotField>,
+    #[serde(default)]
+    pub fields: Vec<PersonCompositionSnapshotField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PersonCompositionSnapshotReadError {
+    #[error("person not found: {0}")]
+    PersonNotFound(String),
+    #[error("person composition snapshot read failed: {0}")]
+    ReadFailed(String),
+}
+
+pub type PersonCompositionSnapshotReadFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<PersonCompositionSnapshot, PersonCompositionSnapshotReadError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Service-owned Person page input bundle for non-claim display facts.
+/// Implementations must wrap every non-identity field with sensitivity,
+/// source/freshness, trust, and provenance metadata before ability code may
+/// render it.
+pub trait PersonCompositionSnapshotReadHandle: Send + Sync {
+    fn read_person_composition_snapshot<'a>(
+        &'a self,
+        person_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> PersonCompositionSnapshotReadFuture<'a>;
+}
+
+pub type ActionCompositionSnapshotSensitivity = AccountCompositionSnapshotSensitivity;
+pub type ActionCompositionProvenanceKind = AccountCompositionProvenanceKind;
+pub type ActionCompositionSnapshotField = AccountCompositionSnapshotField;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ActionCompositionSnapshot {
+    pub action_id: String,
+    pub title: ActionCompositionSnapshotField,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ActionCompositionSnapshotField>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<ActionCompositionSnapshotField>,
+    #[serde(default)]
+    pub fields: Vec<ActionCompositionSnapshotField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ActionCompositionSnapshotReadError {
+    #[error("action not found: {0}")]
+    ActionNotFound(String),
+    #[error("action composition snapshot read failed: {0}")]
+    ReadFailed(String),
+}
+
+pub type ActionCompositionSnapshotReadFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ActionCompositionSnapshot, ActionCompositionSnapshotReadError>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// Service-owned Action Detail input bundle for non-claim display facts.
+/// Action is a first-class composition subject, not a generic entity type.
+pub trait ActionCompositionSnapshotReadHandle: Send + Sync {
+    fn read_action_composition_snapshot<'a>(
+        &'a self,
+        action_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> ActionCompositionSnapshotReadFuture<'a>;
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -2126,6 +2260,9 @@ impl<'a> ServiceContext<'a> {
             meeting_prep_status_reader: None,
             claim_receipt_reader: None,
             account_composition_snapshot_reader: None,
+            project_composition_snapshot_reader: None,
+            person_composition_snapshot_reader: None,
+            action_composition_snapshot_reader: None,
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
@@ -2168,6 +2305,9 @@ impl<'a> ServiceContext<'a> {
             meeting_prep_status_reader: None,
             claim_receipt_reader: None,
             account_composition_snapshot_reader: None,
+            project_composition_snapshot_reader: None,
+            person_composition_snapshot_reader: None,
+            action_composition_snapshot_reader: None,
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
@@ -2221,6 +2361,9 @@ impl<'a> ServiceContext<'a> {
             meeting_prep_status_reader: None,
             claim_receipt_reader: None,
             account_composition_snapshot_reader: None,
+            project_composition_snapshot_reader: None,
+            person_composition_snapshot_reader: None,
+            action_composition_snapshot_reader: None,
             account_list_reader: None,
             person_list_reader: None,
             project_list_reader: None,
@@ -2344,6 +2487,30 @@ impl<'a> ServiceContext<'a> {
         reader: Arc<dyn AccountCompositionSnapshotReadHandle>,
     ) -> Self {
         self.account_composition_snapshot_reader = Some(reader);
+        self
+    }
+
+    pub fn with_project_composition_snapshot_reader(
+        mut self,
+        reader: Arc<dyn ProjectCompositionSnapshotReadHandle>,
+    ) -> Self {
+        self.project_composition_snapshot_reader = Some(reader);
+        self
+    }
+
+    pub fn with_person_composition_snapshot_reader(
+        mut self,
+        reader: Arc<dyn PersonCompositionSnapshotReadHandle>,
+    ) -> Self {
+        self.person_composition_snapshot_reader = Some(reader);
+        self
+    }
+
+    pub fn with_action_composition_snapshot_reader(
+        mut self,
+        reader: Arc<dyn ActionCompositionSnapshotReadHandle>,
+    ) -> Self {
+        self.action_composition_snapshot_reader = Some(reader);
         self
     }
 
@@ -2504,6 +2671,51 @@ impl<'a> ServiceContext<'a> {
         };
         reader
             .read_account_composition_snapshot(account_id, surface)
+            .await
+    }
+
+    pub async fn read_project_composition_snapshot(
+        &self,
+        project_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> Result<ProjectCompositionSnapshot, ProjectCompositionSnapshotReadError> {
+        let Some(reader) = &self.project_composition_snapshot_reader else {
+            return Err(ProjectCompositionSnapshotReadError::ReadFailed(
+                self.missing_reader_error("project_composition_snapshot_reader"),
+            ));
+        };
+        reader
+            .read_project_composition_snapshot(project_id, surface)
+            .await
+    }
+
+    pub async fn read_person_composition_snapshot(
+        &self,
+        person_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> Result<PersonCompositionSnapshot, PersonCompositionSnapshotReadError> {
+        let Some(reader) = &self.person_composition_snapshot_reader else {
+            return Err(PersonCompositionSnapshotReadError::ReadFailed(
+                self.missing_reader_error("person_composition_snapshot_reader"),
+            ));
+        };
+        reader
+            .read_person_composition_snapshot(person_id, surface)
+            .await
+    }
+
+    pub async fn read_action_composition_snapshot(
+        &self,
+        action_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> Result<ActionCompositionSnapshot, ActionCompositionSnapshotReadError> {
+        let Some(reader) = &self.action_composition_snapshot_reader else {
+            return Err(ActionCompositionSnapshotReadError::ReadFailed(
+                self.missing_reader_error("action_composition_snapshot_reader"),
+            ));
+        };
+        reader
+            .read_action_composition_snapshot(action_id, surface)
             .await
     }
 
@@ -2887,7 +3099,10 @@ fn entity_context_entry_for_claim(claim: IntelligenceClaim) -> Result<EntityCont
         ClaimSubjectRef::Person { id } => ("person".to_string(), id),
         ClaimSubjectRef::Project { id } => ("project".to_string(), id),
         ClaimSubjectRef::Meeting { id } => ("meeting".to_string(), id),
-        ClaimSubjectRef::Email { .. } | ClaimSubjectRef::Multi(_) | ClaimSubjectRef::Global => {
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Email { .. }
+        | ClaimSubjectRef::Multi(_)
+        | ClaimSubjectRef::Global => {
             return Err(format!(
                 "Claim `{}` has unsupported entity context subject",
                 claim.id

--- a/src-tauri/abilities-runtime/src/types.rs
+++ b/src-tauri/abilities-runtime/src/types.rs
@@ -140,6 +140,7 @@ pub struct EntityContextEntry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClaimSubjectRef {
     Account { id: String },
+    Action { id: String },
     Meeting { id: String },
     Person { id: String },
     Project { id: String },
@@ -159,6 +160,9 @@ pub fn subject_ref_from_json(value: &serde_json::Value) -> Result<ClaimSubjectRe
 
     match kind.as_str() {
         "account" | "accounts" => Ok(ClaimSubjectRef::Account {
+            id: subject_id(value)?,
+        }),
+        "action" | "actions" => Ok(ClaimSubjectRef::Action {
             id: subject_id(value)?,
         }),
         "meeting" | "meetings" => Ok(ClaimSubjectRef::Meeting {

--- a/src-tauri/src/commands/abilities.rs
+++ b/src-tauri/src/commands/abilities.rs
@@ -21,7 +21,8 @@ use crate::bridges::{
 };
 use crate::observability::aggregate_metric::{MetricDimensions, MetricValue, Outcome};
 use crate::services::composition_render_orchestrator::{
-    project_composition_for_surface, resolve_producer_ability_name,
+    project_composition_for_surface_with_options, resolve_producer_ability_name,
+    ProjectCompositionRenderOptions,
 };
 use crate::state::AppState;
 
@@ -130,6 +131,7 @@ pub async fn get_projected_composition(
     composition_id: String,
     composition_version: Option<i64>,
     cache_hint_token: Option<String>,
+    force_refresh: Option<bool>,
 ) -> Result<ProjectedCompositionCommandResponse, BridgeSurfaceError> {
     let _ = composition_version;
     let _ = cache_hint_token;
@@ -153,11 +155,14 @@ pub async fn get_projected_composition(
         .ok_or(BridgeSurfaceError::AbilityUnavailable)?;
 
     let app_state = state.inner().clone();
-    let render = match project_composition_for_surface(
+    let render = match project_composition_for_surface_with_options(
         app_state.as_ref(),
         Actor::User,
         SurfaceKind::TauriApp,
         &composition_id,
+        ProjectCompositionRenderOptions {
+            force_refresh: force_refresh.unwrap_or(false),
+        },
         |producer_input| {
             let input = producer_input.to_json();
             let app_state = app_state.clone();

--- a/src-tauri/src/db/claim_invalidation.rs
+++ b/src-tauri/src/db/claim_invalidation.rs
@@ -9,14 +9,14 @@
 //! Architecture:
 //!
 //! - **Per-entity** `claim_version` on `accounts`, `projects`, `people`,
-//!   `meetings_history`. Bumped synchronously inside the same transaction
+//!   `meetings`, `emails`, and `actions`. Bumped synchronously inside the same transaction
 //!   as the claim write (`services::claims::commit_claim` calls into this module).
 //!   Readers check `entity.claim_version` off the row they already loaded
 //!   — no extra query.
 //!
 //! - **`SubjectRef::Multi`** uses deterministic lock ordering: claim subjects
 //!   are sorted by `(entity_type_order, id)` lexicographically with precedence
-//!   `Account < Meeting < Person < Project` before bumping. SQLite's serialized
+//!   `Account < Meeting < Person < Project < Email < Action` before bumping. SQLite's serialized
 //!   writer + `BEGIN IMMEDIATE` makes concurrent transactions safe; the sort
 //!   gives deterministic update ordering.
 //!
@@ -44,7 +44,7 @@ use crate::db::{ActionDb, DbError};
 /// claim's `subject_ref` JSON column and passes to `bump_for_subject`.
 ///
 /// Variants are listed in the entity-type lock-order precedence:
-/// `Account < Meeting < Person < Project`. The `Multi` variant carries a
+/// `Account < Meeting < Person < Project < Email < Action`. The `Multi` variant carries a
 /// `Vec<SubjectRef>` that is sorted via `entity_type_order()` + `id` before
 /// bumping, providing deterministic update ordering across concurrent commits.
 ///
@@ -76,6 +76,11 @@ pub enum SubjectRef {
     Email {
         id: String,
     },
+    /// First-class action subjects for action-detail claim-backed surfaces.
+    /// Bumps `actions.claim_version` (added by migration v276).
+    Action {
+        id: String,
+    },
     /// Multiple entities affected by one claim. Sorted before bumping.
     Multi(Vec<SubjectRef>),
     /// v1.4.1+ only; bumps `migration_state.global_claim_epoch` instead of
@@ -94,7 +99,7 @@ pub enum SubjectRef {
 }
 
 impl SubjectRef {
-    /// Lock-order precedence: `Account < Meeting < Person < Project`. Used
+    /// Lock-order precedence: `Account < Meeting < Person < Project < Email < Action`. Used
     /// to sort `Multi` subjects before bumping so concurrent commits with
     /// reversed orderings produce deterministic update sequences.
     ///
@@ -107,6 +112,7 @@ impl SubjectRef {
             Self::Person { .. } => 2,
             Self::Project { .. } => 3,
             Self::Email { .. } => 4,
+            Self::Action { .. } => 5,
             Self::Multi(_) | Self::Global => {
                 debug_assert!(
                     false,
@@ -123,7 +129,8 @@ impl SubjectRef {
             | Self::Meeting { id }
             | Self::Person { id }
             | Self::Project { id }
-            | Self::Email { id } => id.as_str(),
+            | Self::Email { id }
+            | Self::Action { id } => id.as_str(),
             Self::Multi(_) | Self::Global => "",
         }
     }
@@ -149,6 +156,7 @@ impl ActionDb {
             SubjectRef::Person { id } => ("people", "id", id.as_str()),
             SubjectRef::Meeting { id } => ("meetings", "id", id.as_str()),
             SubjectRef::Email { id } => ("emails", "email_id", id.as_str()),
+            SubjectRef::Action { id } => ("actions", "id", id.as_str()),
             SubjectRef::Multi(_) | SubjectRef::Global => {
                 return Err(DbError::InvalidArgument(
                     "bump_entity_claim_version called with Multi/Global; \
@@ -199,7 +207,8 @@ impl ActionDb {
             | SubjectRef::Project { .. }
             | SubjectRef::Person { .. }
             | SubjectRef::Meeting { .. }
-            | SubjectRef::Email { .. } => {
+            | SubjectRef::Email { .. }
+            | SubjectRef::Action { .. } => {
                 self.bump_entity_claim_version(subject)?;
                 Ok(())
             }
@@ -296,6 +305,15 @@ mod tests {
             .expect("seed meeting");
     }
 
+    fn seed_action(db: &ActionDb, id: &str) {
+        db.conn_ref()
+            .execute(
+                "INSERT INTO actions (id, title, created_at, updated_at) VALUES (?1, ?2, ?3, ?3)",
+                params![id, format!("action-{}", id), TS],
+            )
+            .expect("seed action");
+    }
+
     fn read_claim_version(db: &ActionDb, table: &str, id: &str) -> i64 {
         let sql = format!("SELECT claim_version FROM {} WHERE id = ?1", table);
         db.conn_ref()
@@ -344,6 +362,7 @@ mod tests {
         seed_project(&db, "p");
         seed_person(&db, "ps");
         seed_meeting(&db, "m");
+        seed_action(&db, "act");
 
         db.bump_entity_claim_version(&SubjectRef::Account { id: "a".into() })
             .unwrap();
@@ -353,11 +372,14 @@ mod tests {
             .unwrap();
         db.bump_entity_claim_version(&SubjectRef::Meeting { id: "m".into() })
             .unwrap();
+        db.bump_entity_claim_version(&SubjectRef::Action { id: "act".into() })
+            .unwrap();
 
         assert_eq!(read_claim_version(&db, "accounts", "a"), 1);
         assert_eq!(read_claim_version(&db, "projects", "p"), 1);
         assert_eq!(read_claim_version(&db, "people", "ps"), 1);
         assert_eq!(read_claim_version(&db, "meetings", "m"), 1);
+        assert_eq!(read_claim_version(&db, "actions", "act"), 1);
     }
 
     #[test]

--- a/src-tauri/src/db/core.rs
+++ b/src-tauri/src/db/core.rs
@@ -471,11 +471,7 @@ impl ActionDb {
         // budget_violations counter surfaces routine contention. The 250 ms
         // AC threshold is captured by the separate `_over_250ms` rollup below.
         let gate_wait_ms = gate_started.elapsed().as_millis();
-        crate::latency::record_latency(
-            "action_db.write_transaction_gate_wait",
-            gate_wait_ms,
-            100,
-        );
+        crate::latency::record_latency("action_db.write_transaction_gate_wait", gate_wait_ms, 100);
         // Dedicated rollup for the AC4 threshold (zero gate-waits > 250 ms at
         // user-active times). Records only when above the threshold so the
         // rollup's sample count IS the violation count.

--- a/src-tauri/src/db/invalidation_jobs.rs
+++ b/src-tauri/src/db/invalidation_jobs.rs
@@ -379,6 +379,7 @@ impl ActionDb {
             "person" => Some(("people", "id")),
             "meeting" => Some(("meetings", "id")),
             "email" => Some(("emails", "email_id")),
+            "action" => Some(("actions", "id")),
             "global" => {
                 return self
                     .conn_ref()

--- a/src-tauri/src/db_backup.rs
+++ b/src-tauri/src/db_backup.rs
@@ -738,7 +738,9 @@ mod tests {
         // 1024 pages * 4 KB = 4 MB; seed with 8 MB worth of payload so the copy
         // requires at least two chunked-step iterations.
         let payload = vec![0xA5_u8; 8192];
-        let mut stmt = src.prepare("INSERT INTO rows (payload) VALUES (?1)").expect("prep");
+        let mut stmt = src
+            .prepare("INSERT INTO rows (payload) VALUES (?1)")
+            .expect("prep");
         for _ in 0..1024 {
             stmt.execute([&payload]).expect("insert");
         }

--- a/src-tauri/src/db_service.rs
+++ b/src-tauri/src/db_service.rs
@@ -698,9 +698,8 @@ impl DbService {
     /// the call returns without truncating and we try again next interval.
     fn spawn_checkpoint_task(weak_svc: std::sync::Weak<DbService>) {
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(
-                WAL_CHECKPOINT_INTERVAL_SECS,
-            ));
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(WAL_CHECKPOINT_INTERVAL_SECS));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             // First tick fires immediately; consume it so the first real
             // checkpoint happens one interval after open, not at t=0.

--- a/src-tauri/src/demo.rs
+++ b/src-tauri/src/demo.rs
@@ -181,8 +181,8 @@ pub fn install_demo(db: &ActionDb, workspace: Option<&Path>) -> Result<(), Strin
     for (id, title, priority, status, account_id, due_date, context) in &actions {
         conn.execute(
             "INSERT OR REPLACE INTO actions (id, title, priority, status, created_at, due_date, \
-             account_id, context, updated_at, is_demo) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
+             account_id, context, updated_at, is_demo, claim_version) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, 0)",
             rusqlite::params![
                 id, title, priority, status, &today, due_date, account_id, context, &today
             ],
@@ -697,18 +697,18 @@ pub fn install_demo(db: &ActionDb, workspace: Option<&Path>) -> Result<(), Strin
 
     // Transcript-extracted actions for demo meetings
     conn.execute_batch(
-        "INSERT OR IGNORE INTO actions (id, title, status, priority, source_type, source_id, account_id, created_at, updated_at, is_demo) VALUES
+        "INSERT OR IGNORE INTO actions (id, title, status, priority, source_type, source_id, account_id, created_at, updated_at, is_demo, claim_version) VALUES
          -- Today's meetings
-         ('demo-act-at1', 'Deliver ROI analysis deck to Acme CFO', 'backlog', 1, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1),
-         ('demo-act-at2', 'Build custom billing report template for Acme', 'backlog', 1, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1),
-         ('demo-act-at3', 'Schedule billing team training session', 'backlog', 3, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1),
-         ('demo-act-gt1', 'Create Team B 30-60-90 re-engagement plan', 'backlog', 1, 'transcript', 'demo-mtg-globex', 'demo-globex', datetime('now'), datetime('now'), 1),
-         ('demo-act-gt2', 'Complete champion context transfer to Casey Kim', 'backlog', 1, 'transcript', 'demo-mtg-globex', 'demo-globex', datetime('now'), datetime('now'), 1),
+         ('demo-act-at1', 'Deliver ROI analysis deck to Acme CFO', 'backlog', 1, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1, 0),
+         ('demo-act-at2', 'Build custom billing report template for Acme', 'backlog', 1, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1, 0),
+         ('demo-act-at3', 'Schedule billing team training session', 'backlog', 3, 'transcript', 'demo-mtg-acme', 'demo-acme', datetime('now'), datetime('now'), 1, 0),
+         ('demo-act-gt1', 'Create Team B 30-60-90 re-engagement plan', 'backlog', 1, 'transcript', 'demo-mtg-globex', 'demo-globex', datetime('now'), datetime('now'), 1, 0),
+         ('demo-act-gt2', 'Complete champion context transfer to Casey Kim', 'backlog', 1, 'transcript', 'demo-mtg-globex', 'demo-globex', datetime('now'), datetime('now'), 1, 0),
          -- Historical meetings
-         ('demo-act-a1', 'Send updated ROI analysis to Acme', 'completed', 1, 'transcript', 'demo-mh-acme-7d', 'demo-acme', datetime('now', '-7 days'), datetime('now', '-3 days'), 1),
-         ('demo-act-a2', 'Schedule billing team feedback session', 'unstarted', 1, 'transcript', 'demo-mh-acme-7d', 'demo-acme', datetime('now', '-7 days'), datetime('now', '-7 days'), 1),
-         ('demo-act-g1', 'Coordinate Team B enablement workshop', 'unstarted', 1, 'transcript', 'demo-mh-globex-14d', 'demo-globex', datetime('now', '-14 days'), datetime('now', '-14 days'), 1),
-         ('demo-act-g2', 'Draft champion transition plan for Casey Kim', 'unstarted', 3, 'transcript', 'demo-mh-globex-14d', 'demo-globex', datetime('now', '-14 days'), datetime('now', '-14 days'), 1);"
+         ('demo-act-a1', 'Send updated ROI analysis to Acme', 'completed', 1, 'transcript', 'demo-mh-acme-7d', 'demo-acme', datetime('now', '-7 days'), datetime('now', '-3 days'), 1, 0),
+         ('demo-act-a2', 'Schedule billing team feedback session', 'unstarted', 1, 'transcript', 'demo-mh-acme-7d', 'demo-acme', datetime('now', '-7 days'), datetime('now', '-7 days'), 1, 0),
+         ('demo-act-g1', 'Coordinate Team B enablement workshop', 'unstarted', 1, 'transcript', 'demo-mh-globex-14d', 'demo-globex', datetime('now', '-14 days'), datetime('now', '-14 days'), 1, 0),
+         ('demo-act-g2', 'Draft champion transition plan for Casey Kim', 'unstarted', 3, 'transcript', 'demo-mh-globex-14d', 'demo-globex', datetime('now', '-14 days'), datetime('now', '-14 days'), 1, 0);"
     ).ok();
 
     // Seed health score history for trend computation demo

--- a/src-tauri/src/granola/poller.rs
+++ b/src-tauri/src/granola/poller.rs
@@ -394,15 +394,8 @@ fn process_granola_document(
             reason = "intentional best-effort discard; preserves existing non-blocking behavior"
         )]
         // dos7-allowed: transcript-db-write - transcript sync-state write; not workspace-file ingestion
-        let _ = crate::quill::sync::transition_state(
-            db,
-            sync_id,
-            "processing",
-            None,
-            None,
-            None,
-            None,
-        );
+        let _ =
+            crate::quill::sync::transition_state(db, sync_id, "processing", None, None, None, None);
 
         Ok((calendar_event, workspace, profile, ai_config))
     })?; // DB lock dropped

--- a/src-tauri/src/latency.rs
+++ b/src-tauri/src/latency.rs
@@ -224,9 +224,7 @@ pub fn snapshot_for_persistence() -> LatencyPersistentSnapshot {
 pub fn apply_persistent_snapshot(snapshot: LatencyPersistentSnapshot) {
     static HYDRATED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
     if HYDRATED.set(()).is_err() {
-        log::debug!(
-            "latency hydrate skipped: already applied in this process (snapshot dropped)"
-        );
+        log::debug!("latency hydrate skipped: already applied in this process (snapshot dropped)");
         return;
     }
     let mut windows = LatencyRecorder::global().windows.lock();

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1111,6 +1111,13 @@ const MIGRATIONS: &[Migration] = &[
         version: 275,
         sql: include_str!("migrations/275_composition_layout_overlays.sql"),
     },
+    // v1.5.0 W3 — Action Detail uses first-class Action claim subjects, so
+    // actions need the same per-subject invalidation watermark as other claim
+    // subjects.
+    Migration::Sql {
+        version: 276,
+        sql: include_str!("migrations/276_action_claim_version.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;

--- a/src-tauri/src/migrations/276_action_claim_version.sql
+++ b/src-tauri/src/migrations/276_action_claim_version.sql
@@ -1,0 +1,5 @@
+-- Add per-action claim_version so first-class Action subjects participate
+-- in the same claim invalidation and repair machinery as Account, Project,
+-- Person, Meeting, and Email subjects.
+
+ALTER TABLE actions ADD COLUMN claim_version INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/services/actions.rs
+++ b/src-tauri/src/services/actions.rs
@@ -102,6 +102,30 @@ fn sync_action_claim_after_mutation(
     }
 }
 
+fn emit_action_composition_field_changed_signal(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    action_id: &str,
+    field: &str,
+    value: serde_json::Value,
+) {
+    let payload = serde_json::json!({
+        "field": field,
+        "value": value,
+    })
+    .to_string();
+    crate::services::signals::emit_or_log(
+        ctx,
+        db,
+        "action",
+        action_id,
+        "action.field_changed",
+        "user_edit",
+        Some(&payload),
+        0.8,
+    );
+}
+
 /// Complete an action and emit the completion signal.
 pub fn complete_action(
     ctx: &ServiceContext<'_>,
@@ -113,6 +137,13 @@ pub fn complete_action(
     let action = db.get_action_by_id(id).ok().flatten();
     db.complete_action(id).map_err(|e| e.to_string())?;
     sync_action_claim_after_mutation(ctx, db, id, "complete");
+    emit_action_composition_field_changed_signal(
+        ctx,
+        db,
+        id,
+        "status",
+        serde_json::Value::from("completed"),
+    );
 
     if let Some(ref action) = action {
         let (entity_type, entity_id) = action_entity_info(action, id);
@@ -167,6 +198,13 @@ pub fn reopen_action(
     let action = db.get_action_by_id(id).ok().flatten();
     db.reopen_action(id).map_err(|e| e.to_string())?;
     sync_action_claim_after_mutation(ctx, db, id, "reopen");
+    emit_action_composition_field_changed_signal(
+        ctx,
+        db,
+        id,
+        "status",
+        serde_json::Value::from("unstarted"),
+    );
 
     if let Some(ref action) = action {
         let (entity_type, entity_id) = action_entity_info(action, id);
@@ -382,6 +420,13 @@ pub fn update_action_priority(
     db.update_action_priority(id, priority)
         .map_err(|e| e.to_string())?;
     sync_action_claim_after_mutation(ctx, db, id, "priority_update");
+    emit_action_composition_field_changed_signal(
+        ctx,
+        db,
+        id,
+        "priority",
+        serde_json::Value::from(priority),
+    );
 
     if let Some(ref action) = action {
         let (entity_type, entity_id) = action_entity_info(action, id);
@@ -737,20 +782,27 @@ pub(crate) fn apply_update_action(
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Action not found: {id}"))?;
 
+    let mut changed_fields: Vec<(&'static str, serde_json::Value)> = Vec::new();
     if let Some(t) = title {
+        changed_fields.push(("title", serde_json::Value::from(t.clone())));
         action.title = t;
     }
     if let Some(p) = priority {
+        changed_fields.push(("priority", serde_json::Value::from(p.clone())));
         action.priority = p.parse::<i32>().unwrap_or(3);
     }
     if clear_due_date == Some(true) {
         action.due_date = None;
+        changed_fields.push(("due_date", serde_json::Value::Null));
     } else if let Some(d) = due_date {
+        changed_fields.push(("due_date", serde_json::Value::from(d.clone())));
         action.due_date = Some(d);
     }
     if clear_context == Some(true) {
         action.context = None;
+        changed_fields.push(("context", serde_json::Value::Null));
     } else if let Some(c) = context {
+        changed_fields.push(("context", serde_json::Value::from(c.clone())));
         action.context = Some(c);
     }
     if clear_owner == Some(true) {
@@ -758,7 +810,9 @@ pub(crate) fn apply_update_action(
         action.owner_entity_id = None;
         action.owner_confidence = None;
         action.owner_source = Some("user_reassigned".to_string());
+        changed_fields.push(("owner_raw", serde_json::Value::Null));
     } else if let Some(owner) = owner_raw {
+        changed_fields.push(("owner_raw", serde_json::Value::from(owner.clone())));
         let commitment_id = action
             .commitment_id
             .clone()
@@ -781,28 +835,39 @@ pub(crate) fn apply_update_action(
     }
     if clear_source_label == Some(true) {
         action.source_label = None;
+        changed_fields.push(("source_label", serde_json::Value::Null));
     } else if let Some(s) = source_label {
+        changed_fields.push(("source_label", serde_json::Value::from(s.clone())));
         action.source_label = Some(s);
     }
     if clear_account == Some(true) {
         action.account_id = None;
+        changed_fields.push(("account_id", serde_json::Value::Null));
     } else if let Some(a) = account_id {
+        changed_fields.push(("account_id", serde_json::Value::from(a.clone())));
         action.account_id = Some(a);
     }
     if clear_project == Some(true) {
         action.project_id = None;
+        changed_fields.push(("project_id", serde_json::Value::Null));
     } else if let Some(p) = project_id {
+        changed_fields.push(("project_id", serde_json::Value::from(p.clone())));
         action.project_id = Some(p);
     }
     if clear_person == Some(true) {
         action.person_id = None;
+        changed_fields.push(("person_id", serde_json::Value::Null));
     } else if let Some(p) = person_id {
+        changed_fields.push(("person_id", serde_json::Value::from(p.clone())));
         action.person_id = Some(p);
     }
 
     action.updated_at = ctx.clock.now().to_rfc3339();
     db.upsert_action(&action).map_err(|e| e.to_string())?;
     sync_action_claim_after_mutation(ctx, db, &action.id, "update");
+    for (field, value) in changed_fields {
+        emit_action_composition_field_changed_signal(ctx, db, &action.id, field, value);
+    }
     Ok(())
 }
 

--- a/src-tauri/src/services/claim_receipt/privacy.rs
+++ b/src-tauri/src/services/claim_receipt/privacy.rs
@@ -500,6 +500,7 @@ fn scrub_subject_to_type(subject: &SubjectRef) -> SubjectRef {
         SubjectRef::Account(_) => SubjectRef::Account(String::new()),
         SubjectRef::Project(_) => SubjectRef::Project(String::new()),
         SubjectRef::Person(_) => SubjectRef::Person(String::new()),
+        SubjectRef::Action(_) => SubjectRef::Action(String::new()),
         SubjectRef::Meeting(_) => SubjectRef::Meeting(String::new()),
         SubjectRef::User(_) => SubjectRef::User(String::new()),
         SubjectRef::Global => SubjectRef::Global,

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -2841,6 +2841,7 @@ fn compact_subject_ref(value: &serde_json::Value) -> Result<String, ClaimError> 
 pub(crate) fn canonical_subject_ref(subject: &SubjectRef) -> Result<String, ClaimError> {
     let (kind, id) = match subject {
         SubjectRef::Account { id } => ("account", id.as_str()),
+        SubjectRef::Action { id } => ("action", id.as_str()),
         SubjectRef::Meeting { id } => ("meeting", id.as_str()),
         SubjectRef::Person { id } => ("person", id.as_str()),
         SubjectRef::Project { id } => ("project", id.as_str()),
@@ -2863,6 +2864,7 @@ pub(crate) fn canonical_subject_ref(subject: &SubjectRef) -> Result<String, Clai
 fn subject_kind_label(subject: &SubjectRef) -> Option<&'static str> {
     match subject {
         SubjectRef::Account { .. } => Some("Account"),
+        SubjectRef::Action { .. } => Some("Action"),
         SubjectRef::Meeting { .. } => Some("Meeting"),
         SubjectRef::Person { .. } => Some("Person"),
         SubjectRef::Project { .. } => Some("Project"),
@@ -2874,6 +2876,7 @@ fn subject_kind_label(subject: &SubjectRef) -> Option<&'static str> {
 fn subject_id_for_lookup(subject: &SubjectRef) -> Option<&str> {
     match subject {
         SubjectRef::Account { id }
+        | SubjectRef::Action { id }
         | SubjectRef::Meeting { id }
         | SubjectRef::Person { id }
         | SubjectRef::Project { id }
@@ -3205,6 +3208,7 @@ fn subject_ref_from_canonical_entity(entity: &EntityRef) -> Option<SubjectRef> {
         .as_str()
     {
         "account" => Some(SubjectRef::Account { id: id.to_string() }),
+        "action" => Some(SubjectRef::Action { id: id.to_string() }),
         "meeting" => Some(SubjectRef::Meeting { id: id.to_string() }),
         "person" => Some(SubjectRef::Person { id: id.to_string() }),
         "project" => Some(SubjectRef::Project { id: id.to_string() }),
@@ -3304,6 +3308,9 @@ pub(crate) fn subject_ref_from_json(value: &serde_json::Value) -> Result<Subject
 
     match kind.as_str() {
         "account" | "accounts" => Ok(SubjectRef::Account {
+            id: subject_id(value)?,
+        }),
+        "action" | "actions" => Ok(SubjectRef::Action {
             id: subject_id(value)?,
         }),
         "meeting" | "meetings" => Ok(SubjectRef::Meeting {
@@ -6112,6 +6119,7 @@ where
     // subject-kind labels.
     let subject_kind_lc = match &subject {
         SubjectRef::Account { .. } => "account",
+        SubjectRef::Action { .. } => "action",
         SubjectRef::Meeting { .. } => "meeting",
         SubjectRef::Person { .. } => "person",
         SubjectRef::Project { .. } => "project",
@@ -8238,6 +8246,7 @@ fn targeted_repair_subject_from_job(
     let id = job.subject_id.clone();
     match job.subject_type.trim().to_ascii_lowercase().as_str() {
         "account" | "accounts" => Ok(SubjectRef::Account { id }),
+        "action" | "actions" => Ok(SubjectRef::Action { id }),
         "meeting" | "meetings" => Ok(SubjectRef::Meeting { id }),
         "person" | "people" => Ok(SubjectRef::Person { id }),
         "project" | "projects" => Ok(SubjectRef::Project { id }),
@@ -9963,6 +9972,7 @@ fn entity_context_subject(
     {
         "account" => "account",
         "meeting" => "meeting",
+        "action" => "action",
         "person" => "person",
         "project" => "project",
         other => {
@@ -10061,7 +10071,7 @@ fn entity_context_related_subjects(
                     }),
             );
         }
-        "meeting" | "person" => {}
+        "action" | "meeting" | "person" => {}
         _ => {}
     }
 
@@ -10146,15 +10156,15 @@ pub struct ShadowTombstoneClaim<'a> {
 
 /// L2 cycle-2 fix #1: normalize the caller-supplied subject_kind into
 /// the lowercase form `subject_ref_from_json` accepts. Runtime callers
-/// pass PascalCase ("Account", "Meeting", "Person", "Project", "Email")
+/// pass PascalCase ("Account", "Action", "Meeting", "Person", "Project", "Email")
 /// — which the parser previously rejected, silently no-op'ing the
 /// shadow write. Returns `None` when the kind has no claim-substrate
-/// representation today (currently: `Email`; tracked as a future
-/// follow-up). Callers MUST handle `None` rather than assuming a
+/// representation today. Callers MUST handle `None` rather than assuming a
 /// successful tombstone; see `shadow_write_tombstone_claim`'s contract.
 fn normalize_subject_kind_for_claim(kind: &str) -> Option<&'static str> {
     match kind.trim() {
         k if k.eq_ignore_ascii_case("account") => Some("account"),
+        k if k.eq_ignore_ascii_case("action") => Some("action"),
         k if k.eq_ignore_ascii_case("meeting") => Some("meeting"),
         k if k.eq_ignore_ascii_case("person") || k.eq_ignore_ascii_case("people") => Some("person"),
         k if k.eq_ignore_ascii_case("project") => Some("project"),
@@ -18586,6 +18596,34 @@ mod tests {
             .expect("PascalCase reader input must parse");
         assert_eq!(claims.len(), 1);
         assert_eq!(claims[0].id, "pascal-active");
+    }
+
+    #[test]
+    fn load_claims_active_accepts_action_subjects() {
+        let db = test_db();
+
+        // dos7-allowed: W3 action-detail regression seed for first-class action subjects
+        db.conn_ref()
+            .execute(
+                "INSERT INTO intelligence_claims \
+                 (id, subject_ref, claim_type, field_path, text, dedup_key, item_hash, \
+                  actor, data_source, observed_at, created_at, provenance_json, \
+                  claim_state, surfacing_state, retraction_reason, \
+                  temporal_scope, sensitivity) \
+                 VALUES \
+                 ('action-active', \
+                  '{\"kind\":\"Action\",\"id\":\"action-1\"}', 'open_loop', 'actions.action-1', \
+                  'first', 'k-action', 'h-action', 'agent:test', 'unit_test', \
+                  ?1, ?1, '{}', 'active', 'active', NULL, 'state', 'internal')",
+                params![TS],
+            )
+            .unwrap();
+
+        let reader_input = r#"{"kind":"action","id":"action-1"}"#;
+        let claims = load_claims_active(&db, reader_input, Some("open_loop"))
+            .expect("Action reader input must parse");
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0].id, "action-active");
     }
 
     /// L2 cycle-15 fix #1: two semantically-equal subjects with

--- a/src-tauri/src/services/claims/link_map.rs
+++ b/src-tauri/src/services/claims/link_map.rs
@@ -199,7 +199,7 @@ fn subject_type_and_id(subject: &SubjectRef) -> Option<(CanonicalSubjectType, St
         SubjectRef::Person { id } => Some((CanonicalSubjectType::Person, id.clone())),
         SubjectRef::Project { id } => Some((CanonicalSubjectType::Project, id.clone())),
         SubjectRef::Email { id } => Some((CanonicalSubjectType::Email, id.clone())),
-        SubjectRef::Multi(_) | SubjectRef::Global => None,
+        SubjectRef::Action { .. } | SubjectRef::Multi(_) | SubjectRef::Global => None,
     }
 }
 

--- a/src-tauri/src/services/composition_render_orchestrator.rs
+++ b/src-tauri/src/services/composition_render_orchestrator.rs
@@ -258,21 +258,94 @@ pub struct CacheStorePayload {
 #[derive(Debug, Clone)]
 pub struct ProducerProjectionInput {
     pub ability_name: &'static str,
-    pub account_id: String,
+    pub subject: ProducerSubject,
     pub composition_id: String,
     pub schema_version: u32,
     pub expected_composition_version: u64,
 }
 
 impl ProducerProjectionInput {
+    fn with_expected_composition_version(&self, expected_composition_version: u64) -> Self {
+        Self {
+            expected_composition_version,
+            ..self.clone()
+        }
+    }
+
     pub fn to_json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "account_id": self.account_id,
+        let mut value = serde_json::json!({
             "composition_id": self.composition_id,
             "schema_version": self.schema_version,
             "expected_composition_version": self.expected_composition_version,
-        })
+        });
+        let object = value.as_object_mut().expect("producer input json object");
+        match &self.subject {
+            ProducerSubject::Entity {
+                entity_type,
+                entity_id,
+            } => {
+                object.insert(
+                    "entity_type".to_string(),
+                    serde_json::Value::from(entity_type.as_str()),
+                );
+                object.insert(
+                    "entity_id".to_string(),
+                    serde_json::Value::from(entity_id.as_str()),
+                );
+                object.insert(
+                    entity_type.input_key().to_string(),
+                    serde_json::Value::from(entity_id.as_str()),
+                );
+            }
+            ProducerSubject::Action { action_id } => {
+                object.insert(
+                    "action_id".to_string(),
+                    serde_json::Value::from(action_id.as_str()),
+                );
+                object.insert(
+                    "subject_ref".to_string(),
+                    serde_json::json!({ "action": action_id.as_str() }),
+                );
+            }
+        }
+        value
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProducerEntityType {
+    Account,
+    Project,
+    Person,
+}
+
+impl ProducerEntityType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Account => "account",
+            Self::Project => "project",
+            Self::Person => "person",
+        }
+    }
+
+    const fn input_key(self) -> &'static str {
+        match self {
+            Self::Account => "account_id",
+            Self::Project => "project_id",
+            Self::Person => "person_id",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProducerSubject {
+    Entity {
+        entity_type: ProducerEntityType,
+        entity_id: String,
+    },
+    Action {
+        action_id: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -281,6 +354,11 @@ pub struct ProjectedCompositionRender {
     pub cache_hint_token: String,
     pub served_from_cache: bool,
     pub rendered_provenance: Option<RenderedProvenance>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProjectCompositionRenderOptions {
+    pub force_refresh: bool,
 }
 
 /// Shared projection pipeline for Tauri, local loopback, and signed surface
@@ -292,18 +370,39 @@ pub async fn project_composition_for_surface<F, Fut>(
     actor: Actor,
     surface_kind: SurfaceKind,
     composition_id: &str,
+    invoke_producer: F,
+) -> Result<ProjectedCompositionRender, BridgeSurfaceError>
+where
+    F: FnMut(ProducerProjectionInput) -> Fut,
+    Fut: Future<Output = Result<AbilityResponseJson, BridgeSurfaceError>>,
+{
+    project_composition_for_surface_with_options(
+        state,
+        actor,
+        surface_kind,
+        composition_id,
+        ProjectCompositionRenderOptions::default(),
+        invoke_producer,
+    )
+    .await
+}
+
+/// Variant of [`project_composition_for_surface`] that lets first-party
+/// mutation flows force a recomposition after service-owned writes. External
+/// surfaces keep the default cache behavior.
+pub async fn project_composition_for_surface_with_options<F, Fut>(
+    state: &AppState,
+    actor: Actor,
+    surface_kind: SurfaceKind,
+    composition_id: &str,
+    options: ProjectCompositionRenderOptions,
     mut invoke_producer: F,
 ) -> Result<ProjectedCompositionRender, BridgeSurfaceError>
 where
     F: FnMut(ProducerProjectionInput) -> Fut,
     Fut: Future<Output = Result<AbilityResponseJson, BridgeSurfaceError>>,
 {
-    let Some(ability_name) = resolve_producer_ability_name(composition_id) else {
-        return Err(BridgeSurfaceError::Validation(
-            "project_composition_unknown_producer".to_string(),
-        ));
-    };
-    let Some(account_id) = extract_account_id_from_composition_id(composition_id) else {
+    let Some(producer_input_template) = parse_producer_projection_input(composition_id, 0) else {
         return Err(BridgeSurfaceError::Validation(
             "project_composition_invalid_id".to_string(),
         ));
@@ -313,19 +412,21 @@ where
     let current_db_version_for_lookup = current_composition_version(state, composition_id).await;
     let current_db_version = i64::try_from(current_db_version_for_lookup).unwrap_or(i64::MAX);
 
-    if let Some(cached) = orchestrator.cache_lookup(
-        &actor,
-        composition_id,
-        current_db_version,
-        surface_kind,
-        FALLBACK_POLICY_VERSION,
-    ) {
-        return Ok(ProjectedCompositionRender {
-            projection: cached.projection,
-            cache_hint_token: cached.cache_hint_token,
-            served_from_cache: true,
-            rendered_provenance: cached.rendered_provenance,
-        });
+    if !options.force_refresh {
+        if let Some(cached) = orchestrator.cache_lookup(
+            &actor,
+            composition_id,
+            current_db_version,
+            surface_kind,
+            FALLBACK_POLICY_VERSION,
+        ) {
+            return Ok(ProjectedCompositionRender {
+                projection: cached.projection,
+                cache_hint_token: cached.cache_hint_token,
+                served_from_cache: true,
+                rendered_provenance: cached.rendered_provenance,
+            });
+        }
     }
 
     let _miss_guard = orchestrator
@@ -340,31 +441,28 @@ where
 
     let guarded_db_version_for_lookup = current_composition_version(state, composition_id).await;
     let guarded_db_version = i64::try_from(guarded_db_version_for_lookup).unwrap_or(i64::MAX);
-    if let Some(cached) = orchestrator.cache_lookup(
-        &actor,
-        composition_id,
-        guarded_db_version,
-        surface_kind,
-        FALLBACK_POLICY_VERSION,
-    ) {
-        return Ok(ProjectedCompositionRender {
-            projection: cached.projection,
-            cache_hint_token: cached.cache_hint_token,
-            served_from_cache: true,
-            rendered_provenance: cached.rendered_provenance,
-        });
+    if !options.force_refresh {
+        if let Some(cached) = orchestrator.cache_lookup(
+            &actor,
+            composition_id,
+            guarded_db_version,
+            surface_kind,
+            FALLBACK_POLICY_VERSION,
+        ) {
+            return Ok(ProjectedCompositionRender {
+                projection: cached.projection,
+                cache_hint_token: cached.cache_hint_token,
+                served_from_cache: true,
+                rendered_provenance: cached.rendered_provenance,
+            });
+        }
     }
 
     let mut expected_composition_version = guarded_db_version_for_lookup;
     let mut response = None;
     for attempt in 0..2 {
-        let producer_input = ProducerProjectionInput {
-            ability_name,
-            account_id: account_id.to_string(),
-            composition_id: composition_id.to_string(),
-            schema_version: 1,
-            expected_composition_version,
-        };
+        let producer_input =
+            producer_input_template.with_expected_composition_version(expected_composition_version);
         match invoke_producer(producer_input).await {
             Ok(invocation_response) => {
                 response = Some(invocation_response);
@@ -466,23 +564,92 @@ pub fn project_from_ability_data(
         .map_err(|e| OrchestratorError::ProjectionFailed(format!("{e:?}")))
 }
 
-/// Map a SurfaceClient request's composition_id back to the producer ability
-/// name. v1.4.2 ships a single producer: `dailyos/account-overview`.
-/// composition IDs of the form `dailyos/account-overview:account:{account_id}`
-/// resolve to the account-overview ability; any other shape is rejected so
-/// the orchestrator never invokes a foreign producer.
+/// Map a request composition_id back to its producer ability name. W3 keeps
+/// this bounded to the four first-party detail composition ids so the
+/// orchestrator never invokes a foreign producer.
 pub fn resolve_producer_ability_name(composition_id: &str) -> Option<&'static str> {
-    if composition_id.starts_with("dailyos/account-overview:") {
-        Some("dailyos/account-overview")
-    } else {
-        None
-    }
+    parse_producer_projection_input(composition_id, 0).map(|input| input.ability_name)
 }
 
 /// Extract the account_id encoded in an `account-overview` composition_id.
 /// Pattern: `dailyos/account-overview:account:{account_id}`.
 pub fn extract_account_id_from_composition_id(composition_id: &str) -> Option<&str> {
-    composition_id.strip_prefix("dailyos/account-overview:account:")
+    let parts = split_composition_id(composition_id)?;
+    (parts.ability == "dailyos/account-overview" && parts.subject_key == "account")
+        .then_some(parts.subject_id)
+}
+
+pub fn parse_producer_projection_input(
+    composition_id: &str,
+    expected_composition_version: u64,
+) -> Option<ProducerProjectionInput> {
+    let parts = split_composition_id(composition_id)?;
+    let (ability_name, subject) = match (parts.ability, parts.subject_key) {
+        ("dailyos/account-overview", "account") => (
+            "dailyos/account-overview",
+            ProducerSubject::Entity {
+                entity_type: ProducerEntityType::Account,
+                entity_id: parts.subject_id.to_string(),
+            },
+        ),
+        ("dailyos/project-overview", "project") => (
+            "dailyos/project-overview",
+            ProducerSubject::Entity {
+                entity_type: ProducerEntityType::Project,
+                entity_id: parts.subject_id.to_string(),
+            },
+        ),
+        ("dailyos/person-overview", "person") => (
+            "dailyos/person-overview",
+            ProducerSubject::Entity {
+                entity_type: ProducerEntityType::Person,
+                entity_id: parts.subject_id.to_string(),
+            },
+        ),
+        ("dailyos/action-detail", "action") => (
+            "dailyos/action-detail",
+            ProducerSubject::Action {
+                action_id: parts.subject_id.to_string(),
+            },
+        ),
+        _ => return None,
+    };
+    Some(ProducerProjectionInput {
+        ability_name,
+        subject,
+        composition_id: composition_id.to_string(),
+        schema_version: 1,
+        expected_composition_version,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParsedCompositionId<'a> {
+    ability: &'a str,
+    subject_key: &'a str,
+    subject_id: &'a str,
+}
+
+fn split_composition_id(composition_id: &str) -> Option<ParsedCompositionId<'_>> {
+    if composition_id.chars().any(char::is_control) {
+        return None;
+    }
+    let mut parts = composition_id.split(':');
+    let ability = parts.next()?;
+    let subject_key = parts.next()?;
+    let subject_id = parts.next()?;
+    if parts.next().is_some()
+        || ability.trim().is_empty()
+        || subject_key.trim().is_empty()
+        || subject_id.trim().is_empty()
+    {
+        return None;
+    }
+    Some(ParsedCompositionId {
+        ability,
+        subject_key,
+        subject_id,
+    })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -717,11 +884,38 @@ mod tests {
 
     #[test]
     fn unknown_producer_rejected() {
-        assert_eq!(
-            resolve_producer_ability_name("dailyos/account-overview:account:x"),
-            Some("dailyos/account-overview")
-        );
+        let valid_ids = [
+            (
+                "dailyos/account-overview:account:acct-1",
+                "dailyos/account-overview",
+            ),
+            (
+                "dailyos/project-overview:project:project-1",
+                "dailyos/project-overview",
+            ),
+            (
+                "dailyos/person-overview:person:person-1",
+                "dailyos/person-overview",
+            ),
+            (
+                "dailyos/action-detail:action:action-1",
+                "dailyos/action-detail",
+            ),
+        ];
+        for (composition_id, ability_name) in valid_ids {
+            assert_eq!(
+                resolve_producer_ability_name(composition_id),
+                Some(ability_name)
+            );
+        }
+
         assert!(resolve_producer_ability_name("foreign/ability").is_none());
+        assert!(
+            resolve_producer_ability_name("dailyos/project-overview:person:person-1").is_none()
+        );
+        assert!(
+            resolve_producer_ability_name("dailyos/account-overview:account:acct:extra").is_none()
+        );
     }
 
     #[test]
@@ -731,5 +925,77 @@ mod tests {
             Some("acct-42")
         );
         assert!(extract_account_id_from_composition_id("dailyos/other:foo").is_none());
+        assert!(extract_account_id_from_composition_id(
+            "dailyos/account-overview:account:acct-42:extra"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn producer_projection_input_emits_subject_specific_json() {
+        let project =
+            parse_producer_projection_input("dailyos/project-overview:project:project-42", 9)
+                .expect("project input");
+        assert_eq!(project.ability_name, "dailyos/project-overview");
+        assert_eq!(
+            project.subject,
+            ProducerSubject::Entity {
+                entity_type: ProducerEntityType::Project,
+                entity_id: "project-42".to_string(),
+            }
+        );
+        assert_eq!(
+            project.to_json(),
+            serde_json::json!({
+                "composition_id": "dailyos/project-overview:project:project-42",
+                "schema_version": 1,
+                "expected_composition_version": 9,
+                "entity_type": "project",
+                "entity_id": "project-42",
+                "project_id": "project-42",
+            })
+        );
+
+        let action = parse_producer_projection_input("dailyos/action-detail:action:action-42", 12)
+            .expect("action input");
+        assert_eq!(action.ability_name, "dailyos/action-detail");
+        assert_eq!(
+            action.subject,
+            ProducerSubject::Action {
+                action_id: "action-42".to_string(),
+            }
+        );
+        assert_eq!(
+            action.to_json(),
+            serde_json::json!({
+                "composition_id": "dailyos/action-detail:action:action-42",
+                "schema_version": 1,
+                "expected_composition_version": 12,
+                "action_id": "action-42",
+                "subject_ref": { "action": "action-42" },
+            })
+        );
+    }
+
+    #[test]
+    fn producer_projection_input_fails_closed_for_malformed_ids() {
+        let malformed = [
+            "",
+            "dailyos/account-overview:account:",
+            "dailyos/account-overview::acct-1",
+            "dailyos/account-overview:account:acct-1:extra",
+            "dailyos/account-overview:project:project-1",
+            "dailyos/project-overview:account:acct-1",
+            "dailyos/person-overview:action:action-1",
+            "dailyos/action-detail:person:person-1",
+            "dailyos/action-detail:action:action-1\n",
+            "dailyos/unknown:account:acct-1",
+        ];
+        for composition_id in malformed {
+            assert!(
+                parse_producer_projection_input(composition_id, 0).is_none(),
+                "{composition_id:?} must be rejected"
+            );
+        }
     }
 }

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -68,6 +68,9 @@ pub struct LiveSourceManagementActionHandler {
 }
 pub struct LiveEntityContextClaimReader;
 pub struct LiveAccountCompositionSnapshotReader;
+pub struct LiveProjectCompositionSnapshotReader;
+pub struct LivePersonCompositionSnapshotReader;
+pub struct LiveActionCompositionSnapshotReader;
 pub struct LivePrepareMeetingContextReader;
 pub struct LiveDailyReadinessContextReader;
 pub struct LiveTemporalWorkspaceReader;
@@ -107,6 +110,15 @@ pub fn attach_live_workspace_readers_with_signal_engine(
         .with_entity_context_claim_reader(Arc::new(LiveEntityContextClaimReader))
         .with_account_composition_snapshot_reader(Arc::new(
             LiveAccountCompositionSnapshotReader,
+        ))
+        .with_project_composition_snapshot_reader(Arc::new(
+            LiveProjectCompositionSnapshotReader,
+        ))
+        .with_person_composition_snapshot_reader(Arc::new(
+            LivePersonCompositionSnapshotReader,
+        ))
+        .with_action_composition_snapshot_reader(Arc::new(
+            LiveActionCompositionSnapshotReader,
         ))
         .with_prepare_meeting_context_reader(Arc::new(LivePrepareMeetingContextReader))
         .with_daily_readiness_context_reader(Arc::new(LiveDailyReadinessContextReader))
@@ -1049,6 +1061,90 @@ impl AccountCompositionSnapshotReadHandle for LiveAccountCompositionSnapshotRead
     }
 }
 
+impl ProjectCompositionSnapshotReadHandle for LiveProjectCompositionSnapshotReader {
+    fn read_project_composition_snapshot<'a>(
+        &'a self,
+        project_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> ProjectCompositionSnapshotReadFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let db = crate::db::ActionDb::open_readonly(std::sync::Arc::new(
+                    crate::db::LocalKeychain::new(),
+                ))
+                .map_err(|error| {
+                    ProjectCompositionSnapshotReadError::ReadFailed(format!(
+                        "Database unavailable: {error}"
+                    ))
+                })?;
+                read_project_composition_snapshot_from_db(&db, &project_id, surface)
+            })
+            .await
+            .map_err(|error| {
+                ProjectCompositionSnapshotReadError::ReadFailed(format!(
+                    "project composition snapshot task failed: {error}"
+                ))
+            })?
+        })
+    }
+}
+
+impl PersonCompositionSnapshotReadHandle for LivePersonCompositionSnapshotReader {
+    fn read_person_composition_snapshot<'a>(
+        &'a self,
+        person_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> PersonCompositionSnapshotReadFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let db = crate::db::ActionDb::open_readonly(std::sync::Arc::new(
+                    crate::db::LocalKeychain::new(),
+                ))
+                .map_err(|error| {
+                    PersonCompositionSnapshotReadError::ReadFailed(format!(
+                        "Database unavailable: {error}"
+                    ))
+                })?;
+                read_person_composition_snapshot_from_db(&db, &person_id, surface)
+            })
+            .await
+            .map_err(|error| {
+                PersonCompositionSnapshotReadError::ReadFailed(format!(
+                    "person composition snapshot task failed: {error}"
+                ))
+            })?
+        })
+    }
+}
+
+impl ActionCompositionSnapshotReadHandle for LiveActionCompositionSnapshotReader {
+    fn read_action_composition_snapshot<'a>(
+        &'a self,
+        action_id: String,
+        surface: ClaimDismissalSurface,
+    ) -> ActionCompositionSnapshotReadFuture<'a> {
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || {
+                let db = crate::db::ActionDb::open_readonly(std::sync::Arc::new(
+                    crate::db::LocalKeychain::new(),
+                ))
+                .map_err(|error| {
+                    ActionCompositionSnapshotReadError::ReadFailed(format!(
+                        "Database unavailable: {error}"
+                    ))
+                })?;
+                read_action_composition_snapshot_from_db(&db, &action_id, surface)
+            })
+            .await
+            .map_err(|error| {
+                ActionCompositionSnapshotReadError::ReadFailed(format!(
+                    "action composition snapshot task failed: {error}"
+                ))
+            })?
+        })
+    }
+}
+
 fn read_account_composition_snapshot_from_db(
     db: &crate::db::ActionDb,
     account_id: &str,
@@ -1251,6 +1347,1105 @@ fn read_account_composition_snapshot_from_db(
         )),
         fields,
     })
+}
+
+fn read_project_composition_snapshot_from_db(
+    db: &crate::db::ActionDb,
+    project_id: &str,
+    _surface: ClaimDismissalSurface,
+) -> Result<ProjectCompositionSnapshot, ProjectCompositionSnapshotReadError> {
+    let project = db
+        .get_project(project_id)
+        .map_err(|error| {
+            ProjectCompositionSnapshotReadError::ReadFailed(format!("project read failed: {error}"))
+        })?
+        .ok_or_else(|| {
+            ProjectCompositionSnapshotReadError::ProjectNotFound(project_id.to_string())
+        })?;
+
+    let child_projects = db.get_child_projects(&project.id).map_err(|error| {
+        ProjectCompositionSnapshotReadError::ReadFailed(format!(
+            "project children read failed: {error}"
+        ))
+    })?;
+    let open_actions = db.get_project_actions(&project.id).map_err(|error| {
+        ProjectCompositionSnapshotReadError::ReadFailed(format!(
+            "project actions read failed: {error}"
+        ))
+    })?;
+    let recent_meetings = db
+        .get_meetings_for_project(&project.id, 10)
+        .map_err(|error| {
+            ProjectCompositionSnapshotReadError::ReadFailed(format!(
+                "project meetings read failed: {error}"
+            ))
+        })?;
+    let linked_people = db.get_people_for_entity(&project.id).map_err(|error| {
+        ProjectCompositionSnapshotReadError::ReadFailed(format!(
+            "project people read failed: {error}"
+        ))
+    })?;
+    let recent_captures = db
+        .get_captures_for_project(&project.id, 90)
+        .map_err(|error| {
+            ProjectCompositionSnapshotReadError::ReadFailed(format!(
+                "project captures read failed: {error}"
+            ))
+        })?;
+    let recent_email_signals = db
+        .list_recent_email_signals_for_entity(&project.id, 12)
+        .map_err(|error| {
+            ProjectCompositionSnapshotReadError::ReadFailed(format!(
+                "project email signal read failed: {error}"
+            ))
+        })?;
+
+    let signals = db.get_project_signals(&project.id).ok();
+    let parent_name = project.parent_id.as_ref().and_then(|parent_id| {
+        db.get_project(parent_id)
+            .ok()
+            .flatten()
+            .map(|parent| parent.name)
+    });
+    let parent_aggregate = if child_projects.is_empty() {
+        None
+    } else {
+        db.get_project_parent_aggregate(&project.id).ok()
+    };
+
+    let mut fields = Vec::new();
+    let source_asof = Some(project.updated_at.as_str());
+    push_project_field(
+        &mut fields,
+        "/vitals/status",
+        "Status",
+        Some(serde_json::Value::from(project.status.clone())),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/vitals/milestone",
+        "Milestone",
+        project.milestone.as_deref().map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/vitals/owner",
+        "Owner",
+        project.owner.as_deref().map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/vitals/target_date",
+        "Target date",
+        project.target_date.as_deref().map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/trajectory/description",
+        "Description",
+        project.description.as_deref().map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::ManualUser,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-record/notes",
+        "Notes",
+        project.notes.as_deref().map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::ManualUser,
+    );
+    push_project_field(
+        &mut fields,
+        "/trajectory/milestones",
+        "Milestones",
+        project
+            .milestones
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok()),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/portfolio/parent",
+        "Parent project",
+        parent_name.map(serde_json::Value::from),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/portfolio/children",
+        "Sub-projects",
+        (!child_projects.is_empty()).then(|| {
+            serde_json::Value::from(
+                child_projects
+                    .iter()
+                    .map(|child| {
+                        serde_json::json!({
+                            "id": child.id.as_str(),
+                            "name": child.name.as_str(),
+                            "status": child.status.as_str(),
+                            "milestone": child.milestone.as_deref(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/portfolio/aggregate",
+        "Portfolio aggregate",
+        parent_aggregate.map(|aggregate| {
+            serde_json::json!({
+                "child_count": aggregate.child_count,
+                "active_count": aggregate.active_count,
+                "on_hold_count": aggregate.on_hold_count,
+                "completed_count": aggregate.completed_count,
+                "nearest_target_date": aggregate.nearest_target_date,
+            })
+        }),
+        "project",
+        source_asof,
+        AccountCompositionProvenanceKind::Derived,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-horizon/signals",
+        "Project signals",
+        signals.map(|signals| {
+            serde_json::json!({
+                "meeting_frequency_30d": signals.meeting_frequency_30d,
+                "meeting_frequency_90d": signals.meeting_frequency_90d,
+                "last_meeting": signals.last_meeting,
+                "days_until_target": signals.days_until_target,
+                "open_action_count": signals.open_action_count,
+                "temperature": signals.temperature,
+                "trend": signals.trend,
+            })
+        }),
+        "project_signals",
+        source_asof,
+        AccountCompositionProvenanceKind::Derived,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-room/linked_people",
+        "Project people",
+        (!linked_people.is_empty()).then(|| {
+            serde_json::Value::from(
+                linked_people
+                    .iter()
+                    .map(|person| {
+                        serde_json::json!({
+                            "id": person.id.as_str(),
+                            "name": person.name.as_str(),
+                            "role": person.role.as_deref(),
+                            "relationship": person.relationship.as_str(),
+                            "last_seen": person.last_seen.as_deref(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project_people",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-work/open_actions",
+        "Open actions",
+        (!open_actions.is_empty()).then(|| {
+            serde_json::Value::from(
+                open_actions
+                    .iter()
+                    .take(10)
+                    .map(|action| {
+                        serde_json::json!({
+                            "id": action.id.as_str(),
+                            "title": action.title.as_str(),
+                            "status": action.status.as_str(),
+                            "priority": action.priority,
+                            "due_date": action.due_date.as_deref(),
+                            "trust_band": action.trust_band.as_deref(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project_actions",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-record/recent_meetings",
+        "Recent meetings",
+        (!recent_meetings.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_meetings
+                    .iter()
+                    .map(|meeting| {
+                        serde_json::json!({
+                            "id": meeting.id.as_str(),
+                            "title": meeting.title.as_str(),
+                            "start_time": meeting.start_time.as_str(),
+                            "meeting_type": meeting.meeting_type.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project_meetings",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-record/captures",
+        "Recent captures",
+        (!recent_captures.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_captures
+                    .iter()
+                    .take(12)
+                    .map(|capture| {
+                        serde_json::json!({
+                            "id": capture.id.as_str(),
+                            "meeting_id": capture.meeting_id.as_str(),
+                            "meeting_title": capture.meeting_title.as_str(),
+                            "capture_type": capture.capture_type.as_str(),
+                            "content": capture.content.as_str(),
+                            "captured_at": capture.captured_at.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project_captures",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+    push_project_field(
+        &mut fields,
+        "/the-record/email_signals",
+        "Email signals",
+        (!recent_email_signals.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_email_signals
+                    .iter()
+                    .take(12)
+                    .map(|signal| {
+                        serde_json::json!({
+                            "id": signal.id,
+                            "signal_type": signal.signal_type.as_str(),
+                            "signal_text": signal.signal_text.as_str(),
+                            "confidence": signal.confidence,
+                            "sentiment": signal.sentiment.as_deref(),
+                            "urgency": signal.urgency.as_deref(),
+                            "detected_at": signal.detected_at.as_str(),
+                            "source": signal.source.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "project_email_signals",
+        source_asof,
+        AccountCompositionProvenanceKind::SourceField,
+    );
+
+    Ok(ProjectCompositionSnapshot {
+        project_id: project.id.clone(),
+        display_name: project_identity_field(
+            "/identity/display_name",
+            "Project",
+            serde_json::Value::from(project.name),
+        ),
+        status: Some(project_identity_field(
+            "/identity/status",
+            "Status",
+            serde_json::Value::from(project.status),
+        )),
+        is_parent: !child_projects.is_empty(),
+        fields,
+    })
+}
+
+fn read_person_composition_snapshot_from_db(
+    db: &crate::db::ActionDb,
+    person_id: &str,
+    _surface: ClaimDismissalSurface,
+) -> Result<PersonCompositionSnapshot, PersonCompositionSnapshotReadError> {
+    let person = db
+        .get_person(person_id)
+        .map_err(|error| {
+            PersonCompositionSnapshotReadError::ReadFailed(format!("person read failed: {error}"))
+        })?
+        .ok_or_else(|| PersonCompositionSnapshotReadError::PersonNotFound(person_id.to_string()))?;
+
+    let signals = db.get_person_signals(&person.id).ok();
+    let linked_entities = db.get_entities_for_person(&person.id).map_err(|error| {
+        PersonCompositionSnapshotReadError::ReadFailed(format!(
+            "person entities read failed: {error}"
+        ))
+    })?;
+    let relationships = db
+        .get_relationships_for_person(&person.id)
+        .map_err(|error| {
+            PersonCompositionSnapshotReadError::ReadFailed(format!(
+                "person relationships read failed: {error}"
+            ))
+        })?;
+    let recent_meetings = db.get_person_meetings(&person.id, 10).map_err(|error| {
+        PersonCompositionSnapshotReadError::ReadFailed(format!(
+            "person meetings read failed: {error}"
+        ))
+    })?;
+    let upcoming_meetings =
+        db.get_upcoming_meetings_for_person(&person.id, 5)
+            .map_err(|error| {
+                PersonCompositionSnapshotReadError::ReadFailed(format!(
+                    "person upcoming meetings read failed: {error}"
+                ))
+            })?;
+    let open_actions = db.get_person_actions(&person.id).map_err(|error| {
+        PersonCompositionSnapshotReadError::ReadFailed(format!(
+            "person actions read failed: {error}"
+        ))
+    })?;
+    let recent_captures = db
+        .get_captures_for_person(&person.id, 90)
+        .map_err(|error| {
+            PersonCompositionSnapshotReadError::ReadFailed(format!(
+                "person captures read failed: {error}"
+            ))
+        })?;
+    let recent_email_signals = db
+        .list_recent_email_signals_for_entity(&person.id, 12)
+        .map_err(|error| {
+            PersonCompositionSnapshotReadError::ReadFailed(format!(
+                "person email signal read failed: {error}"
+            ))
+        })?;
+
+    let mut fields = Vec::new();
+    let source_asof = Some(person.updated_at.as_str());
+    push_person_field(
+        &mut fields,
+        "/vitals/relationship",
+        "Relationship",
+        Some(serde_json::Value::from(person.relationship.clone())),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/vitals/organization",
+        "Organization",
+        person.organization.as_deref().map(serde_json::Value::from),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/vitals/role",
+        "Role",
+        person.role.as_deref().map(serde_json::Value::from),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/vitals/meeting_count",
+        "Meeting count",
+        Some(serde_json::Value::from(person.meeting_count)),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::Derived,
+    );
+    push_person_field(
+        &mut fields,
+        "/vitals/last_seen",
+        "Last seen",
+        person.last_seen.as_deref().map(serde_json::Value::from),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/relationship/signals",
+        "Relationship signals",
+        signals.map(|signals| {
+            serde_json::json!({
+                "meeting_frequency_30d": signals.meeting_frequency_30d,
+                "meeting_frequency_90d": signals.meeting_frequency_90d,
+                "last_meeting": signals.last_meeting,
+                "temperature": signals.temperature,
+                "trend": signals.trend,
+            })
+        }),
+        "person_signals",
+        source_asof,
+        PersonCompositionProvenanceKind::Derived,
+    );
+    push_person_field(
+        &mut fields,
+        "/their-orbit/linked_entities",
+        "Linked entities",
+        (!linked_entities.is_empty()).then(|| {
+            serde_json::Value::from(
+                linked_entities
+                    .iter()
+                    .map(|entity| {
+                        serde_json::json!({
+                            "id": entity.id.as_str(),
+                            "name": entity.name.as_str(),
+                            "entity_type": entity.entity_type.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_entities",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/their-network/relationships",
+        "Relationships",
+        (!relationships.is_empty()).then(|| {
+            serde_json::Value::from(
+                relationships
+                    .iter()
+                    .take(12)
+                    .map(|relationship| {
+                        serde_json::json!({
+                            "id": relationship.id.as_str(),
+                            "from_person_id": relationship.from_person_id.as_str(),
+                            "to_person_id": relationship.to_person_id.as_str(),
+                            "from_person_name": relationship.from_person_name.as_deref(),
+                            "to_person_name": relationship.to_person_name.as_deref(),
+                            "relationship_type": relationship.relationship_type.to_string(),
+                            "direction": relationship.direction.as_str(),
+                            "effective_confidence": relationship.effective_confidence,
+                            "source": relationship.source.as_str(),
+                            "updated_at": relationship.updated_at.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_relationships",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/state/bio",
+        "Bio",
+        person.bio.as_deref().map(serde_json::Value::from),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/state/company_context",
+        "Company context",
+        (person.company_industry.is_some()
+            || person.company_size.is_some()
+            || person.company_hq.is_some())
+        .then(|| {
+            serde_json::json!({
+                "industry": person.company_industry.as_deref(),
+                "size": person.company_size.as_deref(),
+                "hq": person.company_hq.as_deref(),
+            })
+        }),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/the-record/notes",
+        "Notes",
+        person.notes.as_deref().map(serde_json::Value::from),
+        "person",
+        source_asof,
+        PersonCompositionProvenanceKind::ManualUser,
+    );
+    push_person_field(
+        &mut fields,
+        "/open-threads/upcoming_meetings",
+        "Upcoming meetings",
+        (!upcoming_meetings.is_empty()).then(|| {
+            serde_json::Value::from(
+                upcoming_meetings
+                    .iter()
+                    .map(|meeting| {
+                        serde_json::json!({
+                            "id": meeting.id.as_str(),
+                            "title": meeting.title.as_str(),
+                            "start_time": meeting.start_time.as_str(),
+                            "meeting_type": meeting.meeting_type.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_meetings",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/the-work/open_actions",
+        "Open actions",
+        (!open_actions.is_empty()).then(|| {
+            serde_json::Value::from(
+                open_actions
+                    .iter()
+                    .take(10)
+                    .map(|action| {
+                        serde_json::json!({
+                            "id": action.id.as_str(),
+                            "title": action.title.as_str(),
+                            "status": action.status.as_str(),
+                            "priority": action.priority,
+                            "due_date": action.due_date.as_deref(),
+                            "trust_band": action.trust_band.as_deref(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_actions",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/the-record/recent_meetings",
+        "Recent meetings",
+        (!recent_meetings.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_meetings
+                    .iter()
+                    .map(|meeting| {
+                        serde_json::json!({
+                            "id": meeting.id.as_str(),
+                            "title": meeting.title.as_str(),
+                            "start_time": meeting.start_time.as_str(),
+                            "meeting_type": meeting.meeting_type.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_meetings",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/the-record/captures",
+        "Recent captures",
+        (!recent_captures.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_captures
+                    .iter()
+                    .take(12)
+                    .map(|capture| {
+                        serde_json::json!({
+                            "id": capture.id.as_str(),
+                            "meeting_id": capture.meeting_id.as_str(),
+                            "meeting_title": capture.meeting_title.as_str(),
+                            "capture_type": capture.capture_type.as_str(),
+                            "content": capture.content.as_str(),
+                            "captured_at": capture.captured_at.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_captures",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+    push_person_field(
+        &mut fields,
+        "/the-record/email_signals",
+        "Email signals",
+        (!recent_email_signals.is_empty()).then(|| {
+            serde_json::Value::from(
+                recent_email_signals
+                    .iter()
+                    .take(12)
+                    .map(|signal| {
+                        serde_json::json!({
+                            "id": signal.id,
+                            "signal_type": signal.signal_type.as_str(),
+                            "signal_text": signal.signal_text.as_str(),
+                            "confidence": signal.confidence,
+                            "sentiment": signal.sentiment.as_deref(),
+                            "urgency": signal.urgency.as_deref(),
+                            "detected_at": signal.detected_at.as_str(),
+                            "source": signal.source.as_str(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        }),
+        "person_email_signals",
+        source_asof,
+        PersonCompositionProvenanceKind::SourceField,
+    );
+
+    Ok(PersonCompositionSnapshot {
+        person_id: person.id.clone(),
+        display_name: person_identity_field(
+            "/identity/display_name",
+            "Person",
+            serde_json::Value::from(person.name),
+        ),
+        relationship: Some(person_identity_field(
+            "/identity/relationship",
+            "Relationship",
+            serde_json::Value::from(person.relationship),
+        )),
+        organization: person.organization.as_deref().map(|organization| {
+            person_identity_field(
+                "/identity/organization",
+                "Organization",
+                serde_json::Value::from(organization),
+            )
+        }),
+        role: person.role.as_deref().map(|role| {
+            person_identity_field("/identity/role", "Role", serde_json::Value::from(role))
+        }),
+        fields,
+    })
+}
+
+fn read_action_composition_snapshot_from_db(
+    db: &crate::db::ActionDb,
+    action_id: &str,
+    _surface: ClaimDismissalSurface,
+) -> Result<ActionCompositionSnapshot, ActionCompositionSnapshotReadError> {
+    let action = db
+        .get_action_by_id(action_id)
+        .map_err(|error| {
+            ActionCompositionSnapshotReadError::ReadFailed(format!("action read failed: {error}"))
+        })?
+        .ok_or_else(|| ActionCompositionSnapshotReadError::ActionNotFound(action_id.to_string()))?;
+
+    let account_name = action
+        .account_id
+        .as_deref()
+        .and_then(|account_id| db.get_account(account_id).ok().flatten())
+        .map(|account| account.name);
+    let source_meeting_title = action
+        .source_id
+        .as_deref()
+        .and_then(|source_id| db.get_meeting_by_id(source_id).ok().flatten())
+        .map(|meeting| meeting.title);
+    let trust_band = action_snapshot_trust_band(action.trust_band.as_deref());
+    let source_asof = Some(action.updated_at.as_str());
+
+    let title = action_snapshot_field(
+        "/headline/title",
+        "Title",
+        serde_json::Value::from(action.title.clone()),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    let status = action_snapshot_field(
+        "/headline/status",
+        "Status",
+        serde_json::Value::from(action.status.clone()),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    let priority = action_snapshot_field(
+        "/headline/priority",
+        "Priority",
+        serde_json::json!({
+            "value": action.priority,
+            "label": action_priority_label(action.priority),
+        }),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+
+    let mut fields = vec![title.clone(), status.clone(), priority.clone()];
+    push_action_field(
+        &mut fields,
+        "/status/current",
+        "Current state",
+        Some(serde_json::Value::from(action.status.clone())),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/status/completed_at",
+        "Completed",
+        action.completed_at.as_deref().map(serde_json::Value::from),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/status/waiting_on",
+        "Waiting on",
+        action.waiting_on.as_deref().map(serde_json::Value::from),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/priority/value",
+        "Priority",
+        Some(serde_json::json!({
+            "value": action.priority,
+            "label": action_priority_label(action.priority),
+        })),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/context/body",
+        "Context",
+        action.context.as_deref().map(serde_json::Value::from),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::ManualUser,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/account",
+        "Account",
+        action.account_id.as_deref().map(|account_id| {
+            serde_json::json!({
+                "id": account_id,
+                "name": account_name.as_deref(),
+            })
+        }),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/project",
+        "Project",
+        action.project_id.as_deref().map(|project_id| {
+            serde_json::json!({
+                "id": project_id,
+            })
+        }),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/person",
+        "Person",
+        action.person_id.as_deref().map(|person_id| {
+            serde_json::json!({
+                "id": person_id,
+            })
+        }),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/due_date",
+        "Due",
+        action.due_date.as_deref().map(serde_json::Value::from),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/created_at",
+        "Created",
+        Some(serde_json::Value::from(action.created_at.clone())),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/reference/source",
+        "Source",
+        (action.source_type.is_some()
+            || action.source_id.is_some()
+            || action.source_label.is_some())
+        .then(|| {
+            serde_json::json!({
+                "type": action.source_type.as_deref(),
+                "id": action.source_id.as_deref(),
+                "label": action.source_label.as_deref(),
+                "meeting_title": source_meeting_title.as_deref(),
+            })
+        }),
+        action.source_type.as_deref().unwrap_or("action"),
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/linear/issue",
+        "Linear issue",
+        action.linear_identifier.as_deref().map(|identifier| {
+            serde_json::json!({
+                "identifier": identifier,
+                "url": action.linear_url.as_deref(),
+            })
+        }),
+        "linear",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SourceField,
+    );
+    push_action_field(
+        &mut fields,
+        "/action-bar/status_toggle",
+        "Action bar",
+        Some(serde_json::json!({
+            "can_complete": action.status != "completed",
+            "can_reopen": action.status == "completed",
+            "status": action.status.as_str(),
+        })),
+        "action",
+        source_asof,
+        trust_band,
+        ActionCompositionProvenanceKind::SystemConfig,
+    );
+
+    Ok(ActionCompositionSnapshot {
+        action_id: action.id.clone(),
+        title,
+        status: Some(status),
+        priority: Some(priority),
+        fields,
+    })
+}
+
+fn action_snapshot_trust_band(value: Option<&str>) -> TrustBand {
+    match value {
+        Some("likely_current") => TrustBand::LikelyCurrent,
+        Some("use_with_caution") => TrustBand::UseWithCaution,
+        Some("needs_verification") => TrustBand::NeedsVerification,
+        _ => TrustBand::UseWithCaution,
+    }
+}
+
+fn action_priority_label(priority: i32) -> &'static str {
+    if priority <= 1 {
+        "Urgent"
+    } else if priority <= 2 {
+        "High"
+    } else if priority >= 4 {
+        "Low"
+    } else {
+        "Medium"
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn action_snapshot_field(
+    field_path: &str,
+    label: &str,
+    value: serde_json::Value,
+    source_label: &str,
+    source_asof: Option<&str>,
+    trust_band: TrustBand,
+    provenance_kind: ActionCompositionProvenanceKind,
+) -> ActionCompositionSnapshotField {
+    AccountCompositionSnapshotField {
+        field_path: field_path.to_string(),
+        label: label.to_string(),
+        value,
+        sensitivity: AccountCompositionSnapshotSensitivity::Internal,
+        source_label: Some(source_label.to_string()),
+        source_ref: None,
+        source_asof: source_asof.map(ToString::to_string),
+        trust_band,
+        trust_status: trust_status(trust_band).to_string(),
+        provenance_kind,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_action_field(
+    fields: &mut Vec<ActionCompositionSnapshotField>,
+    field_path: &str,
+    label: &str,
+    value: Option<serde_json::Value>,
+    source_label: &str,
+    source_asof: Option<&str>,
+    trust_band: TrustBand,
+    provenance_kind: ActionCompositionProvenanceKind,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    fields.push(action_snapshot_field(
+        field_path,
+        label,
+        value,
+        source_label,
+        source_asof,
+        trust_band,
+        provenance_kind,
+    ));
+}
+
+fn push_person_field(
+    fields: &mut Vec<PersonCompositionSnapshotField>,
+    field_path: &str,
+    label: &str,
+    value: Option<serde_json::Value>,
+    source_label: &str,
+    source_asof: Option<&str>,
+    provenance_kind: PersonCompositionProvenanceKind,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    fields.push(AccountCompositionSnapshotField {
+        field_path: field_path.to_string(),
+        label: label.to_string(),
+        value,
+        sensitivity: AccountCompositionSnapshotSensitivity::Internal,
+        source_label: Some(source_label.to_string()),
+        source_ref: None,
+        source_asof: source_asof.map(ToString::to_string),
+        trust_band: TrustBand::UseWithCaution,
+        trust_status: trust_status(TrustBand::UseWithCaution).to_string(),
+        provenance_kind,
+    });
+}
+
+fn person_identity_field(
+    field_path: &str,
+    label: &str,
+    value: serde_json::Value,
+) -> PersonCompositionSnapshotField {
+    AccountCompositionSnapshotField {
+        field_path: field_path.to_string(),
+        label: label.to_string(),
+        value,
+        sensitivity: AccountCompositionSnapshotSensitivity::NonSensitiveIdentity,
+        source_label: None,
+        source_ref: None,
+        source_asof: None,
+        trust_band: TrustBand::LikelyCurrent,
+        trust_status: trust_status(TrustBand::LikelyCurrent).to_string(),
+        provenance_kind: AccountCompositionProvenanceKind::NonSensitiveIdentity,
+    }
+}
+
+fn push_project_field(
+    fields: &mut Vec<ProjectCompositionSnapshotField>,
+    field_path: &str,
+    label: &str,
+    value: Option<serde_json::Value>,
+    source_label: &str,
+    source_asof: Option<&str>,
+    provenance_kind: AccountCompositionProvenanceKind,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    fields.push(AccountCompositionSnapshotField {
+        field_path: field_path.to_string(),
+        label: label.to_string(),
+        value,
+        sensitivity: AccountCompositionSnapshotSensitivity::Internal,
+        source_label: Some(source_label.to_string()),
+        source_ref: None,
+        source_asof: source_asof.map(ToString::to_string),
+        trust_band: TrustBand::UseWithCaution,
+        trust_status: trust_status(TrustBand::UseWithCaution).to_string(),
+        provenance_kind,
+    });
+}
+
+fn project_identity_field(
+    field_path: &str,
+    label: &str,
+    value: serde_json::Value,
+) -> ProjectCompositionSnapshotField {
+    AccountCompositionSnapshotField {
+        field_path: field_path.to_string(),
+        label: label.to_string(),
+        value,
+        sensitivity: AccountCompositionSnapshotSensitivity::NonSensitiveIdentity,
+        source_label: None,
+        source_ref: None,
+        source_asof: None,
+        trust_band: TrustBand::LikelyCurrent,
+        trust_status: trust_status(TrustBand::LikelyCurrent).to_string(),
+        provenance_kind: AccountCompositionProvenanceKind::NonSensitiveIdentity,
+    }
 }
 
 fn push_account_vital_field(

--- a/src-tauri/src/services/derived_state.rs
+++ b/src-tauri/src/services/derived_state.rs
@@ -909,9 +909,10 @@ fn entity_identity_from_subject_ref(
         SubjectRef::Meeting { id } => Ok((id, "meeting")),
         SubjectRef::Person { id } => Ok((id, "person")),
         SubjectRef::Project { id } => Ok((id, "project")),
-        SubjectRef::Email { .. } | SubjectRef::Multi(_) | SubjectRef::Global => {
-            Err(ProjectionErrorClass::ValidationError)
-        }
+        SubjectRef::Action { .. }
+        | SubjectRef::Email { .. }
+        | SubjectRef::Multi(_)
+        | SubjectRef::Global => Err(ProjectionErrorClass::ValidationError),
     }
 }
 

--- a/src-tauri/src/services/entity_context.rs
+++ b/src-tauri/src/services/entity_context.rs
@@ -390,6 +390,7 @@ pub fn entity_context_entry_for_claim(
         .map_err(|error| format!("Invalid entity context claim subject_ref: {error}"))?
     {
         crate::db::claim_invalidation::SubjectRef::Account { id } => ("account".to_string(), id),
+        crate::db::claim_invalidation::SubjectRef::Action { id } => ("action".to_string(), id),
         crate::db::claim_invalidation::SubjectRef::Person { id } => ("person".to_string(), id),
         crate::db::claim_invalidation::SubjectRef::Project { id } => ("project".to_string(), id),
         crate::db::claim_invalidation::SubjectRef::Meeting { id } => ("meeting".to_string(), id),

--- a/src-tauri/src/services/linear.rs
+++ b/src-tauri/src/services/linear.rs
@@ -238,6 +238,16 @@ pub async fn push_action_to_linear(
         ) {
             log::warn!("emit Linear push signal failed for {entity_type}:{entity_id}: {e}");
         }
+        crate::services::signals::emit_or_log(
+            ctx,
+            db,
+            "action",
+            action_id,
+            "action.field_changed",
+            "user_action",
+            Some(&signal_value),
+            0.9,
+        );
 
         // Positive Bayesian feedback when an AI-suggested action is
         // pushed to Linear — validates the suggestion quality.

--- a/src-tauri/src/services/meetings.rs
+++ b/src-tauri/src/services/meetings.rs
@@ -43,8 +43,7 @@ pub fn upsert_meeting_for_reconcile(
             user_notes: meeting.user_notes.clone(),
             intelligence_state: meeting.intelligence_state.clone(),
         };
-        crate::services::meetings_writer::write(tx, &write_req)
-            .map_err(|e| e.to_string())?;
+        crate::services::meetings_writer::write(tx, &write_req).map_err(|e| e.to_string())?;
         crate::services::signals::emit(
             ctx,
             tx,
@@ -4408,6 +4407,9 @@ fn trust_subject_ref_from_subject(
         }
         crate::db::claim_invalidation::SubjectRef::Meeting { id } => {
             crate::abilities::provenance::SubjectRef::Meeting(id)
+        }
+        crate::db::claim_invalidation::SubjectRef::Action { id } => {
+            crate::abilities::provenance::SubjectRef::Action(id)
         }
         crate::db::claim_invalidation::SubjectRef::Multi(subjects) => {
             crate::abilities::provenance::SubjectRef::Multi(

--- a/src-tauri/src/services/meetings_view.rs
+++ b/src-tauri/src/services/meetings_view.rs
@@ -86,7 +86,6 @@ pub fn read_surface_meetings(
     Ok(out)
 }
 
-
 fn intent_includes(intent: MeetingsViewIntent, meeting_type: &str) -> bool {
     match intent {
         MeetingsViewIntent::Briefing | MeetingsViewIntent::Schedule => meeting_type != "personal",

--- a/src-tauri/src/services/meetings_writer/backfill_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/backfill_adapter.rs
@@ -14,7 +14,10 @@ pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteErr
     debug_assert_eq!(req.source, MeetingSource::Backfill);
     invariants::validate(req)?;
 
-    let existed = db.get_meeting_by_id(&req.id).map_err(WriteError::from)?.is_some();
+    let existed = db
+        .get_meeting_by_id(&req.id)
+        .map_err(WriteError::from)?
+        .is_some();
     let meeting = build_db_meeting(req);
     db.upsert_meeting(&meeting)?;
 

--- a/src-tauri/src/services/meetings_writer/reconcile_adapter.rs
+++ b/src-tauri/src/services/meetings_writer/reconcile_adapter.rs
@@ -15,7 +15,10 @@ pub fn write(db: &ActionDb, req: &WriteRequest) -> Result<WriteOutcome, WriteErr
     debug_assert_eq!(req.source, MeetingSource::Reconcile);
     invariants::validate(req)?;
 
-    let existed = db.get_meeting_by_id(&req.id).map_err(WriteError::from)?.is_some();
+    let existed = db
+        .get_meeting_by_id(&req.id)
+        .map_err(WriteError::from)?
+        .is_some();
     let meeting = build_db_meeting(req);
     db.upsert_meeting(&meeting)?;
 

--- a/src-tauri/src/services/meetings_writer/types.rs
+++ b/src-tauri/src/services/meetings_writer/types.rs
@@ -84,10 +84,7 @@ pub enum WriteError {
         field: &'static str,
     },
     #[error("invalid value for {field}: {reason}")]
-    InvalidValue {
-        field: &'static str,
-        reason: String,
-    },
+    InvalidValue { field: &'static str, reason: String },
     #[error("database write failed: {0}")]
     Database(String),
 }

--- a/src-tauri/src/services/people.rs
+++ b/src-tauri/src/services/people.rs
@@ -615,6 +615,8 @@ pub fn update_person_field(
     db.update_person_field(person_id, field, value)
         .map_err(|e| e.to_string())?;
 
+    let field_signal_payload = person_field_signal_payload(field, value);
+
     // Emit field update signal + self-healing evaluation. Best-effort:
     // failure should NOT roll back the field update but must warn so ops
     // can detect lost self-healing triggers.
@@ -626,11 +628,7 @@ pub fn update_person_field(
         person_id,
         "field_updated",
         "user_edit",
-        Some(&format!(
-            "{{\"field\":\"{}\",\"value\":\"{}\"}}",
-            field,
-            value.replace('"', "\\\"")
-        )),
+        Some(&field_signal_payload),
         0.8,
         &state.intel_queue,
     ) {
@@ -638,6 +636,7 @@ pub fn update_person_field(
             "people: emit_propagate_and_evaluate dropped on person={person_id} field={field}: {e}"
         );
     }
+    emit_person_composition_field_changed_signal(ctx, db, person_id, &field_signal_payload);
 
     // Self-healing: record user correction for Clay-enrichable fields
     if matches!(field, "linkedin_url" | "role" | "organization" | "name") {
@@ -687,6 +686,32 @@ pub fn update_person_field(
     }
 
     Ok(())
+}
+
+fn person_field_signal_payload(field: &str, value: &str) -> String {
+    serde_json::json!({
+        "field": field,
+        "value": value,
+    })
+    .to_string()
+}
+
+fn emit_person_composition_field_changed_signal(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    person_id: &str,
+    payload: &str,
+) {
+    crate::services::signals::emit_or_log(
+        ctx,
+        db,
+        "person",
+        person_id,
+        "person.field_changed",
+        "user_edit",
+        Some(payload),
+        0.8,
+    );
 }
 
 /// Link a person to an entity and regenerate workspace files.
@@ -884,6 +909,9 @@ pub fn create_person(
 mod tests {
     use super::*;
     use crate::db::test_utils::test_db;
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use chrono::TimeZone;
+    use rusqlite::params;
 
     #[test]
     fn stakeholder_entity_type_for_id_rejects_unknown_entity_id() {
@@ -893,6 +921,34 @@ mod tests {
             .expect_err("unknown entity_id should be rejected");
 
         assert!(err.contains("unknown stakeholder entity_id"));
+    }
+
+    #[test]
+    fn person_field_change_signal_records_composition_invalidation_payload() {
+        let db = test_db();
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(42);
+        let external = ExternalClients::default();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        let payload = person_field_signal_payload("role", "VP \"Customer\"");
+
+        emit_person_composition_field_changed_signal(&ctx, &db, "person-signal-1", &payload);
+
+        let value: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT value
+                 FROM signal_events
+                 WHERE entity_type = 'person'
+                   AND entity_id = 'person-signal-1'
+                   AND signal_type = 'person.field_changed'",
+                params![],
+                |row| row.get(0),
+            )
+            .expect("read person field signal payload");
+        let json: serde_json::Value = serde_json::from_str(&value).expect("payload is valid json");
+        assert_eq!(json["field"], "role");
+        assert_eq!(json["value"], "VP \"Customer\"");
     }
 }
 

--- a/src-tauri/src/services/projects.rs
+++ b/src-tauri/src/services/projects.rs
@@ -322,20 +322,7 @@ pub async fn update_project_field(
             let rng = crate::services::context::SystemRng;
             let ext = crate::services::context::ExternalClients::default();
             let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-            crate::services::signals::emit_or_log(
-                &ctx,
-                db,
-                "project",
-                &project_id,
-                "field_updated",
-                "user_edit",
-                Some(&format!(
-                    "{{\"field\":\"{}\",\"value\":\"{}\"}}",
-                    field,
-                    value.replace('"', "\\\"")
-                )),
-                0.8,
-            );
+            emit_project_field_change_signals(&ctx, db, &project_id, &field, &value);
 
             // Self-healing: event-driven trigger evaluation
             #[allow(clippy::let_underscore_must_use, reason = "intentional best-effort discard; preserves existing non-blocking behavior")]
@@ -438,29 +425,40 @@ pub async fn update_project_notes(
                 let rng = crate::services::context::SystemRng;
                 let ext = crate::services::context::ExternalClients::default();
                 let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext);
-                crate::services::signals::emit_or_log(
-                    &ctx,
-                    db,
-                    "project",
-                    &project_id,
-                    "field_updated",
-                    "user_edit",
-                    Some(&format!(
-                        "{{\"field\":\"notes\",\"value\":\"{}\"}}",
-                        notes
-                            .chars()
-                            .take(100)
-                            .collect::<String>()
-                            .replace('"', "\\\"")
-                    )),
-                    0.8,
-                );
+                let notes_preview = notes.chars().take(100).collect::<String>();
+                emit_project_field_change_signals(&ctx, db, &project_id, "notes", &notes_preview);
             }
 
             Ok(())
         })
         .await
         .map_err(String::from)
+}
+
+fn emit_project_field_change_signals(
+    ctx: &crate::services::context::ServiceContext<'_>,
+    db: &ActionDb,
+    project_id: &str,
+    field: &str,
+    value: &str,
+) {
+    let payload = serde_json::json!({
+        "field": field,
+        "value": value,
+    })
+    .to_string();
+    for signal_type in ["field_updated", "project.field_changed"] {
+        crate::services::signals::emit_or_log(
+            ctx,
+            db,
+            "project",
+            project_id,
+            signal_type,
+            "user_edit",
+            Some(&payload),
+            0.8,
+        );
+    }
 }
 
 /// Bulk-create projects from a list of names.
@@ -581,4 +579,75 @@ pub fn archive_project(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use chrono::TimeZone;
+    use rusqlite::params;
+
+    fn test_context<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external)
+    }
+
+    fn signal_count(db: &ActionDb, signal_type: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM signal_events
+                 WHERE entity_type = 'project'
+                   AND entity_id = 'project-signal-1'
+                   AND signal_type = ?1",
+                params![signal_type],
+                |row| row.get(0),
+            )
+            .expect("count signal rows")
+    }
+
+    fn signal_payload(db: &ActionDb, signal_type: &str) -> serde_json::Value {
+        let value: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT value
+                 FROM signal_events
+                 WHERE entity_type = 'project'
+                   AND entity_id = 'project-signal-1'
+                   AND signal_type = ?1",
+                params![signal_type],
+                |row| row.get(0),
+            )
+            .expect("read signal payload");
+        serde_json::from_str(&value).expect("payload is valid json")
+    }
+
+    #[test]
+    fn project_field_changes_emit_legacy_and_composition_invalidation_signals() {
+        let db = test_db();
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap());
+        let rng = SeedableRng::new(42);
+        let external = ExternalClients::default();
+        let ctx = test_context(&clock, &rng, &external);
+
+        emit_project_field_change_signals(
+            &ctx,
+            &db,
+            "project-signal-1",
+            "notes",
+            "quoted \" field value",
+        );
+
+        assert_eq!(signal_count(&db, "field_updated"), 1);
+        assert_eq!(signal_count(&db, "project.field_changed"), 1);
+
+        let payload = signal_payload(&db, "project.field_changed");
+        assert_eq!(payload["field"], "notes");
+        assert_eq!(payload["value"], "quoted \" field value");
+    }
 }

--- a/src-tauri/src/services/recommendations/recommendation.rs
+++ b/src-tauri/src/services/recommendations/recommendation.rs
@@ -82,6 +82,9 @@ fn subject_ref_for_commit_claim(
         SubjectRef::Account(id) => subject_json("account", id)?,
         SubjectRef::Project(id) => subject_json("project", id)?,
         SubjectRef::Person(id) => subject_json("person", id)?,
+        SubjectRef::Action(_) => {
+            return Err(RecommendationProposalError::UnsupportedSubjectKind { kind: "action" });
+        }
         SubjectRef::Meeting(_) => {
             return Err(RecommendationProposalError::UnsupportedSubjectKind { kind: "meeting" });
         }

--- a/src-tauri/src/services/recommendations/render.rs
+++ b/src-tauri/src/services/recommendations/render.rs
@@ -771,6 +771,7 @@ fn subject_filter(subject: Option<&SubjectRef>) -> Result<Option<(String, String
         Some(SubjectRef::Account(id)) => Some(("account".to_string(), non_empty_id(id)?)),
         Some(SubjectRef::Project(id)) => Some(("project".to_string(), non_empty_id(id)?)),
         Some(SubjectRef::Person(id)) => Some(("person".to_string(), non_empty_id(id)?)),
+        Some(SubjectRef::Action(id)) => Some(("action".to_string(), non_empty_id(id)?)),
         Some(SubjectRef::Meeting(id)) => Some(("meeting".to_string(), non_empty_id(id)?)),
         Some(SubjectRef::User(id)) => Some(("user".to_string(), non_empty_id(id)?)),
         Some(SubjectRef::Multi(_)) => {
@@ -803,6 +804,7 @@ fn subject_ref_from_storage(raw: &str) -> Result<SubjectRef> {
         "account" => SubjectRef::Account(id),
         "project" => SubjectRef::Project(id),
         "person" => SubjectRef::Person(id),
+        "action" => SubjectRef::Action(id),
         "meeting" => SubjectRef::Meeting(id),
         "user" => SubjectRef::User(id),
         "global" => SubjectRef::Global,

--- a/src-tauri/src/services/source_management_ledger.rs
+++ b/src-tauri/src/services/source_management_ledger.rs
@@ -1169,7 +1169,8 @@ fn subjects_from_claim_ref(subject: &ClaimSubjectRef) -> BTreeSet<EntitySubject>
             .iter()
             .flat_map(subjects_from_claim_ref)
             .collect::<BTreeSet<_>>(),
-        ClaimSubjectRef::Meeting { .. }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Meeting { .. }
         | ClaimSubjectRef::Email { .. }
         | ClaimSubjectRef::Global => BTreeSet::new(),
     }
@@ -1187,6 +1188,10 @@ fn subjects_from_ref(subject: &SubjectRef) -> BTreeSet<EntitySubject> {
         }]),
         SubjectRef::Project(id) => BTreeSet::from([EntitySubject {
             entity_type: "project".to_string(),
+            entity_id: id.clone(),
+        }]),
+        SubjectRef::Action(id) => BTreeSet::from([EntitySubject {
+            entity_type: "action".to_string(),
             entity_id: id.clone(),
         }]),
         SubjectRef::Multi(subjects) => subjects

--- a/src-tauri/src/services/workspace_ingestion/graph.rs
+++ b/src-tauri/src/services/workspace_ingestion/graph.rs
@@ -1267,7 +1267,8 @@ fn subjects_from_claim_ref(subject: &ClaimSubjectRef) -> BTreeSet<EntitySubject>
             .iter()
             .flat_map(subjects_from_claim_ref)
             .collect::<BTreeSet<_>>(),
-        ClaimSubjectRef::Meeting { .. }
+        ClaimSubjectRef::Action { .. }
+        | ClaimSubjectRef::Meeting { .. }
         | ClaimSubjectRef::Email { .. }
         | ClaimSubjectRef::Global => BTreeSet::new(),
     }
@@ -1287,6 +1288,7 @@ fn subjects_from_ref(subject: &SubjectRef) -> BTreeSet<EntitySubject> {
             entity_type: "project".to_string(),
             entity_id: id.clone(),
         }]),
+        SubjectRef::Action(_) => BTreeSet::new(),
         SubjectRef::Multi(subjects) => subjects
             .iter()
             .flat_map(subjects_from_ref)

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2285,16 +2285,14 @@ mod tests {
             "SQLCipher key-verify alone must not trigger manual recovery"
         );
 
-        let disk_io_only: DbAccessError =
-            DbAccessError::Other("disk I/O error".to_string());
+        let disk_io_only: DbAccessError = DbAccessError::Other("disk I/O error".to_string());
         assert!(
             !db_access_error_requires_manual_recovery(&disk_io_only),
             "disk I/O alone must not trigger manual recovery"
         );
 
-        let malformed: DbAccessError = DbAccessError::Other(
-            "SQLite error: database disk image is malformed".to_string(),
-        );
+        let malformed: DbAccessError =
+            DbAccessError::Other("SQLite error: database disk image is malformed".to_string());
         assert!(
             db_access_error_requires_manual_recovery(&malformed),
             "real btree corruption must trigger manual recovery"

--- a/src-tauri/src/surface_runtime/mod.rs
+++ b/src-tauri/src/surface_runtime/mod.rs
@@ -4612,6 +4612,8 @@ mod tests {
             "properties": {
                 "account_id": { "type": "string" },
                 "composition_id": { "type": "string" },
+                "entity_id": { "type": "string" },
+                "entity_type": { "type": "string" },
                 "expected_composition_version": { "type": "number" },
                 "schema_version": { "type": "number" }
             },

--- a/src/components/composition/CompositionInlineEdit.tsx
+++ b/src/components/composition/CompositionInlineEdit.tsx
@@ -1,9 +1,13 @@
 import { EditableText } from "@/components/ui/EditableText";
 import { useIntelligenceCorrection } from "@/hooks/useIntelligenceCorrection";
-import type { EditRoute } from "@/services/composition/contracts";
+import type {
+  CompositionFeedbackEntityType,
+  EditRoute,
+} from "@/services/composition/contracts";
 
 interface CompositionInlineEditProps {
   accountId?: string;
+  entityType?: CompositionFeedbackEntityType;
   route: EditRoute | null;
   value: string;
   as?: "span" | "p" | "h1" | "h2" | "h3" | "div";
@@ -27,6 +31,7 @@ function feedbackField(route: EditRoute): string {
 
 export function CompositionInlineEdit({
   accountId,
+  entityType = "account",
   route,
   value,
   as = "span",
@@ -47,7 +52,7 @@ export function CompositionInlineEdit({
       onChange={async (correctedValue) => {
         const ok = await submit({
           entityId: accountId,
-          entityType: "account",
+          entityType,
           field: feedbackField(route),
           action: "corrected",
           itemKey: claimRef.claim_id,

--- a/src/components/composition/ReactBlockRenderer.test.tsx
+++ b/src/components/composition/ReactBlockRenderer.test.tsx
@@ -2,8 +2,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ReactBlockRenderer } from "@/components/composition/ReactBlockRenderer";
 import { BLOCK_RENDERERS } from "@/components/composition/blocks/BlockComponents";
 import {
@@ -11,12 +11,16 @@ import {
   type ProjectedBlock,
 } from "@/services/composition/contracts";
 
+const { submitMock } = vi.hoisted(() => ({
+  submitMock: vi.fn(async () => true),
+}));
+
 vi.mock("@/hooks/useIntelligenceCorrection", () => ({
   useIntelligenceCorrection: () => ({
     submitting: false,
     success: false,
     error: null,
-    submit: async () => true,
+    submit: submitMock,
     reset: () => {},
   }),
 }));
@@ -44,6 +48,10 @@ function block(overrides: Partial<ProjectedBlock> = {}): ProjectedBlock {
 }
 
 describe("ReactBlockRenderer", () => {
+  beforeEach(() => {
+    submitMock.mockClear();
+  });
+
   it("keeps frontend renderer coverage exhaustive with Rust BlockType", () => {
     const rustSource = fs.readFileSync(
       path.resolve(process.cwd(), "src-tauri/abilities-runtime/src/abilities/composition.rs"),
@@ -120,6 +128,45 @@ describe("ReactBlockRenderer", () => {
     expect(screen.getByRole("button", { name: "Partially" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "No" })).toBeInTheDocument();
     expect(screen.queryByText("/text")).not.toBeInTheDocument();
+  });
+
+  it("routes claim feedback to the provided composition entity", async () => {
+    render(
+      <ReactBlockRenderer
+        entityId="project-feedback"
+        entityType="project"
+        block={block({
+          selected_known_type_id: "claim_summary",
+          payload: {
+            title: "Current signal",
+            text: "The project risk is rising.",
+            trust_band: "use_with_caution",
+          },
+          claim_refs: [{ claim_id: "claim-feedback", claim_version: 3, field_path: "/text" }],
+          edit_routes: [
+            {
+              field_path: "/text",
+              role: "feedback_target",
+              claim_refs: [{ claim_id: "claim-feedback", claim_version: 3, field_path: "/text" }],
+              feedback_allowed: true,
+              refusal_reason: null,
+            },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+    await waitFor(() =>
+      expect(submitMock).toHaveBeenCalledWith({
+        entityId: "project-feedback",
+        entityType: "project",
+        field: "composition:text",
+        action: "confirmed",
+        source: undefined,
+      }),
+    );
   });
 
   it("surfaces account snapshot degradation without exposing the internal reason", () => {

--- a/src/components/composition/ReactBlockRenderer.tsx
+++ b/src/components/composition/ReactBlockRenderer.tsx
@@ -1,21 +1,36 @@
-import type { ProjectedBlock, RenderedProvenance } from "@/services/composition/contracts";
+import type {
+  CompositionFeedbackEntityType,
+  ProjectedBlock,
+  RenderedProvenance,
+} from "@/services/composition/contracts";
 import { BLOCK_RENDERERS, GenericTextBlock } from "@/components/composition/blocks/BlockComponents";
 import pageStyles from "@/pages/AccountDetailPage.module.css";
 
 export interface ReactBlockRendererProps {
   block: ProjectedBlock;
   accountId?: string;
+  entityId?: string;
+  entityType?: CompositionFeedbackEntityType;
   renderedProvenance?: RenderedProvenance | null;
   editMode?: boolean;
 }
 
-export function ReactBlockRenderer({ block, accountId, renderedProvenance, editMode = false }: ReactBlockRendererProps) {
+export function ReactBlockRenderer({
+  block,
+  accountId,
+  entityId,
+  entityType = "account",
+  renderedProvenance,
+  editMode = false,
+}: ReactBlockRendererProps) {
   const Renderer = BLOCK_RENDERERS[block.selected_known_type_id as keyof typeof BLOCK_RENDERERS];
+  const feedbackEntityId = entityId ?? accountId;
   if (Renderer) {
     return (
       <Renderer
         block={block}
-        accountId={accountId}
+        accountId={feedbackEntityId}
+        entityType={entityType}
         payload={block.payload}
         renderedProvenance={renderedProvenance}
         editMode={editMode}
@@ -26,7 +41,8 @@ export function ReactBlockRenderer({ block, accountId, renderedProvenance, editM
     return (
       <GenericTextBlock
         block={block}
-        accountId={accountId}
+        accountId={feedbackEntityId}
+        entityType={entityType}
         payload={block.payload}
         renderedProvenance={renderedProvenance}
         editMode={editMode}

--- a/src/components/composition/blocks/BlockComponents.tsx
+++ b/src/components/composition/blocks/BlockComponents.tsx
@@ -8,6 +8,7 @@ import { HealthBadge } from "@/components/shared/HealthBadge";
 import { CompositionInlineEdit } from "@/components/composition/CompositionInlineEdit";
 import { normalizeTrustBand } from "@/services/composition/contracts";
 import type {
+  CompositionFeedbackEntityType,
   EditRoute,
   KnownCompositionBlockType,
   ProjectedBlock,
@@ -19,6 +20,7 @@ type Payload = Record<string, unknown>;
 type BlockComponentProps = {
   block: ProjectedBlock;
   accountId?: string;
+  entityType?: CompositionFeedbackEntityType;
   payload: Payload;
   renderedProvenance?: RenderedProvenance | null;
   editMode?: boolean;
@@ -193,10 +195,12 @@ function feedbackCurrentValue(payload: Payload, route: EditRoute): string | null
 
 function BlockFeedback({
   accountId,
+  entityType = "account",
   block,
   payload,
 }: {
   accountId?: string;
+  entityType?: CompositionFeedbackEntityType;
   block: ProjectedBlock;
   payload: Payload;
 }) {
@@ -209,7 +213,7 @@ function BlockFeedback({
     <div className={pageStyles.compositionFeedbackRow}>
       <IntelligenceCorrection
         entityId={accountId}
-        entityType="account"
+        entityType={entityType}
         field={feedbackField(route)}
         itemKey={claimRef.claim_id}
         currentValue={currentValue}
@@ -222,6 +226,7 @@ function BlockFeedback({
 function BlockShell({
   block,
   accountId,
+  entityType,
   payload,
   renderedProvenance,
   title,
@@ -231,6 +236,7 @@ function BlockShell({
 }: {
   block: ProjectedBlock;
   accountId?: string;
+  entityType?: CompositionFeedbackEntityType;
   payload: Payload;
   renderedProvenance?: RenderedProvenance | null;
   title?: string | null;
@@ -278,13 +284,14 @@ function BlockShell({
         </header>
       )}
       {children}
-      <BlockFeedback accountId={accountId} block={block} payload={payload} />
+      <BlockFeedback accountId={accountId} entityType={entityType} block={block} payload={payload} />
     </article>
   );
 }
 
 function EditableBlockText({
   accountId,
+  entityType,
   block,
   editMode,
   fieldPath,
@@ -294,6 +301,7 @@ function EditableBlockText({
   multiline = true,
 }: {
   accountId?: string;
+  entityType?: CompositionFeedbackEntityType;
   block: ProjectedBlock;
   editMode?: boolean;
   fieldPath: string;
@@ -307,6 +315,7 @@ function EditableBlockText({
   return (
     <CompositionInlineEdit
       accountId={accountId}
+      entityType={entityType}
       route={feedbackRouteForPath(block, fieldPath)}
       value={value}
       as={as}
@@ -317,13 +326,13 @@ function EditableBlockText({
   );
 }
 
-function AccountOverviewBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+function AccountOverviewBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const account = object(payload.account) ?? {};
   const vitals = array(payload.vitals);
   const contexts = array(payload.context);
   const snapshotDegraded = Boolean(text(payload.snapshot_degraded));
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} featured title={text(account.display_name) ?? text(payload.title)}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} featured title={text(account.display_name) ?? text(payload.title)}>
       {snapshotDegraded && (
         <div className={pageStyles.compositionDegradedState} role="status">
           <p className={pageStyles.compositionStateLabel}>Account details unavailable</p>
@@ -333,6 +342,7 @@ function AccountOverviewBlock({ block, accountId, payload, renderedProvenance, e
       {text(payload.summary) && (
         <EditableBlockText
           accountId={accountId}
+          entityType={entityType}
           block={block}
           editMode={editMode}
           fieldPath="/summary"
@@ -362,24 +372,24 @@ function AccountOverviewBlock({ block, accountId, payload, renderedProvenance, e
   );
 }
 
-function ClaimSummaryBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+function ClaimSummaryBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const empty = payload.empty_state === true;
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? text(payload.intent)} empty={empty}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? text(payload.intent)} empty={empty}>
       {text(payload.text) && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath="/text" value={text(payload.text) ?? ""} as="p" className={pageStyles.compositionNarrative} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath="/text" value={text(payload.text) ?? ""} as="p" className={pageStyles.compositionNarrative} />
       )}
       {text(payload.body) && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath="/body" value={text(payload.body) ?? ""} as="p" className={pageStyles.compositionBodyText} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath="/body" value={text(payload.body) ?? ""} as="p" className={pageStyles.compositionBodyText} />
       )}
     </BlockShell>
   );
 }
 
-function HealthSnapshotBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+function HealthSnapshotBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const band = text(payload.band) ?? text(payload.trust_band);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title="Health">
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title="Health">
       <div className={pageStyles.compositionMetricGrid}>
         {typeof payload.score === "number" && (
           <div className={pageStyles.compositionMetric}>
@@ -395,30 +405,30 @@ function HealthSnapshotBlock({ block, accountId, payload, renderedProvenance, ed
         )}
       </div>
       {text(payload.text) && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath="/text" value={text(payload.text) ?? ""} as="p" className={pageStyles.compositionNarrative} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath="/text" value={text(payload.text) ?? ""} as="p" className={pageStyles.compositionNarrative} />
       )}
     </BlockShell>
   );
 }
 
-function RiskCalloutBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+function RiskCalloutBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const primary = text(payload.text) ?? text(payload.body);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Risk"}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Risk"}>
       {primary && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath={text(payload.text) ? "/text" : "/body"} value={primary} as="p" className={pageStyles.compositionNarrative} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath={text(payload.text) ? "/text" : "/body"} value={primary} as="p" className={pageStyles.compositionNarrative} />
       )}
       {text(payload.recommended_action) && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath="/recommended_action" value={text(payload.recommended_action) ?? ""} as="p" className={pageStyles.compositionBodyText} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath="/recommended_action" value={text(payload.recommended_action) ?? ""} as="p" className={pageStyles.compositionBodyText} />
       )}
     </BlockShell>
   );
 }
 
-function RelationshipMapBlock({ block, accountId, payload, renderedProvenance }: BlockComponentProps) {
+function RelationshipMapBlock({ block, accountId, entityType, payload, renderedProvenance }: BlockComponentProps) {
   const nodes = array(payload.nodes);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title="Relationships">
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title="Relationships">
       <div className={pageStyles.compositionRelationshipGrid}>
         {nodes.map((node, index) => (
           <div className={pageStyles.compositionPersonNode} key={`${text(node.claim_id) ?? text(node.label) ?? "node"}-${index}`}>
@@ -431,10 +441,10 @@ function RelationshipMapBlock({ block, accountId, payload, renderedProvenance }:
   );
 }
 
-function ActionListBlock({ block, accountId, payload, renderedProvenance }: BlockComponentProps) {
+function ActionListBlock({ block, accountId, entityType, payload, renderedProvenance }: BlockComponentProps) {
   const items = array(payload.items);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Actions"} empty={items.length === 0}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Actions"} empty={items.length === 0}>
       <div className={pageStyles.compositionBlockStack}>
         {items.map((item, index) => (
           <div className={pageStyles.compositionActionRow} key={`${text(item.claim_id) ?? text(item.title) ?? "action"}-${index}`}>
@@ -450,10 +460,10 @@ function ActionListBlock({ block, accountId, payload, renderedProvenance }: Bloc
   );
 }
 
-function EvidenceListBlock({ block, accountId, payload, renderedProvenance }: BlockComponentProps) {
+function EvidenceListBlock({ block, accountId, entityType, payload, renderedProvenance }: BlockComponentProps) {
   const items = array(payload.items);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Evidence"} empty={items.length === 0}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title) ?? "Evidence"} empty={items.length === 0}>
       <div className={pageStyles.compositionEvidenceList}>
         {items.map((item, index) => (
           <div className={pageStyles.compositionEvidenceRow} key={`${text(item.label) ?? "evidence"}-${index}`}>
@@ -470,12 +480,12 @@ function EvidenceListBlock({ block, accountId, payload, renderedProvenance }: Bl
   );
 }
 
-function MarkdownDocumentBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+function MarkdownDocumentBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const sections = array(payload.sections);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title)}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={text(payload.title)}>
       {text(payload.body) && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath="/body" value={text(payload.body) ?? ""} as="p" className={pageStyles.compositionBodyText} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath="/body" value={text(payload.body) ?? ""} as="p" className={pageStyles.compositionBodyText} />
       )}
       {sections.map((section, index) => (
         <section key={`${text(section.heading) ?? "section"}-${index}`}>
@@ -487,25 +497,25 @@ function MarkdownDocumentBlock({ block, accountId, payload, renderedProvenance, 
   );
 }
 
-export function GenericTextBlock({ block, accountId, payload, renderedProvenance, editMode }: BlockComponentProps) {
+export function GenericTextBlock({ block, accountId, entityType, payload, renderedProvenance, editMode }: BlockComponentProps) {
   const title = text(payload.title) ?? text(payload.label);
   const body = text(payload.text) ?? text(payload.body);
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance} title={title}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance} title={title}>
       {body && (
-        <EditableBlockText accountId={accountId} block={block} editMode={editMode} fieldPath={text(payload.text) ? "/text" : "/body"} value={body} as="p" className={pageStyles.compositionBodyText} />
+        <EditableBlockText accountId={accountId} entityType={entityType} block={block} editMode={editMode} fieldPath={text(payload.text) ? "/text" : "/body"} value={body} as="p" className={pageStyles.compositionBodyText} />
       )}
     </BlockShell>
   );
 }
 
-function PrimitiveBlock({ block, accountId, payload, renderedProvenance }: BlockComponentProps) {
+function PrimitiveBlock({ block, accountId, entityType, payload, renderedProvenance }: BlockComponentProps) {
   const label = text(payload.label) ?? text(object(payload.payload)?.text) ?? text(payload.text) ?? block.selected_known_type_id;
   if (block.selected_known_type_id === "dailyos/health-badge") {
     const rawBand = text(payload.band);
     const band = rawBand === "green" || rawBand === "yellow" || rawBand === "red" ? rawBand : "yellow";
     return (
-      <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance}>
+      <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance}>
         <HealthBadge
           band={band}
           score={typeof payload.score === "number" ? payload.score : 0}
@@ -517,7 +527,7 @@ function PrimitiveBlock({ block, accountId, payload, renderedProvenance }: Block
     );
   }
   return (
-    <BlockShell block={block} accountId={accountId} payload={payload} renderedProvenance={renderedProvenance}>
+    <BlockShell block={block} accountId={accountId} entityType={entityType} payload={payload} renderedProvenance={renderedProvenance}>
       <span className={pageStyles.compositionButton}>{label}</span>
     </BlockShell>
   );

--- a/src/components/ui/IntelligenceCorrection.tsx
+++ b/src/components/ui/IntelligenceCorrection.tsx
@@ -31,14 +31,15 @@
  */
 import { useCallback, useRef, useState } from "react";
 import { useIntelligenceCorrection } from "@/hooks/useIntelligenceCorrection";
+import type { CompositionFeedbackEntityType } from "@/services/composition/contracts";
 import { AccuracyPrompt, type AccuracyPromptOutcome } from "./AccuracyPrompt";
 import styles from "./IntelligenceCorrection.module.css";
 
 export interface IntelligenceCorrectionProps {
   /** Entity the AI assessment belongs to. */
   entityId: string;
-  /** Always "account" today — the component is account-only per the current implementation. */
-  entityType: "account";
+  /** Entity kind the AI assessment belongs to. */
+  entityType: CompositionFeedbackEntityType;
   /** Field key the correction targets (e.g. "state_of_play", "health"). */
   field: string;
   /**

--- a/src/hooks/useChapterLayout.test.tsx
+++ b/src/hooks/useChapterLayout.test.tsx
@@ -214,6 +214,31 @@ describe("useChapterLayout", () => {
     expect(result.current.view.sections[1].blocks[0].variant).toBe("compact");
   });
 
+  it("keeps action layouts local instead of calling persisted entity overlay commands", async () => {
+    const { result } = renderHook(() =>
+      useChapterLayout({ projection: accountProjection(), entityType: "action" }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invokeMock).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.setBlockHidden("risk-a", true);
+    });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.saving).toBe(false);
+    expect(result.current.layoutRevision).toBe(0);
+    expect(result.current.view.hiddenItems.map((item) => item.id)).toEqual(["risk-a"]);
+
+    await act(async () => {
+      await result.current.resetLayout();
+    });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.view.hiddenItems).toEqual([]);
+  });
+
   it("optimistically saves block visibility and accepts the saved revision", async () => {
     const save = deferred<LayoutOverlayResponse>();
     invokeMock

--- a/src/hooks/useChapterLayout.ts
+++ b/src/hooks/useChapterLayout.ts
@@ -38,7 +38,7 @@ export interface RenderableCompositionView {
 
 export interface UseChapterLayoutArgs {
   projection: ProjectedComposition | null;
-  entityType: CompositionEntityType;
+  entityType: CompositionLayoutSubjectType;
   surfaceKey?: CompositionSurfaceKey;
 }
 
@@ -59,6 +59,14 @@ export interface UseChapterLayoutResult {
 
 const CORE_SECTION_IDS = new Set(["headline", "masthead", "lead"]);
 const CORE_BLOCK_TYPES = new Set(["account_overview"]);
+
+type CompositionLayoutSubjectType = CompositionEntityType | "action";
+
+function supportsPersistedLayoutOverlay(
+  entityType: CompositionLayoutSubjectType,
+): entityType is CompositionEntityType {
+  return entityType === "account" || entityType === "project" || entityType === "person";
+}
 
 function defaultOverlay(): CompositionLayoutOverlay {
   return {
@@ -230,6 +238,19 @@ export function useChapterLayout({
     loadSequenceRef.current = sequence;
     setLoading(true);
     setError(null);
+
+    if (!supportsPersistedLayoutOverlay(entityType)) {
+      const next = defaultOverlay();
+      overlayRef.current = next;
+      persistedOverlayRef.current = next;
+      persistedLayoutRevisionRef.current = 0;
+      lastPersistedMutationSequenceRef.current = mutationSequenceAtStart;
+      setOverlay(next);
+      setLayoutRevision(0);
+      setLoading(false);
+      return;
+    }
+
     getCompositionLayoutOverlay({ entityType, surfaceKey })
       .then((response) => {
         if (loadSequenceRef.current !== sequence) return;
@@ -265,6 +286,15 @@ export function useChapterLayout({
       setOverlay(next);
       setSaving(true);
       setError(null);
+
+      if (!supportsPersistedLayoutOverlay(entityType)) {
+        persistedOverlayRef.current = next;
+        persistedLayoutRevisionRef.current = 0;
+        lastPersistedMutationSequenceRef.current = sequence;
+        setLayoutRevision(0);
+        setSaving(false);
+        return;
+      }
 
       void saveCompositionLayoutOverlay({ entityType, surfaceKey, overlay: next })
         .then((response: LayoutOverlayResponse) => {
@@ -359,6 +389,14 @@ export function useChapterLayout({
     setOverlay(next);
     setSaving(true);
     setError(null);
+    if (!supportsPersistedLayoutOverlay(entityType)) {
+      persistedOverlayRef.current = next;
+      persistedLayoutRevisionRef.current = 0;
+      lastPersistedMutationSequenceRef.current = sequence;
+      setLayoutRevision(0);
+      setSaving(false);
+      return;
+    }
     try {
       const response = await resetCompositionLayoutOverlay({ entityType, surfaceKey });
       const reset = normalizeCompositionLayoutOverlay(response.overlay);

--- a/src/hooks/useProjectedComposition.test.tsx
+++ b/src/hooks/useProjectedComposition.test.tsx
@@ -3,7 +3,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { useProjectedComposition } from "@/hooks/useProjectedComposition";
+import {
+  compositionIdForSubject,
+  useProjectedComposition,
+  type CompositionSubjectKind,
+} from "@/hooks/useProjectedComposition";
 import type { ProjectedCompositionCommandResponse } from "@/services/composition/contracts";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -25,19 +29,21 @@ function deferred<T>() {
 function response(
   overrides: {
     accountId?: string;
+    compositionId?: string;
     requestId?: string;
     version?: number;
     cacheHintToken?: string;
   } = {},
 ): ProjectedCompositionCommandResponse {
   const accountId = overrides.accountId ?? "acct-fixture";
+  const compositionId = overrides.compositionId ?? `dailyos/account-overview:account:${accountId}`;
   return {
     ok: true,
     request_id: overrides.requestId ?? "request-fixture",
     cache_hint_token: overrides.cacheHintToken ?? "cache-fixture",
     served_from_cache: false,
     projection: {
-      composition_id: `dailyos/account-overview:account:${accountId}`,
+      composition_id: compositionId,
       composition_version: overrides.version ?? 7,
       fallback_policy_version: 3,
       sections: [],
@@ -56,6 +62,15 @@ describe("useProjectedComposition", () => {
     invokeMock.mockReset();
   });
 
+  it.each([
+    ["account", "acct-fixture", "dailyos/account-overview:account:acct-fixture"],
+    ["project", "project-fixture", "dailyos/project-overview:project:project-fixture"],
+    ["person", "person-fixture", "dailyos/person-overview:person:person-fixture"],
+    ["action", "action-fixture", "dailyos/action-detail:action:action-fixture"],
+  ] as const)("builds the %s composition id", (entityType, entityId, expected) => {
+    expect(compositionIdForSubject({ entityType, entityId })).toBe(expected);
+  });
+
   it("invokes projected composition once for an account load", async () => {
     invokeMock.mockResolvedValueOnce(response());
 
@@ -71,6 +86,52 @@ describe("useProjectedComposition", () => {
     });
     expect(result.current.data?.projection.composition_version).toBe(7);
     expect(result.current.renderedProvenance?.surface).toBe("tauri_app");
+  });
+
+  it.each([
+    ["project", "project-fixture", "dailyos/project-overview:project:project-fixture"],
+    ["person", "person-fixture", "dailyos/person-overview:person:person-fixture"],
+    ["action", "action-fixture", "dailyos/action-detail:action:action-fixture"],
+  ] as const)("invokes projected composition for a %s subject", async (entityType, entityId, compositionId) => {
+    invokeMock.mockResolvedValueOnce(response({ compositionId }));
+
+    const { result } = renderHook(() => useProjectedComposition({ entityType, entityId }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("get_projected_composition", {
+      compositionId,
+      compositionVersion: 0,
+      cacheHintToken: null,
+    });
+    expect(result.current.data?.projection.composition_id).toBe(compositionId);
+  });
+
+  it("passes forceRefresh only for explicit mutation refreshes", async () => {
+    invokeMock
+      .mockResolvedValueOnce(response())
+      .mockResolvedValueOnce(response({ requestId: "request-refresh", version: 8 }));
+
+    const { result } = renderHook(() => useProjectedComposition("acct-fixture"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.refetch({ forceRefresh: true });
+    });
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "get_projected_composition", {
+      compositionId: "dailyos/account-overview:account:acct-fixture",
+      compositionVersion: 0,
+      cacheHintToken: null,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "get_projected_composition", {
+      compositionId: "dailyos/account-overview:account:acct-fixture",
+      compositionVersion: 7,
+      cacheHintToken: "cache-fixture",
+      forceRefresh: true,
+    });
   });
 
   it("ignores stale responses after account navigation", async () => {
@@ -103,6 +164,47 @@ describe("useProjectedComposition", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.data?.request_id).toBe("new-request");
     expect(result.current.data?.projection.composition_id).toBe("dailyos/account-overview:account:acct-b");
+  });
+
+  it("ignores stale responses after subject-type navigation", async () => {
+    const first = deferred<ProjectedCompositionCommandResponse>();
+    const second = deferred<ProjectedCompositionCommandResponse>();
+    invokeMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { result, rerender } = renderHook(
+      ({ entityType, entityId }: { entityType: CompositionSubjectKind; entityId: string }) =>
+        useProjectedComposition({ entityType, entityId }),
+      { initialProps: { entityType: "project" as CompositionSubjectKind, entityId: "project-a" } },
+    );
+
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(1));
+    rerender({ entityType: "person", entityId: "person-b" });
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      first.resolve(response({
+        compositionId: "dailyos/project-overview:project:project-a",
+        requestId: "old-request",
+        version: 1,
+      }));
+      await first.promise;
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+
+    await act(async () => {
+      second.resolve(response({
+        compositionId: "dailyos/person-overview:person:person-b",
+        requestId: "new-request",
+        version: 9,
+      }));
+      await second.promise;
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.request_id).toBe("new-request");
+    expect(result.current.data?.projection.composition_id).toBe("dailyos/person-overview:person:person-b");
   });
 
   it("clears previous account data while the next account loads", async () => {

--- a/src/hooks/useProjectedComposition.ts
+++ b/src/hooks/useProjectedComposition.ts
@@ -10,59 +10,104 @@ interface UseProjectedCompositionState {
   loading: boolean;
   error: string | null;
   renderedProvenance: RenderedProvenance | null;
-  refetch: () => Promise<void>;
+  refetch: (options?: UseProjectedCompositionRefetchOptions) => Promise<void>;
 }
 
-function compositionIdForAccount(accountId: string): string {
-  return `dailyos/account-overview:account:${accountId}`;
+export type CompositionSubjectKind = "account" | "project" | "person" | "action";
+
+export interface ProjectedCompositionSubject {
+  entityType: CompositionSubjectKind;
+  entityId: string | undefined;
 }
 
-export function useProjectedComposition(accountId: string | undefined): UseProjectedCompositionState {
+type UseProjectedCompositionInput = string | ProjectedCompositionSubject | undefined;
+
+interface UseProjectedCompositionRefetchOptions {
+  forceRefresh?: boolean;
+}
+
+const PRODUCER_BY_SUBJECT: Record<CompositionSubjectKind, string> = {
+  account: "dailyos/account-overview",
+  project: "dailyos/project-overview",
+  person: "dailyos/person-overview",
+  action: "dailyos/action-detail",
+};
+
+function normalizeSubject(input: UseProjectedCompositionInput): ProjectedCompositionSubject | null {
+  if (typeof input === "string") {
+    return { entityType: "account", entityId: input };
+  }
+  return input ?? null;
+}
+
+export function compositionIdForSubject(subject: ProjectedCompositionSubject | null): string | null {
+  if (!subject?.entityId?.trim()) return null;
+  return `${PRODUCER_BY_SUBJECT[subject.entityType]}:${subject.entityType}:${subject.entityId}`;
+}
+
+export function useProjectedComposition(accountId: string | undefined): UseProjectedCompositionState;
+export function useProjectedComposition(subject: ProjectedCompositionSubject | undefined): UseProjectedCompositionState;
+export function useProjectedComposition(input: UseProjectedCompositionInput): UseProjectedCompositionState {
+  const subject = normalizeSubject(input);
+  const entityLabel = subject?.entityType ? subject.entityType[0].toUpperCase() + subject.entityType.slice(1) : "Subject";
+  const compositionId = useMemo(() => compositionIdForSubject(subject), [subject?.entityId, subject?.entityType]);
   const [data, setData] = useState<ProjectedCompositionCommandResponse | null>(null);
-  const [loading, setLoading] = useState(Boolean(accountId));
+  const [loading, setLoading] = useState(Boolean(compositionId));
   const [error, setError] = useState<string | null>(null);
   const cacheHintTokenRef = useRef<string | null>(null);
   const compositionVersionRef = useRef<number>(0);
   const requestSequenceRef = useRef(0);
-  const loadedAccountIdRef = useRef<string | null>(null);
+  const loadedCompositionIdRef = useRef<string | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (options?: UseProjectedCompositionRefetchOptions) => {
     const requestSequence = requestSequenceRef.current + 1;
     requestSequenceRef.current = requestSequence;
     const isActiveRequest = () => requestSequenceRef.current === requestSequence;
 
-    if (!accountId) {
+    if (!compositionId) {
       setData(null);
       setLoading(false);
-      setError("Account not found");
-      loadedAccountIdRef.current = null;
+      setError(`${entityLabel} not found`);
+      loadedCompositionIdRef.current = null;
       return;
     }
 
-    if (loadedAccountIdRef.current !== accountId) {
+    if (loadedCompositionIdRef.current !== compositionId) {
       setData(null);
     }
     setLoading(true);
     setError(null);
     try {
-      const response = await invoke<ProjectedCompositionCommandResponse>("get_projected_composition", {
-        compositionId: compositionIdForAccount(accountId),
+      const request: {
+        compositionId: string;
+        compositionVersion: number;
+        cacheHintToken: string | null;
+        forceRefresh?: boolean;
+      } = {
+        compositionId,
         compositionVersion: compositionVersionRef.current,
         cacheHintToken: cacheHintTokenRef.current,
-      });
+      };
+      if (options?.forceRefresh) {
+        request.forceRefresh = true;
+      }
+      const response = await invoke<ProjectedCompositionCommandResponse>(
+        "get_projected_composition",
+        request,
+      );
       if (!isActiveRequest()) return;
       cacheHintTokenRef.current = response.cache_hint_token;
       compositionVersionRef.current = response.projection.composition_version ?? 0;
-      loadedAccountIdRef.current = accountId;
+      loadedCompositionIdRef.current = compositionId;
       setData(response);
     } catch (err) {
       if (!isActiveRequest()) return;
-      loadedAccountIdRef.current = accountId;
+      loadedCompositionIdRef.current = compositionId;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       if (isActiveRequest()) setLoading(false);
     }
-  }, [accountId]);
+  }, [compositionId, entityLabel]);
 
   useEffect(() => {
     cacheHintTokenRef.current = null;
@@ -70,10 +115,10 @@ export function useProjectedComposition(accountId: string | undefined): UseProje
     void load();
   }, [load]);
 
-  const accountMatchesLoadedData = Boolean(accountId) && loadedAccountIdRef.current === accountId;
-  const visibleData = accountMatchesLoadedData ? data : null;
-  const visibleError = accountMatchesLoadedData || !accountId ? error : null;
-  const visibleLoading = Boolean(accountId) && !visibleError && (!accountMatchesLoadedData || loading);
+  const subjectMatchesLoadedData = Boolean(compositionId) && loadedCompositionIdRef.current === compositionId;
+  const visibleData = subjectMatchesLoadedData ? data : null;
+  const visibleError = subjectMatchesLoadedData || !compositionId ? error : null;
+  const visibleLoading = Boolean(compositionId) && !visibleError && (!subjectMatchesLoadedData || loading);
 
   const renderedProvenance = useMemo(
     () => visibleData?.rendered_provenance ?? null,

--- a/src/pages/ActionDetailPage.module.css
+++ b/src/pages/ActionDetailPage.module.css
@@ -8,6 +8,11 @@
   margin: 0 auto;
 }
 
+.controlsPanel {
+  border-top: 1px solid var(--color-rule-light);
+  margin-top: 56px;
+}
+
 /* ── Loading skeleton ── */
 
 .loadingSkeleton {

--- a/src/pages/ActionDetailPage.test.tsx
+++ b/src/pages/ActionDetailPage.test.tsx
@@ -1,0 +1,558 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ActionDetailPage from "@/pages/ActionDetailPage";
+import type {
+  ProjectedBlock,
+  ProjectedComposition,
+  ProjectedCompositionCommandResponse,
+} from "@/services/composition/contracts";
+import type { ActionDetail } from "@/types";
+
+const {
+  invokeMock,
+  navigateMock,
+  projectedRefetchMock,
+  useChapterLayoutMock,
+  useProjectedCompositionMock,
+  useRegisterMagazineShellMock,
+} = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  navigateMock: vi.fn(),
+  projectedRefetchMock: vi.fn(),
+  useChapterLayoutMock: vi.fn(),
+  useProjectedCompositionMock: vi.fn(),
+  useRegisterMagazineShellMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ actionId: "action-test-1" }),
+  useNavigate: () => navigateMock,
+  Link: ({ children, to, className }: { children: ReactNode; to: string; className?: string }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useProjectedComposition", () => ({
+  useProjectedComposition: (subject: unknown) => useProjectedCompositionMock(subject),
+}));
+
+vi.mock("@/hooks/useRevealObserver", () => ({
+  useRevealObserver: vi.fn(),
+}));
+
+vi.mock("@/hooks/useMagazineShell", () => ({
+  useRegisterMagazineShell: (config: unknown) => useRegisterMagazineShellMock(config),
+}));
+
+vi.mock("@/hooks/useChapterLayout", () => ({
+  useChapterLayout: (args: { projection: ProjectedComposition | null; entityType: string }) => {
+    useChapterLayoutMock(args);
+    const blockLabel = (block: ProjectedBlock | undefined) => {
+      const value = block?.payload.title ?? block?.payload.text;
+      return typeof value === "string" ? value : block?.block_id ?? "";
+    };
+    const sections =
+      args.projection?.sections.map((section) => ({
+        section,
+        label: section.label ?? section.section_id,
+        coreLocked: section.section_id === "headline",
+        blocks: section.block_indexes.map((index) => {
+          const block = args.projection?.blocks[index] as ProjectedBlock;
+          return {
+            block,
+            sectionId: section.section_id,
+            label: blockLabel(block),
+            variant: "default",
+            coreLocked: section.section_id === "headline",
+          };
+        }),
+        hiddenBlocks: [],
+      })) ?? [];
+    return {
+      overlay: null,
+      layoutRevision: 0,
+      view: {
+        sections,
+        hiddenSections: [],
+        hiddenItems: [],
+        hasVisibleNonCore: sections.some((section) => !section.coreLocked),
+      },
+      loading: false,
+      saving: false,
+      error: null,
+      setBlockHidden: vi.fn(),
+      setSectionHidden: vi.fn(),
+      setBlockVariant: vi.fn(),
+      setSectionLabel: vi.fn(),
+      reorderBlocks: vi.fn(),
+      resetLayout: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("@/components/composition/ReactBlockRenderer", () => ({
+  ReactBlockRenderer: ({
+    block,
+    entityId,
+    entityType,
+  }: {
+    block: ProjectedBlock;
+    entityId?: string;
+    entityType?: string;
+  }) => (
+    <div
+      data-testid="composition-block"
+      data-block-id={block.block_id}
+      data-entity-id={entityId}
+      data-entity-type={entityType}
+    >
+      {typeof block.payload.title === "string"
+        ? block.payload.title
+        : typeof block.payload.text === "string"
+          ? block.payload.text
+          : block.block_id}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/folio-refresh-button", () => ({
+  FolioRefreshButton: () => <button type="button">Refresh</button>,
+}));
+
+vi.mock("@/components/editorial/EditorialLoading", () => ({
+  EditorialLoading: () => <div data-testid="editorial-loading">Loading</div>,
+}));
+
+vi.mock("@/components/editorial/EditorialError", () => ({
+  EditorialError: ({ message }: { message: string }) => (
+    <div data-testid="editorial-error">{message}</div>
+  ),
+}));
+
+vi.mock("@/components/editorial/EditorialEmpty", () => ({
+  EditorialEmpty: ({ title }: { title: string }) => <div data-testid="editorial-empty">{title}</div>,
+}));
+
+vi.mock("@/components/editorial/FinisMarker", () => ({
+  FinisMarker: () => <div data-testid="finis-marker" />,
+}));
+
+vi.mock("@/components/ui/EditableText", () => ({
+  EditableText: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <button type="button" data-testid="editable-title" onClick={() => onChange("Renamed action")}>
+      {value}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/editable-textarea", () => ({
+  EditableTextarea: ({
+    value,
+    onSave,
+    placeholder,
+  }: {
+    value: string;
+    onSave: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <button type="button" data-testid="editable-context" onClick={() => onSave("Updated context")}>
+      {value || placeholder}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/editable-date", () => ({
+  EditableDate: ({ value, onSave }: { value: string; onSave: (value: string) => void }) => (
+    <button type="button" data-testid="editable-due" onClick={() => onSave("2026-06-12")}>
+      {value || "Add due date"}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/editable-inline", () => ({
+  EditableInline: ({
+    value,
+    onSave,
+    placeholder,
+  }: {
+    value: string;
+    onSave: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <button type="button" data-testid="editable-source" onClick={() => onSave("Manual source")}>
+      {value || placeholder}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/entity-picker", () => ({
+  EntityPicker: ({
+    onChange,
+    placeholder,
+  }: {
+    onChange: (id: string | null, name?: string, entityType?: "account" | "project") => void;
+    placeholder?: string;
+  }) => (
+    <button type="button" data-testid="account-picker" onClick={() => onChange("acct-new", "New Account", "account")}>
+      {placeholder}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/priority-picker", () => ({
+  PriorityPicker: ({ onChange }: { value: number; onChange: (priority: number) => void }) => (
+    <button type="button" data-testid="priority-picker" onClick={() => onChange(2)}>
+      Set high priority
+    </button>
+  ),
+}));
+
+function block(
+  blockId: string,
+  sectionIndex: number,
+  selectedKnownTypeId: string,
+  payload: Record<string, unknown>,
+): ProjectedBlock {
+  return {
+    block_id: blockId,
+    block_index: sectionIndex,
+    original_type_id: selectedKnownTypeId,
+    selected_known_type_id: selectedKnownTypeId,
+    payload,
+    banner: null,
+    trust_band: "likely_current",
+    claim_refs: [],
+    provenance: [],
+    edit_routes: [],
+    diagnostics: [],
+  };
+}
+
+function projection(overrides: Partial<ProjectedComposition> = {}): ProjectedComposition {
+  const blocks = [
+    block("headline-block", 0, "account_overview", {
+      action: { title: "Projected Action" },
+      title: "Projected Action",
+    }),
+    block("status-block", 1, "claim_summary", { text: "Open and owned" }),
+    block("priority-block", 2, "risk_callout", { title: "High priority" }),
+    block("context-block", 3, "claim_summary", { text: "Customer context" }),
+    block("reference-block", 4, "evidence_list", { title: "References" }),
+    block("linear-block", 5, "evidence_list", { title: "Linear issue" }),
+    block("action-bar-block", 6, "action_list", { title: "Next action" }),
+  ];
+  return {
+    composition_id: "dailyos/action-detail:action:action-test-1",
+    composition_version: 1,
+    fallback_policy_version: 3,
+    sections: [
+      {
+        section_id: "headline",
+        section_index: 0,
+        label: "Headline",
+        layout: "stacked",
+        salience: { weight: 0.95, band: "critical", reason: "action masthead" },
+        block_ids: ["headline-block"],
+        block_indexes: [0],
+      },
+      {
+        section_id: "status",
+        section_index: 1,
+        label: "Status",
+        layout: "stacked",
+        salience: { weight: 0.86, band: "important", reason: "action status" },
+        block_ids: ["status-block"],
+        block_indexes: [1],
+      },
+      {
+        section_id: "priority",
+        section_index: 2,
+        label: "Priority",
+        layout: "stacked",
+        salience: { weight: 0.78, band: "important", reason: "action priority" },
+        block_ids: ["priority-block"],
+        block_indexes: [2],
+      },
+      {
+        section_id: "context",
+        section_index: 3,
+        label: "Context",
+        layout: "stacked",
+        salience: { weight: 0.7, band: "contextual", reason: "action context" },
+        block_ids: ["context-block"],
+        block_indexes: [3],
+      },
+      {
+        section_id: "reference",
+        section_index: 4,
+        label: "Reference",
+        layout: "stacked",
+        salience: { weight: 0.6, band: "contextual", reason: "action reference" },
+        block_ids: ["reference-block"],
+        block_indexes: [4],
+      },
+      {
+        section_id: "linear",
+        section_index: 5,
+        label: "Linear",
+        layout: "stacked",
+        salience: { weight: 0.55, band: "background", reason: "linear link" },
+        block_ids: ["linear-block"],
+        block_indexes: [5],
+      },
+      {
+        section_id: "action-bar",
+        section_index: 6,
+        label: "Action bar",
+        layout: "stacked",
+        salience: { weight: 0.75, band: "important", reason: "action controls" },
+        block_ids: ["action-bar-block"],
+        block_indexes: [6],
+      },
+    ],
+    blocks,
+    diagnostics: [],
+    unknown_block_count: 0,
+    unknown_block_cap: 5,
+    dropped_unknown_block_count: 0,
+    ...overrides,
+  };
+}
+
+function response(
+  projectionValue: ProjectedComposition,
+): ProjectedCompositionCommandResponse {
+  return {
+    ok: true,
+    request_id: "request-test",
+    projection: projectionValue,
+    cache_hint_token: "cache-test",
+    served_from_cache: false,
+    rendered_provenance: { surface: "tauri_app", value: { ok: true } },
+  };
+}
+
+function actionDetail(overrides: Partial<ActionDetail> = {}): ActionDetail {
+  return {
+    id: "action-test-1",
+    title: "Detail Action",
+    priority: 3,
+    status: "unstarted",
+    createdAt: "2026-06-01T14:00:00Z",
+    dueDate: undefined,
+    completedAt: undefined,
+    accountId: undefined,
+    accountName: undefined,
+    projectId: undefined,
+    sourceType: "manual",
+    sourceId: undefined,
+    sourceLabel: undefined,
+    actionKind: "task",
+    commitmentId: undefined,
+    ownerRaw: undefined,
+    ownerEntityId: undefined,
+    ownerConfidence: undefined,
+    ownerSource: undefined,
+    trustScore: undefined,
+    trustBand: undefined,
+    commitmentSourceCount: undefined,
+    context: "Existing context",
+    waitingOn: undefined,
+    updatedAt: "2026-06-01T14:00:00Z",
+    personId: undefined,
+    nextMeetingTitle: undefined,
+    nextMeetingStart: undefined,
+    needsDecision: undefined,
+    decisionOwner: undefined,
+    decisionStakes: undefined,
+    linearIdentifier: undefined,
+    linearUrl: undefined,
+    sourceMeetingTitle: undefined,
+    ...overrides,
+  };
+}
+
+describe("ActionDetailPage", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    navigateMock.mockReset();
+    projectedRefetchMock.mockReset();
+    projectedRefetchMock.mockResolvedValue(undefined);
+    useChapterLayoutMock.mockReset();
+    useProjectedCompositionMock.mockReset();
+    useRegisterMagazineShellMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "get_action_detail") return Promise.resolve(actionDetail());
+      if (command === "get_linear_status") return Promise.resolve({ enabled: true, apiKeySet: true });
+      if (command === "get_linear_teams") return Promise.resolve([{ id: "team-1", name: "Team One" }]);
+      if (command === "push_action_to_linear") {
+        return Promise.resolve({ identifier: "DOS-1", url: "https://linear.example/DOS-1" });
+      }
+      return Promise.resolve(null);
+    });
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection()),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: projectedRefetchMock,
+    });
+  });
+
+  it("renders Action Detail from the projected composition and derives shell chapters", async () => {
+    render(<ActionDetailPage />);
+
+    expect(useProjectedCompositionMock).toHaveBeenCalledWith({
+      entityType: "action",
+      entityId: "action-test-1",
+    });
+    expect(useChapterLayoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: "action" }),
+    );
+    expect(screen.getByText("Projected Action")).toBeInTheDocument();
+    expect(screen.getByText("Open and owned")).toBeInTheDocument();
+    expect(screen.getByText("High priority")).toBeInTheDocument();
+    expect(screen.getByText("Customer context")).toBeInTheDocument();
+    expect(await screen.findByTestId("editable-title")).toHaveTextContent("Detail Action");
+
+    for (const renderedBlock of screen.getAllByTestId("composition-block")) {
+      expect(renderedBlock).toHaveAttribute("data-entity-id", "action-test-1");
+      expect(renderedBlock).toHaveAttribute("data-entity-type", "action");
+    }
+
+    const shellConfig = useRegisterMagazineShellMock.mock.calls.at(-1)?.[0] as {
+      chapters: Array<{ id: string; label: string }>;
+    };
+    expect(shellConfig.chapters.map((chapter) => chapter.id)).toEqual([
+      "headline",
+      "status",
+      "priority",
+      "context",
+      "reference",
+      "linear",
+      "action-bar",
+    ]);
+  });
+
+  it("preserves existing action edit controls through their Tauri commands", async () => {
+    render(<ActionDetailPage />);
+
+    fireEvent.click(await screen.findByTestId("editable-title"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", title: "Renamed action" },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("priority-picker"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", priority: 2 },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("editable-context"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", context: "Updated context" },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("editable-due"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", dueDate: "2026-06-12" },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("account-picker"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", accountId: "acct-new" },
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("editable-source"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("update_action", {
+        request: { id: "action-test-1", sourceLabel: "Manual source" },
+      }),
+    );
+
+    fireEvent.change(await screen.findByRole("combobox"), { target: { value: "team-1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Linear Issue" }));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("push_action_to_linear", {
+        actionId: "action-test-1",
+        teamId: "team-1",
+        title: "Detail Action",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark Complete" }));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("complete_action", { id: "action-test-1" }),
+    );
+    expect(projectedRefetchMock).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it("shows producer errors without falling back to the old template", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: "action producer unavailable",
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<ActionDetailPage />);
+
+    expect(screen.getByTestId("editorial-error")).toHaveTextContent("action producer unavailable");
+    expect(screen.queryByTestId("composition-block")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Action controls")).not.toBeInTheDocument();
+  });
+
+  it("shows a composition empty state when no projected sections are renderable", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection({ sections: [], blocks: [] })),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: vi.fn(),
+    });
+
+    render(<ActionDetailPage />);
+
+    expect(screen.getByTestId("editorial-empty")).toHaveTextContent("No action composition");
+  });
+
+  it("shows loading while the first projected composition is pending", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: true,
+      error: null,
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<ActionDetailPage />);
+
+    expect(screen.getByTestId("editorial-loading")).toBeInTheDocument();
+  });
+});

--- a/src/pages/ActionDetailPage.tsx
+++ b/src/pages/ActionDetailPage.tsx
@@ -1,18 +1,35 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import type { ReactNode } from "react";
 import { useParams, Link, useNavigate } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
+import { useRevealObserver } from "@/hooks/useRevealObserver";
+import {
+  useChapterLayout,
+  type RenderableCompositionBlock,
+  type RenderableCompositionSection,
+} from "@/hooks/useChapterLayout";
+import { useProjectedComposition } from "@/hooks/useProjectedComposition";
 import { PriorityPicker } from "@/components/ui/priority-picker";
 import { EntityPicker } from "@/components/ui/entity-picker";
 import { EditableInline } from "@/components/ui/editable-inline";
 import { EditableTextarea } from "@/components/ui/editable-textarea";
 import { EditableDate } from "@/components/ui/editable-date";
 import { EditableText } from "@/components/ui/EditableText";
+import { EditorialLoading } from "@/components/editorial/EditorialLoading";
+import { EditorialError } from "@/components/editorial/EditorialError";
+import { EditorialEmpty } from "@/components/editorial/EditorialEmpty";
+import { FinisMarker } from "@/components/editorial/FinisMarker";
+import { FolioRefreshButton } from "@/components/ui/folio-refresh-button";
+import { ReactBlockRenderer } from "@/components/composition/ReactBlockRenderer";
 import { formatFullDate } from "@/lib/utils";
 import { classifyAction } from "@/lib/entity-utils";
-import { Check, Circle, ExternalLink } from "lucide-react";
+import { Check, Circle, ExternalLink, FileText, Flag, Link as LinkIcon, ListChecks, Send } from "lucide-react";
 import type { ActionDetail, LinearPushResult } from "@/types";
+import type { ProjectedBlock } from "@/services/composition/contracts";
+import shared from "@/styles/entity-detail.module.css";
+import accountStyles from "./AccountDetailPage.module.css";
 import s from "./ActionDetailPage.module.css";
 
 // =============================================================================
@@ -33,6 +50,35 @@ function priorityAccent(priority: number | string): string {
   return "var(--color-garden-larkspur)";
 }
 
+const SECTION_ICONS: Record<string, ReactNode> = {
+  headline: <ListChecks size={18} strokeWidth={1.5} />,
+  status: <Check size={18} strokeWidth={1.5} />,
+  priority: <Flag size={18} strokeWidth={1.5} />,
+  context: <FileText size={18} strokeWidth={1.5} />,
+  reference: <LinkIcon size={18} strokeWidth={1.5} />,
+  linear: <Send size={18} strokeWidth={1.5} />,
+  "action-bar": <ListChecks size={18} strokeWidth={1.5} />,
+};
+
+function actionTitleFromBlocks(
+  blocks: ProjectedBlock[],
+  detail: ActionDetail | null,
+  actionId: string | undefined,
+): string {
+  const overview = blocks.find((block) => block.selected_known_type_id === "account_overview");
+  const action = overview?.payload.action;
+  if (action && typeof action === "object" && !Array.isArray(action)) {
+    const title = (action as Record<string, unknown>).title;
+    if (typeof title === "string" && title.trim()) return title;
+  }
+  const account = overview?.payload.account;
+  if (account && typeof account === "object" && !Array.isArray(account)) {
+    const displayName = (account as Record<string, unknown>).display_name;
+    if (typeof displayName === "string" && displayName.trim()) return displayName;
+  }
+  return detail?.title ?? actionId ?? "Action";
+}
+
 // =============================================================================
 // Main component
 // =============================================================================
@@ -46,6 +92,13 @@ export default function ActionDetailPage() {
   const [toggling, setToggling] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const composition = useProjectedComposition(
+    actionId ? { entityType: "action", entityId: actionId } : undefined,
+  );
+  const projection = composition.data?.projection ?? null;
+  const layout = useChapterLayout({ projection, entityType: "action" });
+  const visibleSections = layout.view.sections;
+  const actionTitle = actionTitleFromBlocks(projection?.blocks ?? [], detail, actionId);
 
   // Linear push state
   const [linearEnabled, setLinearEnabled] = useState(false);
@@ -53,19 +106,53 @@ export default function ActionDetailPage() {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [pushing, setPushing] = useState(false);
 
+  useRevealObserver(!composition.loading && !!projection);
+
+  const chapters = useMemo(
+    () =>
+      visibleSections.map(({ section, label }) => ({
+        id: section.section_id,
+        label,
+        icon: SECTION_ICONS[section.section_id] ?? <FileText size={18} strokeWidth={1.5} />,
+      })),
+    [visibleSections],
+  );
+
   // Register magazine shell
   const shellConfig = useMemo(
     () => ({
-      folioLabel: detail?.title ? (detail.title.length > 30 ? detail.title.slice(0, 30) + "…" : detail.title) : "Action",
+      folioLabel: actionTitle.length > 30 ? actionTitle.slice(0, 30) + "…" : actionTitle,
       atmosphereColor: "terracotta" as const,
       activePage: "actions" as const,
       breadcrumbs: [
         { label: "Actions", onClick: () => navigate({ to: "/actions", search: { search: undefined } }) },
-        { label: detail?.title ?? "Action" },
+        { label: actionTitle },
       ],
-      folioStatusText: saveStatus === "saving" ? "Saving…" : saveStatus === "saved" ? "✓ Saved" : undefined,
+      chapters,
+      folioStatusText: composition.loading
+        ? "Composing..."
+        : saveStatus === "saving"
+          ? "Saving..."
+          : saveStatus === "saved"
+            ? "Saved"
+            : composition.data?.served_from_cache
+              ? "Projected from cache"
+              : undefined,
+      folioActions: (
+        <div className={shared.folioActions}>
+          <FolioRefreshButton onClick={composition.refetch} loading={composition.loading} />
+        </div>
+      ),
     }),
-    [detail?.title, navigate, saveStatus],
+    [
+      actionTitle,
+      chapters,
+      composition.data?.served_from_cache,
+      composition.loading,
+      composition.refetch,
+      navigate,
+      saveStatus,
+    ],
   );
   useRegisterMagazineShell(shellConfig);
 
@@ -84,6 +171,13 @@ export default function ActionDetailPage() {
       setLoading(false);
     }
   }, [actionId]);
+
+  const reloadAfterActionMutation = useCallback(async () => {
+    await Promise.all([
+      load(),
+      composition.refetch({ forceRefresh: true }),
+    ]);
+  }, [composition.refetch, load]);
 
   useEffect(() => {
     load();
@@ -112,7 +206,7 @@ export default function ActionDetailPage() {
       } else {
         await invoke("complete_action", { id: detail.id });
       }
-      await load();
+      await reloadAfterActionMutation();
     } finally {
       setToggling(false);
     }
@@ -126,7 +220,7 @@ export default function ActionDetailPage() {
       await invoke("update_action", {
         request: { id: detail.id, ...updates },
       });
-      await load();
+      await reloadAfterActionMutation();
       setSaveStatus("saved");
       saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 1500);
     } catch (e) {
@@ -146,7 +240,7 @@ export default function ActionDetailPage() {
         title: detail.title,
       });
       toast.success(`Created ${result.identifier}`);
-      await load();
+      await reloadAfterActionMutation();
     } catch (e) {
       toast.error(`Push failed: ${e instanceof Error ? e.message : String(e)}`);
     } finally {
@@ -154,40 +248,65 @@ export default function ActionDetailPage() {
     }
   }
 
-  // ── Loading state ──
+  if (composition.loading && !projection) return <EditorialLoading />;
+
+  if (composition.error) {
+    return <EditorialError message={composition.error} onRetry={composition.refetch} />;
+  }
+
+  if (!projection || projection.sections.length === 0 || projection.blocks.length === 0) {
+    return (
+      <EditorialEmpty
+        title="No action composition"
+        message="DailyOS has not produced an action detail surface yet."
+      />
+    );
+  }
+
+  const renderBlock = (item: RenderableCompositionBlock) => (
+    <ReactBlockRenderer
+      key={item.block.block_id}
+      block={item.block}
+      entityId={actionId}
+      entityType="action"
+      renderedProvenance={composition.renderedProvenance}
+    />
+  );
+
+  const renderSectionTitle = (section: RenderableCompositionSection) => (
+    <h2 className={accountStyles.compositionSectionTitle}>{section.label}</h2>
+  );
+
+  let controlsContent: ReactNode;
 
   if (loading) {
-    return (
-      <div className={`editorial-loading ${s.loadingSkeleton}`}>
-        <div className={`${s.skeletonBar} ${s.skeletonTitle}`} />
-        <div className={`${s.skeletonBar} ${s.skeletonHeadline}`} />
-        <div className={`${s.skeletonBar} ${s.skeletonSubhead}`} />
-        <div className={s.skeletonRule} />
-        <div className={s.skeletonBody}>
-          <div className={`${s.skeletonBlock} ${s.skeletonBlockSmall}`} />
-          <div className={`${s.skeletonBlock} ${s.skeletonBlockLarge}`} />
+    controlsContent = (
+      <section className={s.controlsPanel} aria-label="Action controls">
+        <div className={`editorial-loading ${s.loadingSkeleton}`}>
+          <div className={`${s.skeletonBar} ${s.skeletonTitle}`} />
+          <div className={`${s.skeletonBar} ${s.skeletonHeadline}`} />
+          <div className={`${s.skeletonBar} ${s.skeletonSubhead}`} />
+          <div className={s.skeletonRule} />
+          <div className={s.skeletonBody}>
+            <div className={`${s.skeletonBlock} ${s.skeletonBlockSmall}`} />
+            <div className={`${s.skeletonBlock} ${s.skeletonBlockLarge}`} />
+          </div>
         </div>
-      </div>
+      </section>
     );
-  }
-
-  // ── Error state ──
-
-  if (error || !detail) {
-    return (
-      <div className={s.errorState}>
-        <p className={s.errorTitle}>
-          Something went wrong
-        </p>
-        <p className={s.errorMessage}>
-          {error ?? "Action not found"}
-        </p>
-        <button onClick={load} className={s.retryButton}>
-          Try again
-        </button>
-      </div>
+  } else if (error || !detail) {
+    controlsContent = (
+      <section className={s.controlsPanel} aria-label="Action controls">
+        <div className={s.errorState}>
+          <p className={s.errorTitle}>Action controls unavailable</p>
+          <p className={s.errorMessage}>{error ?? "Action not found"}</p>
+          <button onClick={load} className={s.retryButton}>
+            Try again
+          </button>
+        </div>
+      </section>
     );
-  }
+  } else {
 
   const isCompleted = detail.status === "completed";
   const hasSource = detail.sourceId && detail.sourceMeetingTitle;
@@ -204,8 +323,9 @@ export default function ActionDetailPage() {
         ? "var(--color-spice-turmeric)"
         : undefined;
 
-  return (
-    <div className={s.container}>
+  controlsContent = (
+    <section className={s.controlsPanel} aria-label="Action controls">
+      <div className={s.container}>
 
         {/* ── Title band ── */}
         <div className={s.titleBand}>
@@ -477,6 +597,55 @@ export default function ActionDetailPage() {
             {isCompleted ? "Reopen" : "Mark Complete"}
           </button>
         </div>
-    </div>
+      </div>
+    </section>
+  );
+  }
+
+  return (
+    <main
+      className={accountStyles.compositionSurface}
+      data-composition-id={projection.composition_id}
+      data-composition-version={projection.composition_version ?? 0}
+      data-fallback-policy-version={projection.fallback_policy_version}
+    >
+      {visibleSections.map((renderableSection) => {
+        const section = renderableSection.section;
+        const isHeadline = section.section_id === "headline";
+        return (
+          <section
+            key={section.section_id}
+            id={section.section_id}
+            className={isHeadline ? accountStyles.compositionMasthead : accountStyles.compositionSection}
+            data-section-id={section.section_id}
+            data-section-layout={section.layout}
+            data-section-salience={section.salience.band}
+          >
+            {isHeadline ? (
+              <div className={accountStyles.compositionMastheadGrid}>
+                {renderableSection.blocks.map(renderBlock)}
+              </div>
+            ) : (
+              <>
+                <div className={accountStyles.compositionSectionLabel}>{renderableSection.label}</div>
+                <div className={accountStyles.compositionSectionBody}>
+                  <header className={accountStyles.compositionSectionHeader}>
+                    <div>{renderSectionTitle(renderableSection)}</div>
+                    {section.salience.reason && (
+                      <p className={accountStyles.compositionSectionMeta}>{section.salience.reason}</p>
+                    )}
+                  </header>
+                  <div className={accountStyles.compositionBlockStack}>
+                    {renderableSection.blocks.map(renderBlock)}
+                  </div>
+                </div>
+              </>
+            )}
+          </section>
+        );
+      })}
+      {controlsContent}
+      <FinisMarker />
+    </main>
   );
 }

--- a/src/pages/PersonDetailEditorial.module.css
+++ b/src/pages/PersonDetailEditorial.module.css
@@ -2,6 +2,65 @@
    PERSON DETAIL — Page-specific styles
    ============================================================================= */
 
-/* (Person page has minimal page-specific styles — most patterns are in the
-   shared entity-detail module. This file exists for future person-specific
-   additions and to maintain the consistent import pattern.) */
+.personControlPanel {
+  display: grid;
+  gap: var(--space-md);
+  padding: var(--space-lg) 0;
+  border-top: 1px solid var(--color-rule-heavy);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.personControlForm {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-md);
+  align-items: end;
+}
+
+.personControlField {
+  display: grid;
+  gap: 6px;
+}
+
+.personControlField span,
+.personPanelLabel {
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.personControlActions,
+.personActionComposer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.personControlActions {
+  grid-column: 1 / -1;
+}
+
+.personActionComposer {
+  padding-top: var(--space-sm);
+}
+
+.personActionComposer > input {
+  max-width: 360px;
+}
+
+.personRelationshipControls {
+  display: grid;
+  gap: var(--space-lg);
+  padding: var(--space-lg) 0;
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+@media (max-width: 860px) {
+  .personControlForm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/PersonDetailEditorial.test.tsx
+++ b/src/pages/PersonDetailEditorial.test.tsx
@@ -1,0 +1,470 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PersonDetailEditorial from "@/pages/PersonDetailEditorial";
+import type {
+  ProjectedBlock,
+  ProjectedComposition,
+  ProjectedCompositionCommandResponse,
+} from "@/services/composition/contracts";
+
+const {
+  invokeMock,
+  navigateMock,
+  usePersonDetailMock,
+  useProjectedCompositionMock,
+  projectedRefetchMock,
+  useRegisterMagazineShellMock,
+} = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  navigateMock: vi.fn(),
+  usePersonDetailMock: vi.fn(),
+  useProjectedCompositionMock: vi.fn(),
+  projectedRefetchMock: vi.fn(),
+  useRegisterMagazineShellMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ personId: "person-test-1" }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/hooks/usePersonDetail", () => ({
+  usePersonDetail: () => usePersonDetailMock(),
+}));
+
+vi.mock("@/hooks/useProjectedComposition", () => ({
+  useProjectedComposition: (subject: unknown) => useProjectedCompositionMock(subject),
+}));
+
+vi.mock("@/hooks/useActivePreset", () => ({
+  useActivePreset: () => null,
+}));
+
+vi.mock("@/hooks/useRevealObserver", () => ({
+  useRevealObserver: vi.fn(),
+}));
+
+vi.mock("@/hooks/useMagazineShell", () => ({
+  useRegisterMagazineShell: (config: unknown) => useRegisterMagazineShellMock(config),
+}));
+
+vi.mock("@/hooks/useChapterLayout", () => ({
+  useChapterLayout: ({ projection }: { projection: ProjectedComposition | null }) => {
+    const sections =
+      projection?.sections.map((section) => ({
+        section,
+        label: section.label ?? section.section_id,
+        coreLocked: section.section_id === "headline",
+        blocks: section.block_indexes.map((index) => {
+          const block = projection.blocks[index];
+          return {
+            block,
+            sectionId: section.section_id,
+            label: String(block?.payload.title ?? block?.payload.text ?? block?.block_id),
+            variant: "default",
+            coreLocked: section.section_id === "headline",
+          };
+        }),
+        hiddenBlocks: [],
+      })) ?? [];
+    return {
+      overlay: null,
+      layoutRevision: 0,
+      view: {
+        sections,
+        hiddenSections: [],
+        hiddenItems: [],
+        hasVisibleNonCore: sections.some((section) => !section.coreLocked),
+      },
+      loading: false,
+      saving: false,
+      error: null,
+      setBlockHidden: vi.fn(),
+      setSectionHidden: vi.fn(),
+      setBlockVariant: vi.fn(),
+      setSectionLabel: vi.fn(),
+      reorderBlocks: vi.fn(),
+      resetLayout: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("@/components/composition/ReactBlockRenderer", () => ({
+  ReactBlockRenderer: ({
+    block,
+    entityId,
+    entityType,
+  }: {
+    block: ProjectedBlock;
+    entityId?: string;
+    entityType?: string;
+  }) => (
+    <div
+      data-testid="composition-block"
+      data-block-id={block.block_id}
+      data-entity-id={entityId}
+      data-entity-type={entityType}
+    >
+      {String(block.payload.title ?? block.payload.text ?? block.block_id)}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/person/PersonNetwork", () => ({
+  PersonNetwork: ({
+    onLink,
+    onUnlink,
+  }: {
+    onLink?: (entityId: string) => Promise<void> | void;
+    onUnlink?: (entityId: string) => Promise<void> | void;
+  }) => (
+    <section data-testid="person-network-controls">
+      <button type="button" onClick={() => void onLink?.("entity-link-test")}>
+        Link entity
+      </button>
+      <button type="button" onClick={() => void onUnlink?.("entity-unlink-test")}>
+        Unlink entity
+      </button>
+    </section>
+  ),
+}));
+
+vi.mock("@/components/person/PersonRelationships", () => ({
+  PersonRelationships: ({
+    onRelationshipsChanged,
+  }: {
+    onRelationshipsChanged?: () => void;
+  }) => (
+    <section data-testid="person-relationship-controls">
+      <button type="button" onClick={() => onRelationshipsChanged?.()}>
+        Relationship changed
+      </button>
+    </section>
+  ),
+}));
+
+vi.mock("@/components/person/PersonAppendix", () => ({
+  PersonAppendix: () => <section data-testid="person-appendix" />,
+}));
+
+vi.mock("@/components/ui/folio-refresh-button", () => ({
+  FolioRefreshButton: () => <button type="button">Refresh</button>,
+}));
+
+vi.mock("@/components/editorial/EditorialLoading", () => ({
+  EditorialLoading: () => <div data-testid="editorial-loading">Loading</div>,
+}));
+
+vi.mock("@/components/editorial/EditorialError", () => ({
+  EditorialError: ({ message }: { message: string }) => (
+    <div data-testid="editorial-error">{message}</div>
+  ),
+}));
+
+vi.mock("@/components/editorial/EditorialEmpty", () => ({
+  EditorialEmpty: ({ title }: { title: string }) => <div data-testid="editorial-empty">{title}</div>,
+}));
+
+vi.mock("@/components/editorial/FinisMarker", () => ({
+  FinisMarker: () => <div data-testid="finis-marker" />,
+}));
+
+function block(
+  blockId: string,
+  sectionIndex: number,
+  selectedKnownTypeId: string,
+  payload: Record<string, unknown>,
+): ProjectedBlock {
+  return {
+    block_id: blockId,
+    block_index: sectionIndex,
+    original_type_id: selectedKnownTypeId,
+    selected_known_type_id: selectedKnownTypeId,
+    payload,
+    banner: null,
+    trust_band: "likely_current",
+    claim_refs: [],
+    provenance: [],
+    edit_routes: [],
+    diagnostics: [],
+  };
+}
+
+function projection(overrides: Partial<ProjectedComposition> = {}): ProjectedComposition {
+  const blocks = [
+    block("headline-block", 0, "account_overview", {
+      person: { display_name: "Projected Person" },
+      title: "Projected Person",
+    }),
+    block("dynamic-block", 1, "claim_summary", { text: "Relationship dynamic" }),
+    block("network-block", 2, "relationship_map", { title: "Relationships" }),
+    block("thread-block", 3, "action_list", { title: "Open threads" }),
+  ];
+  return {
+    composition_id: "dailyos/person-overview:person:person-test-1",
+    composition_version: 2,
+    fallback_policy_version: 3,
+    sections: [
+      {
+        section_id: "headline",
+        section_index: 0,
+        label: "Headline",
+        layout: "stacked",
+        salience: { weight: 0.95, band: "critical", reason: "person masthead" },
+        block_ids: ["headline-block"],
+        block_indexes: [0],
+      },
+      {
+        section_id: "the-dynamic",
+        section_index: 1,
+        label: "The dynamic",
+        layout: "stacked",
+        salience: { weight: 0.86, band: "important", reason: "person dynamic" },
+        block_ids: ["dynamic-block"],
+        block_indexes: [1],
+      },
+      {
+        section_id: "their-network",
+        section_index: 2,
+        label: "Their network",
+        layout: "grid",
+        salience: { weight: 0.72, band: "contextual", reason: "person network" },
+        block_ids: ["network-block"],
+        block_indexes: [2],
+      },
+      {
+        section_id: "open-threads",
+        section_index: 3,
+        label: "Open threads",
+        layout: "stacked",
+        salience: { weight: 0.78, band: "important", reason: "person open threads" },
+        block_ids: ["thread-block"],
+        block_indexes: [3],
+      },
+    ],
+    blocks,
+    diagnostics: [],
+    unknown_block_count: 0,
+    unknown_block_cap: 5,
+    dropped_unknown_block_count: 0,
+    ...overrides,
+  };
+}
+
+function response(
+  projectionValue: ProjectedComposition,
+): ProjectedCompositionCommandResponse {
+  return {
+    ok: true,
+    request_id: "request-test",
+    projection: projectionValue,
+    cache_hint_token: "cache-test",
+    served_from_cache: false,
+    rendered_provenance: { surface: "tauri_app", value: { ok: true } },
+  };
+}
+
+function personHook(overrides: Record<string, unknown> = {}) {
+  return {
+    detail: {
+      id: "person-test-1",
+      email: "person@example.com",
+      name: "Detail Person",
+      relationship: "external",
+      meetingCount: 0,
+      updatedAt: "2026-05-15T00:00:00Z",
+      archived: false,
+      entities: [],
+      recentMeetings: [],
+      recentCaptures: [],
+      recentEmailSignals: [],
+      openActions: [],
+      upcomingMeetings: [],
+    },
+    intelligence: null,
+    loading: false,
+    error: null,
+    load: vi.fn(),
+    silentRefresh: vi.fn(),
+    editName: "Detail Person",
+    setEditName: vi.fn(),
+    editRole: "",
+    setEditRole: vi.fn(),
+    dirty: false,
+    setDirty: vi.fn(),
+    saving: false,
+    handleSave: vi.fn(),
+    saveField: vi.fn(),
+    handleCancelEdit: vi.fn(),
+    enriching: false,
+    enrichSeconds: 0,
+    handleEnrich: vi.fn(),
+    handleLinkEntity: vi.fn(),
+    handleUnlinkEntity: vi.fn(),
+    mergeDialogOpen: false,
+    setMergeDialogOpen: vi.fn(),
+    mergeTarget: null,
+    setMergeTarget: vi.fn(),
+    mergeConfirmOpen: false,
+    setMergeConfirmOpen: vi.fn(),
+    mergeSearchQuery: "",
+    setMergeSearchQuery: vi.fn(),
+    mergeSearchResults: [],
+    merging: false,
+    openMergeDialog: vi.fn(),
+    handleMerge: vi.fn(),
+    handleOpenSuggestedMerge: vi.fn(),
+    deleteConfirmOpen: false,
+    setDeleteConfirmOpen: vi.fn(),
+    handleDelete: vi.fn(),
+    duplicateCandidates: [],
+    files: [],
+    indexing: false,
+    indexFeedback: null,
+    handleIndexFiles: vi.fn(),
+    handleArchive: vi.fn(),
+    handleUnarchive: vi.fn(),
+    addingAction: false,
+    setAddingAction: vi.fn(),
+    newActionTitle: "",
+    setNewActionTitle: vi.fn(),
+    creatingAction: false,
+    handleCreateAction: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("PersonDetailEditorial", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue([]);
+    navigateMock.mockReset();
+    useRegisterMagazineShellMock.mockReset();
+    projectedRefetchMock.mockReset();
+    projectedRefetchMock.mockResolvedValue(undefined);
+    usePersonDetailMock.mockReturnValue(personHook());
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection()),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: projectedRefetchMock,
+    });
+  });
+
+  it("renders Person Detail from projected composition and derives shell chapters", () => {
+    render(<PersonDetailEditorial />);
+
+    expect(useProjectedCompositionMock).toHaveBeenCalledWith({
+      entityType: "person",
+      entityId: "person-test-1",
+    });
+    expect(screen.getByText("Projected Person")).toBeInTheDocument();
+    expect(screen.getByText("Relationship dynamic")).toBeInTheDocument();
+    expect(screen.getByText("Relationships")).toBeInTheDocument();
+    expect(screen.getAllByText("Open threads")).toHaveLength(3);
+    expect(screen.getByTestId("person-network-controls")).toBeInTheDocument();
+    expect(screen.getByTestId("person-relationship-controls")).toBeInTheDocument();
+
+    for (const renderedBlock of screen.getAllByTestId("composition-block")) {
+      expect(renderedBlock).toHaveAttribute("data-entity-id", "person-test-1");
+      expect(renderedBlock).toHaveAttribute("data-entity-type", "person");
+    }
+
+    const shellConfig = useRegisterMagazineShellMock.mock.calls.at(-1)?.[0] as {
+      chapters: Array<{ id: string; label: string }>;
+    };
+    expect(shellConfig.chapters.map((chapter) => chapter.id)).toEqual([
+      "headline",
+      "the-dynamic",
+      "their-network",
+      "open-threads",
+    ]);
+  });
+
+  it("shows producer errors without falling back to the old template", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: "person producer unavailable",
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<PersonDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-error")).toHaveTextContent("person producer unavailable");
+    expect(screen.queryByTestId("composition-block")).not.toBeInTheDocument();
+  });
+
+  it("force-refreshes projected composition after person controls save", async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+    usePersonDetailMock.mockReturnValue(personHook({ dirty: true, handleSave }));
+
+    render(<PersonDetailEditorial />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(handleSave).toHaveBeenCalled());
+    expect(projectedRefetchMock).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it("force-refreshes projected composition after relationship mutations", async () => {
+    const handleLinkEntity = vi.fn().mockResolvedValue(undefined);
+    const handleUnlinkEntity = vi.fn().mockResolvedValue(undefined);
+    usePersonDetailMock.mockReturnValue(
+      personHook({
+        handleLinkEntity,
+        handleUnlinkEntity,
+      }),
+    );
+
+    render(<PersonDetailEditorial />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Link entity" }));
+    await waitFor(() => expect(handleLinkEntity).toHaveBeenCalledWith("entity-link-test"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Unlink entity" }));
+    await waitFor(() => expect(handleUnlinkEntity).toHaveBeenCalledWith("entity-unlink-test"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Relationship changed" }));
+    await waitFor(() =>
+      expect(projectedRefetchMock).toHaveBeenCalledWith({ forceRefresh: true }),
+    );
+    expect(projectedRefetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("shows a composition empty state when no projected sections are renderable", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection({ sections: [], blocks: [] })),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: vi.fn(),
+    });
+
+    render(<PersonDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-empty")).toHaveTextContent("No person composition");
+  });
+
+  it("shows loading while the first projected composition is pending", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: true,
+      error: null,
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<PersonDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-loading")).toBeInTheDocument();
+  });
+});

--- a/src/pages/PersonDetailEditorial.tsx
+++ b/src/pages/PersonDetailEditorial.tsx
@@ -1,35 +1,31 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
-import { toast } from "sonner";
-import { formatShortDate } from "@/lib/utils";
-import type { VitalDisplay } from "@/lib/entity-types";
-import { usePersonDetail } from "@/hooks/usePersonDetail";
-import type { PersonRelationshipEdge } from "@/types";
-import { useActivePreset } from "@/hooks/useActivePreset";
-import { useIntelligenceFieldUpdate } from "@/hooks/useIntelligenceFieldUpdate";
-import { useRevealObserver } from "@/hooks/useRevealObserver";
-import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
 import {
-  AlignLeft,
-  Zap,
-  RefreshCw,
-  Network,
-  Users,
-  Eye,
   Activity,
+  AlignLeft,
+  Archive,
   CheckSquare2,
+  Eye,
+  FileText,
+  GitMerge,
+  Network,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Save,
+  Sparkles,
+  Trash2,
+  Users,
+  X,
+  Zap,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { EditorialLoading } from "@/components/editorial/EditorialLoading";
 import { EditorialError } from "@/components/editorial/EditorialError";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { EditorialEmpty } from "@/components/editorial/EditorialEmpty";
+import { FinisMarker } from "@/components/editorial/FinisMarker";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,91 +36,191 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { PersonHero } from "@/components/person/PersonHero";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { PersonAppendix } from "@/components/person/PersonAppendix";
 import { PersonNetwork } from "@/components/person/PersonNetwork";
 import { PersonRelationships } from "@/components/person/PersonRelationships";
-import { PersonAppendix } from "@/components/person/PersonAppendix";
-import { PersonInsightChapter } from "@/components/person/PersonInsightChapter";
-import { VitalsStrip } from "@/components/entity/VitalsStrip";
-import { EditableVitalsStrip } from "@/components/entity/EditableVitalsStrip";
-import { WatchList } from "@/components/entity/WatchList";
-import { UnifiedTimeline } from "@/components/entity/UnifiedTimeline";
-import { TheWork } from "@/components/entity/TheWork";
-import { RecommendedActions } from "@/components/entity/RecommendedActions";
-import { FinisMarker } from "@/components/editorial/FinisMarker";
-import { AddToRecord } from "@/components/entity/AddToRecord";
-import { useEntityContextEntries } from "@/hooks/useEntityContextEntries";
+import { ReactBlockRenderer } from "@/components/composition/ReactBlockRenderer";
+import { FolioRefreshButton } from "@/components/ui/folio-refresh-button";
+import { useActivePreset } from "@/hooks/useActivePreset";
+import { usePersonDetail } from "@/hooks/usePersonDetail";
+import { useRevealObserver } from "@/hooks/useRevealObserver";
+import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
+import {
+  useChapterLayout,
+  type RenderableCompositionBlock,
+  type RenderableCompositionSection,
+} from "@/hooks/useChapterLayout";
+import { useProjectedComposition } from "@/hooks/useProjectedComposition";
+import type { PersonDetail, PersonRelationshipEdge } from "@/types";
+import type { ProjectedBlock } from "@/services/composition/contracts";
 import shared from "@/styles/entity-detail.module.css";
+import accountStyles from "./AccountDetailPage.module.css";
 import styles from "./PersonDetailEditorial.module.css";
-import { useIntelligenceFeedback } from "@/hooks/useIntelligenceFeedback";
-import { IntelligenceFeedback } from "@/components/ui/IntelligenceFeedback";
 
-// Suppress unused import warning — styles reserved for future person-specific classes
-void styles;
+const SECTION_ICONS: Record<string, React.ReactNode> = {
+  headline: <AlignLeft size={18} strokeWidth={1.5} />,
+  "the-dynamic": <Zap size={18} strokeWidth={1.5} />,
+  "the-rhythm": <RefreshCw size={18} strokeWidth={1.5} />,
+  "their-orbit": <Network size={18} strokeWidth={1.5} />,
+  "their-network": <Users size={18} strokeWidth={1.5} />,
+  "the-landscape": <Eye size={18} strokeWidth={1.5} />,
+  "open-threads": <CheckSquare2 size={18} strokeWidth={1.5} />,
+  "the-record": <Activity size={18} strokeWidth={1.5} />,
+  "the-work": <CheckSquare2 size={18} strokeWidth={1.5} />,
+};
 
-/* ── Vitals assembly ── */
-
-function buildPersonVitals(detail: {
-  meetingCount: number;
-  signals?: {
-    meetingFrequency30d: number;
-    meetingFrequency90d: number;
-    temperature: string;
-    trend: string;
-    lastMeeting?: string;
-  };
-}): VitalDisplay[] {
-  const vitals: VitalDisplay[] = [];
-  const sig = detail.signals;
-
-  if (sig) {
-    // Lead with temperature badge — relationship warmth signal
-    if (sig.temperature) {
-      vitals.push({
-        text: sig.temperature,
-        highlight: sig.temperature === "hot"
-          ? "larkspur"
-          : sig.temperature === "warm"
-            ? "turmeric"
-            : sig.temperature === "cold"
-              ? "turmeric"
-              : undefined,
-      });
-    }
-    const trendArrow =
-      sig.trend === "increasing" ? " \u2191" : sig.trend === "decreasing" ? " \u2193" : "";
-    vitals.push({ text: `${sig.meetingFrequency30d} meetings / 30d${trendArrow}` });
-    if (sig.lastMeeting) {
-      vitals.push({ text: `Last: ${formatShortDate(sig.lastMeeting)}` });
-    }
+function personNameFromBlocks(
+  blocks: ProjectedBlock[],
+  detail: PersonDetail | null,
+  personId: string | undefined,
+): string {
+  const overview = blocks.find((block) => block.selected_known_type_id === "account_overview");
+  const person = overview?.payload.person;
+  if (person && typeof person === "object" && !Array.isArray(person)) {
+    const displayName = (person as Record<string, unknown>).display_name;
+    if (typeof displayName === "string" && displayName.trim()) return displayName;
   }
-
-  if (detail.meetingCount > 0) {
-    vitals.push({ text: `${detail.meetingCount} total meetings` });
+  const account = overview?.payload.account;
+  if (account && typeof account === "object" && !Array.isArray(account)) {
+    const displayName = (account as Record<string, unknown>).display_name;
+    if (typeof displayName === "string" && displayName.trim()) return displayName;
   }
-
-  return vitals;
+  return detail?.name ?? personId ?? "Person";
 }
 
-/* ── Chapters (adaptive based on relationship) ── */
+function PersonControlsPanel({
+  detail,
+  person,
+  onArchive,
+  onAfterMutation,
+}: {
+  detail: PersonDetail;
+  person: ReturnType<typeof usePersonDetail>;
+  onArchive: () => void;
+  onAfterMutation: () => Promise<void>;
+}) {
+  const runMutationAndRefresh = (mutation: () => Promise<void>) => {
+    void (async () => {
+      await mutation();
+      await onAfterMutation();
+    })();
+  };
 
-function buildChapters(relationship: string) {
-  const isInternal = relationship === "internal";
-  return [
-    { id: "headline", label: "The Profile", icon: <AlignLeft size={18} strokeWidth={1.5} /> },
-    {
-      id: isInternal ? "the-rhythm" : "the-dynamic",
-      label: isInternal ? "The Rhythm" : "The Dynamic",
-      icon: isInternal
-        ? <RefreshCw size={18} strokeWidth={1.5} />
-        : <Zap size={18} strokeWidth={1.5} />,
-    },
-    { id: "their-orbit", label: "Their Orbit", icon: <Network size={18} strokeWidth={1.5} /> },
-    { id: "their-network", label: "Their Network", icon: <Users size={18} strokeWidth={1.5} /> },
-    { id: "the-landscape", label: "The Landscape", icon: <Eye size={18} strokeWidth={1.5} /> },
-    { id: "the-record", label: "The Record", icon: <Activity size={18} strokeWidth={1.5} /> },
-    { id: "the-work", label: "The Work", icon: <CheckSquare2 size={18} strokeWidth={1.5} /> },
-  ];
+  return (
+    <section className={styles.personControlPanel} aria-label="Person controls">
+      <form
+        className={styles.personControlForm}
+        onSubmit={(event) => {
+          event.preventDefault();
+          runMutationAndRefresh(person.handleSave);
+        }}
+      >
+        <label className={styles.personControlField}>
+          <span>Name</span>
+          <Input
+            value={person.editName}
+            onChange={(event) => {
+              person.setEditName(event.target.value);
+              person.setDirty(true);
+            }}
+          />
+        </label>
+        <label className={styles.personControlField}>
+          <span>Role</span>
+          <Input
+            value={person.editRole}
+            onChange={(event) => {
+              person.setEditRole(event.target.value);
+              person.setDirty(true);
+            }}
+          />
+        </label>
+        <div className={styles.personControlActions}>
+          <Button type="submit" disabled={!person.dirty || person.saving}>
+            <Save size={15} strokeWidth={1.7} />
+            {person.saving ? "Saving" : "Save"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={!person.dirty}
+            onClick={person.handleCancelEdit}
+          >
+            <X size={15} strokeWidth={1.7} />
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => runMutationAndRefresh(person.handleEnrich)}
+            disabled={person.enriching}
+          >
+            <Sparkles size={15} strokeWidth={1.7} />
+            {person.enriching ? `${person.enrichSeconds}s` : "Refresh"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={detail.archived ? () => runMutationAndRefresh(person.handleUnarchive) : onArchive}
+          >
+            {detail.archived ? (
+              <RotateCcw size={15} strokeWidth={1.7} />
+            ) : (
+              <Archive size={15} strokeWidth={1.7} />
+            )}
+            {detail.archived ? "Restore" : "Archive"}
+          </Button>
+          <Button type="button" variant="ghost" onClick={person.openMergeDialog}>
+            <GitMerge size={15} strokeWidth={1.7} />
+            Merge
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => person.setDeleteConfirmOpen(true)}
+          >
+            <Trash2 size={15} strokeWidth={1.7} />
+            Delete
+          </Button>
+        </div>
+      </form>
+      <div className={styles.personActionComposer}>
+        {person.addingAction ? (
+          <>
+            <Input
+              value={person.newActionTitle}
+              onChange={(event) => person.setNewActionTitle(event.target.value)}
+              placeholder="Action title"
+            />
+            <Button
+              type="button"
+              onClick={() => runMutationAndRefresh(person.handleCreateAction)}
+              disabled={person.creatingAction || !person.newActionTitle.trim()}
+            >
+              <Plus size={15} strokeWidth={1.7} />
+              {person.creatingAction ? "Creating" : "Create"}
+            </Button>
+            <Button type="button" variant="ghost" onClick={() => person.setAddingAction(false)}>
+              <X size={15} strokeWidth={1.7} />
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button type="button" variant="ghost" onClick={() => person.setAddingAction(true)}>
+            <Plus size={15} strokeWidth={1.7} />
+            Action
+          </Button>
+        )}
+      </div>
+    </section>
+  );
 }
 
 export default function PersonDetailEditorial() {
@@ -132,41 +228,65 @@ export default function PersonDetailEditorial() {
   const navigate = useNavigate();
   const person = usePersonDetail(personId);
   const preset = useActivePreset();
-  useRevealObserver(!person.loading && !!person.detail);
+  const composition = useProjectedComposition(
+    personId ? { entityType: "person", entityId: personId } : undefined,
+  );
+  const projection = composition.data?.projection ?? null;
+  const layout = useChapterLayout({ projection, entityType: "person" });
+  const visibleSections = layout.view.sections;
+  const personName = personNameFromBlocks(projection?.blocks ?? [], person.detail, personId);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+  const [relationships, setRelationships] = useState<PersonRelationshipEdge[]>([]);
 
-  // Shared folio save status hook (must be before shellConfig useMemo)
-  const {
-    saveStatus,
-    setSaveStatus: setFolioSaveStatus,
-  } = useIntelligenceFieldUpdate("person", personId, person.silentRefresh);
+  useRevealObserver(!composition.loading && !!projection);
 
-  const finishFolioSave = useCallback(() => {
-    setFolioSaveStatus("saved");
-    window.setTimeout(() => setFolioSaveStatus("idle"), 2000);
-  }, [setFolioSaveStatus]);
-
-  const saveMetadata = useCallback(
-    async (updated: Record<string, string>) => {
-      if (!personId) return;
-      setFolioSaveStatus("saving");
-      try {
-        await invoke("update_entity_metadata", {
-          entityId: personId,
-          entityType: "person",
-          metadata: JSON.stringify(updated),
-        });
-        finishFolioSave();
-      } catch (err) {
-        console.error("update_entity_metadata failed:", err);
-        toast.error("Failed to save metadata");
-        setFolioSaveStatus("idle");
-        throw err;
-      }
-    },
-    [finishFolioSave, personId, setFolioSaveStatus],
+  const forceRefreshProjectedComposition = useCallback(
+    () => composition.refetch({ forceRefresh: true }),
+    [composition.refetch],
   );
 
-  const relationship = person.detail?.relationship ?? "unknown";
+  const loadRelationships = useCallback(() => {
+    if (!personId) return;
+    invoke<PersonRelationshipEdge[]>("get_person_relationships", { personId })
+      .then(setRelationships)
+      .catch(() => setRelationships([]));
+  }, [personId]);
+
+  useEffect(() => {
+    loadRelationships();
+  }, [loadRelationships]);
+
+  const handleLinkEntity = useCallback(
+    async (entityId: string) => {
+      await person.handleLinkEntity(entityId);
+      await forceRefreshProjectedComposition();
+    },
+    [forceRefreshProjectedComposition, person],
+  );
+
+  const handleUnlinkEntity = useCallback(
+    async (entityId: string) => {
+      await person.handleUnlinkEntity(entityId);
+      await forceRefreshProjectedComposition();
+    },
+    [forceRefreshProjectedComposition, person],
+  );
+
+  const handleRelationshipsChanged = useCallback(() => {
+    loadRelationships();
+    void forceRefreshProjectedComposition();
+  }, [forceRefreshProjectedComposition, loadRelationships]);
+
+  const chapters = useMemo(
+    () =>
+      visibleSections.map(({ section, label }) => ({
+        id: section.section_id,
+        label,
+        icon: SECTION_ICONS[section.section_id] ?? <FileText size={18} strokeWidth={1.5} />,
+      })),
+    [visibleSections],
+  );
+
   const shellConfig = useMemo(
     () => ({
       folioLabel: "Person",
@@ -174,290 +294,274 @@ export default function PersonDetailEditorial() {
       activePage: "people" as const,
       breadcrumbs: [
         { label: "People", onClick: () => navigate({ to: "/people" }) },
-        { label: person.detail?.name ?? "Person" },
+        { label: personName },
       ],
-      chapters: buildChapters(relationship),
-      folioStatusText: saveStatus === "saving" ? "Saving\u2026" : saveStatus === "saved" ? "\u2713 Saved" : undefined,
+      chapters,
+      folioStatusText: composition.loading
+        ? "Composing..."
+        : person.saving
+          ? "Saving..."
+          : composition.data?.served_from_cache
+            ? "Projected from cache"
+            : undefined,
+      folioActions: (
+        <div className={shared.folioActions}>
+          <FolioRefreshButton onClick={composition.refetch} loading={composition.loading} />
+        </div>
+      ),
     }),
-    [navigate, person.detail?.name, relationship, saveStatus],
+    [
+      chapters,
+      composition.data?.served_from_cache,
+      composition.loading,
+      composition.refetch,
+      navigate,
+      person.saving,
+      personName,
+    ],
   );
   useRegisterMagazineShell(shellConfig);
 
-  // Person relationships
-  const [relationships, setRelationships] = useState<PersonRelationshipEdge[]>([]);
-  const loadRelationships = useCallback(() => {
-    if (!personId) return;
-    invoke<PersonRelationshipEdge[]>("get_person_relationships", { personId })
-      .then(setRelationships)
-      .catch(() => setRelationships([]));
-  }, [personId]);
-  useEffect(() => { loadRelationships(); }, [loadRelationships]);
+  if (composition.loading && !projection) return <EditorialLoading />;
 
-  // Preset metadata state
-  const [metadataValues, setMetadataValues] = useState<Record<string, string>>({});
-  useEffect(() => {
-    if (!personId) return;
-    invoke<string>("get_entity_metadata", { entityType: "person", entityId: personId })
-      .then((json) => {
-        try { setMetadataValues(JSON.parse(json) ?? {}); } catch { setMetadataValues({}); }
-      })
-      .catch((err) => {
-        console.error("get_entity_metadata (person) failed:", err); // Expected: background data fetch on mount
-        setMetadataValues({});
-      });
-  }, [personId]);
-
-  // Intelligence quality feedback
-  const feedback = useIntelligenceFeedback(personId, "person");
-
-  // Context entries — must be before early returns (React hooks rule)
-  const entityCtx = useEntityContextEntries("person", personId ?? null);
-
-  if (person.loading) return <EditorialLoading />;
-
-  if (person.error || !person.detail) {
-    return <EditorialError message={person.error ?? "Person not found"} onRetry={person.load} />;
+  if (composition.error) {
+    return <EditorialError message={composition.error} onRetry={composition.refetch} />;
   }
 
-  const { detail, intelligence } = person;
+  if (!projection || projection.sections.length === 0 || projection.blocks.length === 0) {
+    return (
+      <EditorialEmpty
+        title="No person composition"
+        message="DailyOS has not produced a person surface yet."
+      />
+    );
+  }
+
+  const renderBlock = (item: RenderableCompositionBlock) => (
+    <ReactBlockRenderer
+      key={item.block.block_id}
+      block={item.block}
+      entityId={personId}
+      entityType="person"
+      renderedProvenance={composition.renderedProvenance}
+    />
+  );
+
+  const renderSectionTitle = (section: RenderableCompositionSection) => (
+    <h2 className={accountStyles.compositionSectionTitle}>{section.label}</h2>
+  );
+
+  const detail = person.detail;
 
   return (
-    <>
-      {/* Chapter 1: The Profile (Hero) */}
-      <section id="headline" className={shared.chapterSection}>
-        <PersonHero
-          detail={detail}
-          intelligence={intelligence}
-          editName={person.editName}
-          setEditName={(v) => { person.setEditName(v); person.setDirty(true); }}
-          editRole={person.editRole}
-          setEditRole={(v) => { person.setEditRole(v); person.setDirty(true); }}
-          onSave={person.handleSave}
-          onSaveField={person.saveField}
-          onEnrich={person.handleEnrich}
-          enriching={person.enriching}
-          enrichSeconds={person.enrichSeconds}
-          onMerge={person.openMergeDialog}
-          onArchive={() => person.handleArchive()}
-          onUnarchive={person.handleUnarchive}
-          onDelete={() => person.setDeleteConfirmOpen(true)}
-        />
-        <div className="editorial-reveal">
-          {preset ? (
-            <EditableVitalsStrip
-              fields={preset.vitals.person}
-              metadataFields={preset.metadata.person}
-              entityData={{ ...detail, signals: detail.signals as Record<string, unknown> | undefined }}
-              metadata={metadataValues}
-              onFieldChange={(key, _columnMapping, source, value) => {
-                if (source === "metadata") {
-                  setMetadataValues((prev) => {
-                    const updated = { ...prev, [key]: value };
-                    void saveMetadata(updated);
-                    return updated;
-                  });
-                }
-              }}
-            />
-          ) : (
-            <VitalsStrip vitals={buildPersonVitals(detail)} />
-          )}
-        </div>
-      </section>
-
-      {/* Chapter 2: The Dynamic / The Rhythm */}
-      <div id={relationship === "internal" ? "the-rhythm" : "the-dynamic"} className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-        <PersonInsightChapter
-          detail={detail}
-          intelligence={intelligence}
-          feedbackSlot={
-            <IntelligenceFeedback
-              value={feedback.getFeedback("person_insight")}
-              onFeedback={(type) => feedback.submitFeedback("person_insight", type)}
-            />
-          }
-        />
-      </div>
-
-      {/* Chapter 3: Their Orbit */}
-      <div id="their-orbit" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-        <PersonNetwork
-          entities={detail.entities}
-          personId={personId}
-          onLink={person.handleLinkEntity}
-          onUnlink={person.handleUnlinkEntity}
-          chapterTitle="Their Orbit"
-        />
-      </div>
-
-      {/* Chapter 4: Their Network */}
-      <div id="their-network" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-        <PersonRelationships
-          personId={personId ?? ""}
-          network={intelligence?.network}
-          relationships={relationships}
-          preset={preset ?? undefined}
-          chapterTitle="Their Network"
-          onRelationshipsChanged={loadRelationships}
-        />
-      </div>
-
-      {/* Chapter 5: The Landscape */}
-      <div id="the-landscape" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-        <WatchList
-          intelligence={intelligence}
-          sectionId="the-landscape"
-          chapterTitle="The Landscape"
-          getItemFeedback={(fieldPath) => feedback.getFeedback(fieldPath)}
-          onItemFeedback={(fieldPath, type) => feedback.submitFeedback(fieldPath, type)}
-        />
-      </div>
-
-      {/* Chapter 6: The Record */}
-      <div id="the-record" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-        <UnifiedTimeline
-          data={{
-            recentMeetings: detail.recentMeetings ?? [],
-            recentCaptures: detail.recentCaptures,
-            recentEmailSignals: detail.recentEmailSignals,
-            contextEntries: entityCtx.entries,
-          }}
-          sectionId=""
-          actionSlot={<AddToRecord onAdd={(title, content) => entityCtx.createEntry(title, content)} />}
-        />
-      </div>
-
-      {/* Chapter 6: The Work (suppressed when empty per) */}
-      {(detail.openActions.length > 0 || (detail.upcomingMeetings ?? []).length > 0 || (intelligence?.recommendedActions?.length ?? 0) > 0) && (
-        <div id="the-work" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-          {intelligence?.recommendedActions && intelligence.recommendedActions.length > 0 && (
-            <RecommendedActions entityId={detail.id} entityType="person"
-              actions={intelligence.recommendedActions} onRefresh={person.silentRefresh} />
-          )}
-          <TheWork
-            data={detail}
-            addingAction={person.addingAction}
-            setAddingAction={person.setAddingAction}
-            newActionTitle={person.newActionTitle}
-            setNewActionTitle={person.setNewActionTitle}
-            creatingAction={person.creatingAction}
-            onCreateAction={person.handleCreateAction}
-          />
+    <main
+      className={accountStyles.compositionSurface}
+      data-composition-id={projection.composition_id}
+      data-composition-version={projection.composition_version ?? 0}
+      data-fallback-policy-version={projection.fallback_policy_version}
+    >
+      {person.error && (
+        <div className={accountStyles.compositionDegradedState} role="status">
+          <p className={accountStyles.compositionStateLabel}>Person controls unavailable</p>
+          <p className={accountStyles.compositionStateText}>{person.error}</p>
         </div>
       )}
 
-      {/* Appendix */}
-      <div className="editorial-reveal">
-        <PersonAppendix
-          detail={detail}
-          duplicateCandidates={person.duplicateCandidates}
-          onMergeSuggested={person.handleOpenSuggestedMerge}
-          merging={person.merging}
-          files={person.files}
-          onIndexFiles={person.handleIndexFiles}
-          indexing={person.indexing}
-          indexFeedback={person.indexFeedback}
-        />
-      </div>
-
-      {/* Finis marker */}
-      <div className="editorial-reveal">
-        <FinisMarker enrichedAt={intelligence?.enrichedAt} />
-      </div>
-
-      {/* Merge Person Picker Dialog */}
-      <Dialog open={person.mergeDialogOpen} onOpenChange={person.setMergeDialogOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Merge {detail.name} into...</DialogTitle>
-            <DialogDescription>
-              Search for the person to merge into. All meetings, entity links, and actions will transfer to the selected person.
-            </DialogDescription>
-          </DialogHeader>
-          <Input
-            placeholder="Search by name or email..."
-            value={person.mergeSearchQuery}
-            onChange={(e) => person.setMergeSearchQuery(e.target.value)}
-            autoFocus
-          />
-          {person.mergeSearchResults.length > 0 && (
-            <div className={shared.mergeSearchResults}>
-              {person.mergeSearchResults.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => {
-                    person.setMergeTarget(p);
-                    person.setMergeDialogOpen(false);
-                    person.setMergeConfirmOpen(true);
-                  }}
-                  className={`${shared.mergeSearchButton} hover:bg-muted`}
-                >
-                  <div className={shared.mergeAvatar}>
-                    {p.name.charAt(0).toUpperCase()}
-                  </div>
-                  <div className={shared.mergePersonInfo}>
-                    <div className={shared.mergePersonName}>
-                      {p.name}
-                    </div>
-                    <div className={shared.mergePersonEmail}>
-                      {p.email}
-                      {p.organization && ` \u00B7 ${p.organization}`}
-                    </div>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-          {person.mergeSearchQuery.length >= 2 && person.mergeSearchResults.length === 0 && (
-            <p className={shared.mergeEmptyState}>
-              No matching people found
-            </p>
-          )}
-        </DialogContent>
-      </Dialog>
-
-      {/* Merge Confirmation */}
-      <AlertDialog open={person.mergeConfirmOpen} onOpenChange={person.setMergeConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Merge {detail.name}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Permanently merge <strong>{detail.name}</strong> ({detail.email}) into{" "}
-              <strong>{person.mergeTarget?.name}</strong> ({person.mergeTarget?.email}).
-              All meetings, entity links, and actions will transfer. This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={person.merging}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={person.handleMerge} disabled={person.merging}>
-              {person.merging ? "Merging…" : "Merge"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Delete Confirmation */}
-      <AlertDialog open={person.deleteConfirmOpen} onOpenChange={person.setDeleteConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete {detail.name}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              All meeting attendance records, entity links, and action associations for{" "}
-              <strong>{detail.name}</strong> will be removed. This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={person.merging}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={person.handleDelete}
-              disabled={person.merging}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      {visibleSections.map((renderableSection) => {
+        const section = renderableSection.section;
+        const blocks = renderableSection.blocks;
+        if (section.section_id === "headline") {
+          return (
+            <section
+              key={section.section_id}
+              id={section.section_id}
+              className={accountStyles.compositionMasthead}
+              data-section-id={section.section_id}
+              data-section-layout={section.layout}
             >
-              {person.merging ? "Deleting…" : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+              <div className={accountStyles.compositionMastheadGrid}>
+                {blocks.map(renderBlock)}
+              </div>
+            </section>
+          );
+        }
+
+        return (
+          <section
+            key={section.section_id}
+            id={section.section_id}
+            className={accountStyles.compositionSection}
+            data-section-id={section.section_id}
+            data-section-layout={section.layout}
+            data-section-salience={section.salience.band}
+          >
+            <div className={accountStyles.compositionSectionLabel}>{renderableSection.label}</div>
+            <div className={accountStyles.compositionSectionBody}>
+              <header className={accountStyles.compositionSectionHeader}>
+                <div>{renderSectionTitle(renderableSection)}</div>
+                <p className={accountStyles.compositionSectionMeta}>{section.salience.reason}</p>
+              </header>
+              <div className={accountStyles.compositionBlockStack}>
+                {blocks.length > 0 ? (
+                  blocks.map(renderBlock)
+                ) : (
+                  <div className={accountStyles.compositionDegradedState}>
+                    <p className={accountStyles.compositionStateLabel}>Empty section</p>
+                    <p className={accountStyles.compositionStateText}>
+                      No renderable blocks are available for this section.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+        );
+      })}
+
+      {detail && (
+        <>
+          <PersonControlsPanel
+            detail={detail}
+            person={person}
+            onArchive={() => setArchiveDialogOpen(true)}
+            onAfterMutation={forceRefreshProjectedComposition}
+          />
+          <section className={styles.personRelationshipControls} aria-label="Relationship controls">
+            <PersonNetwork
+              entities={detail.entities}
+              personId={personId}
+              onLink={handleLinkEntity}
+              onUnlink={handleUnlinkEntity}
+              chapterTitle="Their Orbit"
+            />
+            <PersonRelationships
+              personId={personId ?? ""}
+              network={person.intelligence?.network}
+              relationships={relationships}
+              preset={preset ?? undefined}
+              chapterTitle="Their Network"
+              onRelationshipsChanged={handleRelationshipsChanged}
+            />
+          </section>
+          <PersonAppendix
+            detail={detail}
+            duplicateCandidates={person.duplicateCandidates}
+            onMergeSuggested={person.handleOpenSuggestedMerge}
+            merging={person.merging}
+            files={person.files}
+            onIndexFiles={person.handleIndexFiles}
+            indexing={person.indexing}
+            indexFeedback={person.indexFeedback}
+          />
+        </>
+      )}
+
+      <FinisMarker enrichedAt={person.intelligence?.enrichedAt} />
+
+      {detail && (
+        <AlertDialog open={archiveDialogOpen} onOpenChange={setArchiveDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Archive Person</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will hide {detail.name} from active views. You can restore them later.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={person.handleArchive}>Archive</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {detail && (
+        <Dialog open={person.mergeDialogOpen} onOpenChange={person.setMergeDialogOpen}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Merge {detail.name} into...</DialogTitle>
+              <DialogDescription>
+                Search for the person to merge into. Meetings, entity links, and actions transfer to the selected person.
+              </DialogDescription>
+            </DialogHeader>
+            <Input
+              placeholder="Search by name or email..."
+              value={person.mergeSearchQuery}
+              onChange={(event) => person.setMergeSearchQuery(event.target.value)}
+              autoFocus
+            />
+            {person.mergeSearchResults.length > 0 && (
+              <div className={shared.mergeSearchResults}>
+                {person.mergeSearchResults.map((candidate) => (
+                  <button
+                    key={candidate.id}
+                    type="button"
+                    onClick={() => {
+                      person.setMergeTarget(candidate);
+                      person.setMergeDialogOpen(false);
+                      person.setMergeConfirmOpen(true);
+                    }}
+                    className={`${shared.mergeSearchButton} hover:bg-muted`}
+                  >
+                    <div className={shared.mergeAvatar}>{candidate.name.charAt(0).toUpperCase()}</div>
+                    <div className={shared.mergePersonInfo}>
+                      <div className={shared.mergePersonName}>{candidate.name}</div>
+                      <div className={shared.mergePersonEmail}>
+                        {candidate.email}
+                        {candidate.organization && ` · ${candidate.organization}`}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+            {person.mergeSearchQuery.length >= 2 && person.mergeSearchResults.length === 0 && (
+              <p className={shared.mergeEmptyState}>No matching people found</p>
+            )}
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {detail && (
+        <AlertDialog open={person.mergeConfirmOpen} onOpenChange={person.setMergeConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Merge {detail.name}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Permanently merge <strong>{detail.name}</strong> ({detail.email}) into{" "}
+                <strong>{person.mergeTarget?.name}</strong> ({person.mergeTarget?.email}).
+                Meetings, entity links, and actions transfer. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={person.merging}>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={person.handleMerge} disabled={person.merging}>
+                {person.merging ? "Merging..." : "Merge"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {detail && (
+        <AlertDialog open={person.deleteConfirmOpen} onOpenChange={person.setDeleteConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete {detail.name}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                All meeting attendance records, entity links, and action associations for{" "}
+                <strong>{detail.name}</strong> will be removed. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={person.merging}>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={person.handleDelete} disabled={person.merging}>
+                {person.merging ? "Deleting..." : "Delete"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </main>
   );
 }

--- a/src/pages/ProjectDetailEditorial.module.css
+++ b/src/pages/ProjectDetailEditorial.module.css
@@ -79,3 +79,116 @@
   border-radius: 50%;
   background: var(--color-garden-larkspur);
 }
+
+/* ── Service-backed project controls ── */
+
+.projectControlPanel {
+  display: grid;
+  gap: var(--space-md);
+  padding: var(--space-lg) 0;
+  border-top: 1px solid var(--color-rule-heavy);
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.projectControlForm {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-md);
+  align-items: end;
+}
+
+.projectControlField {
+  display: grid;
+  gap: 6px;
+}
+
+.projectControlField span,
+.projectPanelLabel {
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.projectControlActions,
+.projectActionComposer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.projectControlActions {
+  grid-column: 1 / -1;
+}
+
+.projectActionComposer {
+  padding-top: var(--space-sm);
+}
+
+.projectActionComposer > input {
+  max-width: 360px;
+}
+
+.projectHierarchyPanel {
+  display: grid;
+  gap: var(--space-sm);
+  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--color-rule-light);
+}
+
+.projectPanelLabel {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.projectHierarchyLink,
+.projectHierarchyChild {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.projectHierarchyLink {
+  width: fit-content;
+  color: var(--color-garden-olive);
+}
+
+.projectHierarchyChildren {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.projectHierarchyChild {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-md);
+  padding: var(--space-xs) 0;
+  border-top: 1px solid var(--color-rule-light);
+}
+
+.projectHierarchyChild span:last-child {
+  color: var(--color-text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 860px) {
+  .projectControlForm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .projectHierarchyChild {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/ProjectDetailEditorial.test.tsx
+++ b/src/pages/ProjectDetailEditorial.test.tsx
@@ -1,0 +1,394 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectDetailEditorial from "@/pages/ProjectDetailEditorial";
+import type {
+  ProjectedBlock,
+  ProjectedComposition,
+  ProjectedCompositionCommandResponse,
+} from "@/services/composition/contracts";
+
+const {
+  invokeMock,
+  navigateMock,
+  useProjectDetailMock,
+  useProjectedCompositionMock,
+  projectedRefetchMock,
+  useRegisterMagazineShellMock,
+} = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  navigateMock: vi.fn(),
+  useProjectDetailMock: vi.fn(),
+  useProjectedCompositionMock: vi.fn(),
+  projectedRefetchMock: vi.fn(),
+  useRegisterMagazineShellMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ projectId: "project-test-1" }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/hooks/useProjectDetail", () => ({
+  useProjectDetail: () => useProjectDetailMock(),
+}));
+
+vi.mock("@/hooks/useProjectedComposition", () => ({
+  useProjectedComposition: (subject: unknown) => useProjectedCompositionMock(subject),
+}));
+
+vi.mock("@/hooks/useRevealObserver", () => ({
+  useRevealObserver: vi.fn(),
+}));
+
+vi.mock("@/hooks/useMagazineShell", () => ({
+  useRegisterMagazineShell: (config: unknown) => useRegisterMagazineShellMock(config),
+}));
+
+vi.mock("@/hooks/useChapterLayout", () => ({
+  useChapterLayout: ({ projection }: { projection: ProjectedComposition | null }) => {
+    const sections =
+      projection?.sections.map((section) => ({
+        section,
+        label: section.label ?? section.section_id,
+        coreLocked: section.section_id === "headline",
+        blocks: section.block_indexes.map((index) => {
+          const block = projection.blocks[index];
+          return {
+            block,
+            sectionId: section.section_id,
+            label: String(block?.payload.title ?? block?.payload.text ?? block?.block_id),
+            variant: "default",
+            coreLocked: section.section_id === "headline",
+          };
+        }),
+        hiddenBlocks: [],
+      })) ?? [];
+    return {
+      overlay: null,
+      layoutRevision: 0,
+      view: {
+        sections,
+        hiddenSections: [],
+        hiddenItems: [],
+        hasVisibleNonCore: sections.some((section) => !section.coreLocked),
+      },
+      loading: false,
+      saving: false,
+      error: null,
+      setBlockHidden: vi.fn(),
+      setSectionHidden: vi.fn(),
+      setBlockVariant: vi.fn(),
+      setSectionLabel: vi.fn(),
+      reorderBlocks: vi.fn(),
+      resetLayout: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("@/components/composition/ReactBlockRenderer", () => ({
+  ReactBlockRenderer: ({
+    block,
+    entityId,
+    entityType,
+  }: {
+    block: ProjectedBlock;
+    entityId?: string;
+    entityType?: string;
+  }) => (
+    <div
+      data-testid="composition-block"
+      data-block-id={block.block_id}
+      data-entity-id={entityId}
+      data-entity-type={entityType}
+    >
+      {String(block.payload.title ?? block.payload.text ?? block.block_id)}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/entity/LinearIssuesChapter", () => ({
+  LinearIssuesChapter: () => <section id="linear-issues" data-testid="linear-issues" />,
+}));
+
+vi.mock("@/components/ui/folio-refresh-button", () => ({
+  FolioRefreshButton: () => <button type="button">Refresh</button>,
+}));
+
+vi.mock("@/components/editorial/EditorialLoading", () => ({
+  EditorialLoading: () => <div data-testid="editorial-loading">Loading</div>,
+}));
+
+vi.mock("@/components/editorial/EditorialError", () => ({
+  EditorialError: ({ message }: { message: string }) => (
+    <div data-testid="editorial-error">{message}</div>
+  ),
+}));
+
+vi.mock("@/components/editorial/EditorialEmpty", () => ({
+  EditorialEmpty: ({ title }: { title: string }) => <div data-testid="editorial-empty">{title}</div>,
+}));
+
+vi.mock("@/components/editorial/FinisMarker", () => ({
+  FinisMarker: () => <div data-testid="finis-marker" />,
+}));
+
+function block(
+  blockId: string,
+  sectionIndex: number,
+  selectedKnownTypeId: string,
+  payload: Record<string, unknown>,
+): ProjectedBlock {
+  return {
+    block_id: blockId,
+    block_index: sectionIndex,
+    original_type_id: selectedKnownTypeId,
+    selected_known_type_id: selectedKnownTypeId,
+    payload,
+    banner: null,
+    trust_band: "likely_current",
+    claim_refs: [],
+    provenance: [],
+    edit_routes: [],
+    diagnostics: [],
+  };
+}
+
+function projection(overrides: Partial<ProjectedComposition> = {}): ProjectedComposition {
+  const blocks = [
+    block("headline-block", 0, "account_overview", {
+      project: { display_name: "Projected Project" },
+      title: "Projected Project",
+    }),
+    block("trajectory-block", 1, "claim_summary", { text: "Trajectory signal" }),
+    block("work-block", 2, "action_list", { title: "Actions" }),
+  ];
+  return {
+    composition_id: "dailyos/project-overview:project:project-test-1",
+    composition_version: 3,
+    fallback_policy_version: 3,
+    sections: [
+      {
+        section_id: "headline",
+        section_index: 0,
+        label: "Headline",
+        layout: "stacked",
+        salience: { weight: 0.95, band: "critical", reason: "project masthead" },
+        block_ids: ["headline-block"],
+        block_indexes: [0],
+      },
+      {
+        section_id: "trajectory",
+        section_index: 1,
+        label: "Trajectory",
+        layout: "stacked",
+        salience: { weight: 0.8, band: "important", reason: "project trajectory" },
+        block_ids: ["trajectory-block"],
+        block_indexes: [1],
+      },
+      {
+        section_id: "the-work",
+        section_index: 2,
+        label: "The work",
+        layout: "stacked",
+        salience: { weight: 0.5, band: "background", reason: "project work" },
+        block_ids: ["work-block"],
+        block_indexes: [2],
+      },
+    ],
+    blocks,
+    diagnostics: [],
+    unknown_block_count: 0,
+    unknown_block_cap: 5,
+    dropped_unknown_block_count: 0,
+    ...overrides,
+  };
+}
+
+function response(
+  projectionValue: ProjectedComposition,
+): ProjectedCompositionCommandResponse {
+  return {
+    ok: true,
+    request_id: "request-test",
+    projection: projectionValue,
+    cache_hint_token: "cache-test",
+    served_from_cache: false,
+    rendered_provenance: { surface: "tauri_app", value: { ok: true } },
+  };
+}
+
+function projectHook(overrides: Record<string, unknown> = {}) {
+  return {
+    detail: {
+      id: "project-test-1",
+      name: "Detail Project",
+      status: "active",
+      milestone: "Beta",
+      owner: "Owner",
+      targetDate: "",
+      openActionCount: 0,
+      archived: false,
+      childCount: 1,
+      isParent: true,
+      milestones: [],
+      openActions: [],
+      recentMeetings: [],
+      linkedPeople: [],
+      recentCaptures: [],
+      children: [{ id: "project-child-1", name: "Child Project", status: "active", openActionCount: 0 }],
+    },
+    intelligence: null,
+    loading: false,
+    error: null,
+    files: [],
+    load: vi.fn(),
+    silentRefresh: vi.fn(),
+    editName: "Detail Project",
+    setEditName: vi.fn(),
+    editStatus: "active",
+    setEditStatus: vi.fn(),
+    editMilestone: "Beta",
+    setEditMilestone: vi.fn(),
+    editOwner: "Owner",
+    setEditOwner: vi.fn(),
+    editTargetDate: "",
+    setEditTargetDate: vi.fn(),
+    dirty: false,
+    setDirty: vi.fn(),
+    saving: false,
+    handleSave: vi.fn(),
+    saveField: vi.fn(),
+    handleCancelEdit: vi.fn(),
+    enriching: false,
+    enrichSeconds: 0,
+    handleEnrich: vi.fn(),
+    handleArchive: vi.fn(),
+    handleUnarchive: vi.fn(),
+    addingAction: false,
+    setAddingAction: vi.fn(),
+    newActionTitle: "",
+    setNewActionTitle: vi.fn(),
+    creatingAction: false,
+    handleCreateAction: vi.fn(),
+    createChildOpen: false,
+    setCreateChildOpen: vi.fn(),
+    childName: "",
+    setChildName: vi.fn(),
+    childDescription: "",
+    setChildDescription: vi.fn(),
+    creatingChild: false,
+    handleCreateChild: vi.fn(),
+    indexing: false,
+    indexFeedback: null,
+    handleIndexFiles: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("ProjectDetailEditorial", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue([]);
+    navigateMock.mockReset();
+    useRegisterMagazineShellMock.mockReset();
+    projectedRefetchMock.mockReset();
+    projectedRefetchMock.mockResolvedValue(undefined);
+    useProjectDetailMock.mockReturnValue(projectHook());
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection()),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: projectedRefetchMock,
+    });
+  });
+
+  it("renders Project Detail from the projected composition and derives shell chapters", () => {
+    render(<ProjectDetailEditorial />);
+
+    expect(useProjectedCompositionMock).toHaveBeenCalledWith({
+      entityType: "project",
+      entityId: "project-test-1",
+    });
+    expect(screen.getByText("Projected Project")).toBeInTheDocument();
+    expect(screen.getByText("Trajectory signal")).toBeInTheDocument();
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+    expect(screen.getByTestId("linear-issues")).toBeInTheDocument();
+
+    for (const renderedBlock of screen.getAllByTestId("composition-block")) {
+      expect(renderedBlock).toHaveAttribute("data-entity-id", "project-test-1");
+      expect(renderedBlock).toHaveAttribute("data-entity-type", "project");
+    }
+
+    const shellConfig = useRegisterMagazineShellMock.mock.calls.at(-1)?.[0] as {
+      chapters: Array<{ id: string; label: string }>;
+    };
+    expect(shellConfig.chapters.map((chapter) => chapter.id)).toEqual([
+      "headline",
+      "trajectory",
+      "the-work",
+      "linear-issues",
+    ]);
+  });
+
+  it("shows producer errors without falling back to the old template", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: "project producer unavailable",
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<ProjectDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-error")).toHaveTextContent("project producer unavailable");
+    expect(screen.queryByTestId("composition-block")).not.toBeInTheDocument();
+  });
+
+  it("force-refreshes projected composition after project controls save", async () => {
+    const handleSave = vi.fn().mockResolvedValue(undefined);
+    useProjectDetailMock.mockReturnValue(projectHook({ dirty: true, handleSave }));
+
+    render(<ProjectDetailEditorial />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(handleSave).toHaveBeenCalled());
+    expect(projectedRefetchMock).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it("shows a composition empty state when no projected sections are renderable", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: response(projection({ sections: [], blocks: [] })),
+      renderedProvenance: { surface: "tauri_app", value: { ok: true } },
+      refetch: vi.fn(),
+    });
+
+    render(<ProjectDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-empty")).toHaveTextContent("No project composition");
+  });
+
+  it("shows loading while the first projected composition is pending", () => {
+    useProjectedCompositionMock.mockReturnValue({
+      loading: true,
+      error: null,
+      data: null,
+      renderedProvenance: null,
+      refetch: vi.fn(),
+    });
+
+    render(<ProjectDetailEditorial />);
+
+    expect(screen.getByTestId("editorial-loading")).toBeInTheDocument();
+  });
+});

--- a/src/pages/ProjectDetailEditorial.tsx
+++ b/src/pages/ProjectDetailEditorial.tsx
@@ -1,27 +1,29 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
-import { toast } from "sonner";
-import type { VitalDisplay } from "@/lib/entity-types";
-import { useProjectDetail } from "@/hooks/useProjectDetail";
-import { useActivePreset } from "@/hooks/useActivePreset";
-import { useIntelligenceFieldUpdate } from "@/hooks/useIntelligenceFieldUpdate";
-import { useRevealObserver } from "@/hooks/useRevealObserver";
-import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
 import {
-  AlignLeft,
-  Briefcase,
-  TrendingUp,
-  Compass,
-  Users,
-  Eye,
   Activity,
+  AlignLeft,
+  Archive,
+  Briefcase,
   CheckSquare2,
+  Compass,
+  Eye,
+  FileText,
+  GitBranch,
+  Plus,
+  RotateCcw,
+  Save,
+  Sparkles,
+  Users,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { EditorialLoading } from "@/components/editorial/EditorialLoading";
 import { EditorialError } from "@/components/editorial/EditorialError";
+import { EditorialEmpty } from "@/components/editorial/EditorialEmpty";
+import { FinisMarker } from "@/components/editorial/FinisMarker";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -39,174 +41,304 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ProjectHero } from "@/components/project/ProjectHero";
-import { ProjectAppendix } from "@/components/project/ProjectAppendix";
-import { WatchListMilestones } from "@/components/project/WatchListMilestones";
-import { TrajectoryChapter } from "@/components/project/TrajectoryChapter";
-import { HorizonChapter } from "@/components/project/HorizonChapter";
-import { VitalsStrip } from "@/components/entity/VitalsStrip";
-import { EditableVitalsStrip } from "@/components/entity/EditableVitalsStrip";
-import { StakeholderGallery } from "@/components/entity/StakeholderGallery";
-import { WatchList } from "@/components/entity/WatchList";
-import { UnifiedTimeline } from "@/components/entity/UnifiedTimeline";
-import { TheWork } from "@/components/entity/TheWork";
-import { RecommendedActions } from "@/components/entity/RecommendedActions";
-import { ChapterHeading } from "@/components/editorial/ChapterHeading";
-import { AddToRecord } from "@/components/entity/AddToRecord";
 import { LinearIssuesChapter } from "@/components/entity/LinearIssuesChapter";
-import { useEntityContextEntries } from "@/hooks/useEntityContextEntries";
-import { useIntelligenceFeedback } from "@/hooks/useIntelligenceFeedback";
-import { IntelligenceFeedback } from "@/components/ui/IntelligenceFeedback";
+import { ReactBlockRenderer } from "@/components/composition/ReactBlockRenderer";
+import { FolioRefreshButton } from "@/components/ui/folio-refresh-button";
+import { useProjectDetail } from "@/hooks/useProjectDetail";
+import { useRevealObserver } from "@/hooks/useRevealObserver";
+import { useRegisterMagazineShell } from "@/hooks/useMagazineShell";
+import {
+  useChapterLayout,
+  type RenderableCompositionBlock,
+  type RenderableCompositionSection,
+} from "@/hooks/useChapterLayout";
+import { useProjectedComposition } from "@/hooks/useProjectedComposition";
+import type { ProjectDetail } from "@/types";
+import type { ProjectedBlock } from "@/services/composition/contracts";
 import shared from "@/styles/entity-detail.module.css";
+import accountStyles from "./AccountDetailPage.module.css";
 import styles from "./ProjectDetailEditorial.module.css";
 
-/* ── Vitals assembly ── */
-
-function buildProjectVitals(detail: {
-  status?: string;
-  owner?: string;
-  targetDate?: string;
-  milestones?: { status: string }[];
-  signals?: {
-    meetingFrequency30d?: number;
-    meetingFrequency90d?: number;
-    openActionCount?: number;
-    daysUntilTarget?: number;
-    trend?: string;
-  };
-}): VitalDisplay[] {
-  const vitals: VitalDisplay[] = [];
-  if (detail.status) {
-    vitals.push({
-      text: detail.status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
-      highlight: "olive",
-    });
-  }
-  if (detail.signals?.daysUntilTarget != null) {
-    const trend = detail.signals.trend;
-    const arrow = trend === "improving" ? " \u2191" : trend === "declining" ? " \u2193" : "";
-    vitals.push({ text: `${detail.signals.daysUntilTarget}d to target${arrow}` });
-  }
-  if (detail.milestones) {
-    const done = detail.milestones.filter(
-      (m) => m.status.toLowerCase() === "completed" || m.status.toLowerCase() === "done",
-    ).length;
-    const total = detail.milestones.length;
-    if (total > 0) vitals.push({ text: `${done} of ${total} milestones` });
-  }
-  if (detail.signals?.meetingFrequency30d != null) {
-    const f30 = detail.signals.meetingFrequency30d;
-    const f90 = detail.signals.meetingFrequency90d;
-    const arrow =
-      f90 != null && f90 > 0
-        ? f30 > f90 / 3 ? " \u2191" : f30 < f90 / 3 ? " \u2193" : ""
-        : "";
-    vitals.push({ text: `${f30} meetings / 30d${arrow}` });
-  }
-  if (detail.signals?.openActionCount != null) {
-    vitals.push({ text: `${detail.signals.openActionCount} open actions` });
-  }
-  return vitals;
-}
-
-/* ── Chapters ── */
-
-const BASE_CHAPTERS: { id: string; label: string; icon: React.ReactNode }[] = [
-  { id: "headline", label: "The Mission", icon: <AlignLeft size={18} strokeWidth={1.5} /> },
-  { id: "trajectory", label: "Trajectory", icon: <TrendingUp size={18} strokeWidth={1.5} /> },
-  { id: "the-horizon", label: "The Horizon", icon: <Compass size={18} strokeWidth={1.5} /> },
-  { id: "the-landscape", label: "The Landscape", icon: <Eye size={18} strokeWidth={1.5} /> },
-  { id: "the-room", label: "The Team", icon: <Users size={18} strokeWidth={1.5} /> },
-  { id: "the-record", label: "The Record", icon: <Activity size={18} strokeWidth={1.5} /> },
-  { id: "the-work", label: "The Work", icon: <CheckSquare2 size={18} strokeWidth={1.5} /> },
-  { id: "linear-issues", label: "Linear Issues", icon: <CheckSquare2 size={18} strokeWidth={1.5} /> },
-];
-
-const PORTFOLIO_CHAPTER = {
-  id: "portfolio",
-  label: "Portfolio",
-  icon: <Briefcase size={18} strokeWidth={1.5} />,
+const SECTION_ICONS: Record<string, React.ReactNode> = {
+  headline: <AlignLeft size={18} strokeWidth={1.5} />,
+  portfolio: <Briefcase size={18} strokeWidth={1.5} />,
+  trajectory: <Activity size={18} strokeWidth={1.5} />,
+  "the-horizon": <Compass size={18} strokeWidth={1.5} />,
+  "the-landscape": <Eye size={18} strokeWidth={1.5} />,
+  "the-room": <Users size={18} strokeWidth={1.5} />,
+  "whats-next": <CheckSquare2 size={18} strokeWidth={1.5} />,
+  "the-record": <FileText size={18} strokeWidth={1.5} />,
+  "the-work": <CheckSquare2 size={18} strokeWidth={1.5} />,
+  "linear-issues": <CheckSquare2 size={18} strokeWidth={1.5} />,
 };
 
-function buildChapters(isParent: boolean) {
-  if (!isParent) return BASE_CHAPTERS;
-  // Portfolio appears after headline, before Trajectory
-  return [BASE_CHAPTERS[0], PORTFOLIO_CHAPTER, ...BASE_CHAPTERS.slice(1)];
+function projectNameFromBlocks(
+  blocks: ProjectedBlock[],
+  detail: ProjectDetail | null,
+  projectId: string | undefined,
+): string {
+  const overview = blocks.find((block) => block.selected_known_type_id === "account_overview");
+  const project = overview?.payload.project;
+  if (project && typeof project === "object" && !Array.isArray(project)) {
+    const displayName = (project as Record<string, unknown>).display_name;
+    if (typeof displayName === "string" && displayName.trim()) return displayName;
+  }
+  const account = overview?.payload.account;
+  if (account && typeof account === "object" && !Array.isArray(account)) {
+    const displayName = (account as Record<string, unknown>).display_name;
+    if (typeof displayName === "string" && displayName.trim()) return displayName;
+  }
+  return detail?.name ?? projectId ?? "Project";
 }
 
-function getStatusColorClass(status: string): string {
-  if (status === "active") return styles.statusActive;
-  if (status === "on_hold") return styles.statusOnHold;
-  return styles.statusCompleted;
+function ProjectControlsPanel({
+  detail,
+  project,
+  onArchive,
+  onAfterMutation,
+}: {
+  detail: ProjectDetail;
+  project: ReturnType<typeof useProjectDetail>;
+  onArchive: () => void;
+  onAfterMutation: () => Promise<void>;
+}) {
+  const runMutationAndRefresh = (mutation: () => Promise<void>) => {
+    void (async () => {
+      await mutation();
+      await onAfterMutation();
+    })();
+  };
+
+  return (
+    <section className={styles.projectControlPanel} aria-label="Project controls">
+      <form
+        className={styles.projectControlForm}
+        onSubmit={(event) => {
+          event.preventDefault();
+          runMutationAndRefresh(project.handleSave);
+        }}
+      >
+        <label className={styles.projectControlField}>
+          <span>Name</span>
+          <Input
+            value={project.editName}
+            onChange={(event) => {
+              project.setEditName(event.target.value);
+              project.setDirty(true);
+            }}
+          />
+        </label>
+        <label className={styles.projectControlField}>
+          <span>Status</span>
+          <Input
+            value={project.editStatus}
+            onChange={(event) => {
+              project.setEditStatus(event.target.value);
+              project.setDirty(true);
+            }}
+          />
+        </label>
+        <label className={styles.projectControlField}>
+          <span>Milestone</span>
+          <Input
+            value={project.editMilestone}
+            onChange={(event) => {
+              project.setEditMilestone(event.target.value);
+              project.setDirty(true);
+            }}
+          />
+        </label>
+        <label className={styles.projectControlField}>
+          <span>Owner</span>
+          <Input
+            value={project.editOwner}
+            onChange={(event) => {
+              project.setEditOwner(event.target.value);
+              project.setDirty(true);
+            }}
+          />
+        </label>
+        <label className={styles.projectControlField}>
+          <span>Target</span>
+          <Input
+            value={project.editTargetDate}
+            onChange={(event) => {
+              project.setEditTargetDate(event.target.value);
+              project.setDirty(true);
+            }}
+          />
+        </label>
+        <div className={styles.projectControlActions}>
+          <Button type="submit" disabled={!project.dirty || project.saving}>
+            <Save size={15} strokeWidth={1.7} />
+            {project.saving ? "Saving" : "Save"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={!project.dirty}
+            onClick={project.handleCancelEdit}
+          >
+            <X size={15} strokeWidth={1.7} />
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => runMutationAndRefresh(project.handleEnrich)}
+            disabled={project.enriching}
+          >
+            <Sparkles size={15} strokeWidth={1.7} />
+            {project.enriching ? `${project.enrichSeconds}s` : "Refresh"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={detail.archived ? () => runMutationAndRefresh(project.handleUnarchive) : onArchive}
+          >
+            {detail.archived ? (
+              <RotateCcw size={15} strokeWidth={1.7} />
+            ) : (
+              <Archive size={15} strokeWidth={1.7} />
+            )}
+            {detail.archived ? "Restore" : "Archive"}
+          </Button>
+        </div>
+      </form>
+      <div className={styles.projectActionComposer}>
+        {project.addingAction ? (
+          <>
+            <Input
+              value={project.newActionTitle}
+              onChange={(event) => project.setNewActionTitle(event.target.value)}
+              placeholder="Action title"
+            />
+            <Button
+              type="button"
+              onClick={() => runMutationAndRefresh(project.handleCreateAction)}
+              disabled={project.creatingAction || !project.newActionTitle.trim()}
+            >
+              <Plus size={15} strokeWidth={1.7} />
+              {project.creatingAction ? "Creating" : "Create"}
+            </Button>
+            <Button type="button" variant="ghost" onClick={() => project.setAddingAction(false)}>
+              <X size={15} strokeWidth={1.7} />
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button type="button" variant="ghost" onClick={() => project.setAddingAction(true)}>
+            <Plus size={15} strokeWidth={1.7} />
+            Action
+          </Button>
+        )}
+      </div>
+    </section>
+  );
 }
 
-function getStatusDotClass(status: string): string {
-  if (status === "active") return styles.statusDotActive;
-  if (status === "on_hold") return styles.statusDotOnHold;
-  return styles.statusDotCompleted;
+function ProjectHierarchyNav({
+  detail,
+  navigate,
+}: {
+  detail: ProjectDetail;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  if (!detail.parentId && detail.children.length === 0) return null;
+  return (
+    <section className={styles.projectHierarchyPanel} aria-label="Project hierarchy">
+      <div className={styles.projectPanelLabel}>
+        <GitBranch size={14} strokeWidth={1.7} />
+        Hierarchy
+      </div>
+      {detail.parentId && (
+        <button
+          type="button"
+          className={styles.projectHierarchyLink}
+          onClick={() =>
+            navigate({
+              to: "/projects/$projectId",
+              params: { projectId: detail.parentId ?? "" },
+            })
+          }
+        >
+          {detail.parentName ?? "Parent project"}
+        </button>
+      )}
+      {detail.children.length > 0 && (
+        <div className={styles.projectHierarchyChildren}>
+          {detail.children.map((child) => (
+            <button
+              type="button"
+              key={child.id}
+              className={styles.projectHierarchyChild}
+              onClick={() =>
+                navigate({
+                  to: "/projects/$projectId",
+                  params: { projectId: child.id },
+                })
+              }
+            >
+              <span>{child.name}</span>
+              <span>{child.status.replace(/_/g, " ")}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
 }
 
 export default function ProjectDetailEditorial() {
   const { projectId } = useParams({ strict: false });
   const navigate = useNavigate();
-  const proj = useProjectDetail(projectId);
-  const preset = useActivePreset();
-  useRevealObserver(!proj.loading && !!proj.detail);
-
-  // Shared folio save status hook (must be before shellConfig useMemo)
-  const {
-    saveStatus,
-    setSaveStatus: setFolioSaveStatus,
-  } = useIntelligenceFieldUpdate("project", projectId, proj.silentRefresh);
-
-  const finishFolioSave = () => {
-    setFolioSaveStatus("saved");
-    window.setTimeout(() => setFolioSaveStatus("idle"), 2000);
-  };
-
-  const saveMetadata = async (updated: Record<string, string>) => {
-    if (!projectId) return;
-    setFolioSaveStatus("saving");
-    try {
-      await invoke("update_entity_metadata", {
-        entityId: projectId,
-        entityType: "project",
-        metadata: JSON.stringify(updated),
-      });
-      finishFolioSave();
-    } catch (err) {
-      console.error("update_entity_metadata failed:", err);
-      toast.error("Failed to save metadata");
-      setFolioSaveStatus("idle");
-      throw err;
-    }
-  };
-
-  const saveProjectField = async (field: string, value: string) => {
-    if (!proj.detail) return;
-    setFolioSaveStatus("saving");
-    try {
-      await invoke("update_project_field", { projectId: proj.detail.id, field, value });
-      await proj.load();
-      finishFolioSave();
-    } catch (err) {
-      console.error("update_project_field failed:", err);
-      toast.error("Failed to save field");
-      setFolioSaveStatus("idle");
-    }
-  };
-
-  // Fetch ancestor projects for FolioBar breadcrumb navigation.
+  const project = useProjectDetail(projectId);
+  const composition = useProjectedComposition(
+    projectId ? { entityType: "project", entityId: projectId } : undefined,
+  );
+  const projection = composition.data?.projection ?? null;
+  const layout = useChapterLayout({ projection, entityType: "project" });
+  const visibleSections = layout.view.sections;
+  const projectName = projectNameFromBlocks(projection?.blocks ?? [], project.detail, projectId);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
   const [ancestors, setAncestors] = useState<{ id: string; name: string }[]>([]);
+
+  useRevealObserver(!composition.loading && !!projection);
+
+  const forceRefreshProjectedComposition = useCallback(
+    () => composition.refetch({ forceRefresh: true }),
+    [composition.refetch],
+  );
+
   useEffect(() => {
     if (!projectId) return;
     invoke<{ id: string; name: string }[]>("get_project_ancestors", { projectId })
       .then(setAncestors)
       .catch((err) => {
-        console.error("get_project_ancestors failed:", err); // Expected: background data fetch on mount
+        console.error("get_project_ancestors failed:", err);
         setAncestors([]);
       });
   }, [projectId]);
+
+  const chapters = useMemo(
+    () => [
+      ...visibleSections.map(({ section, label }) => ({
+        id: section.section_id,
+        label,
+        icon: SECTION_ICONS[section.section_id] ?? <FileText size={18} strokeWidth={1.5} />,
+      })),
+      ...(project.detail
+        ? [
+            {
+              id: "linear-issues",
+              label: "Linear Issues",
+              icon: SECTION_ICONS["linear-issues"],
+            },
+          ]
+        : []),
+    ],
+    [project.detail, visibleSections],
+  );
 
   const shellConfig = useMemo(
     () => ({
@@ -219,367 +351,212 @@ export default function ProjectDetailEditorial() {
           label: ancestor.name,
           onClick: () => navigate({ to: "/projects/$projectId", params: { projectId: ancestor.id } }),
         })),
-        { label: proj.detail?.name ?? "Project" },
+        { label: projectName },
       ],
-      chapters: buildChapters(proj.detail?.isParent ?? false),
-      folioStatusText: saveStatus === "saving" ? "Saving\u2026" : saveStatus === "saved" ? "\u2713 Saved" : undefined,
-      folioActions: proj.detail?.isParent ? (
-        <button
-          onClick={() => proj.setCreateChildOpen(true)}
-          className={styles.addChildButton}
-        >
-          + Sub-Project
-        </button>
-      ) : undefined,
+      chapters,
+      folioStatusText: composition.loading
+        ? "Composing..."
+        : project.saving
+          ? "Saving..."
+          : composition.data?.served_from_cache
+            ? "Projected from cache"
+            : undefined,
+      folioActions: (
+        <div className={shared.folioActions}>
+          {project.detail?.isParent && (
+            <button
+              type="button"
+              onClick={() => project.setCreateChildOpen(true)}
+              className={styles.addChildButton}
+            >
+              + Sub-Project
+            </button>
+          )}
+          <FolioRefreshButton onClick={composition.refetch} loading={composition.loading} />
+        </div>
+      ),
     }),
-    [ancestors, navigate, proj.detail, proj.setCreateChildOpen, saveStatus],
+    [
+      ancestors,
+      chapters,
+      composition.data?.served_from_cache,
+      composition.loading,
+      composition.refetch,
+      navigate,
+      project.detail?.isParent,
+      project.saving,
+      project.setCreateChildOpen,
+      projectName,
+    ],
   );
   useRegisterMagazineShell(shellConfig);
 
-  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
+  if (composition.loading && !projection) return <EditorialLoading />;
 
-  // Preset metadata state
-  const [metadataValues, setMetadataValues] = useState<Record<string, string>>({});
-  useEffect(() => {
-    if (!projectId) return;
-    invoke<string>("get_entity_metadata", { entityType: "project", entityId: projectId })
-      .then((json) => {
-        try { setMetadataValues(JSON.parse(json) ?? {}); } catch { setMetadataValues({}); }
-      })
-      .catch((err) => {
-        console.error("get_entity_metadata (project) failed:", err); // Expected: background data fetch on mount
-        setMetadataValues({});
-      });
-  }, [projectId]);
-
-  // Intelligence quality feedback
-  const feedback = useIntelligenceFeedback(projectId, "project");
-
-  // Context entries — must be before early returns (React hooks rule)
-  const entityCtx = useEntityContextEntries("project", projectId ?? null);
-
-  if (proj.loading) return <EditorialLoading />;
-
-  if (proj.error || !proj.detail) {
-    return <EditorialError message={proj.error ?? "Project not found"} onRetry={proj.load} />;
+  if (composition.error) {
+    return <EditorialError message={composition.error} onRetry={composition.refetch} />;
   }
 
-  const { detail, intelligence, files } = proj;
+  if (!projection || projection.sections.length === 0 || projection.blocks.length === 0) {
+    return (
+      <EditorialEmpty
+        title="No project composition"
+        message="DailyOS has not produced a project surface yet."
+      />
+    );
+  }
+
+  const renderBlock = (item: RenderableCompositionBlock) => (
+    <ReactBlockRenderer
+      key={item.block.block_id}
+      block={item.block}
+      entityId={projectId}
+      entityType="project"
+      renderedProvenance={composition.renderedProvenance}
+    />
+  );
+
+  const renderSectionTitle = (section: RenderableCompositionSection) => (
+    <h2 className={accountStyles.compositionSectionTitle}>{section.label}</h2>
+  );
+
+  const detail = project.detail;
 
   return (
-    <>
-      {/* Chapter 1: The Mission (Hero) */}
-      <section id="headline" className={shared.chapterSection}>
-        <ProjectHero
-          detail={detail}
-          intelligence={intelligence}
-          editName={proj.editName}
-          setEditName={(v) => { proj.setEditName(v); proj.setDirty(true); }}
-          editStatus={proj.editStatus}
-          setEditStatus={(v) => { proj.setEditStatus(v); proj.setDirty(true); }}
-          onSave={proj.handleSave}
-          onSaveField={proj.saveField}
-          onEnrich={proj.handleEnrich}
-          enriching={proj.enriching}
-          enrichSeconds={proj.enrichSeconds}
-          onArchive={() => setArchiveDialogOpen(true)}
-          onUnarchive={proj.handleUnarchive}
-        />
-        <div className="editorial-reveal">
-          {preset ? (
-            <EditableVitalsStrip
-              fields={preset.vitals.project}
-              metadataFields={preset.metadata.project}
-              entityData={detail}
-              metadata={metadataValues}
-              onFieldChange={(key, columnMapping, source, value) => {
-                if (source === "metadata") {
-                  setMetadataValues((prev) => {
-                    const updated = { ...prev, [key]: value };
-                    void saveMetadata(updated);
-                    return updated;
-                  });
-                } else if (source === "column") {
-                  const field = columnMapping ?? key;
-                  void saveProjectField(field, value);
-                }
-              }}
-            />
-          ) : (
-            <VitalsStrip vitals={buildProjectVitals(detail)} />
-          )}
+    <main
+      className={accountStyles.compositionSurface}
+      data-composition-id={projection.composition_id}
+      data-composition-version={projection.composition_version ?? 0}
+      data-fallback-policy-version={projection.fallback_policy_version}
+    >
+      {project.error && (
+        <div className={accountStyles.compositionDegradedState} role="status">
+          <p className={accountStyles.compositionStateLabel}>Project controls unavailable</p>
+          <p className={accountStyles.compositionStateText}>{project.error}</p>
         </div>
-      </section>
-
-      {/* Portfolio chapter — only for parent projects */}
-      {detail.isParent && detail.children.length > 0 && (
-        <section id="portfolio" className={`editorial-reveal ${shared.chapterSectionWithPadding}`}>
-          <ChapterHeading title="Portfolio" />
-
-          {/* Portfolio narrative */}
-          {intelligence?.portfolio?.portfolioNarrative && (
-            <div className={shared.portfolioNarrative}>
-              <p className={shared.portfolioNarrativeText}>
-                {intelligence.portfolio.portfolioNarrative}
-              </p>
-            </div>
-          )}
-
-          {/* Hotspots — child projects needing attention */}
-          {intelligence?.portfolio?.hotspots && intelligence.portfolio.hotspots.length > 0 && (
-            <div className={shared.portfolioHotspotsSection}>
-              <div className={shared.portfolioSectionLabelTerracotta}>
-                Needs Attention
-              </div>
-              {intelligence.portfolio.hotspots.map((hotspot, i) => (
-                <div
-                  key={hotspot.childId}
-                  className={
-                    i === intelligence.portfolio!.hotspots.length - 1
-                      ? shared.hotspotRow
-                      : shared.hotspotRowBorder
-                  }
-                >
-                  <span className={shared.hotspotDot} />
-                  <div className={shared.hotspotContent}>
-                    <button
-                      onClick={() =>
-                        navigate({
-                          to: "/projects/$projectId",
-                          params: { projectId: hotspot.childId },
-                        })
-                      }
-                      className={styles.hotspotLinkOlive}
-                    >
-                      {hotspot.childName}
-                    </button>
-                    <p className={shared.hotspotReason}>
-                      {hotspot.reason}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Cross-project patterns — only shown when non-empty */}
-          {intelligence?.portfolio?.crossBuPatterns && intelligence.portfolio.crossBuPatterns.length > 0 && (
-            <div className={shared.crossPatternsBlock}>
-              <div className={shared.portfolioSectionLabelLarkspur}>
-                Cross-Project Patterns
-              </div>
-              {intelligence.portfolio.crossBuPatterns.map((pattern, i) => (
-                <p
-                  key={i}
-                  className={i === 0 ? shared.crossPatternTextFirst : shared.crossPatternTextSubsequent}
-                >
-                  {pattern}
-                </p>
-              ))}
-            </div>
-          )}
-
-          {/* Condensed child list */}
-          <div className={shared.childListSection}>
-            <div className={shared.portfolioSectionLabelTertiary}>
-              Sub-Projects
-            </div>
-            {detail.children.map((child, i) => (
-              <div
-                key={child.id}
-                className={
-                  i === detail.children.length - 1
-                    ? shared.childRow
-                    : shared.childRowBorder
-                }
-              >
-                <button
-                  onClick={() =>
-                    navigate({
-                      to: "/projects/$projectId",
-                      params: { projectId: child.id },
-                    })
-                  }
-                  className={shared.childNameButton}
-                >
-                  {child.name}
-                </button>
-                {/* Status indicator */}
-                <span className={`${shared.statusIndicator} ${getStatusColorClass(child.status)}`}>
-                  <span className={getStatusDotClass(child.status)} />
-                  {child.status === "active"
-                    ? "Active"
-                    : child.status === "on_hold"
-                      ? "On Hold"
-                      : "Completed"}
-                </span>
-                {/* Open actions count */}
-                {child.openActionCount > 0 && (
-                  <span className={shared.secondaryMetric}>
-                    {child.openActionCount} action{child.openActionCount !== 1 ? "s" : ""}
-                  </span>
-                )}
-              </div>
-            ))}
-          </div>
-        </section>
       )}
 
-      {/* Chapter 2: Trajectory */}
-      <div id="trajectory" className={`editorial-reveal ${shared.chapterSection}`}>
-        <TrajectoryChapter
-          detail={detail}
-          intelligence={intelligence}
-          feedbackSlot={
-            <IntelligenceFeedback
-              value={feedback.getFeedback("trajectory")}
-              onFeedback={(type) => feedback.submitFeedback("trajectory", type)}
-            />
-          }
-        />
-      </div>
+      {visibleSections.map((renderableSection) => {
+        const section = renderableSection.section;
+        const blocks = renderableSection.blocks;
+        if (section.section_id === "headline") {
+          return (
+            <section
+              key={section.section_id}
+              id={section.section_id}
+              className={accountStyles.compositionMasthead}
+              data-section-id={section.section_id}
+              data-section-layout={section.layout}
+            >
+              <div className={accountStyles.compositionMastheadGrid}>
+                {blocks.map(renderBlock)}
+              </div>
+            </section>
+          );
+        }
 
-      {/* Chapter 3: The Horizon */}
-      <div id="the-horizon" className={`editorial-reveal ${shared.chapterSection}`}>
-        <HorizonChapter
-          detail={detail}
-          intelligence={intelligence}
-          feedbackSlot={
-            <IntelligenceFeedback
-              value={feedback.getFeedback("horizon")}
-              onFeedback={(type) => feedback.submitFeedback("horizon", type)}
-            />
-          }
-        />
-      </div>
-
-      {/* Chapter 4: The Landscape */}
-      <div id="the-landscape" className={`editorial-reveal ${shared.chapterSection}`}>
-        <WatchList
-          intelligence={intelligence}
-          sectionId="the-landscape"
-          chapterTitle="The Landscape"
-          getItemFeedback={(fieldPath) => feedback.getFeedback(fieldPath)}
-          onItemFeedback={(fieldPath, type) => feedback.submitFeedback(fieldPath, type)}
-          bottomSection={
-            detail.milestones.length > 0 ? (
-              <WatchListMilestones milestones={detail.milestones} />
-            ) : undefined
-          }
-        />
-      </div>
-
-      {/* Chapter 5: The Team */}
-      <div id="the-room" className={`editorial-reveal ${shared.chapterSection}`}>
-        <StakeholderGallery
-          intelligence={intelligence}
-          linkedPeople={detail.linkedPeople}
-          chapterTitle="The Team"
-          sectionId="the-room"
-          entityId={projectId}
-          entityType="project"
-          onIntelligenceUpdated={proj.silentRefresh}
-        />
-      </div>
-
-      {/* Chapter 6: The Record */}
-      <div id="the-record" className={`editorial-reveal ${shared.chapterSection}`}>
-        <UnifiedTimeline
-          data={{ ...detail, contextEntries: entityCtx.entries }}
-          sectionId=""
-          actionSlot={<AddToRecord onAdd={(title, content) => entityCtx.createEntry(title, content)} />}
-        />
-      </div>
-
-      {/* Chapter 7: The Work  */}
-      <div id="the-work" className={`editorial-reveal ${shared.chapterSection}`}>
-        {intelligence?.recommendedActions && intelligence.recommendedActions.length > 0 && (
-          <RecommendedActions entityId={detail.id} entityType="project"
-            actions={intelligence.recommendedActions} onRefresh={proj.silentRefresh} />
-        )}
-        <TheWork
-          data={detail}
-          addingAction={proj.addingAction}
-          setAddingAction={proj.setAddingAction}
-          newActionTitle={proj.newActionTitle}
-          setNewActionTitle={proj.setNewActionTitle}
-          creatingAction={proj.creatingAction}
-          onCreateAction={proj.handleCreateAction}
-        />
-      </div>
-
-      {/* Appendix */}
-      <div className="editorial-reveal">
-        <ProjectAppendix
-          detail={detail}
-          files={files}
-          onIndexFiles={proj.handleIndexFiles}
-          indexing={proj.indexing}
-          indexFeedback={proj.indexFeedback}
-        />
-      </div>
-
-      <LinearIssuesChapter
-        entityRef={{ kind: "project", id: detail.id }}
-        actorScope="user"
-      />
-
-      {/* Archive Confirmation */}
-      <AlertDialog open={archiveDialogOpen} onOpenChange={setArchiveDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Archive Project</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will hide {detail.name} from active views.
-              You can unarchive it later.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={proj.handleArchive}>Archive</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Sub-Project Creation Dialog */}
-      <Dialog open={proj.createChildOpen} onOpenChange={proj.setCreateChildOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Create Sub-Project</DialogTitle>
-            <DialogDescription>
-              Create a new sub-project under {detail.name}.
-            </DialogDescription>
-          </DialogHeader>
-          <div className={shared.dialogForm}>
-            <Input
-              value={proj.childName}
-              onChange={(e) => proj.setChildName(e.target.value)}
-              placeholder="Name"
-            />
-            <Input
-              value={proj.childDescription}
-              onChange={(e) => proj.setChildDescription(e.target.value)}
-              placeholder="Description (optional)"
-            />
-            <div className={shared.dialogActions}>
-              <Button
-                variant="ghost"
-                onClick={() => proj.setCreateChildOpen(false)}
-                className={shared.dialogButton}
-              >
-                Cancel
-              </Button>
-              <Button
-                onClick={proj.handleCreateChild}
-                disabled={proj.creatingChild || !proj.childName.trim()}
-                className={shared.dialogButton}
-              >
-                {proj.creatingChild ? "Creating..." : "Create"}
-              </Button>
+        return (
+          <section
+            key={section.section_id}
+            id={section.section_id}
+            className={accountStyles.compositionSection}
+            data-section-id={section.section_id}
+            data-section-layout={section.layout}
+            data-section-salience={section.salience.band}
+          >
+            <div className={accountStyles.compositionSectionLabel}>{renderableSection.label}</div>
+            <div className={accountStyles.compositionSectionBody}>
+              <header className={accountStyles.compositionSectionHeader}>
+                <div>{renderSectionTitle(renderableSection)}</div>
+                <p className={accountStyles.compositionSectionMeta}>{section.salience.reason}</p>
+              </header>
+              <div className={accountStyles.compositionBlockStack}>
+                {blocks.length > 0 ? (
+                  blocks.map(renderBlock)
+                ) : (
+                  <div className={accountStyles.compositionDegradedState}>
+                    <p className={accountStyles.compositionStateLabel}>Empty section</p>
+                    <p className={accountStyles.compositionStateText}>
+                      No renderable blocks are available for this section.
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </>
+          </section>
+        );
+      })}
+
+      {detail && (
+        <>
+          <ProjectControlsPanel
+            detail={detail}
+            project={project}
+            onArchive={() => setArchiveDialogOpen(true)}
+            onAfterMutation={forceRefreshProjectedComposition}
+          />
+          <ProjectHierarchyNav detail={detail} navigate={navigate} />
+          <LinearIssuesChapter entityRef={{ kind: "project", id: detail.id }} actorScope="user" />
+        </>
+      )}
+
+      <FinisMarker />
+
+      {detail && (
+        <AlertDialog open={archiveDialogOpen} onOpenChange={setArchiveDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Archive Project</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will hide {detail.name} from active views. You can restore it later.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={project.handleArchive}>Archive</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {detail && (
+        <Dialog open={project.createChildOpen} onOpenChange={project.setCreateChildOpen}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Create Sub-Project</DialogTitle>
+              <DialogDescription>Create a new sub-project under {detail.name}.</DialogDescription>
+            </DialogHeader>
+            <div className={shared.dialogForm}>
+              <Input
+                value={project.childName}
+                onChange={(event) => project.setChildName(event.target.value)}
+                placeholder="Name"
+              />
+              <Input
+                value={project.childDescription}
+                onChange={(event) => project.setChildDescription(event.target.value)}
+                placeholder="Description (optional)"
+              />
+              <div className={shared.dialogActions}>
+                <Button
+                  variant="ghost"
+                  onClick={() => project.setCreateChildOpen(false)}
+                  className={shared.dialogButton}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={project.handleCreateChild}
+                  disabled={project.creatingChild || !project.childName.trim()}
+                  className={shared.dialogButton}
+                >
+                  {project.creatingChild ? "Creating..." : "Create"}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </main>
   );
 }

--- a/src/services/composition/contracts.ts
+++ b/src/services/composition/contracts.ts
@@ -1,5 +1,7 @@
 export type TrustBand = "likely_current" | "use_with_caution" | "needs_verification" | "unscored";
 
+export type CompositionFeedbackEntityType = "account" | "project" | "person" | "action";
+
 export type SectionLayout = "stacked" | "grid" | "inline";
 
 export interface Salience {

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -45,6 +45,69 @@
       }
     },
     {
+      "name": "dailyos/action-detail",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.action_detail"
+      ],
+      "mcp_exposure": "invocable",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "dailyos/person-overview",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.person_overview"
+      ],
+      "mcp_exposure": "invocable",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "dailyos/project-overview",
+      "description": "",
+      "category": "read",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "read.project_overview"
+      ],
+      "mcp_exposure": "invocable",
+      "client_side_executable": false,
+      "idempotency_class": "idempotent",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "detect_risk_shift",
       "description": "",
       "category": "transform",


### PR DESCRIPTION
## Linear ticket

DOS-850 — https://linear.app/a8c/issue/DOS-850

## Summary

Adds W3 forward detail composition surfaces for Project Detail, Person Detail, and Action Detail, carrying the W1 Account composition vertical forward through subject-keyed producers, projection routing, and service-owned refresh after mutations.

## What changed

- Add subject-keyed Project, Person, and Action Detail composition producers and route Tauri detail pages through projected compositions.
- Add first-class action subject read/provenance/invalidation support with `actions.claim_version`.
- Preserve existing detail controls and force-refresh projected compositions after service-owned mutations.
- Update Action Detail reference/mock demo data and include W3 L0/L2/proof artifacts.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` passes (frontend changes)
- [x] Manual verification: L4 sanitized Project/Person/Action detail screenshots captured in `.docs/proofs/v1.5.0/W3-proof-bundle.md`; replica smoke recorded structural projection counts only.

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field above is set false): _none_

**Exemption rationale**: N/A.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [ ] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- Nonblocking path-alpha test-depth item filed as DOS-849.

## Notes for review

- L0 passed in cycle 2: `.docs/reviews/v1.5.0-w3-l0-cycle-2.md`.
- L2 passed in cycle 3: `.docs/reviews/v1.5.0-w3-l2-cycle-3.md`.
- Replica smoke recorded only structural counts; no live replica content is included.
- Action Detail is modeled as an action subject, not a generic entity type.