### PR TITLE
DOS-628 claim file projection abilities

### DIFF
--- a/.docs/plans/dos-628/dos-628-l0-packet.md
+++ b/.docs/plans/dos-628/dos-628-l0-packet.md
@@ -1,6 +1,6 @@
 # DOS-628 L0 Packet -- Claims To Editable Readable Files
 
-> Status: L0-approved locally after K-in, feasibility, security, adversarial document review, and Codex challenge.
+> Status: L0-approved locally after cycle review: K-in PASS, feasibility PASS, security PASS, adversarial/Codex challenge PASS.
 > Issue: DOS-628.
 > Wave: v1.4.9 W3 -- Claims -> editable readable files.
 > Branch: `codex/v1.4.9-w3-dos628`.
@@ -21,6 +21,8 @@ The user outcome is the first leg of the v1.4.9 north star: a user can correct a
 ## 1. Trust Topology
 
 Topology is `local-to-local single-user` for the app/file path. The user edits files in their own workspace on the same machine. Do not add multi-actor gates, app/file scope grants, or principal differentiation to this path.
+
+The W3 abilities for this slice are therefore `Actor::User` only. `SurfaceClient` and MCP client invocation are not accepted for `render_entity_claim_file` or `apply_claim_file_corrections`; those surfaces must continue to consume canonical claim abilities rather than projected local files.
 
 The safety requirements that still apply:
 
@@ -109,7 +111,7 @@ The sidecar is the authoritative rebuild input for correction replay. It must in
 - `schema_version`.
 - `projection_version`.
 - Entity subject reference.
-- Stable claim semantic identity: `item_hash`, compact subject identity, `claim_type`, and `field_path`, matching the `compute_dedup_key` shape.
+- Stable claim semantic identity: `item_hash`, compact subject identity, `claim_type`, and `field_path`, matching the `compute_dedup_key` shape for non-user-note claims, plus `actor` where user-note replay depends on actor identity.
 - Runtime claim id and claim version as debugging aids only, never as the replay key.
 - `source_ref`, `observed_at`, and `source_asof` where available for non-unique tie-breaks.
 - Feedback rows as typed `FeedbackAction` plus actor, actor id when available, payload JSON, submitted/applied timestamps.
@@ -132,8 +134,9 @@ The sidecar identity is `ClaimSemanticIdentityV1`:
 - `subject_ref`: the structured `SubjectRef` serialized canonically for validation and diagnostics.
 - `claim_type`: exact canonical claim type string.
 - `field_path`: exact canonical field path string; `null` in the sidecar maps to the empty fourth component in `compute_dedup_key`.
-- `dedup_key_components_hash`: SHA-256 over the four canonical components for content-redacted logs.
+- `dedup_key_components_hash`: SHA-256 over the four canonical components for non-`UserNote` claims; for `UserNote`, the value is the existing `compute_user_note_dedup_key(subject_ref_compact, actor, observed_at)` replay key.
 - `source_ref`, `data_source`, `observed_at`, `source_asof`, and `source_content_hash` where present.
+- `actor`: exact canonical claim actor, required for `UserNote` replay identity and retained for diagnostics on other claim kinds.
 - `runtime_claim_id` and `runtime_claim_version`: diagnostics only, never the replay key.
 - `claim_state`: active/dormant/withdrawn/tombstoned/superseded plus supersession target identity when present.
 
@@ -163,8 +166,9 @@ Minimum ledger schema:
 - `status` is constrained to `committed`, `failed`, or `repaired`.
 - `projection_root` is constrained to the managed projection root named in D8.
 - `claim_watermark` is a SHA-256 over sorted `claim_id:claim_version` entries plus the per-entity invalidation version. It is the repair/re-render trigger, not a trust input.
-- `sidecar_checksum` is SHA-256 over canonical JSON serialization of the sidecar. The markdown block points to this checksum; apply refuses mismatched markdown/sidecar pairs and records `sidecar_mismatch`.
+- `sidecar_checksum` is SHA-256 over canonical JSON serialization of the sidecar. The markdown block points to this checksum; apply refuses mismatched markdown/sidecar pairs and returns a redacted `sidecar_mismatch` apply-failure artifact without writing feedback rows.
 - Repair worklist query is `status = 'failed' OR current_claim_watermark != claim_watermark`, ordered by `attempted_at`, bounded by service-owned batch size.
+- The service surface must expose `detect_entity_claim_file_changes(subject)` to compare the current entity claim watermark against the latest ledger run, and `repair_claim_file_projection(subject)` to idempotently re-render through the same projection writer. A successful repair of a failed run records a `repaired` run linked by `repaired_from_run_id`; stale or missing projections produce a normal committed render.
 
 Projection repair must be idempotent. A failed projection must not abort the authoritative claim feedback write that caused it.
 
@@ -204,6 +208,7 @@ Required shape:
 - Relative paths only. No user-supplied absolute output root in the first slice.
 - Apply commands canonicalize paths and require them to remain under `_dailyos_claims`.
 - Projection files may be user-edited locally, but source ingestion treats them as managed output, not evidence.
+- Existing projection files must never be read or written through symlinks or hardlinks. Apply reads must use non-following opens plus metadata validation that rejects multi-link files. Projection writes must use a new temp file in the managed directory with exclusive create and no-follow semantics before atomic rename; they must not truncate through an existing path.
 
 Required source-ingestion fence:
 
@@ -221,7 +226,7 @@ Add the main implementation under `src-tauri/src/services/claim_files/` or equiv
 Proposed service responsibilities:
 
 - `render_entity_claim_file(subject)`: reads canonical claims and writes readable markdown plus sidecar.
-- `detect_entity_claim_file_changes(subject/path)`: compares file/sidecar/projection ledger.
+- `detect_entity_claim_file_changes(subject)`: compares the current claim watermark to the latest projection ledger row and reports failed, stale, or missing projection state.
 - `parse_claim_file_corrections(path, sidecar)`: maps structured editable blocks to typed correction candidates.
 - `apply_claim_file_corrections(corrections)`: builds file-surface feedback envelopes and calls `submit_claim_feedback` with `Actor::User`.
 - `repair_claim_file_projection(subject)`: retries failed projection/sidecar writes idempotently.
@@ -309,7 +314,7 @@ A correction that tombstones/withdraws/supersedes a claim is represented in the 
 
 ### AC9 -- Path Boundary
 
-Projection and apply paths reject files outside the configured workspace root, symlink escapes, `..` traversal, malformed entity slugs, and any path outside `_dailyos_claims`.
+Projection and apply paths reject files outside the configured workspace root, symlink escapes, hardlinked projection files, `..` traversal, malformed entity slugs, and any path outside `_dailyos_claims`.
 
 ### AC10 -- Sensitivity And MCP Carve-Out
 
@@ -340,15 +345,18 @@ Workspace ingestion does not ingest `_dailyos_claims/**/*.md` or sidecar files a
 Unit tests:
 
 - Semantic identity generation matches `compute_dedup_key` components.
-- `UserNote` identity uses the existing user-note identity kind and never falls back to runtime UUID.
+- `UserNote` identity includes actor and matches `compute_user_note_dedup_key(subject_ref_compact, actor, observed_at)`; it never falls back to runtime UUID.
 - Subject-ref compacting is deterministic across JSON key order.
 - Markdown parser ignores arbitrary prose and only reads bounded claim edit blocks.
+- Unsupported actions, ambiguous blocks, and `sidecar_mismatch` return redacted apply-failure artifacts and do not write feedback rows.
 - Each supported edit maps to the correct `FeedbackAction`.
 - Per-action metadata validation failures leave DB unchanged.
 - `WrongSource` goes through receipt validation and rejects mismatched `source_content_hash`.
 - `WrongSubject` uses `corrected_subject_ref`; receipt validation forwards it to targeted repair/replay and rejects malformed subject refs.
 - Sidecar serialization/deserialization round-trips all required fields.
-- Path validator rejects traversal and symlink escapes.
+- Path validator rejects traversal, symlink escapes, and hardlinked projection files.
+- Projection writer uses exclusive no-follow temp-file creation and atomic rename rather than truncating through existing paths.
+- Projection ledger tests cover failed-run detection, repaired-run linkage, and repaired-run claim membership.
 - Workspace backfill and explicit workspace intake reject `_dailyos_claims` projected markdown and sidecars as managed output.
 - Redacted logging tests assert raw claim/correction text is absent.
 
@@ -394,7 +402,15 @@ Required local L0 reviewers:
 - Add security lens because W3 touches filesystem paths, prompt-injection boundaries, sensitivity policy, and claim write paths.
 - Add adversarial document review because this packet resolves stale issue text into a safer contract and gates DOS-832.
 
-Codex challenge cycle 1 returned `CHANGES_REQUIRED` on two blockers: `_dailyos_claims` exclusion covered backfill but not explicit workspace intake, and `WrongSubject` metadata did not line up between receipt validation and targeted repair. Both were folded into D2, D8, AC15, and the test plan. Codex challenge cycle 2 returned `APPROVE` with no blocking findings.
+Cycle 1 local L0 results:
+
+- K-in: PASS. Prior substrate reviewed: `claim-producers-require-runtime-wide-trust-audit`, ADR-0123 typed claim feedback, ADR-0126 memory substrate invariants, ADR-0113 first-class claim sources, ADR-0105/0108 provenance and privacy, ADR-0125 claim anatomy/sensitivity, ADR-0093 prompt-injection hardening, ADR-0101 service boundary enforcement, ADR-0080/0115 signals, ADR-0048 three-tier data model, migration slot convention, and K-in grep-substrate guidance.
+- Security lens: BLOCKED. The packet did not explicitly require hardlink rejection or no-follow exclusive projection writes. Remediation: D8, AC9, and the test plan now require hardlink rejection, stable no-follow reads, and exclusive no-follow temp-file writes before atomic rename.
+- Feasibility reviewer: BLOCKED. User-note identity omitted actor, projection repair was only a ledger record, and claim-file abilities admitted `SurfaceClient` despite the user-only write path. Remediation: D4 now requires actor-based user-note identity; D5/Service Boundary require detect/repair surfaces; Trust Topology states User-only abilities.
+- Adversarial document reviewer: BLOCKED. Same user-note identity and SurfaceClient topology blockers. The reviewer also flagged `v276_action_claim_version.sql`; local diff verification shows `v276` is already present in `public/dev`, while W3 adds only reserved slots `v280` and `v281`.
+- Adversarial document reviewer cycle 2: BLOCKED. Parser/mapping failures still returned top-level request errors instead of the packet-required apply-failure artifact. Remediation: apply now converts parser failures into redacted `ClaimFileApplyFailure` results with no feedback responses, no rerender, and no canonical writes; tests cover `sidecar_mismatch` and unsupported actions.
+
+- Adversarial document reviewer cycle 2 follow-up: PASS after parser/mapping failures were converted into redacted apply-failure artifacts. W3 L0 is approved locally with unanimous reviewer pass.
 
 ## 9. Resolved L0 Decisions
 

--- a/.docs/plans/dos-628/dos-628-l0-packet.md
+++ b/.docs/plans/dos-628/dos-628-l0-packet.md
@@ -1,0 +1,417 @@
+# DOS-628 L0 Packet -- Claims To Editable Readable Files
+
+> Status: L0-approved locally after K-in, feasibility, security, adversarial document review, and Codex challenge.
+> Issue: DOS-628.
+> Wave: v1.4.9 W3 -- Claims -> editable readable files.
+> Branch: `codex/v1.4.9-w3-dos628`.
+> Base: `public/dev` at `da1df394`.
+> Scope tier: Wave/critical-path substrate surface. W3 is the first visible correction-loop slice and is a prerequisite for DOS-832 rebuild correction preservation.
+
+## 0. Origination
+
+Extension, not incident recovery. DOS-628 predates v1.4.9 and originally asked for "bidirectional markdown <-> substrate ingestion" as a missing leg from older three-view consistency plans. The v1.4.9 wave plan deliberately narrows and corrects that framing:
+
+- SQLite/claim substrate is authority.
+- Readable files are projection out, not files-as-truth.
+- A file edit is a correction input routed through typed claim feedback, not an in-place claim update.
+- The structured corrections sidecar is the bridge that makes user corrections survive DOS-832 rebuild.
+
+The user outcome is the first leg of the v1.4.9 north star: a user can correct a claim by editing a readable entity file, and the next projection reflects that correction through the same substrate that app and MCP feedback use.
+
+## 1. Trust Topology
+
+Topology is `local-to-local single-user` for the app/file path. The user edits files in their own workspace on the same machine. Do not add multi-actor gates, app/file scope grants, or principal differentiation to this path.
+
+The safety requirements that still apply:
+
+- Workspace-root confinement for all file paths.
+- Symlink/`..`/canonicalization checks before reading or writing.
+- File-read content is untrusted evidence. If it reaches prompt construction, it is ADR-0093 Tier-2-classified and Tier-3-handled via `wrap_user_data`.
+- File-provided correction text and provenance explanations are sanitized/redacted per ADR-0108.
+- MCP remains a separate carve-out: `Confidential`/`UserOnly` claims never cross MCP even if the same file is readable locally.
+
+## 2. Source Reconciliation
+
+### Linear Issue
+
+DOS-628 currently says markdown should be generated from substrate and re-ingested when edited out of band. That text is stale relative to v1.4.9's accepted wave-plan decisions. The usable part is the need for a durable, user-readable file surface that can accept out-of-band edits.
+
+### Version Plan
+
+`.docs/plans/v1.4.9-waves.md` is the authority:
+
+- W3 is `Claims -> editable readable files`.
+- DOS-628 projects per-entity claims to markdown and a structured corrections sidecar.
+- File-to-claim write-back is `Actor::User`, workspace-root-confined, sensitivity re-validated, and routed through `services/claims.rs` as typed `FeedbackAction`.
+- File-read content is ADR-0093 Tier-2-classified and Tier-3-handled.
+- W3 must run the full `claim-producers-require-runtime-wide-trust-audit` inventory on write-back.
+- DOS-832 depends on the W3 sidecar for correction-preserving rebuild.
+
+### Current Code Evidence
+
+- `services/claims.rs::commit_claim` is the only writer for `intelligence_claims`.
+- `services/claims.rs::record_claim_feedback` inserts `claim_feedback`, updates verification/lifecycle through the service, bumps claim invalidation, and emits `claim_feedback_recorded`.
+- `record_claim_feedback` rejects non-user feedback actors.
+- `abilities-runtime/src/abilities/feedback.rs::FeedbackAction` is the 10-variant typed feedback contract.
+- `services/claim_receipt/feedback.rs::submit_claim_feedback` already validates envelope target binding, sensitivity/surface access, per-action metadata, sanitizer warnings, idempotency, and routes into `record_claim_feedback`.
+- `services/claims.rs::compute_dedup_key(item_hash, subject_ref_compact, claim_type, field_path)` is the content-derived semantic identity W3/DOS-832 must use for rebuild-stable correction keys.
+- `services/derived_state.rs` and `claim_projection_status` show the existing pattern: canonical claim writes can drive projection status without making projections authoritative.
+- `services/workspace_ingestion/registry.rs` already has a canonicalize-and-child-of-workspace-root pattern to reuse for path validation.
+
+## 3. Non-Negotiable Decisions
+
+### D1 -- Files Are Projection, Not Authority
+
+The per-entity markdown file is a readable projection of canonical claim state. It must not become a source-of-truth file that can overwrite `intelligence_claims`.
+
+Implementation must not:
+
+- Parse arbitrary prose into fresh claims.
+- Update immutable claim columns (`text`, `subject_ref`, `claim_type`, `source_asof`, `created_at`) in place.
+- Bypass `services/claims.rs`.
+- Teach runtime prompt/context builders to treat projected markdown as trusted fact.
+
+Implementation must:
+
+- Select claims from canonical services/readers.
+- Render claim identity, trust band, provenance summary, sensitivity-safe labels, and editable correction affordances.
+- Re-render projection after accepted corrections.
+- Treat unparseable or ambiguous edits as review/quarantine, not silent claim writes.
+
+### D2 -- File Edits Become Typed Corrections
+
+An edit to a projected claim block is a user correction event. The write path routes through the receipt-level feedback validator (`submit_claim_feedback`) with `Actor::User`; the receipt path then calls `record_claim_feedback`. W3 does not add a direct call path that bypasses receipt validation.
+
+Supported edit mappings for L1:
+
+| File edit shape | FeedbackAction |
+| --- | --- |
+| User confirms a claim remains true/current | `ConfirmCurrent` |
+| User marks a claim false | `MarkFalse` |
+| User marks a claim outdated or no longer current | `MarkOutdated` |
+| User corrects claim text in an editable text block | `NeedsNuance` with `corrected_text` |
+| User marks claim as attached to the wrong subject | `WrongSubject` with `corrected_subject_ref` when the user supplies the correct subject |
+| User says the cited evidence does not support the claim | `WrongSource` with source-content hash metadata |
+| User cannot verify from surfaced evidence | `CannotVerify` |
+
+If a file edit cannot be deterministically mapped to one of those actions, L1 must not invent a new action. It records an explicit parse/reconciliation failure artifact and leaves canonical claim state unchanged.
+
+`WrongSource` always uses the receipt-level source-content-hash contract. The sidecar stores the `source_content_hash` derived from the current claim source tuple. Apply builds a file-surface feedback envelope from the sidecar, calls `submit_claim_feedback`, and lets the existing validator reject stale or mismatched hashes as `SourceNoLongerInClaim`. L1 must not route `WrongSource` directly to `record_claim_feedback` with only `source_ref`.
+
+`WrongSubject` uses `corrected_subject_ref` as the canonical metadata field: a JSON `SubjectRef` object or encoded string accepted by `subject_ref_from_json`. Current receipt validation only allowlists legacy `corrected_to`, while targeted repair consumes `corrected_subject` / `corrected_subject_ref`; L1 must close that mismatch before file apply ships. Required behavior: receipt validation accepts `corrected_subject_ref`, sanitizes/rejects malformed subject refs, forwards the field unchanged to `record_claim_feedback`, and may bridge legacy `corrected_to` into `corrected_subject_ref` for compatibility. Tests must prove the corrected subject reaches targeted repair/replay rather than being silently dropped.
+
+### D3 -- Structured Corrections Sidecar Is Required
+
+Markdown alone is too lossy for DOS-832. W3 must write a structured corrections sidecar next to the readable projection under the managed `_dailyos_claims` root.
+
+The sidecar is the authoritative rebuild input for correction replay. It must include, at minimum:
+
+- `schema_version`.
+- `projection_version`.
+- Entity subject reference.
+- Stable claim semantic identity: `item_hash`, compact subject identity, `claim_type`, and `field_path`, matching the `compute_dedup_key` shape.
+- Runtime claim id and claim version as debugging aids only, never as the replay key.
+- `source_ref`, `observed_at`, and `source_asof` where available for non-unique tie-breaks.
+- Feedback rows as typed `FeedbackAction` plus actor, actor id when available, payload JSON, submitted/applied timestamps.
+- Lifecycle effects needed for rebuild: tombstone/withdrawn/superseded/dormant state, supersession link, render/surfacing suppression, contradiction edge references.
+- Contradiction endpoints by semantic identity plus `reconciliation_kind`, not by UUID alone.
+- Orphan/replay status fields for DOS-832 to record ambiguous or missing endpoints without dropping data.
+
+The sidecar must not include raw customer PII beyond what is already present in the user's local projected files. Logs and PR fixtures must stay generic. Sidecar retention is tied to the projection/rebuild lifecycle: it is durable enough for DOS-832 replay and repair, but not a separate archival store for raw correction prose.
+
+### D4 -- Rebuild Identity Is Content-Derived And Tombstone-Aware
+
+W3 owns the exact semantic identity that DOS-832 replays. The key is the canonical `compute_dedup_key` shape, not the raw `dedup_key` column as a universal truth.
+
+The sidecar identity is `ClaimSemanticIdentityV1`:
+
+- `identity_version`: `1`.
+- `identity_kind`: `claim_dedup_v1` for non-`UserNote` claims, `user_note_v1` for `ClaimType::UserNote`.
+- `item_hash`: the canonical `intelligence_claims.item_hash` captured when the projection is rendered. It is anchored to the original canonical claim text and is not recomputed from user-edited correction prose.
+- `subject_ref_compact`: the same compact subject string used by `commit_claim` before it calls `compute_dedup_key`.
+- `subject_ref`: the structured `SubjectRef` serialized canonically for validation and diagnostics.
+- `claim_type`: exact canonical claim type string.
+- `field_path`: exact canonical field path string; `null` in the sidecar maps to the empty fourth component in `compute_dedup_key`.
+- `dedup_key_components_hash`: SHA-256 over the four canonical components for content-redacted logs.
+- `source_ref`, `data_source`, `observed_at`, `source_asof`, and `source_content_hash` where present.
+- `runtime_claim_id` and `runtime_claim_version`: diagnostics only, never the replay key.
+- `claim_state`: active/dormant/withdrawn/tombstoned/superseded plus supersession target identity when present.
+
+For non-`UserNote` claims, DOS-832 recomputes `compute_dedup_key(item_hash, subject_ref_compact, claim_type, field_path)` from the fresh claim row and matches against the sidecar identity. For `UserNote`, DOS-832 uses the existing `compute_user_note_dedup_key(subject_ref_compact, actor, observed_at)` identity kind and never falls back to runtime UUID.
+
+Replay matching algorithm:
+
+1. Build candidate fresh claims by `identity_kind` and exact semantic identity.
+2. If no candidate exists, record `orphan_missing` and leave canonical state unchanged.
+3. If one candidate exists, validate `source_content_hash` when the correction action requires source binding, then replay the typed `FeedbackAction` through the service path.
+4. If multiple candidates exist, filter by exact `source_ref` and `observed_at`; if that yields one candidate, replay to that candidate.
+5. If still ambiguous, filter by `source_content_hash`; if that yields one candidate, replay to that candidate.
+6. If still ambiguous, record `orphan_ambiguous` and leave canonical state unchanged.
+7. Resolve contradiction endpoints independently with the same algorithm. If either endpoint is missing or ambiguous, record an orphaned edge and do not attach it to a guessed UUID.
+8. Apply terminal lifecycle state before surfacing projection results. A sidecar tombstone/withdrawal/supersession replays as typed feedback/state through services; a freshly regenerated matching claim is demoted before it can appear as active. No replay path creates a fresh active claim to satisfy an orphan.
+
+Ambiguous replay is an orphan, never a guessed correction.
+
+### D5 -- Projection Write State Is Durable And Idempotent
+
+W3 adds a dedicated readable-file projection ledger instead of extending `claim_projection_status`. The existing table is per `(claim_id, projection_target)` and constrained to legacy targets; readable files need entity/path/version/checksum state. Use W3 migration slot `v280` for `claim_file_projection_runs` and `v281` for its claim-membership table/indexes if needed.
+
+Minimum ledger schema:
+
+- `claim_file_projection_runs`: `id`, `entity_subject_ref_json`, `entity_subject_compact`, `projection_root`, `markdown_rel_path`, `sidecar_rel_path`, `projection_version`, `sidecar_schema_version`, `entity_claim_invalidation_version`, `claim_watermark`, `markdown_checksum`, `sidecar_checksum`, `status`, `error_class`, `error_detail_hash`, `attempted_at`, `succeeded_at`, `repaired_from_run_id`, `created_at`, `updated_at`.
+- `claim_file_projection_run_claims`: `run_id`, `claim_id`, `claim_version`, `semantic_identity_json`, `trust_band`, `sensitivity`, with primary key `(run_id, claim_id)`.
+- `status` is constrained to `committed`, `failed`, or `repaired`.
+- `projection_root` is constrained to the managed projection root named in D8.
+- `claim_watermark` is a SHA-256 over sorted `claim_id:claim_version` entries plus the per-entity invalidation version. It is the repair/re-render trigger, not a trust input.
+- `sidecar_checksum` is SHA-256 over canonical JSON serialization of the sidecar. The markdown block points to this checksum; apply refuses mismatched markdown/sidecar pairs and records `sidecar_mismatch`.
+- Repair worklist query is `status = 'failed' OR current_claim_watermark != claim_watermark`, ordered by `attempted_at`, bounded by service-owned batch size.
+
+Projection repair must be idempotent. A failed projection must not abort the authoritative claim feedback write that caused it.
+
+### D6 -- Sensitivity And Prompt-Injection Boundaries Are Explicit
+
+Local file output can include content the user can already access, but the projection must still preserve sensitivity metadata so downstream consumers do not flatten policy.
+
+Requirements:
+
+- Each projected claim block carries sensitivity and trust band metadata in machine-readable form.
+- MCP readers do not read these files as a way around the ADR-0125 MCP sensitivity gate.
+- File-read correction content is never interpolated into prompts without `wrap_user_data`.
+- Free-text correction fields use the ADR-0108 sanitizer before rendering/logging.
+- Logs include claim ids, action names, paths relative to workspace, and error classes; they do not include raw correction prose or claim text.
+
+### D7 -- W3 Emits W4-Consumable Signals
+
+W3 is not complete if it only writes files. A successful file edit must produce the same substrate effects as app feedback:
+
+- `claim_feedback` row inserted.
+- `claim_feedback_recorded` signal emitted.
+- `claim_verification_state_changed` emitted when applicable.
+- Per-entity claim invalidation version bumped.
+- Targeted repair job enqueued where the `FeedbackAction` semantics require one.
+- Projection re-render scheduled or completed.
+
+This is how W4/DOS-834 consumes W3. Do not add a parallel "file correction" signal family unless it is a thin source annotation on the existing feedback signal.
+
+### D8 -- Projection Files Live In A Managed Scanner-Excluded Root
+
+Readable projections are written under `<workspace>/_dailyos_claims/`, never under the ordinary per-entity document folders that workspace ingestion scans as source evidence. Existing backfill skips roots beginning with `_` except `_inbox`, but explicit workspace intake can still open any in-workspace path through `WorkspaceSourceRegistry::open_validated`; D8 therefore applies to every source-ingestion path, not only backfill.
+
+Required shape:
+
+- Markdown: `_dailyos_claims/<entity-kind>/<entity-slug>/claims.md`.
+- Sidecar: `_dailyos_claims/<entity-kind>/<entity-slug>/claims.corrections.json`.
+- Relative paths only. No user-supplied absolute output root in the first slice.
+- Apply commands canonicalize paths and require them to remain under `_dailyos_claims`.
+- Projection files may be user-edited locally, but source ingestion treats them as managed output, not evidence.
+
+Required source-ingestion fence:
+
+- Add a shared managed-root predicate for `_dailyos_claims`.
+- Backfill must skip the root before classification.
+- Explicit workspace intake (`entity_intake`, MCP/tool placement paths that call `WorkspaceSourceRegistry::open_validated`, and any command that turns a workspace file into source evidence) must reject `_dailyos_claims` paths with a managed-output rejection before opening/running the ingestion pipeline.
+- The rejection must be content-redacted and must not read the projected file before deciding it is managed output.
+
+## 4. Implementation Shape
+
+### Service Boundary
+
+Add the main implementation under `src-tauri/src/services/claim_files/` or equivalent service-owned module. Commands and any doctor/debug entrypoints are thin option validation and dispatch.
+
+Proposed service responsibilities:
+
+- `render_entity_claim_file(subject)`: reads canonical claims and writes readable markdown plus sidecar.
+- `detect_entity_claim_file_changes(subject/path)`: compares file/sidecar/projection ledger.
+- `parse_claim_file_corrections(path, sidecar)`: maps structured editable blocks to typed correction candidates.
+- `apply_claim_file_corrections(corrections)`: builds file-surface feedback envelopes and calls `submit_claim_feedback` with `Actor::User`.
+- `repair_claim_file_projection(subject)`: retries failed projection/sidecar writes idempotently.
+
+### File Format
+
+The markdown should be human-readable but machine-bounded. Use claim blocks with stable IDs and a narrow editable field shape rather than prose scraping.
+
+Required block metadata:
+
+- Claim semantic identity.
+- Runtime claim id/version for diagnostics.
+- Claim type.
+- Subject ref.
+- Trust band and sensitivity.
+- Provenance/source summary.
+- Editable fields allowed for the claim type.
+- Sidecar pointer/checksum.
+
+The sidecar is the machine contract. Markdown is the user surface.
+
+### Apply Boundary
+
+The first L1 slice uses an explicit apply command only. The user edits a file, then the service scans `_dailyos_claims` and applies structured corrections. No file watcher ships in DOS-628.
+
+The explicit command still must avoid applying while a file is mid-write. It uses an atomic read safeguard: read metadata, read file, re-read metadata, and reject/retry if size or mtime changed during the read.
+
+### Migration Slot
+
+W3 has reserved migration slots `v280-v283` in the version plan. DOS-628 uses `v280` for `claim_file_projection_runs` and `v281` for `claim_file_projection_run_claims` or supporting indexes. Slots `v282-v283` remain W3 reserve only; they are not used unless L1 needs a follow-on migration for the same projection/sidecar substrate.
+
+### Runtime-Wide Trust Audit Inventory
+
+Authoritative audit source: `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md`. There is no separate L0 script; the required check is this inventory against the solution note's five dimensions.
+
+Audit result:
+
+- Claim type metadata: DOS-628 adds no new `ClaimType`. It consumes existing claim metadata and `FeedbackAction` semantics. Allowed actor for file write-back is `Actor::User`; MCP actor labels remain separate and are not collapsed.
+- Producer path: projection out is read-only and does not commit claims. File apply is a correction producer, not a claim producer: `_dailyos_claims` -> `claim_files` service -> `submit_claim_feedback` -> `record_claim_feedback` -> `claim_feedback`.
+- Trust inputs: W3 carries existing trust inputs (`source_asof`, `observed_at`, `data_source`, `source_ref`, source reliability, lifecycle state, corrections, contradictions, and sensitivity) into the sidecar/projection. It does not seed trust scores or invent a file-specific trust rule.
+- Recompute trigger: accepted corrections use the existing feedback signal/invalidation path. Projection repair is a consumer of invalidation state, not an alternate trust compiler.
+- Surface behavior: projected markdown renders centralized trust band and sensitivity metadata. Missing or stale provenance/source hashes degrade to `needs_verification` or an orphan/needs-review status; they never render as fully trusted by default.
+
+Runtime path inventory:
+
+- App feedback: existing receipt/service path remains the model path.
+- File apply: must use the same receipt/service path and action metadata validation, with a file-surface source annotation only.
+- MCP feedback, if present: continues through canonical services and render policy; it cannot read `_dailyos_claims` to bypass sensitivity.
+- DOS-832 rebuild replay: replays typed corrections through services after semantic-identity matching; it does not raw-insert `claim_feedback` rows or mutate `intelligence_claims`.
+- Existing claim producers: unchanged by W3. If L1 touches any `commit_claim` producer while implementing projection, it must update this inventory before PR.
+
+## 5. Acceptance Criteria
+
+### AC1 -- Projection Out
+
+For an account, project, and person with active public/internal claims, L1 writes a readable markdown file and structured sidecar containing claim identity, trust band, sensitivity, provenance summary, and editable correction metadata.
+
+### AC2 -- No Files-As-Truth
+
+Tests prove arbitrary markdown prose cannot create or update canonical claims. Only recognized structured edit blocks can produce typed correction candidates, and all candidates route through the receipt/service path.
+
+### AC3 -- Typed Correction Write-Back
+
+Editing a projected claim block to mark false/outdated/needs nuance/wrong subject/wrong source/cannot verify produces the expected `FeedbackAction` row through `submit_claim_feedback` and the underlying `record_claim_feedback` writer.
+
+### AC4 -- Immutable Core Preserved
+
+File corrections do not update immutable claim columns directly. Lifecycle/verification changes are service-owned and versioned.
+
+### AC5 -- Signals And Invalidation
+
+Each accepted file correction emits/bounces through the existing feedback signal path and bumps per-entity invalidation. W4 can observe the same effect as app feedback.
+
+### AC6 -- Sidecar Replay Contract
+
+The sidecar contains rebuild-stable semantic identities and typed correction rows sufficient for DOS-832 to replay corrections after fresh UUID generation. Runtime UUIDs are diagnostic only.
+
+### AC7 -- Ambiguity Is Safe
+
+If semantic identity matches multiple fresh claims and `source_ref` + `observed_at` + `source_content_hash` does not disambiguate, replay/apply records an orphan/needs-review status and leaves canonical state unchanged.
+
+### AC8 -- Tombstones Stay Tombstoned
+
+A correction that tombstones/withdraws/supersedes a claim is represented in the sidecar and prevents DOS-832 replay from resurrecting the claim.
+
+### AC9 -- Path Boundary
+
+Projection and apply paths reject files outside the configured workspace root, symlink escapes, `..` traversal, malformed entity slugs, and any path outside `_dailyos_claims`.
+
+### AC10 -- Sensitivity And MCP Carve-Out
+
+Local projection preserves sensitivity metadata. MCP cannot consume the projected files to bypass existing public/internal-only claim gates.
+
+### AC11 -- Prompt Injection Handling
+
+Hostile file-edited content containing fake instructions, XML/HTML delimiters, fake JSON markers, or invisible Unicode remains data. Any prompt-bound path wraps it with `wrap_user_data`; logs and rendered explanations are sanitized.
+
+### AC12 -- Projection Ledger
+
+Projection status is durable, idempotent, repairable, and content-redacted. Failed projection writes are visible to repair tooling without aborting canonical claim writes.
+
+### AC13 -- Producer Trust Audit
+
+This L0 packet includes the runtime-wide claim-producer/trust audit for the write-back path. The W3 L1 PR must verify the implementation still matches that inventory and update it if any producer path changes.
+
+### AC14 -- Real-Data Proof
+
+Dogfood proof uses real local workspace data and redacted output evidence: edit one projected claim file, apply it, observe claim feedback/lifecycle/signal/projection effects, re-render the file, and confirm the correction remains visible.
+
+### AC15 -- Managed Projection Root Exclusion
+
+Workspace ingestion does not ingest `_dailyos_claims/**/*.md` or sidecar files as source evidence. Tests prove projected markdown is excluded from backfill `EntityDoc`/`Notes` classification and rejected by explicit workspace intake / MCP placement paths before the ingestion pipeline opens the file.
+
+## 6. Test Plan
+
+Unit tests:
+
+- Semantic identity generation matches `compute_dedup_key` components.
+- `UserNote` identity uses the existing user-note identity kind and never falls back to runtime UUID.
+- Subject-ref compacting is deterministic across JSON key order.
+- Markdown parser ignores arbitrary prose and only reads bounded claim edit blocks.
+- Each supported edit maps to the correct `FeedbackAction`.
+- Per-action metadata validation failures leave DB unchanged.
+- `WrongSource` goes through receipt validation and rejects mismatched `source_content_hash`.
+- `WrongSubject` uses `corrected_subject_ref`; receipt validation forwards it to targeted repair/replay and rejects malformed subject refs.
+- Sidecar serialization/deserialization round-trips all required fields.
+- Path validator rejects traversal and symlink escapes.
+- Workspace backfill and explicit workspace intake reject `_dailyos_claims` projected markdown and sidecars as managed output.
+- Redacted logging tests assert raw claim/correction text is absent.
+
+Integration tests:
+
+- Render entity claim file and sidecar from seeded account/project/person claims.
+- Apply `NeedsNuance` from a file and verify `claim_feedback`, lifecycle/version event, invalidation bump, signal, and re-render.
+- Apply `WrongSubject` with `corrected_subject_ref` and verify the corrected subject reaches targeted repair/replay; malformed subject metadata leaves DB state unchanged.
+- Apply `WrongSource` using source-content hash and reject stale/mismatched hashes.
+- Apply `CannotVerify` and verify targeted repair enqueue behavior.
+- Simulate ambiguous rebuild replay and assert orphan status.
+- Simulate tombstone replay and assert no resurrection.
+- Run hostile-content fixture through file apply and any prompt-bound path.
+- Projection failure records durable status without rolling back canonical feedback.
+
+Required gates for L1 PR:
+
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `pnpm tsc --noEmit`
+
+Doc-only L0 packet validation:
+
+- `git diff --check`
+- PII/stub marker scan for the packet.
+- Local L0 review loop: K-in, feasibility, security, adversarial document review, and `/codex challenge`.
+
+## 7. Intelligence Loop Integration Check
+
+1. Claim model: Files do not create a parallel fact model. They project claims and route edits to typed `FeedbackAction` against canonical claims.
+2. Provenance and trust: Projection carries provenance/trust/sensitivity metadata. Write-back preserves provenance by adding user correction rows and relying on existing trust compiler semantics.
+3. Signals and invalidation: Accepted corrections emit existing claim feedback signals and bump per-entity invalidation. Projection repair consumes the same invalidation state.
+4. Runtime and surfaces: Tauri/app file path is first-party local. MCP parity consumes canonical claims through existing MCP render policy, not projected markdown.
+5. Feedback loop: Corrections flow into `claim_feedback`, lifecycle/verification, repair jobs, source/linker reliability effects, and DOS-834 propagation.
+
+## 8. Review Routing
+
+Required local L0 reviewers:
+
+- K-in: `ce-learnings-researcher`.
+- Codex challenge: `/codex challenge`.
+- Planning reviewer: `ce-feasibility-reviewer`.
+- Add security lens because W3 touches filesystem paths, prompt-injection boundaries, sensitivity policy, and claim write paths.
+- Add adversarial document review because this packet resolves stale issue text into a safer contract and gates DOS-832.
+
+Codex challenge cycle 1 returned `CHANGES_REQUIRED` on two blockers: `_dailyos_claims` exclusion covered backfill but not explicit workspace intake, and `WrongSubject` metadata did not line up between receipt validation and targeted repair. Both were folded into D2, D8, AC15, and the test plan. Codex challenge cycle 2 returned `APPROVE` with no blocking findings.
+
+## 9. Resolved L0 Decisions
+
+Resolved by this packet:
+
+1. W3 uses a dedicated `claim_file_projection_runs` ledger in migration slot `v280`, plus `v281` for claim membership/index support.
+2. The first L1 slice uses an explicit apply command only; no watcher ships in DOS-628.
+3. `WrongSource` routes through the receipt-level source-content-hash validator.
+4. The authoritative W3 trust audit is the `claim-producers-require-runtime-wide-trust-audit` solution-note checklist, included above as the L0 inventory.
+
+## 10. Done For This Packet
+
+This packet is ready for L0 only when:
+
+- K-in cites prior solution/ADR hits.
+- Feasibility confirms the service/file/sidecar shape is buildable against current code.
+- Security confirms the narrowed local topology while preserving path, prompt-injection, sensitivity, and log-hygiene boundaries.
+- Adversarial review confirms the packet cannot be read as files-as-truth or direct markdown-to-claim mutation.
+- `/codex challenge` approves after the cycle-1 blocker folds.
+- Linear DOS-628 receives the packet path, verdict summary, and PR link.

--- a/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 pub const RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME: &str = "render_entity_claim_file";
 pub const APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME: &str = "apply_claim_file_corrections";
 pub const CLAIM_FILES_SCHEMA_VERSION: u32 = 1;
-pub const CLAIM_FILE_RENDER_SCOPE: &str = "write.claim_files";
-pub const CLAIM_FILE_APPLY_SCOPE: &str = "submit.claim_file_corrections";
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
@@ -1,4 +1,4 @@
-//! Wire contracts for readable claim-file projection abilities (DOS-628).
+//! Wire contracts for readable claim-file projection abilities.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claim_files/contracts.rs
@@ -1,0 +1,78 @@
+//! Wire contracts for readable claim-file projection abilities (DOS-628).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME: &str = "render_entity_claim_file";
+pub const APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME: &str = "apply_claim_file_corrections";
+pub const CLAIM_FILES_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_RENDER_SCOPE: &str = "write.claim_files";
+pub const CLAIM_FILE_APPLY_SCOPE: &str = "submit.claim_file_corrections";
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RenderEntityClaimFileInput {
+    pub schema_version: u32,
+    pub subject_ref: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ApplyClaimFileCorrectionsInput {
+    pub schema_version: u32,
+    pub markdown_rel_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileRenderRequest {
+    pub input: RenderEntityClaimFileInput,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileApplyRequest {
+    pub input: ApplyClaimFileCorrectionsInput,
+    pub actor_principal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileProjectionResult {
+    pub run_id: String,
+    pub markdown_rel_path: String,
+    pub sidecar_rel_path: String,
+    pub claim_count: usize,
+    pub markdown_checksum: String,
+    pub sidecar_checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileApplyResult {
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub failures: Vec<ClaimFileApplyFailure>,
+    pub responses: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rerender: Option<ClaimFileProjectionResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileApplyFailure {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_id: Option<String>,
+    pub error_class: String,
+    pub error_detail_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ClaimFileOperationError {
+    #[error("{0}")]
+    InvalidRequest(String),
+    #[error("{0}")]
+    MutationBlocked(String),
+    #[error("{0}")]
+    OperationFailed(String),
+}

--- a/src-tauri/abilities-runtime/src/abilities/claim_files/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claim_files/mod.rs
@@ -6,8 +6,7 @@ pub use contracts::{
     ApplyClaimFileCorrectionsInput, ClaimFileApplyFailure, ClaimFileApplyRequest,
     ClaimFileApplyResult, ClaimFileOperationError, ClaimFileProjectionResult,
     ClaimFileRenderRequest, RenderEntityClaimFileInput, APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME,
-    CLAIM_FILES_SCHEMA_VERSION, CLAIM_FILE_APPLY_SCOPE, CLAIM_FILE_RENDER_SCOPE,
-    RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME,
+    CLAIM_FILES_SCHEMA_VERSION, RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME,
 };
 
 use dailyos_abilities_macro::ability;
@@ -16,7 +15,7 @@ use crate::abilities::provenance::{
     AbilityExecutionMode, AbilityVersion, FieldAttribution, FieldPath, ProvenanceBuilder,
     ProvenanceBuilderConfig, SchemaVersion, SubjectAttribution, SubjectRef,
 };
-use crate::abilities::registry::{Actor, SurfaceScope};
+use crate::abilities::registry::Actor;
 use crate::abilities::{
     AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult,
 };
@@ -28,11 +27,10 @@ use crate::types::{subject_ref_from_json, ClaimSubjectRef};
     category = Maintenance,
     version = "1.0.0",
     schema_version = 1,
-    allowed_actors = [User, SurfaceClient],
+    allowed_actors = [User],
     allowed_modes = [Live],
     requires_confirmation = false,
     may_publish = true,
-    required_scopes = ["write.claim_files"],
     mcp_exposure = None,
     client_side_executable = false,
     mutates = [claim_file_projection_runs, claim_file_projection_run_claims],
@@ -44,7 +42,7 @@ pub async fn render_entity_claim_file(
     ctx: &AbilityContext<'_>,
     input: RenderEntityClaimFileInput,
 ) -> AbilityResult<ClaimFileProjectionResult> {
-    authorize(ctx, CLAIM_FILE_RENDER_SCOPE)?;
+    authorize_user(ctx)?;
     validate_schema_version(input.schema_version, RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME)?;
     ctx.services()
         .check_mutation_allowed()
@@ -72,11 +70,10 @@ pub async fn render_entity_claim_file(
     category = Maintenance,
     version = "1.0.0",
     schema_version = 1,
-    allowed_actors = [User, SurfaceClient],
+    allowed_actors = [User],
     allowed_modes = [Live],
     requires_confirmation = false,
     may_publish = false,
-    required_scopes = ["submit.claim_file_corrections"],
     mcp_exposure = None,
     client_side_executable = false,
     mutates = [intelligence_claims, claim_feedback, claim_file_projection_runs, claim_file_projection_run_claims],
@@ -88,7 +85,7 @@ pub async fn apply_claim_file_corrections(
     ctx: &AbilityContext<'_>,
     input: ApplyClaimFileCorrectionsInput,
 ) -> AbilityResult<ClaimFileApplyResult> {
-    let actor_principal_id = authorize(ctx, CLAIM_FILE_APPLY_SCOPE)?;
+    let actor_principal_id = authorize_user(ctx)?;
     validate_schema_version(
         input.schema_version,
         APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME,
@@ -116,15 +113,9 @@ pub async fn apply_claim_file_corrections(
     )
 }
 
-fn authorize(ctx: &AbilityContext<'_>, required_scope: &str) -> Result<String, AbilityError> {
+fn authorize_user(ctx: &AbilityContext<'_>) -> Result<String, AbilityError> {
     match &ctx.actor {
         Actor::User => Ok("user".to_string()),
-        Actor::SurfaceClient { instance, scopes } => {
-            if !scopes.contains(&SurfaceScope::new(required_scope)) {
-                return Err(permission_denied(&format!("{required_scope}_required")));
-            }
-            Ok(format!("surface_client:{}", instance.as_str()))
-        }
         _ => Err(permission_denied("actor_not_allowed")),
     }
 }
@@ -299,6 +290,16 @@ mod tests {
         assert_eq!(apply.policy.mcp_exposure, McpExposure::None);
         assert!(render.policy.allowed_actors.contains(&ActorKind::User));
         assert!(apply.policy.allowed_actors.contains(&ActorKind::User));
+        assert!(!render
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::SurfaceClient));
+        assert!(!apply
+            .policy
+            .allowed_actors
+            .contains(&ActorKind::SurfaceClient));
+        assert!(render.policy.required_scopes.is_empty());
+        assert!(apply.policy.required_scopes.is_empty());
     }
 
     #[test]

--- a/src-tauri/abilities-runtime/src/abilities/claim_files/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/claim_files/mod.rs
@@ -1,0 +1,315 @@
+//! `claim_files` projection and correction abilities.
+
+pub mod contracts;
+
+pub use contracts::{
+    ApplyClaimFileCorrectionsInput, ClaimFileApplyFailure, ClaimFileApplyRequest,
+    ClaimFileApplyResult, ClaimFileOperationError, ClaimFileProjectionResult,
+    ClaimFileRenderRequest, RenderEntityClaimFileInput, APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME,
+    CLAIM_FILES_SCHEMA_VERSION, CLAIM_FILE_APPLY_SCOPE, CLAIM_FILE_RENDER_SCOPE,
+    RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME,
+};
+
+use dailyos_abilities_macro::ability;
+
+use crate::abilities::provenance::{
+    AbilityExecutionMode, AbilityVersion, FieldAttribution, FieldPath, ProvenanceBuilder,
+    ProvenanceBuilderConfig, SchemaVersion, SubjectAttribution, SubjectRef,
+};
+use crate::abilities::registry::{Actor, SurfaceScope};
+use crate::abilities::{
+    AbilityCategory, AbilityContext, AbilityError, AbilityErrorKind, AbilityResult,
+};
+use crate::services::context::ServiceError;
+use crate::types::{subject_ref_from_json, ClaimSubjectRef};
+
+#[ability(
+    name = "render_entity_claim_file",
+    category = Maintenance,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [User, SurfaceClient],
+    allowed_modes = [Live],
+    requires_confirmation = false,
+    may_publish = true,
+    required_scopes = ["write.claim_files"],
+    mcp_exposure = None,
+    client_side_executable = false,
+    mutates = [claim_file_projection_runs, claim_file_projection_run_claims],
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn render_entity_claim_file(
+    ctx: &AbilityContext<'_>,
+    input: RenderEntityClaimFileInput,
+) -> AbilityResult<ClaimFileProjectionResult> {
+    authorize(ctx, CLAIM_FILE_RENDER_SCOPE)?;
+    validate_schema_version(input.schema_version, RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME)?;
+    ctx.services()
+        .check_mutation_allowed()
+        .map_err(service_error)?;
+
+    let subject = subject_for_value(&input.subject_ref);
+    let schema_version = input.schema_version;
+    let response = ctx
+        .services()
+        .render_entity_claim_file(ClaimFileRenderRequest { input })
+        .await
+        .map_err(operation_error)?;
+    finalize_output(
+        ctx,
+        RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME,
+        AbilityCategory::Maintenance,
+        schema_version,
+        subject,
+        response,
+    )
+}
+
+#[ability(
+    name = "apply_claim_file_corrections",
+    category = Maintenance,
+    version = "1.0.0",
+    schema_version = 1,
+    allowed_actors = [User, SurfaceClient],
+    allowed_modes = [Live],
+    requires_confirmation = false,
+    may_publish = false,
+    required_scopes = ["submit.claim_file_corrections"],
+    mcp_exposure = None,
+    client_side_executable = false,
+    mutates = [intelligence_claims, claim_feedback, claim_file_projection_runs, claim_file_projection_run_claims],
+    composes = [],
+    experimental = false,
+    signal_policy = { emits_on_output_change = [], coalesce = false }
+)]
+pub async fn apply_claim_file_corrections(
+    ctx: &AbilityContext<'_>,
+    input: ApplyClaimFileCorrectionsInput,
+) -> AbilityResult<ClaimFileApplyResult> {
+    let actor_principal_id = authorize(ctx, CLAIM_FILE_APPLY_SCOPE)?;
+    validate_schema_version(
+        input.schema_version,
+        APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME,
+    )?;
+    ctx.services()
+        .check_mutation_allowed()
+        .map_err(service_error)?;
+
+    let schema_version = input.schema_version;
+    let response = ctx
+        .services()
+        .apply_claim_file_corrections(ClaimFileApplyRequest {
+            input,
+            actor_principal_id,
+        })
+        .await
+        .map_err(operation_error)?;
+    finalize_output(
+        ctx,
+        APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME,
+        AbilityCategory::Maintenance,
+        schema_version,
+        SubjectRef::Global,
+        response,
+    )
+}
+
+fn authorize(ctx: &AbilityContext<'_>, required_scope: &str) -> Result<String, AbilityError> {
+    match &ctx.actor {
+        Actor::User => Ok("user".to_string()),
+        Actor::SurfaceClient { instance, scopes } => {
+            if !scopes.contains(&SurfaceScope::new(required_scope)) {
+                return Err(permission_denied(&format!("{required_scope}_required")));
+            }
+            Ok(format!("surface_client:{}", instance.as_str()))
+        }
+        _ => Err(permission_denied("actor_not_allowed")),
+    }
+}
+
+fn validate_schema_version(schema_version: u32, ability_name: &str) -> Result<(), AbilityError> {
+    if schema_version == CLAIM_FILES_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("unsupported schema_version `{schema_version}` for `{ability_name}`"),
+        })
+    }
+}
+
+fn subject_for_value(value: &serde_json::Value) -> SubjectRef {
+    match subject_ref_from_json(value) {
+        Ok(subject) => provenance_subject(subject),
+        Err(_) => SubjectRef::Unknown,
+    }
+}
+
+fn provenance_subject(subject: ClaimSubjectRef) -> SubjectRef {
+    match subject {
+        ClaimSubjectRef::Account { id } => SubjectRef::Account(id),
+        ClaimSubjectRef::Project { id } => SubjectRef::Project(id),
+        ClaimSubjectRef::Person { id } => SubjectRef::Person(id),
+        ClaimSubjectRef::Action { id } => SubjectRef::Action(id),
+        ClaimSubjectRef::Meeting { id } => SubjectRef::Meeting(id),
+        ClaimSubjectRef::Global => SubjectRef::Global,
+        ClaimSubjectRef::Multi(subjects) => {
+            SubjectRef::Multi(subjects.into_iter().map(provenance_subject).collect())
+        }
+        ClaimSubjectRef::Email { .. } => SubjectRef::Unknown,
+    }
+}
+
+fn finalize_output<T>(
+    ctx: &AbilityContext<'_>,
+    ability_name: &'static str,
+    category: AbilityCategory,
+    schema_version: u32,
+    subject: SubjectRef,
+    response: T,
+) -> AbilityResult<T>
+where
+    T: serde::Serialize,
+{
+    let mut builder = ProvenanceBuilder::new(provenance_config(
+        ctx,
+        ability_name,
+        category,
+        schema_version,
+    ));
+    let subject_attribution = SubjectAttribution::direct_confident(subject);
+    builder.set_subject(subject_attribution.clone());
+    builder
+        .attribute_subtree(
+            FieldPath::root(),
+            FieldAttribution::constant(subject_attribution),
+        )
+        .map_err(provenance_error)?;
+    builder.finalize(response).map_err(provenance_error)
+}
+
+fn provenance_config(
+    ctx: &AbilityContext<'_>,
+    ability_name: &'static str,
+    category: AbilityCategory,
+    schema_version: u32,
+) -> ProvenanceBuilderConfig {
+    let mut config = ProvenanceBuilderConfig::new(ability_name, ctx.services().clock.now());
+    config.ability_version = AbilityVersion::new(1, 0);
+    config.ability_schema_version = SchemaVersion(schema_version);
+    config.actor = provenance_actor(ctx.actor.clone());
+    config.mode = AbilityExecutionMode::from(ctx.mode());
+    config.category = category;
+    config
+}
+
+fn provenance_actor(actor: Actor) -> crate::abilities::provenance::Actor {
+    match actor {
+        Actor::User => crate::abilities::provenance::Actor::User,
+        Actor::SurfaceClient { .. } => crate::abilities::provenance::Actor::Human {
+            role: "surface_client".to_string(),
+            id: "surface_client".to_string(),
+        },
+        Actor::System => crate::abilities::provenance::Actor::System {
+            component: "dailyos".to_string(),
+        },
+        Actor::Agent => crate::abilities::provenance::Actor::Agent {
+            name: "agent".to_string(),
+            version: "unknown".to_string(),
+        },
+        Actor::Admin => crate::abilities::provenance::Actor::Human {
+            role: "admin".to_string(),
+            id: "admin".to_string(),
+        },
+        Actor::McpClient { .. } => crate::abilities::provenance::Actor::Agent {
+            name: "mcp_client".to_string(),
+            version: "unknown".to_string(),
+        },
+    }
+}
+
+fn service_error(error: ServiceError) -> AbilityError {
+    match error {
+        ServiceError::WriteBlockedByMode(mode) => AbilityError {
+            kind: AbilityErrorKind::Capability,
+            message: format!("write_blocked_by_mode: {mode:?}"),
+        },
+        other => AbilityError {
+            kind: AbilityErrorKind::HardError(other.to_string()),
+            message: other.to_string(),
+        },
+    }
+}
+
+fn operation_error(error: ClaimFileOperationError) -> AbilityError {
+    match error {
+        ClaimFileOperationError::InvalidRequest(message) => AbilityError {
+            kind: AbilityErrorKind::Validation,
+            message: format!("invalid_claim_file_request: {message}"),
+        },
+        ClaimFileOperationError::MutationBlocked(message) => AbilityError {
+            kind: AbilityErrorKind::Capability,
+            message: format!("claim_file_mutation_blocked: {message}"),
+        },
+        ClaimFileOperationError::OperationFailed(message) => AbilityError {
+            kind: AbilityErrorKind::HardError(message.clone()),
+            message: format!("claim_file_operation_failed: {message}"),
+        },
+    }
+}
+
+fn permission_denied(reason: &str) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Capability,
+        message: format!("permission_denied: {reason}"),
+    }
+}
+
+fn provenance_error(error: impl std::fmt::Display) -> AbilityError {
+    AbilityError {
+        kind: AbilityErrorKind::Validation,
+        message: format!("provenance construction failed: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abilities::registry::{AbilityRegistry, ActorKind, McpExposure};
+
+    #[test]
+    fn descriptors_are_registered_and_hidden_from_mcp() {
+        let registry = AbilityRegistry::global_checked().expect("registry builds");
+        let render = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == RENDER_ENTITY_CLAIM_FILE_ABILITY_NAME)
+            .expect("render ability is registered");
+        let apply = registry
+            .iter_all()
+            .find(|descriptor| descriptor.name == APPLY_CLAIM_FILE_CORRECTIONS_ABILITY_NAME)
+            .expect("apply ability is registered");
+
+        assert_eq!(render.category, AbilityCategory::Maintenance);
+        assert_eq!(apply.category, AbilityCategory::Maintenance);
+        assert!(render.policy.may_publish);
+        assert!(!apply.policy.may_publish);
+        assert_eq!(render.policy.mcp_exposure, McpExposure::None);
+        assert_eq!(apply.policy.mcp_exposure, McpExposure::None);
+        assert!(render.policy.allowed_actors.contains(&ActorKind::User));
+        assert!(apply.policy.allowed_actors.contains(&ActorKind::User));
+    }
+
+    #[test]
+    fn subject_for_value_maps_entity_subjects() {
+        assert_eq!(
+            subject_for_value(&serde_json::json!({"kind": "account", "id": "acct-1"})),
+            SubjectRef::Account("acct-1".to_string())
+        );
+        assert_eq!(
+            subject_for_value(&serde_json::json!({"kind": "project", "id": "proj-1"})),
+            SubjectRef::Project("proj-1".to_string())
+        );
+    }
+}

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/contracts.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/contracts.rs
@@ -51,6 +51,7 @@ pub enum EntityIntakeError {
     CategoryNotAllowed { allowed: Vec<String> },
     FileNotFound,
     PathTraversalAttempt,
+    ManagedOutputRoot,
     IngestionFailed { message: String },
 }
 

--- a/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
+++ b/src-tauri/abilities-runtime/src/abilities/entity_intake/producer.rs
@@ -172,6 +172,10 @@ fn workspace_intake_error(error: WorkspaceIntakeError) -> AbilityError {
         WorkspaceIntakeError::PathTraversalAttempt | WorkspaceIntakeError::OutsideWorkspace => {
             hard_error("PathTraversalAttempt", "file_ref is outside the workspace")
         }
+        WorkspaceIntakeError::ManagedOutputRoot => hard_error(
+            "ManagedOutputRoot",
+            "file_ref points at DailyOS managed output, not source evidence",
+        ),
         WorkspaceIntakeError::InvalidSourceTypeSlug(value) => {
             hard_error("InvalidSourceType", value)
         }

--- a/src-tauri/abilities-runtime/src/abilities/mod.rs
+++ b/src-tauri/abilities-runtime/src/abilities/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account_overview;
 pub mod action_detail;
+pub mod claim_files;
 pub mod claim_receipt;
 pub mod claims;
 pub mod composition;

--- a/src-tauri/abilities-runtime/src/services/context.rs
+++ b/src-tauri/abilities-runtime/src/services/context.rs
@@ -42,6 +42,10 @@ use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
+pub use crate::abilities::claim_files::contracts::{
+    ClaimFileApplyRequest, ClaimFileApplyResult, ClaimFileOperationError,
+    ClaimFileProjectionResult, ClaimFileRenderRequest,
+};
 use crate::abilities::composition::{Composition, CompositionDocId};
 pub use crate::abilities::markdown_preview::contracts::{
     MarkdownPreviewOutput, MarkdownPreviewReadRequest,
@@ -882,6 +886,7 @@ pub struct ServiceContext<'a> {
     recommendation_feedback_writer: Option<Arc<dyn RecommendationFeedbackWriteHandle>>,
     source_management_action_handler: Option<Arc<dyn SourceManagementActionHandle>>,
     workspace_intake: Option<Arc<dyn WorkspaceIntakeService>>,
+    claim_file_operations: Option<Arc<dyn ClaimFileOperationHandle>>,
 }
 
 pub type EntityContextReadFuture<'a> =
@@ -1546,6 +1551,28 @@ pub trait SourceManagementActionHandle: Send + Sync {
         &'a self,
         request: SourceManagementActionRequest,
     ) -> SourceManagementActionFuture<'a>;
+}
+
+pub type ClaimFileRenderFuture<'a> = Pin<
+    Box<
+        dyn Future<Output = Result<ClaimFileProjectionResult, ClaimFileOperationError>> + Send + 'a,
+    >,
+>;
+
+pub type ClaimFileApplyFuture<'a> = Pin<
+    Box<dyn Future<Output = Result<ClaimFileApplyResult, ClaimFileOperationError>> + Send + 'a>,
+>;
+
+pub trait ClaimFileOperationHandle: Send + Sync {
+    fn render_entity_claim_file<'a>(
+        &'a self,
+        request: ClaimFileRenderRequest,
+    ) -> ClaimFileRenderFuture<'a>;
+
+    fn apply_claim_file_corrections<'a>(
+        &'a self,
+        request: ClaimFileApplyRequest,
+    ) -> ClaimFileApplyFuture<'a>;
 }
 
 // -----------------------------------------------------------------------------
@@ -2274,6 +2301,7 @@ impl<'a> ServiceContext<'a> {
             recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
+            claim_file_operations: None,
         }
     }
 
@@ -2319,6 +2347,7 @@ impl<'a> ServiceContext<'a> {
             recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
+            claim_file_operations: None,
         }
     }
 
@@ -2375,6 +2404,7 @@ impl<'a> ServiceContext<'a> {
             recommendation_feedback_writer: None,
             source_management_action_handler: None,
             workspace_intake: None,
+            claim_file_operations: None,
         }
     }
 
@@ -2584,6 +2614,14 @@ impl<'a> ServiceContext<'a> {
 
     pub fn with_workspace_intake(mut self, service: Arc<dyn WorkspaceIntakeService>) -> Self {
         self.workspace_intake = Some(service);
+        self
+    }
+
+    pub fn with_claim_file_operations(
+        mut self,
+        operations: Arc<dyn ClaimFileOperationHandle>,
+    ) -> Self {
+        self.claim_file_operations = Some(operations);
         self
     }
 
@@ -2975,6 +3013,32 @@ impl<'a> ServiceContext<'a> {
         };
 
         handler.apply_source_management_action(request).await
+    }
+
+    pub async fn render_entity_claim_file(
+        &self,
+        request: ClaimFileRenderRequest,
+    ) -> Result<ClaimFileProjectionResult, ClaimFileOperationError> {
+        let Some(operations) = &self.claim_file_operations else {
+            return Err(ClaimFileOperationError::OperationFailed(
+                self.missing_reader_error("claim_file_operations"),
+            ));
+        };
+
+        operations.render_entity_claim_file(request).await
+    }
+
+    pub async fn apply_claim_file_corrections(
+        &self,
+        request: ClaimFileApplyRequest,
+    ) -> Result<ClaimFileApplyResult, ClaimFileOperationError> {
+        let Some(operations) = &self.claim_file_operations else {
+            return Err(ClaimFileOperationError::OperationFailed(
+                self.missing_reader_error("claim_file_operations"),
+            ));
+        };
+
+        operations.apply_claim_file_corrections(request).await
     }
 
     pub async fn read_trajectory_bundle(

--- a/src-tauri/abilities-runtime/src/services/workspace_intake.rs
+++ b/src-tauri/abilities-runtime/src/services/workspace_intake.rs
@@ -63,6 +63,7 @@ pub enum WorkspaceIntakeError {
     EntityNotFound,
     FileNotFound,
     PathTraversalAttempt,
+    ManagedOutputRoot,
     OutsideWorkspace,
     SymlinkRaced,
     FileTooLarge,

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -20,6 +20,9 @@
 //! Workspace placement idempotency, rate, and audit ledgers are not statically
 //! seeded in mock scenarios: they are service-owned operational records and
 //! must be produced through the workspace placement service path.
+//! Claim file projection ledgers follow the same rule: they are service-owned
+//! operational receipts produced by claim-file render/apply abilities, not
+//! static mock fixture data.
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -20,9 +20,9 @@
 //! Workspace placement idempotency, rate, and audit ledgers are not statically
 //! seeded in mock scenarios: they are service-owned operational records and
 //! must be produced through the workspace placement service path.
-//! Claim file projection ledgers follow the same rule: they are service-owned
-//! operational receipts produced by claim-file render/apply abilities, not
-//! static mock fixture data.
+//! Claim file projection ledgers, path bindings, and correction apply events
+//! follow the same rule: they are service-owned operational receipts produced
+//! by claim-file render/apply abilities, not static mock fixture data.
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1118,12 +1118,12 @@ const MIGRATIONS: &[Migration] = &[
         version: 276,
         sql: include_str!("migrations/276_action_claim_version.sql"),
     },
-    // v1.4.9 W3 / DOS-628 — readable claim-file projection ledger.
+    // v1.4.9 W3 — readable claim-file projection ledger.
     Migration::Sql {
         version: 280,
         sql: include_str!("migrations/280_claim_file_projection_runs.sql"),
     },
-    // v1.4.9 W3 / DOS-628 — per-run projected claim membership.
+    // v1.4.9 W3 — per-run projected claim membership.
     Migration::Sql {
         version: 281,
         sql: include_str!("migrations/281_claim_file_projection_run_claims.sql"),

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -7549,6 +7549,8 @@ mod tests {
         for table_name in [
             "claim_file_projection_runs",
             "claim_file_projection_run_claims",
+            "claim_file_projection_path_bindings",
+            "claim_file_correction_apply_events",
         ] {
             let table_count: i64 = conn
                 .query_row(
@@ -7571,12 +7573,21 @@ mod tests {
         let membership_sql = sqlite_table_sql(&conn, "claim_file_projection_run_claims")
             .expect("read membership DDL");
         assert!(membership_sql.contains("PRIMARY KEY (run_id, claim_id)"));
+        let binding_sql = sqlite_table_sql(&conn, "claim_file_projection_path_bindings")
+            .expect("read path binding DDL");
+        assert!(binding_sql.contains("entity_subject_compact TEXT NOT NULL UNIQUE"));
+        let apply_sql = sqlite_table_sql(&conn, "claim_file_correction_apply_events")
+            .expect("read correction apply DDL");
+        assert!(apply_sql.contains("status IN ('claimed', 'applied', 'failed')"));
 
         for index_name in [
             "idx_claim_file_projection_runs_entity_status",
             "idx_claim_file_projection_runs_repair",
             "idx_claim_file_projection_run_claims_claim",
             "idx_claim_file_projection_run_claims_run_trust",
+            "idx_claim_file_projection_path_bindings_subject",
+            "idx_claim_file_correction_apply_claim_status",
+            "idx_claim_file_correction_apply_sidecar",
         ] {
             assert!(
                 index_exists(&conn, index_name).expect("query projection ledger index"),

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1118,6 +1118,16 @@ const MIGRATIONS: &[Migration] = &[
         version: 276,
         sql: include_str!("migrations/276_action_claim_version.sql"),
     },
+    // v1.4.9 W3 / DOS-628 — readable claim-file projection ledger.
+    Migration::Sql {
+        version: 280,
+        sql: include_str!("migrations/280_claim_file_projection_runs.sql"),
+    },
+    // v1.4.9 W3 / DOS-628 — per-run projected claim membership.
+    Migration::Sql {
+        version: 281,
+        sql: include_str!("migrations/281_claim_file_projection_run_claims.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -7528,6 +7538,55 @@ mod tests {
         assert!(
             current_version(&conn).expect("current version") >= 272,
             "schema version is at least v272"
+        );
+    }
+
+    #[test]
+    fn migration_280_and_281_create_claim_file_projection_ledger() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+
+        for table_name in [
+            "claim_file_projection_runs",
+            "claim_file_projection_run_claims",
+        ] {
+            let table_count: i64 = conn
+                .query_row(
+                    "SELECT count(*)
+                       FROM sqlite_master
+                      WHERE type = 'table'
+                        AND name = ?1",
+                    [table_name],
+                    |row| row.get(0),
+                )
+                .expect("query claim file projection ledger table");
+            assert_eq!(table_count, 1, "{table_name} exists");
+        }
+
+        let runs_sql =
+            sqlite_table_sql(&conn, "claim_file_projection_runs").expect("read runs DDL");
+        assert!(runs_sql.contains("projection_root = '_dailyos_claims'"));
+        assert!(runs_sql.contains("status IN ('committed', 'failed', 'repaired')"));
+
+        let membership_sql = sqlite_table_sql(&conn, "claim_file_projection_run_claims")
+            .expect("read membership DDL");
+        assert!(membership_sql.contains("PRIMARY KEY (run_id, claim_id)"));
+
+        for index_name in [
+            "idx_claim_file_projection_runs_entity_status",
+            "idx_claim_file_projection_runs_repair",
+            "idx_claim_file_projection_run_claims_claim",
+            "idx_claim_file_projection_run_claims_run_trust",
+        ] {
+            assert!(
+                index_exists(&conn, index_name).expect("query projection ledger index"),
+                "{index_name} exists"
+            );
+        }
+
+        assert!(
+            current_version(&conn).expect("current version") >= 281,
+            "schema version is at least v281"
         );
     }
 

--- a/src-tauri/src/migrations/280_claim_file_projection_runs.sql
+++ b/src-tauri/src/migrations/280_claim_file_projection_runs.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS claim_file_projection_runs (
+    id TEXT PRIMARY KEY,
+    entity_subject_ref_json TEXT NOT NULL,
+    entity_subject_compact TEXT NOT NULL,
+    projection_root TEXT NOT NULL DEFAULT '_dailyos_claims'
+        CHECK (projection_root = '_dailyos_claims'),
+    markdown_rel_path TEXT NOT NULL,
+    sidecar_rel_path TEXT NOT NULL,
+    projection_version INTEGER NOT NULL,
+    sidecar_schema_version INTEGER NOT NULL,
+    entity_claim_invalidation_version INTEGER NOT NULL DEFAULT 0,
+    claim_watermark TEXT NOT NULL,
+    markdown_checksum TEXT NOT NULL,
+    sidecar_checksum TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('committed', 'failed', 'repaired')),
+    error_class TEXT,
+    error_detail_hash TEXT,
+    attempted_at TEXT NOT NULL,
+    succeeded_at TEXT,
+    repaired_from_run_id TEXT REFERENCES claim_file_projection_runs(id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_projection_runs_entity_status
+    ON claim_file_projection_runs(entity_subject_compact, status, attempted_at);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_projection_runs_repair
+    ON claim_file_projection_runs(status, attempted_at)
+    WHERE status = 'failed';

--- a/src-tauri/src/migrations/281_claim_file_projection_run_claims.sql
+++ b/src-tauri/src/migrations/281_claim_file_projection_run_claims.sql
@@ -13,3 +13,39 @@ CREATE INDEX IF NOT EXISTS idx_claim_file_projection_run_claims_claim
 
 CREATE INDEX IF NOT EXISTS idx_claim_file_projection_run_claims_run_trust
     ON claim_file_projection_run_claims(run_id, trust_band, sensitivity);
+
+CREATE TABLE IF NOT EXISTS claim_file_projection_path_bindings (
+    markdown_rel_path TEXT PRIMARY KEY,
+    sidecar_rel_path TEXT NOT NULL UNIQUE,
+    entity_subject_compact TEXT NOT NULL UNIQUE,
+    projection_root TEXT NOT NULL DEFAULT '_dailyos_claims'
+        CHECK (projection_root = '_dailyos_claims'),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_projection_path_bindings_subject
+    ON claim_file_projection_path_bindings(entity_subject_compact);
+
+CREATE TABLE IF NOT EXISTS claim_file_correction_apply_events (
+    idempotency_key TEXT PRIMARY KEY,
+    sidecar_checksum TEXT NOT NULL,
+    claim_id TEXT NOT NULL REFERENCES intelligence_claims(id) ON DELETE CASCADE,
+    projected_claim_version INTEGER NOT NULL,
+    projected_identity_hash TEXT NOT NULL,
+    feedback_action TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('claimed', 'applied', 'failed')),
+    feedback_id TEXT REFERENCES claim_feedback(id) ON DELETE SET NULL,
+    error_detail_hash TEXT,
+    claimed_at TEXT NOT NULL,
+    applied_at TEXT,
+    failed_at TEXT,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_correction_apply_claim_status
+    ON claim_file_correction_apply_events(claim_id, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_correction_apply_sidecar
+    ON claim_file_correction_apply_events(sidecar_checksum, status, updated_at);

--- a/src-tauri/src/migrations/281_claim_file_projection_run_claims.sql
+++ b/src-tauri/src/migrations/281_claim_file_projection_run_claims.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS claim_file_projection_run_claims (
+    run_id TEXT NOT NULL REFERENCES claim_file_projection_runs(id) ON DELETE CASCADE,
+    claim_id TEXT NOT NULL REFERENCES intelligence_claims(id) ON DELETE CASCADE,
+    claim_version INTEGER NOT NULL,
+    semantic_identity_json TEXT NOT NULL,
+    trust_band TEXT NOT NULL,
+    sensitivity TEXT NOT NULL,
+    PRIMARY KEY (run_id, claim_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_projection_run_claims_claim
+    ON claim_file_projection_run_claims(claim_id, claim_version);
+
+CREATE INDEX IF NOT EXISTS idx_claim_file_projection_run_claims_run_trust
+    ON claim_file_projection_run_claims(run_id, trust_band, sensitivity);

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use abilities_runtime::abilities::feedback::FeedbackAction;
@@ -14,7 +14,7 @@ use abilities_runtime::abilities::provenance::subject::SubjectRef as ReceiptSubj
 use abilities_runtime::sensitivity::RenderActor;
 use abilities_runtime::types::{ClaimSensitivity, ClaimSubjectRef, IntelligenceClaim};
 use chrono::Utc;
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -61,6 +61,21 @@ pub struct ClaimFileProjectionResult {
     pub claim_count: usize,
     pub markdown_checksum: String,
     pub sidecar_checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileProjectionChangeStatus {
+    pub entity_subject_compact: String,
+    pub current_claim_watermark: String,
+    pub markdown_rel_path: String,
+    pub sidecar_rel_path: String,
+    pub latest_run_id: Option<String>,
+    pub latest_run_status: Option<String>,
+    pub latest_claim_watermark: Option<String>,
+    pub latest_attempted_at: Option<String>,
+    pub needs_repair: bool,
+    pub repair_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -122,6 +137,7 @@ pub struct ClaimSemanticIdentityV1 {
     pub dedup_key_components_hash: String,
     pub source_ref: Option<String>,
     pub data_source: String,
+    pub actor: String,
     pub observed_at: String,
     pub source_asof: Option<String>,
     pub source_content_hash: Option<String>,
@@ -219,6 +235,16 @@ struct FileEnvelope {
     claim_ids: BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProjectionRunSummary {
+    run_id: String,
+    status: String,
+    claim_watermark: String,
+    markdown_rel_path: String,
+    sidecar_rel_path: String,
+    attempted_at: String,
+}
+
 impl EnvelopeView for FileEnvelope {
     fn ability(&self) -> &str {
         "claim_file_projection"
@@ -238,6 +264,47 @@ pub async fn render_entity_claim_file(
     workspace_root: PathBuf,
     subject_ref_json: String,
 ) -> Result<ClaimFileProjectionResult, ClaimFileError> {
+    render_entity_claim_file_for_status(state, workspace_root, subject_ref_json, None).await
+}
+
+pub async fn detect_entity_claim_file_changes(
+    state: &AppState,
+    subject_ref_json: String,
+) -> Result<ClaimFileProjectionChangeStatus, ClaimFileError> {
+    let status = state
+        .db_read(move |db| {
+            let bundle = build_render_bundle_db(db, &subject_ref_json)?;
+            projection_change_status_for_bundle(db, &bundle)
+        })
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))?;
+    Ok(status)
+}
+
+pub async fn repair_claim_file_projection(
+    state: &AppState,
+    workspace_root: PathBuf,
+    subject_ref_json: String,
+) -> Result<ClaimFileProjectionResult, ClaimFileError> {
+    let status = detect_entity_claim_file_changes(state, subject_ref_json.clone()).await?;
+    let repaired_from_run_id = status
+        .latest_run_id
+        .filter(|_| status.latest_run_status.as_deref() == Some("failed"));
+    render_entity_claim_file_for_status(
+        state,
+        workspace_root,
+        subject_ref_json,
+        repaired_from_run_id,
+    )
+    .await
+}
+
+async fn render_entity_claim_file_for_status(
+    state: &AppState,
+    workspace_root: PathBuf,
+    subject_ref_json: String,
+    repaired_from_run_id: Option<String>,
+) -> Result<ClaimFileProjectionResult, ClaimFileError> {
     let bundle = build_render_bundle(state, subject_ref_json).await?;
     let markdown_path = projection_abs_path(&workspace_root, &bundle.markdown_rel_path)?;
     let sidecar_path = projection_abs_path(&workspace_root, &bundle.sidecar_rel_path)?;
@@ -249,7 +316,21 @@ pub async fn render_entity_claim_file(
         &bundle.markdown,
         &bundle.sidecar_json,
     );
-    record_projection_run(state, &bundle, write_result.as_ref().err()).await?;
+    let status = if write_result.is_err() {
+        "failed"
+    } else if repaired_from_run_id.is_some() {
+        "repaired"
+    } else {
+        "committed"
+    };
+    record_projection_run(
+        state,
+        &bundle,
+        status,
+        repaired_from_run_id,
+        write_result.as_ref().err(),
+    )
+    .await?;
     write_result?;
 
     Ok(ClaimFileProjectionResult {
@@ -280,7 +361,10 @@ pub async fn apply_claim_file_corrections(
     verify_sidecar_contract(&sidecar)?;
     verify_sidecar_paths(&sidecar, &markdown_rel_path, &sidecar_rel_path)?;
 
-    let corrections = parse_markdown_corrections(&markdown, &sidecar, &sidecar_checksum)?;
+    let corrections = match parse_markdown_corrections(&markdown, &sidecar, &sidecar_checksum) {
+        Ok(corrections) => corrections,
+        Err(error) => return Ok(parse_failure_apply_result(sidecar.claims.len(), error)),
+    };
     if corrections.is_empty() {
         return Ok(ClaimFileApplyResult {
             applied_count: 0,
@@ -556,7 +640,8 @@ fn semantic_identity_for_claim(
         .item_hash
         .clone()
         .unwrap_or_else(|| sha256_hex(claim.text.as_bytes()));
-    let identity_kind = if claim.claim_type == "user_note" {
+    let is_user_note = claim.claim_type == "user_note";
+    let identity_kind = if is_user_note {
         "user_note_v1"
     } else {
         "claim_dedup_v1"
@@ -566,6 +651,15 @@ fn semantic_identity_for_claim(
         "{}\u{1f}{}\u{1f}{}\u{1f}{}",
         item_hash, subject_ref_compact, claim.claim_type, field_path_component
     );
+    let dedup_key_components_hash = if is_user_note {
+        crate::services::claims::compute_user_note_dedup_key(
+            &subject_ref_compact,
+            &claim.actor,
+            &claim.observed_at,
+        )
+    } else {
+        sha256_hex(components.as_bytes())
+    };
     ClaimSemanticIdentityV1 {
         identity_version: 1,
         identity_kind: identity_kind.to_string(),
@@ -574,9 +668,10 @@ fn semantic_identity_for_claim(
         subject_ref,
         claim_type: claim.claim_type.clone(),
         field_path: claim.field_path.clone(),
-        dedup_key_components_hash: sha256_hex(components.as_bytes()),
+        dedup_key_components_hash,
         source_ref: claim.source_ref.clone(),
         data_source: claim.data_source.clone(),
+        actor: claim.actor.clone(),
         observed_at: claim.observed_at.clone(),
         source_asof: claim.source_asof.clone(),
         source_content_hash: Some(source_content_hash_for_claim(claim)),
@@ -764,22 +859,21 @@ fn render_markdown(sidecar: &ClaimFileSidecar, sidecar_checksum: &str) -> String
 async fn record_projection_run(
     state: &AppState,
     bundle: &RenderBundle,
+    status: &str,
+    repaired_from_run_id: Option<String>,
     write_error: Option<&std::io::Error>,
 ) -> Result<(), ClaimFileError> {
     let run = bundle.clone();
-    let status = if write_error.is_some() {
-        "failed".to_string()
-    } else {
-        "committed".to_string()
-    };
     let error_class = write_error.map(|error| error.kind().to_string());
     let error_detail_hash = write_error.map(|error| redacted_hash(&error.to_string()));
+    let status = status.to_string();
     state
         .db_write(move |db| {
             insert_projection_run(
                 db,
                 &run,
                 &status,
+                repaired_from_run_id.as_deref(),
                 error_class.as_deref(),
                 error_detail_hash.as_deref(),
             )
@@ -793,6 +887,7 @@ fn insert_projection_run(
     db: &ActionDb,
     run: &RenderBundle,
     status: &str,
+    repaired_from_run_id: Option<&str>,
     error_class: Option<&str>,
     error_detail_hash: Option<&str>,
 ) -> Result<(), String> {
@@ -804,8 +899,9 @@ fn insert_projection_run(
                 markdown_rel_path, sidecar_rel_path, projection_version,
                 sidecar_schema_version, entity_claim_invalidation_version,
                 claim_watermark, markdown_checksum, sidecar_checksum, status,
-                error_class, error_detail_hash, attempted_at, succeeded_at, created_at, updated_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?16, ?16)",
+                error_class, error_detail_hash, attempted_at, succeeded_at,
+                repaired_from_run_id, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?16, ?16)",
             params![
                 &run.run_id,
                 &run.subject_ref_json,
@@ -823,11 +919,16 @@ fn insert_projection_run(
                 error_class,
                 error_detail_hash,
                 &now,
-                if status == "committed" { Some(now.as_str()) } else { None },
+                if matches!(status, "committed" | "repaired") {
+                    Some(now.as_str())
+                } else {
+                    None
+                },
+                repaired_from_run_id,
             ],
         )
         .map_err(|error| error.to_string())?;
-    if status == "committed" {
+    if matches!(status, "committed" | "repaired") {
         for claim in &run.sidecar.claims {
             let semantic_identity_json = serde_json::to_string(&claim.semantic_identity)
                 .map_err(|error| error.to_string())?;
@@ -850,6 +951,64 @@ fn insert_projection_run(
         }
     }
     Ok(())
+}
+
+fn projection_change_status_for_bundle(
+    db: &ActionDb,
+    bundle: &RenderBundle,
+) -> Result<ClaimFileProjectionChangeStatus, String> {
+    let latest = latest_projection_run(db, &bundle.entity_subject_compact)?;
+    let mut repair_reasons = Vec::new();
+    if let Some(latest) = &latest {
+        if latest.status == "failed" {
+            repair_reasons.push("previous_projection_failed".to_string());
+        }
+        if latest.claim_watermark != bundle.claim_watermark {
+            repair_reasons.push("claim_watermark_changed".to_string());
+        }
+    } else {
+        repair_reasons.push("missing_projection".to_string());
+    }
+
+    Ok(ClaimFileProjectionChangeStatus {
+        entity_subject_compact: bundle.entity_subject_compact.clone(),
+        current_claim_watermark: bundle.claim_watermark.clone(),
+        markdown_rel_path: path_to_slash_string(&bundle.markdown_rel_path),
+        sidecar_rel_path: path_to_slash_string(&bundle.sidecar_rel_path),
+        latest_run_id: latest.as_ref().map(|run| run.run_id.clone()),
+        latest_run_status: latest.as_ref().map(|run| run.status.clone()),
+        latest_claim_watermark: latest.as_ref().map(|run| run.claim_watermark.clone()),
+        latest_attempted_at: latest.as_ref().map(|run| run.attempted_at.clone()),
+        needs_repair: !repair_reasons.is_empty(),
+        repair_reasons,
+    })
+}
+
+fn latest_projection_run(
+    db: &ActionDb,
+    entity_subject_compact: &str,
+) -> Result<Option<ProjectionRunSummary>, String> {
+    db.conn_ref()
+        .query_row(
+            "SELECT id, status, claim_watermark, markdown_rel_path, sidecar_rel_path, attempted_at
+               FROM claim_file_projection_runs
+              WHERE entity_subject_compact = ?1
+              ORDER BY attempted_at DESC, created_at DESC, id DESC
+              LIMIT 1",
+            [entity_subject_compact],
+            |row| {
+                Ok(ProjectionRunSummary {
+                    run_id: row.get(0)?,
+                    status: row.get(1)?,
+                    claim_watermark: row.get(2)?,
+                    markdown_rel_path: row.get(3)?,
+                    sidecar_rel_path: row.get(4)?,
+                    attempted_at: row.get(5)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|error| error.to_string())
 }
 
 fn parse_markdown_corrections(
@@ -912,6 +1071,39 @@ fn parse_markdown_corrections(
         ));
     }
     Ok(corrections)
+}
+
+fn parse_failure_apply_result(skipped_count: usize, error: ClaimFileError) -> ClaimFileApplyResult {
+    let error_class = parse_failure_error_class(&error).to_string();
+    let error_detail_hash = redacted_hash(&error.to_string());
+    ClaimFileApplyResult {
+        applied_count: 0,
+        skipped_count,
+        failures: vec![ClaimFileApplyFailure {
+            claim_id: None,
+            error_class,
+            error_detail_hash,
+        }],
+        responses: Vec::new(),
+        rerender: None,
+    }
+}
+
+fn parse_failure_error_class(error: &ClaimFileError) -> &'static str {
+    let message = error.to_string();
+    if message.contains("sidecar_mismatch") {
+        "sidecar_mismatch"
+    } else if message.contains("unsupported file feedback action") {
+        "unsupported_action"
+    } else if message.contains("unterminated claim block") {
+        "parse_unterminated_block"
+    } else if message.contains("nested claim block") {
+        "parse_nested_block"
+    } else if message.contains("not present in sidecar") {
+        "unknown_claim"
+    } else {
+        "parse_failed"
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1143,8 +1335,51 @@ fn write_projection_files(
     let canonical_root = workspace_root.canonicalize()?;
     create_projection_parent_dirs(&canonical_root, sidecar_path)?;
     create_projection_parent_dirs(&canonical_root, markdown_path)?;
-    crate::util::atomic_write_str(sidecar_path, sidecar_json)?;
-    crate::util::atomic_write_str(markdown_path, markdown)?;
+    atomic_write_projection_file(sidecar_path, sidecar_json)?;
+    atomic_write_projection_file(markdown_path, markdown)?;
+    Ok(())
+}
+
+fn atomic_write_projection_file(path: &Path, content: &str) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path has no parent",
+        )
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path has no file name",
+        )
+    })?;
+    let tmp_name = format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    );
+    let tmp_path = parent.join(tmp_name);
+    let write_result = write_projection_temp_file(&tmp_path, content.as_bytes())
+        .and_then(|()| fs::rename(&tmp_path, path));
+    if write_result.is_err() {
+        match fs::remove_file(&tmp_path) {
+            Ok(()) | Err(_) => {}
+        }
+    }
+    write_result
+}
+
+fn write_projection_temp_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(content)?;
+    file.sync_all()?;
     Ok(())
 }
 
@@ -1541,6 +1776,7 @@ mod tests {
                     dedup_key_components_hash: "identity-hash-1".to_string(),
                     source_ref: Some("fixture://source-1".to_string()),
                     data_source: "unit_test".to_string(),
+                    actor: "agent:test".to_string(),
                     observed_at: "2026-06-02T12:00:00Z".to_string(),
                     source_asof: Some("2026-06-02T12:00:00Z".to_string()),
                     source_content_hash: Some("abcdef0123456789".to_string()),
@@ -1809,6 +2045,54 @@ dailyos-payload: {}
     }
 
     #[test]
+    fn apply_parse_failure_reports_sidecar_mismatch_artifact_without_responses() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: stale
+dailyos-action: mark_false
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+        let error = parse_markdown_corrections(markdown, &sidecar, "current")
+            .expect_err("sidecar mismatch should fail parsing");
+        let result = parse_failure_apply_result(sidecar.claims.len(), error);
+
+        assert_eq!(result.applied_count, 0);
+        assert_eq!(result.skipped_count, sidecar.claims.len());
+        assert!(result.responses.is_empty());
+        assert!(result.rerender.is_none());
+        assert_eq!(result.failures.len(), 1);
+        assert_eq!(result.failures[0].claim_id, None);
+        assert_eq!(result.failures[0].error_class, "sidecar_mismatch");
+    }
+
+    #[test]
+    fn apply_parse_failure_reports_unsupported_action_artifact_without_responses() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: rewrite_claim
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+        let error = parse_markdown_corrections(markdown, &sidecar, "checksum-1")
+            .expect_err("unsupported action should fail parsing");
+        let result = parse_failure_apply_result(sidecar.claims.len(), error);
+
+        assert_eq!(result.applied_count, 0);
+        assert_eq!(result.skipped_count, sidecar.claims.len());
+        assert!(result.responses.is_empty());
+        assert!(result.rerender.is_none());
+        assert_eq!(result.failures.len(), 1);
+        assert_eq!(result.failures[0].claim_id, None);
+        assert_eq!(result.failures[0].error_class, "unsupported_action");
+    }
+
+    #[test]
     fn parser_ignores_directive_like_text_after_claim_block_header() {
         let sidecar = fixture_sidecar();
         let markdown = "\
@@ -2059,7 +2343,8 @@ dailyos-action: mark_false\n\
 
     #[test]
     fn user_note_identity_uses_user_note_kind() {
-        let claim = fixture_intelligence_claim("user_note", None, Some("note-hash-1"));
+        let mut claim = fixture_intelligence_claim("user_note", None, Some("note-hash-1"));
+        claim.actor = "user:fixture".to_string();
         let identity = semantic_identity_for_claim(
             &claim,
             serde_json::json!({"kind": "account", "id": "acct-1"}),
@@ -2067,6 +2352,95 @@ dailyos-action: mark_false\n\
         );
 
         assert_eq!(identity.identity_kind, "user_note_v1");
+        assert_eq!(identity.actor, "user:fixture");
         assert_eq!(identity.item_hash, "note-hash-1");
+        assert_eq!(
+            identity.dedup_key_components_hash,
+            crate::services::claims::compute_user_note_dedup_key(
+                &identity.subject_ref_compact,
+                "user:fixture",
+                TEST_TS
+            )
+        );
+    }
+
+    #[test]
+    fn projection_change_status_detects_failed_run_and_repaired_success() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        commit_claim(
+            &ctx,
+            &db,
+            fixture_claim_proposal("Claim file repair fixture"),
+        )
+        .expect("commit projection claim");
+        let subject_ref_json = r#"{"kind":"account","id":"acct-1"}"#;
+        let bundle = build_render_bundle_db(&db, subject_ref_json).expect("build render bundle");
+
+        insert_projection_run(
+            &db,
+            &bundle,
+            "failed",
+            None,
+            Some("PermissionDenied"),
+            Some("redacted-error-hash"),
+        )
+        .expect("insert failed projection run");
+        let failed_status =
+            projection_change_status_for_bundle(&db, &bundle).expect("read failed status");
+
+        assert!(failed_status.needs_repair);
+        assert_eq!(failed_status.latest_run_status.as_deref(), Some("failed"));
+        assert!(failed_status
+            .repair_reasons
+            .contains(&"previous_projection_failed".to_string()));
+
+        let repaired_bundle = RenderBundle {
+            run_id: "zz-repaired-run".to_string(),
+            ..bundle.clone()
+        };
+        insert_projection_run(
+            &db,
+            &repaired_bundle,
+            "repaired",
+            Some(&bundle.run_id),
+            None,
+            None,
+        )
+        .expect("insert repaired projection run");
+        let repaired_status = projection_change_status_for_bundle(&db, &repaired_bundle)
+            .expect("read repaired status");
+        let repaired_from_run_id: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT repaired_from_run_id
+                   FROM claim_file_projection_runs
+                  WHERE id = ?1",
+                [&repaired_bundle.run_id],
+                |row| row.get(0),
+            )
+            .expect("read repaired link");
+        let repaired_membership_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                   FROM claim_file_projection_run_claims
+                  WHERE run_id = ?1",
+                [&repaired_bundle.run_id],
+                |row| row.get(0),
+            )
+            .expect("read repaired membership");
+
+        assert!(!repaired_status.needs_repair);
+        assert_eq!(
+            repaired_status.latest_run_status.as_deref(),
+            Some("repaired")
+        );
+        assert_eq!(
+            repaired_from_run_id.as_deref(),
+            Some(bundle.run_id.as_str())
+        );
+        assert!(repaired_membership_count > 0);
     }
 }

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -6,6 +6,7 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 
 use abilities_runtime::abilities::feedback::FeedbackAction;
@@ -18,6 +19,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::db::claim_invalidation::SubjectRef as InvalidationSubjectRef;
 use crate::db::ActionDb;
 use crate::services::claim_receipt::contracts::{ReceiptTarget, SurfaceContext};
 use crate::services::claim_receipt::feedback::{
@@ -321,14 +323,23 @@ pub async fn apply_claim_file_corrections(
     }
 
     let rerender = if failures.is_empty() {
-        Some(
-            render_entity_claim_file(
-                state,
-                workspace_root,
-                serde_json::to_string(&sidecar.entity_subject_ref)?,
-            )
-            .await?,
+        match render_entity_claim_file(
+            state,
+            workspace_root,
+            serde_json::to_string(&sidecar.entity_subject_ref)?,
         )
+        .await
+        {
+            Ok(result) => Some(result),
+            Err(error) => {
+                failures.push(ClaimFileApplyFailure {
+                    claim_id: None,
+                    error_class: "projection_rerender_failed".to_string(),
+                    error_detail_hash: redacted_hash(&error.to_string()),
+                });
+                None
+            }
+        }
     } else {
         None
     };
@@ -360,7 +371,7 @@ fn build_render_bundle_db(db: &ActionDb, subject_ref_json: &str) -> Result<Rende
         serde_json::from_str(subject_ref_json).map_err(|error| error.to_string())?;
     let subject = abilities_runtime::types::subject_ref_from_json(&subject_value)
         .map_err(|error| format!("subject_ref: {error}"))?;
-    let entity_subject_compact = compact_subject_label(&subject);
+    let entity_subject_compact = canonical_subject_compact(&subject)?;
     let entity_kind = supported_entity_kind_slug(&subject).ok_or_else(|| {
         "claim file projection supports account/project/person subjects".to_string()
     })?;
@@ -507,7 +518,7 @@ fn semantic_identity_for_loaded_claim(
         serde_json::from_str(&claim.subject_ref).map_err(|error| error.to_string())?;
     let subject = abilities_runtime::types::subject_ref_from_json(&subject_value)
         .map_err(|error| format!("claim subject_ref: {error}"))?;
-    let subject_ref_compact = compact_subject_label(&subject);
+    let subject_ref_compact = canonical_subject_compact(&subject)?;
     Ok(semantic_identity_for_claim(
         claim,
         subject_value,
@@ -703,6 +714,35 @@ fn render_markdown(sidecar: &ClaimFileSidecar, sidecar_checksum: &str) -> String
         sidecar.sidecar_rel_path, sidecar_checksum
     ));
     for claim in &sidecar.claims {
+        out.push_str(&format!(
+            "## {}\n\n",
+            markdown_inline_text(&claim.claim_text)
+        ));
+        out.push_str(&format!("- Trust: `{}`\n", claim.trust_band));
+        out.push_str(&format!("- Sensitivity: `{}`\n", claim.sensitivity));
+        if claim.lifecycle.claim_state != "active" || claim.lifecycle.surfacing_state != "active" {
+            out.push_str(&format!(
+                "- Lifecycle: `{}` / `{}`\n",
+                claim.lifecycle.claim_state, claim.lifecycle.surfacing_state
+            ));
+        }
+        out.push_str(&format!(
+            "- Source: `{}` `{}`\n",
+            markdown_inline_text(&claim.provenance_summary.data_source),
+            claim
+                .provenance_summary
+                .source_ref
+                .as_deref()
+                .map(markdown_inline_text)
+                .unwrap_or_else(|| "source_ref_unavailable".to_string())
+        ));
+        if let Some(source_asof) = claim.provenance_summary.source_asof.as_deref() {
+            out.push_str(&format!(
+                "- Source as-of: `{}`\n",
+                markdown_inline_text(source_asof)
+            ));
+        }
+        out.push('\n');
         out.push_str("<!-- dailyos-claim-start -->\n");
         out.push_str(&format!("dailyos-claim-id: {}\n", claim.runtime_claim_id));
         out.push_str(&format!(
@@ -716,28 +756,6 @@ fn render_markdown(sidecar: &ClaimFileSidecar, sidecar_checksum: &str) -> String
         out.push_str(&format!("dailyos-sidecar-checksum: {}\n", sidecar_checksum));
         out.push_str("dailyos-action: none\n");
         out.push_str("dailyos-payload: {}\n");
-        out.push('\n');
-        out.push_str(&format!("## {}\n\n", claim.claim_text));
-        out.push_str(&format!("- Trust: `{}`\n", claim.trust_band));
-        out.push_str(&format!("- Sensitivity: `{}`\n", claim.sensitivity));
-        if claim.lifecycle.claim_state != "active" || claim.lifecycle.surfacing_state != "active" {
-            out.push_str(&format!(
-                "- Lifecycle: `{}` / `{}`\n",
-                claim.lifecycle.claim_state, claim.lifecycle.surfacing_state
-            ));
-        }
-        out.push_str(&format!(
-            "- Source: `{}` `{}`\n",
-            claim.provenance_summary.data_source,
-            claim
-                .provenance_summary
-                .source_ref
-                .as_deref()
-                .unwrap_or("source_ref_unavailable")
-        ));
-        if let Some(source_asof) = claim.provenance_summary.source_asof.as_deref() {
-            out.push_str(&format!("- Source as-of: `{source_asof}`\n"));
-        }
         out.push_str("<!-- dailyos-claim-end -->\n\n");
     }
     out
@@ -867,6 +885,13 @@ fn parse_markdown_corrections(
         let Some(block) = current.as_mut() else {
             continue;
         };
+        if block.directives_closed {
+            continue;
+        }
+        if trimmed.is_empty() {
+            block.directives_closed = true;
+            continue;
+        }
         if let Some(value) = trimmed.strip_prefix("dailyos-claim-id:") {
             block.claim_id = Some(value.trim().to_string());
         } else if let Some(value) = trimmed.strip_prefix("dailyos-sidecar-checksum:") {
@@ -875,6 +900,10 @@ fn parse_markdown_corrections(
             block.action = Some(value.trim().to_string());
         } else if let Some(value) = trimmed.strip_prefix("dailyos-payload:") {
             block.payload = Some(value.trim().to_string());
+        } else if trimmed.starts_with("dailyos-") {
+            continue;
+        } else {
+            block.directives_closed = true;
         }
     }
     if current.is_some() {
@@ -891,6 +920,7 @@ struct ParsedBlock {
     sidecar_checksum: Option<String>,
     action: Option<String>,
     payload: Option<String>,
+    directives_closed: bool,
 }
 
 fn correction_from_block(
@@ -1211,17 +1241,50 @@ fn validate_projection_dir_metadata(
 }
 
 fn read_stable_to_string(path: &Path) -> Result<String, ClaimFileError> {
-    let before = fs::symlink_metadata(path)?;
-    validate_projection_file_metadata(&before)?;
-    let content = fs::read_to_string(path)?;
-    let after = fs::symlink_metadata(path)?;
+    let (mut file, before) = open_projection_file_no_follow(path)?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    let after = file.metadata()?;
     validate_projection_file_metadata(&after)?;
-    if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
+    if !same_open_file_metadata(&before, &after)
+        || before.len() != after.len()
+        || before.modified().ok() != after.modified().ok()
+    {
         return Err(ClaimFileError::PathRejected(
             "file changed while reading; retry apply".to_string(),
         ));
     }
     Ok(content)
+}
+
+#[cfg(unix)]
+fn open_projection_file_no_follow(path: &Path) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                ClaimFileError::PathRejected("projection file is a symlink".to_string())
+            } else {
+                ClaimFileError::Io(error)
+            }
+        })?;
+    let metadata = file.metadata()?;
+    validate_projection_file_metadata(&metadata)?;
+    Ok((file, metadata))
+}
+
+#[cfg(not(unix))]
+fn open_projection_file_no_follow(path: &Path) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
+    let before = fs::symlink_metadata(path)?;
+    validate_projection_file_metadata(&before)?;
+    let file = fs::File::open(path)?;
+    let metadata = file.metadata()?;
+    validate_projection_file_metadata(&metadata)?;
+    Ok((file, metadata))
 }
 
 fn validate_projection_file_metadata(metadata: &fs::Metadata) -> Result<(), ClaimFileError> {
@@ -1235,7 +1298,36 @@ fn validate_projection_file_metadata(metadata: &fs::Metadata) -> Result<(), Clai
             "projection path is not a file".to_string(),
         ));
     }
+    if projection_file_has_multiple_links(metadata) {
+        return Err(ClaimFileError::PathRejected(
+            "projection file has multiple hard links".to_string(),
+        ));
+    }
     Ok(())
+}
+
+#[cfg(unix)]
+fn same_open_file_metadata(before: &fs::Metadata, after: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    before.dev() == after.dev() && before.ino() == after.ino()
+}
+
+#[cfg(not(unix))]
+fn same_open_file_metadata(_before: &fs::Metadata, _after: &fs::Metadata) -> bool {
+    true
+}
+
+#[cfg(unix)]
+fn projection_file_has_multiple_links(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    metadata.nlink() > 1
+}
+
+#[cfg(not(unix))]
+fn projection_file_has_multiple_links(_metadata: &fs::Metadata) -> bool {
+    false
 }
 
 fn current_entity_claim_version(db: &ActionDb, subject: &ClaimSubjectRef) -> Result<i64, String> {
@@ -1259,24 +1351,29 @@ fn claim_watermark(claims: &[IntelligenceClaim], entity_claim_version: i64) -> S
     sha256_hex(entries.join("\n").as_bytes())
 }
 
-fn compact_subject_label(subject: &ClaimSubjectRef) -> String {
-    match subject {
-        ClaimSubjectRef::Account { id } => format!("account:{id}"),
-        ClaimSubjectRef::Project { id } => format!("project:{id}"),
-        ClaimSubjectRef::Person { id } => format!("person:{id}"),
-        ClaimSubjectRef::Action { id } => format!("action:{id}"),
-        ClaimSubjectRef::Meeting { id } => format!("meeting:{id}"),
-        ClaimSubjectRef::Email { id } => format!("email:{id}"),
-        ClaimSubjectRef::Global => "global".to_string(),
-        ClaimSubjectRef::Multi(subjects) => {
-            let mut parts = subjects
+fn canonical_subject_compact(subject: &ClaimSubjectRef) -> Result<String, String> {
+    let subject = invalidation_subject_from_claim_subject(subject)?;
+    crate::services::claims::canonical_subject_ref(&subject).map_err(|error| error.to_string())
+}
+
+fn invalidation_subject_from_claim_subject(
+    subject: &ClaimSubjectRef,
+) -> Result<InvalidationSubjectRef, String> {
+    Ok(match subject {
+        ClaimSubjectRef::Account { id } => InvalidationSubjectRef::Account { id: id.clone() },
+        ClaimSubjectRef::Project { id } => InvalidationSubjectRef::Project { id: id.clone() },
+        ClaimSubjectRef::Person { id } => InvalidationSubjectRef::Person { id: id.clone() },
+        ClaimSubjectRef::Action { id } => InvalidationSubjectRef::Action { id: id.clone() },
+        ClaimSubjectRef::Meeting { id } => InvalidationSubjectRef::Meeting { id: id.clone() },
+        ClaimSubjectRef::Email { id } => InvalidationSubjectRef::Email { id: id.clone() },
+        ClaimSubjectRef::Global => InvalidationSubjectRef::Global,
+        ClaimSubjectRef::Multi(subjects) => InvalidationSubjectRef::Multi(
+            subjects
                 .iter()
-                .map(compact_subject_label)
-                .collect::<Vec<_>>();
-            parts.sort();
-            format!("multi:{}", parts.join("|"))
-        }
-    }
+                .map(invalidation_subject_from_claim_subject)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+    })
 }
 
 fn subject_kind_slug(subject: &ClaimSubjectRef) -> Option<&'static str> {
@@ -1374,6 +1471,24 @@ fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+fn markdown_inline_text(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut previous_was_space = false;
+    for ch in value.chars() {
+        let next = if ch.is_control() { ' ' } else { ch };
+        if next.is_whitespace() {
+            if !previous_was_space {
+                out.push(' ');
+                previous_was_space = true;
+            }
+        } else {
+            out.push(next);
+            previous_was_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
 fn path_to_slash_string(path: &Path) -> String {
     path.components()
         .map(|component| component.as_os_str().to_string_lossy())
@@ -1411,7 +1526,7 @@ mod tests {
             schema_version: CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
             projection_version: CLAIM_FILE_PROJECTION_VERSION,
             entity_subject_ref: subject.clone(),
-            entity_subject_compact: "account:acct-1".to_string(),
+            entity_subject_compact: r#"{"id":"acct-1","kind":"account"}"#.to_string(),
             markdown_rel_path: "_dailyos_claims/account/acct-1/claims.md".to_string(),
             sidecar_rel_path: "_dailyos_claims/account/acct-1/claims.corrections.json".to_string(),
             claims: vec![ClaimFileClaim {
@@ -1419,7 +1534,7 @@ mod tests {
                     identity_version: 1,
                     identity_kind: "claim_dedup_v1".to_string(),
                     item_hash: "item-hash-1".to_string(),
-                    subject_ref_compact: "account:acct-1".to_string(),
+                    subject_ref_compact: r#"{"id":"acct-1","kind":"account"}"#.to_string(),
                     subject_ref: subject,
                     claim_type: "risk".to_string(),
                     field_path: Some("health.risk".to_string()),
@@ -1694,6 +1809,47 @@ dailyos-payload: {}
     }
 
     #[test]
+    fn parser_ignores_directive_like_text_after_claim_block_header() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: none
+dailyos-payload: {}
+
+## Source claim text
+dailyos-action: mark_false
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+
+        let corrections =
+            parse_markdown_corrections(markdown, &sidecar, "checksum-1").expect("parse");
+
+        assert!(
+            corrections.is_empty(),
+            "rendered claim prose must not be parsed as correction directives"
+        );
+    }
+
+    #[test]
+    fn render_markdown_keeps_claim_text_outside_machine_block() {
+        let mut sidecar = fixture_sidecar();
+        sidecar.claims[0].claim_text = "Claim text\n\
+dailyos-action: mark_false\n\
+<!-- dailyos-claim-end -->"
+            .to_string();
+
+        let markdown = render_markdown(&sidecar, "checksum-1");
+        let corrections =
+            parse_markdown_corrections(&markdown, &sidecar, "checksum-1").expect("parse");
+
+        assert!(markdown.contains("## Claim text dailyos-action: mark_false"));
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
     fn projection_path_validator_rejects_non_managed_roots_and_traversal() {
         assert!(validate_projection_relative_path(Path::new(
             "_dailyos_claims/account/acct-1/claims.md"
@@ -1751,6 +1907,30 @@ dailyos-payload: {}
             read_stable_to_string(&projection_dir.join(CLAIM_FILE_MARKDOWN_NAME)).unwrap_err();
 
         assert!(err.to_string().contains("symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_stable_to_string_rejects_projection_file_hardlink() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::NamedTempFile::new().expect("outside file");
+        std::fs::write(outside.path(), "outside").expect("write outside file");
+        let projection_dir = workspace
+            .path()
+            .join(CLAIM_FILE_PROJECTION_ROOT)
+            .join("account")
+            .join("acct-1");
+        std::fs::create_dir_all(&projection_dir).expect("projection dir");
+        std::fs::hard_link(
+            outside.path(),
+            projection_dir.join(CLAIM_FILE_MARKDOWN_NAME),
+        )
+        .expect("projection file hardlink");
+
+        let err =
+            read_stable_to_string(&projection_dir.join(CLAIM_FILE_MARKDOWN_NAME)).unwrap_err();
+
+        assert!(err.to_string().contains("hard links"));
     }
 
     #[test]
@@ -1854,14 +2034,25 @@ dailyos-payload: {}
         let identity = semantic_identity_for_claim(
             &claim,
             serde_json::json!({"kind": "account", "id": "acct-1"}),
-            "account:acct-1".to_string(),
+            r#"{"id":"acct-1","kind":"account"}"#.to_string(),
         );
-        let expected_components = "item-hash-1\u{1f}account:acct-1\u{1f}risk\u{1f}health.risk";
+        let expected_subject = r#"{"id":"acct-1","kind":"account"}"#;
+        let expected_components =
+            format!("item-hash-1\u{1f}{expected_subject}\u{1f}risk\u{1f}health.risk");
 
         assert_eq!(identity.identity_kind, "claim_dedup_v1");
         assert_eq!(
             identity.dedup_key_components_hash,
             sha256_hex(expected_components.as_bytes())
+        );
+        assert_eq!(
+            crate::services::claims::compute_dedup_key(
+                "item-hash-1",
+                &identity.subject_ref_compact,
+                "risk",
+                Some("health.risk")
+            ),
+            "item-hash-1:{\"id\":\"acct-1\",\"kind\":\"account\"}:risk:health.risk"
         );
         assert_eq!(identity.runtime_claim_version, 7);
     }
@@ -1872,7 +2063,7 @@ dailyos-payload: {}
         let identity = semantic_identity_for_claim(
             &claim,
             serde_json::json!({"kind": "account", "id": "acct-1"}),
-            "account:acct-1".to_string(),
+            r#"{"id":"acct-1","kind":"account"}"#.to_string(),
         );
 
         assert_eq!(identity.identity_kind, "user_note_v1");

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -1,4 +1,4 @@
-//! Readable claim-file projection and correction apply service (DOS-628).
+//! Readable claim-file projection and correction apply service.
 //!
 //! Files under `_dailyos_claims` are projections of canonical claims. They are
 //! never source evidence, and applying edits routes through the existing

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -5,6 +5,7 @@
 //! receipt-level feedback path.
 
 use std::collections::BTreeSet;
+use std::ffi::OsString;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -13,7 +14,7 @@ use abilities_runtime::abilities::feedback::FeedbackAction;
 use abilities_runtime::abilities::provenance::subject::SubjectRef as ReceiptSubjectRef;
 use abilities_runtime::sensitivity::RenderActor;
 use abilities_runtime::types::{ClaimSensitivity, ClaimSubjectRef, IntelligenceClaim};
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
 use rusqlite::{params, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,8 @@ use crate::db::claim_invalidation::SubjectRef as InvalidationSubjectRef;
 use crate::db::ActionDb;
 use crate::services::claim_receipt::contracts::{ReceiptTarget, SurfaceContext};
 use crate::services::claim_receipt::feedback::{
-    submit_claim_feedback, ClaimFeedbackRequest, ClaimFeedbackResponse, IdempotencyCache,
+    submit_claim_feedback_for_claim_file_apply, ClaimFeedbackRequest, ClaimFeedbackResponse,
+    ClaimFileFeedbackApplyCommit, IdempotencyCache,
 };
 use crate::services::entity_intelligence::auth::{EnvelopeSet, EnvelopeView};
 use crate::services::workspace_ingestion::registry::CLAIM_FILE_PROJECTION_ROOT;
@@ -33,6 +35,7 @@ pub const CLAIM_FILE_PROJECTION_VERSION: u32 = 1;
 pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 1;
 pub const CLAIM_FILE_MARKDOWN_NAME: &str = "claims.md";
 pub const CLAIM_FILE_SIDECAR_NAME: &str = "claims.corrections.json";
+const CLAIM_FILE_CORRECTION_APPLY_LEASE_SECS: i64 = 300;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClaimFileError {
@@ -226,8 +229,38 @@ struct RenderBundle {
 #[derive(Debug, Clone)]
 struct ParsedCorrection {
     claim_id: String,
+    projected_claim_version: u64,
+    projected_identity_hash: String,
     action: FeedbackAction,
     metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CorrectionApplyState {
+    Claimed,
+    AlreadyApplied,
+    InProgress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CorrectionFailureMarkState {
+    MarkedFailed,
+    AlreadyApplied,
+}
+
+struct CorrectionApplyRecord<'a> {
+    apply_key: &'a str,
+    sidecar_checksum: &'a str,
+    claim_id: &'a str,
+    projected_claim_version: u64,
+    projected_identity_hash: &'a str,
+    feedback_action: &'a str,
+    payload_hash: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CommittedProjectionRun {
+    run_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -306,13 +339,11 @@ async fn render_entity_claim_file_for_status(
     repaired_from_run_id: Option<String>,
 ) -> Result<ClaimFileProjectionResult, ClaimFileError> {
     let bundle = build_render_bundle(state, subject_ref_json).await?;
-    let markdown_path = projection_abs_path(&workspace_root, &bundle.markdown_rel_path)?;
-    let sidecar_path = projection_abs_path(&workspace_root, &bundle.sidecar_rel_path)?;
-
+    ensure_projection_path_binding_state(state, &bundle).await?;
     let write_result = write_projection_files(
         &workspace_root,
-        &markdown_path,
-        &sidecar_path,
+        &bundle.markdown_rel_path,
+        &bundle.sidecar_rel_path,
         &bundle.markdown,
         &bundle.sidecar_json,
     );
@@ -350,16 +381,15 @@ pub async fn apply_claim_file_corrections(
     actor_principal_id: String,
 ) -> Result<ClaimFileApplyResult, ClaimFileError> {
     let markdown_rel_path = validate_projection_relative_path(&markdown_rel_path)?;
-    let markdown_path = projection_abs_path(&workspace_root, &markdown_rel_path)?;
     let sidecar_rel_path = sidecar_path_for_markdown_rel(&markdown_rel_path)?;
-    let sidecar_path = projection_abs_path(&workspace_root, &sidecar_rel_path)?;
 
-    let markdown = read_stable_to_string(&markdown_path)?;
-    let sidecar_json = read_stable_to_string(&sidecar_path)?;
+    let markdown = read_stable_to_string(&workspace_root, &markdown_rel_path)?;
+    let sidecar_json = read_stable_to_string(&workspace_root, &sidecar_rel_path)?;
     let sidecar_checksum = sha256_hex(sidecar_json.as_bytes());
     let sidecar: ClaimFileSidecar = serde_json::from_str(&sidecar_json)?;
     verify_sidecar_contract(&sidecar)?;
     verify_sidecar_paths(&sidecar, &markdown_rel_path, &sidecar_rel_path)?;
+    validate_committed_sidecar_projection(state, &sidecar, &sidecar_checksum).await?;
 
     let corrections = match parse_markdown_corrections(&markdown, &sidecar, &sidecar_checksum) {
         Ok(corrections) => corrections,
@@ -374,7 +404,6 @@ pub async fn apply_claim_file_corrections(
             rerender: None,
         });
     }
-
     let claim_ids = sidecar
         .claims
         .iter()
@@ -388,6 +417,38 @@ pub async fn apply_claim_file_corrections(
     let mut failures = Vec::new();
 
     for correction in corrections {
+        let payload_hash = correction_payload_hash(&correction);
+        let apply_key =
+            correction_apply_idempotency_key(&sidecar_checksum, &correction, &payload_hash);
+        match claim_correction_apply(
+            state,
+            &apply_key,
+            &sidecar_checksum,
+            &correction,
+            &payload_hash,
+        )
+        .await?
+        {
+            CorrectionApplyState::AlreadyApplied => continue,
+            CorrectionApplyState::InProgress => {
+                failures.push(ClaimFileApplyFailure {
+                    claim_id: Some(correction.claim_id),
+                    error_class: "correction_apply_in_progress".to_string(),
+                    error_detail_hash: redacted_hash(&apply_key),
+                });
+                continue;
+            }
+            CorrectionApplyState::Claimed => {}
+        }
+        let current_failures =
+            current_projection_failures(state, &sidecar, std::slice::from_ref(&correction)).await?;
+        if let Some(failure) = current_failures.into_iter().next() {
+            match mark_correction_apply_failed(state, &apply_key, "stale_projection").await? {
+                CorrectionFailureMarkState::MarkedFailed => failures.push(failure),
+                CorrectionFailureMarkState::AlreadyApplied => continue,
+            }
+            continue;
+        }
         let target = receipt_target_for_claim(&sidecar, &correction.claim_id)?;
         let request = ClaimFeedbackRequest {
             target,
@@ -396,13 +457,34 @@ pub async fn apply_claim_file_corrections(
             metadata: correction.metadata,
             idempotency_key: None,
         };
-        match submit_claim_feedback(state, &set, &actor, &cache, request).await {
-            Ok(response) => responses.push(response),
-            Err(error) => failures.push(ClaimFileApplyFailure {
-                claim_id: Some(correction.claim_id),
-                error_class: "feedback_rejected".to_string(),
-                error_detail_hash: redacted_hash(&error.to_string()),
-            }),
+        match submit_claim_feedback_for_claim_file_apply(
+            state,
+            &set,
+            &actor,
+            &cache,
+            request,
+            ClaimFileFeedbackApplyCommit {
+                expected_claim_version: correction.projected_claim_version,
+                correction_apply_key: apply_key.clone(),
+            },
+        )
+        .await
+        {
+            Ok(response) => {
+                responses.push(response);
+            }
+            Err(error) => {
+                match mark_correction_apply_failed(state, &apply_key, &error.to_string()).await? {
+                    CorrectionFailureMarkState::MarkedFailed => {
+                        failures.push(ClaimFileApplyFailure {
+                            claim_id: Some(correction.claim_id),
+                            error_class: "feedback_rejected".to_string(),
+                            error_detail_hash: redacted_hash(&error.to_string()),
+                        });
+                    }
+                    CorrectionFailureMarkState::AlreadyApplied => continue,
+                }
+            }
         }
     }
 
@@ -461,14 +543,14 @@ fn build_render_bundle_db(db: &ActionDb, subject_ref_json: &str) -> Result<Rende
     })?;
     let entity_id = subject_id_for_path(&subject)
         .ok_or_else(|| "claim file projection subject requires an id".to_string())?;
-    let entity_slug = slug_segment(entity_id);
+    let entity_slug = projection_entity_slug(entity_id, &entity_subject_compact);
     let markdown_rel_path = PathBuf::from(CLAIM_FILE_PROJECTION_ROOT)
         .join(entity_kind)
-        .join(entity_slug)
+        .join(&entity_slug)
         .join(CLAIM_FILE_MARKDOWN_NAME);
     let sidecar_rel_path = PathBuf::from(CLAIM_FILE_PROJECTION_ROOT)
         .join(entity_kind)
-        .join(slug_segment(entity_id))
+        .join(entity_slug)
         .join(CLAIM_FILE_SIDECAR_NAME);
 
     let mut claims = load_claims_for_projection(db, subject_ref_json, entity_kind, entity_id)?;
@@ -883,6 +965,20 @@ async fn record_projection_run(
     Ok(())
 }
 
+async fn ensure_projection_path_binding_state(
+    state: &AppState,
+    bundle: &RenderBundle,
+) -> Result<(), ClaimFileError> {
+    let bundle = bundle.clone();
+    state
+        .db_write(move |db| {
+            let now = Utc::now().to_rfc3339();
+            ensure_projection_path_binding(db, &bundle, &now)
+        })
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
 fn insert_projection_run(
     db: &ActionDb,
     run: &RenderBundle,
@@ -892,6 +988,7 @@ fn insert_projection_run(
     error_detail_hash: Option<&str>,
 ) -> Result<(), String> {
     let now = Utc::now().to_rfc3339();
+    ensure_projection_path_binding(db, run, &now)?;
     db.conn_ref()
         .execute(
             "INSERT INTO claim_file_projection_runs (
@@ -950,6 +1047,206 @@ fn insert_projection_run(
                 .map_err(|error| error.to_string())?;
         }
     }
+    Ok(())
+}
+
+async fn validate_committed_sidecar_projection(
+    state: &AppState,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+) -> Result<CommittedProjectionRun, ClaimFileError> {
+    let sidecar = sidecar.clone();
+    let sidecar_checksum = sidecar_checksum.to_string();
+    state
+        .db_read(move |db| {
+            validate_committed_sidecar_projection_db(db, &sidecar, &sidecar_checksum)
+        })
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+fn validate_committed_sidecar_projection_db(
+    db: &ActionDb,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+) -> Result<CommittedProjectionRun, String> {
+    let binding: Option<(String, String)> = db
+        .conn_ref()
+        .query_row(
+            "SELECT sidecar_rel_path, entity_subject_compact
+               FROM claim_file_projection_path_bindings
+              WHERE markdown_rel_path = ?1",
+            [&sidecar.markdown_rel_path],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some((bound_sidecar_path, bound_subject)) = binding else {
+        return Err("projection path binding missing".to_string());
+    };
+    if bound_sidecar_path != sidecar.sidecar_rel_path
+        || bound_subject != sidecar.entity_subject_compact
+    {
+        return Err("projection path binding mismatch".to_string());
+    }
+
+    let run_id: Option<String> = db
+        .conn_ref()
+        .query_row(
+            "SELECT id
+               FROM claim_file_projection_runs
+              WHERE entity_subject_compact = ?1
+                AND markdown_rel_path = ?2
+                AND sidecar_rel_path = ?3
+                AND sidecar_checksum = ?4
+                AND projection_root = ?5
+                AND projection_version = ?6
+                AND sidecar_schema_version = ?7
+                AND status IN ('committed', 'repaired')
+              ORDER BY attempted_at DESC, id DESC
+              LIMIT 1",
+            params![
+                &sidecar.entity_subject_compact,
+                &sidecar.markdown_rel_path,
+                &sidecar.sidecar_rel_path,
+                sidecar_checksum,
+                CLAIM_FILE_PROJECTION_ROOT,
+                CLAIM_FILE_PROJECTION_VERSION,
+                CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+            ],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some(run_id) = run_id else {
+        return Err("committed projection run not found for sidecar".to_string());
+    };
+
+    let run_claim_count: i64 = db
+        .conn_ref()
+        .query_row(
+            "SELECT count(*)
+               FROM claim_file_projection_run_claims
+              WHERE run_id = ?1",
+            [&run_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if run_claim_count != sidecar.claims.len() as i64 {
+        return Err("projection claim membership count mismatch".to_string());
+    }
+
+    for claim in &sidecar.claims {
+        if claim.semantic_identity.runtime_claim_id != claim.runtime_claim_id
+            || claim.semantic_identity.runtime_claim_version != claim.runtime_claim_version
+        {
+            return Err("sidecar claim identity/version mismatch".to_string());
+        }
+        let row: Option<(u64, String, String, String)> = db
+            .conn_ref()
+            .query_row(
+                "SELECT claim_version, semantic_identity_json, trust_band, sensitivity
+                   FROM claim_file_projection_run_claims
+                  WHERE run_id = ?1
+                    AND claim_id = ?2",
+                params![&run_id, &claim.runtime_claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(|error| error.to_string())?;
+        let Some((claim_version, semantic_identity_json, trust_band, sensitivity)) = row else {
+            return Err("projection claim membership missing".to_string());
+        };
+        let semantic_identity: ClaimSemanticIdentityV1 =
+            serde_json::from_str(&semantic_identity_json).map_err(|error| error.to_string())?;
+        if claim_version != claim.runtime_claim_version
+            || semantic_identity != claim.semantic_identity
+            || trust_band != claim.trust_band
+            || sensitivity != claim.sensitivity
+        {
+            return Err("projection claim membership mismatch".to_string());
+        }
+    }
+
+    Ok(CommittedProjectionRun { run_id })
+}
+
+fn ensure_projection_path_binding(
+    db: &ActionDb,
+    run: &RenderBundle,
+    now: &str,
+) -> Result<(), String> {
+    let markdown_rel_path = path_to_slash_string(&run.markdown_rel_path);
+    let sidecar_rel_path = path_to_slash_string(&run.sidecar_rel_path);
+    let inserted = db
+        .conn_ref()
+        .execute(
+            "INSERT OR IGNORE INTO claim_file_projection_path_bindings (
+                markdown_rel_path, sidecar_rel_path, entity_subject_compact,
+                projection_root, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
+            params![
+                &markdown_rel_path,
+                &sidecar_rel_path,
+                &run.entity_subject_compact,
+                CLAIM_FILE_PROJECTION_ROOT,
+                now,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    if inserted == 1 {
+        return Ok(());
+    }
+
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT markdown_rel_path, sidecar_rel_path, entity_subject_compact
+               FROM claim_file_projection_path_bindings
+              WHERE markdown_rel_path = ?1
+                 OR sidecar_rel_path = ?2
+                 OR entity_subject_compact = ?3",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = stmt
+        .query_map(
+            params![
+                &markdown_rel_path,
+                &sidecar_rel_path,
+                &run.entity_subject_compact,
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .map_err(|error| error.to_string())?;
+    let mut saw_matching_binding = false;
+    for row in rows {
+        let (existing_markdown, existing_sidecar, existing_subject) =
+            row.map_err(|error| error.to_string())?;
+        if existing_markdown != markdown_rel_path
+            || existing_sidecar != sidecar_rel_path
+            || existing_subject != run.entity_subject_compact
+        {
+            return Err("projection path collision".to_string());
+        }
+        saw_matching_binding = true;
+    }
+    if !saw_matching_binding {
+        return Err("projection path binding missing after insert".to_string());
+    }
+    db.conn_ref()
+        .execute(
+            "UPDATE claim_file_projection_path_bindings
+                SET updated_at = ?1
+              WHERE markdown_rel_path = ?2",
+            params![now, &markdown_rel_path],
+        )
+        .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -1053,6 +1350,10 @@ fn parse_markdown_corrections(
         }
         if let Some(value) = trimmed.strip_prefix("dailyos-claim-id:") {
             block.claim_id = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("dailyos-claim-version:") {
+            block.version_header = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("dailyos-identity-hash:") {
+            block.identity_hash = Some(value.trim().to_string());
         } else if let Some(value) = trimmed.strip_prefix("dailyos-sidecar-checksum:") {
             block.sidecar_checksum = Some(value.trim().to_string());
         } else if let Some(value) = trimmed.strip_prefix("dailyos-action:") {
@@ -1109,6 +1410,8 @@ fn parse_failure_error_class(error: &ClaimFileError) -> &'static str {
 #[derive(Debug, Default)]
 struct ParsedBlock {
     claim_id: Option<String>,
+    version_header: Option<String>,
+    identity_hash: Option<String>,
     sidecar_checksum: Option<String>,
     action: Option<String>,
     payload: Option<String>,
@@ -1136,6 +1439,26 @@ fn correction_from_block(
     if block_checksum != sidecar_checksum {
         return Err(ClaimFileError::BadRequest("sidecar_mismatch".to_string()));
     }
+    let projected_claim_version = block
+        .version_header
+        .ok_or_else(|| {
+            ClaimFileError::BadRequest("claim block missing dailyos-claim-version".to_string())
+        })?
+        .parse::<u64>()
+        .map_err(|_| ClaimFileError::BadRequest("invalid dailyos-claim-version".to_string()))?;
+    if projected_claim_version != claim.runtime_claim_version {
+        return Err(ClaimFileError::BadRequest(
+            "stale_projection_claim_version".to_string(),
+        ));
+    }
+    let projected_identity_hash = block.identity_hash.ok_or_else(|| {
+        ClaimFileError::BadRequest("claim block missing dailyos-identity-hash".to_string())
+    })?;
+    if projected_identity_hash != claim.semantic_identity.dedup_key_components_hash {
+        return Err(ClaimFileError::BadRequest(
+            "stale_projection_identity_hash".to_string(),
+        ));
+    }
     let action_raw = block.action.unwrap_or_else(|| "none".to_string());
     if action_raw == "none" {
         return Ok(None);
@@ -1144,9 +1467,284 @@ fn correction_from_block(
     let metadata = metadata_for_action(action, block.payload.as_deref(), claim)?;
     Ok(Some(ParsedCorrection {
         claim_id,
+        projected_claim_version,
+        projected_identity_hash,
         action,
         metadata,
     }))
+}
+
+async fn current_projection_failures(
+    state: &AppState,
+    sidecar: &ClaimFileSidecar,
+    corrections: &[ParsedCorrection],
+) -> Result<Vec<ClaimFileApplyFailure>, ClaimFileError> {
+    let sidecar = sidecar.clone();
+    let corrections = corrections.to_vec();
+    state
+        .db_read(move |db| current_projection_failures_db(db, &sidecar, &corrections))
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+fn current_projection_failures_db(
+    db: &ActionDb,
+    sidecar: &ClaimFileSidecar,
+    corrections: &[ParsedCorrection],
+) -> Result<Vec<ClaimFileApplyFailure>, String> {
+    let mut failures = Vec::new();
+    for correction in corrections {
+        let Some(projected_claim) = sidecar
+            .claims
+            .iter()
+            .find(|claim| claim.runtime_claim_id == correction.claim_id)
+        else {
+            failures.push(stale_projection_failure(
+                &correction.claim_id,
+                "sidecar_claim_missing",
+            ));
+            continue;
+        };
+        let Some(current_claim) =
+            crate::services::claims::load_claim_by_id(db.conn_ref(), &correction.claim_id)
+                .map_err(|error| error.to_string())?
+        else {
+            failures.push(stale_projection_failure(
+                &correction.claim_id,
+                "claim_missing",
+            ));
+            continue;
+        };
+        let current_identity = semantic_identity_for_claim(
+            &current_claim,
+            sidecar.entity_subject_ref.clone(),
+            sidecar.entity_subject_compact.clone(),
+        );
+        if current_claim.claim_version != correction.projected_claim_version
+            || current_claim.claim_version != projected_claim.runtime_claim_version
+            || current_identity.dedup_key_components_hash != correction.projected_identity_hash
+            || current_identity.dedup_key_components_hash
+                != projected_claim.semantic_identity.dedup_key_components_hash
+        {
+            failures.push(stale_projection_failure(
+                &correction.claim_id,
+                "current_claim_changed",
+            ));
+        }
+    }
+    Ok(failures)
+}
+
+fn stale_projection_failure(claim_id: &str, reason: &str) -> ClaimFileApplyFailure {
+    ClaimFileApplyFailure {
+        claim_id: Some(claim_id.to_string()),
+        error_class: "stale_projection".to_string(),
+        error_detail_hash: redacted_hash(reason),
+    }
+}
+
+fn correction_payload_hash(correction: &ParsedCorrection) -> String {
+    match correction.metadata.as_ref() {
+        Some(metadata) => sha256_hex(metadata.to_string().as_bytes()),
+        None => sha256_hex(b"null"),
+    }
+}
+
+fn correction_apply_idempotency_key(
+    sidecar_checksum: &str,
+    correction: &ParsedCorrection,
+    payload_hash: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"claim_file_correction_apply_v1");
+    hasher.update([0x1f]);
+    hasher.update(sidecar_checksum.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(correction.claim_id.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(correction.projected_claim_version.to_string().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(correction.projected_identity_hash.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(correction.action.as_str().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(payload_hash.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+async fn claim_correction_apply(
+    state: &AppState,
+    apply_key: &str,
+    sidecar_checksum: &str,
+    correction: &ParsedCorrection,
+    payload_hash: &str,
+) -> Result<CorrectionApplyState, ClaimFileError> {
+    let apply_key = apply_key.to_string();
+    let sidecar_checksum = sidecar_checksum.to_string();
+    let claim_id = correction.claim_id.clone();
+    let projected_claim_version = correction.projected_claim_version;
+    let projected_identity_hash = correction.projected_identity_hash.clone();
+    let feedback_action = correction.action.as_str().to_string();
+    let payload_hash = payload_hash.to_string();
+    state
+        .db_write(move |db| {
+            let record = CorrectionApplyRecord {
+                apply_key: &apply_key,
+                sidecar_checksum: &sidecar_checksum,
+                claim_id: &claim_id,
+                projected_claim_version,
+                projected_identity_hash: &projected_identity_hash,
+                feedback_action: &feedback_action,
+                payload_hash: &payload_hash,
+            };
+            claim_correction_apply_db(db, &record)
+        })
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+fn claim_correction_apply_db(
+    db: &ActionDb,
+    record: &CorrectionApplyRecord<'_>,
+) -> Result<CorrectionApplyState, String> {
+    let now = Utc::now();
+    let now_text = now.to_rfc3339();
+    let inserted = db
+        .conn_ref()
+        .execute(
+            "INSERT OR IGNORE INTO claim_file_correction_apply_events (
+                idempotency_key, sidecar_checksum, claim_id,
+                projected_claim_version, projected_identity_hash, feedback_action,
+                payload_hash, status, claimed_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'claimed', ?8, ?8)",
+            params![
+                record.apply_key,
+                record.sidecar_checksum,
+                record.claim_id,
+                record.projected_claim_version,
+                record.projected_identity_hash,
+                record.feedback_action,
+                record.payload_hash,
+                &now_text,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    if inserted == 1 {
+        return Ok(CorrectionApplyState::Claimed);
+    }
+
+    let (status, claimed_at): (String, String) = db
+        .conn_ref()
+        .query_row(
+            "SELECT status, claimed_at
+              FROM claim_file_correction_apply_events
+              WHERE idempotency_key = ?1",
+            [record.apply_key],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "correction apply event missing after insert conflict".to_string())?;
+    match status.as_str() {
+        "applied" => Ok(CorrectionApplyState::AlreadyApplied),
+        "claimed" => {
+            if correction_apply_claim_expired(&claimed_at, now)? {
+                db.conn_ref()
+                    .execute(
+                        "UPDATE claim_file_correction_apply_events
+                            SET claimed_at = ?1,
+                                updated_at = ?1
+                          WHERE idempotency_key = ?2
+                            AND status = 'claimed'",
+                        params![&now_text, record.apply_key],
+                    )
+                    .map_err(|error| error.to_string())?;
+                Ok(CorrectionApplyState::Claimed)
+            } else {
+                Ok(CorrectionApplyState::InProgress)
+            }
+        }
+        "failed" => {
+            db.conn_ref()
+                .execute(
+                    "UPDATE claim_file_correction_apply_events
+                        SET status = 'claimed',
+                            error_detail_hash = NULL,
+                            failed_at = NULL,
+                            claimed_at = ?1,
+                            updated_at = ?1
+                      WHERE idempotency_key = ?2",
+                    params![&now_text, record.apply_key],
+                )
+                .map_err(|error| error.to_string())?;
+            Ok(CorrectionApplyState::Claimed)
+        }
+        other => Err(format!("unknown correction apply status `{other}`")),
+    }
+}
+
+async fn mark_correction_apply_failed(
+    state: &AppState,
+    apply_key: &str,
+    error_detail: &str,
+) -> Result<CorrectionFailureMarkState, ClaimFileError> {
+    let apply_key = apply_key.to_string();
+    let error_detail_hash = redacted_hash(error_detail);
+    state
+        .db_write(move |db| mark_correction_apply_failed_db(db, &apply_key, &error_detail_hash))
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+fn mark_correction_apply_failed_db(
+    db: &ActionDb,
+    apply_key: &str,
+    error_detail_hash: &str,
+) -> Result<CorrectionFailureMarkState, String> {
+    let now = Utc::now().to_rfc3339();
+    let updated = db
+        .conn_ref()
+        .execute(
+            "UPDATE claim_file_correction_apply_events
+                SET status = 'failed',
+                    error_detail_hash = ?1,
+                    failed_at = ?2,
+                    updated_at = ?2
+              WHERE idempotency_key = ?3
+                AND status = 'claimed'",
+            params![error_detail_hash, &now, apply_key],
+        )
+        .map_err(|error| error.to_string())?;
+    if updated == 1 {
+        return Ok(CorrectionFailureMarkState::MarkedFailed);
+    }
+
+    let status: Option<String> = db
+        .conn_ref()
+        .query_row(
+            "SELECT status
+               FROM claim_file_correction_apply_events
+              WHERE idempotency_key = ?1",
+            [apply_key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    match status.as_deref() {
+        Some("applied") => Ok(CorrectionFailureMarkState::AlreadyApplied),
+        Some("failed") => Ok(CorrectionFailureMarkState::MarkedFailed),
+        Some("claimed") => Err("correction apply event was not marked failed".to_string()),
+        Some(other) => Err(format!("unknown correction apply status `{other}`")),
+        None => Err("correction apply event missing while marking failed".to_string()),
+    }
+}
+
+fn correction_apply_claim_expired(claimed_at: &str, now: DateTime<Utc>) -> Result<bool, String> {
+    let claimed_at = DateTime::parse_from_rfc3339(claimed_at)
+        .map_err(|error| format!("invalid correction apply claimed_at: {error}"))?
+        .with_timezone(&Utc);
+    Ok(now.signed_duration_since(claimed_at)
+        > Duration::seconds(CLAIM_FILE_CORRECTION_APPLY_LEASE_SECS))
 }
 
 fn metadata_for_action(
@@ -1325,21 +1923,27 @@ fn verify_sidecar_contract(sidecar: &ClaimFileSidecar) -> Result<(), ClaimFileEr
     Ok(())
 }
 
+#[cfg(unix)]
 fn write_projection_files(
     workspace_root: &Path,
-    markdown_path: &Path,
-    sidecar_path: &Path,
+    markdown_rel_path: &Path,
+    sidecar_rel_path: &Path,
     markdown: &str,
     sidecar_json: &str,
 ) -> std::io::Result<()> {
-    let canonical_root = workspace_root.canonicalize()?;
-    create_projection_parent_dirs(&canonical_root, sidecar_path)?;
-    create_projection_parent_dirs(&canonical_root, markdown_path)?;
-    atomic_write_projection_file(sidecar_path, sidecar_json)?;
-    atomic_write_projection_file(markdown_path, markdown)?;
+    let markdown_rel_path = validate_projection_relative_path_for_io(markdown_rel_path)?;
+    let sidecar_rel_path = validate_projection_relative_path_for_io(sidecar_rel_path)?;
+    let root = open_workspace_root_dir(workspace_root)?;
+    let (sidecar_parent, sidecar_name) =
+        open_projection_parent_dir_at(&root, &sidecar_rel_path, true)?;
+    let (markdown_parent, markdown_name) =
+        open_projection_parent_dir_at(&root, &markdown_rel_path, true)?;
+    atomic_write_projection_file_at(&sidecar_parent, &sidecar_name, sidecar_json.as_bytes())?;
+    atomic_write_projection_file_at(&markdown_parent, &markdown_name, markdown.as_bytes())?;
     Ok(())
 }
 
+#[cfg(not(unix))]
 fn atomic_write_projection_file(path: &Path, content: &str) -> std::io::Result<()> {
     let parent = path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -1369,6 +1973,7 @@ fn atomic_write_projection_file(path: &Path, content: &str) -> std::io::Result<(
     write_result
 }
 
+#[cfg(not(unix))]
 fn write_projection_temp_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
     let mut options = fs::OpenOptions::new();
     options.write(true).create_new(true);
@@ -1383,6 +1988,7 @@ fn write_projection_temp_file(path: &Path, content: &[u8]) -> std::io::Result<()
     Ok(())
 }
 
+#[cfg(not(unix))]
 fn create_projection_parent_dirs(canonical_root: &Path, file_path: &Path) -> std::io::Result<()> {
     let parent = file_path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -1416,6 +2022,247 @@ fn create_projection_parent_dirs(canonical_root: &Path, file_path: &Path) -> std
         }
     }
     Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_projection_files(
+    workspace_root: &Path,
+    markdown_rel_path: &Path,
+    sidecar_rel_path: &Path,
+    markdown: &str,
+    sidecar_json: &str,
+) -> std::io::Result<()> {
+    let canonical_root = workspace_root.canonicalize()?;
+    let markdown_path = projection_abs_path_io(workspace_root, markdown_rel_path)?;
+    let sidecar_path = projection_abs_path_io(workspace_root, sidecar_rel_path)?;
+    create_projection_parent_dirs(&canonical_root, &sidecar_path)?;
+    create_projection_parent_dirs(&canonical_root, &markdown_path)?;
+    atomic_write_projection_file(&sidecar_path, sidecar_json)?;
+    atomic_write_projection_file(&markdown_path, markdown)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_workspace_root_dir(workspace_root: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::MetadataExt;
+
+    let requested_metadata = fs::symlink_metadata(workspace_root)?;
+    if requested_metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "workspace root must not be a symlink",
+        ));
+    }
+    if !requested_metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "workspace root must be a directory",
+        ));
+    }
+    let canonical_root = workspace_root.canonicalize()?;
+    let canonical_metadata = fs::symlink_metadata(&canonical_root)?;
+    let file = open_dir_path(&canonical_root)?;
+    let opened_metadata = file.metadata()?;
+    let requested_matches_opened = requested_metadata.dev() == opened_metadata.dev()
+        && requested_metadata.ino() == opened_metadata.ino();
+    let canonical_matches_opened = canonical_metadata.dev() == opened_metadata.dev()
+        && canonical_metadata.ino() == opened_metadata.ino();
+    if !requested_matches_opened || !canonical_matches_opened {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "workspace root changed while opening",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn open_dir_path(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::fd::FromRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains nul byte")
+    })?;
+    let fd = unsafe {
+        libc::open(
+            c_path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { fs::File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn duplicate_dir_fd(fd: std::os::fd::RawFd) -> std::io::Result<fs::File> {
+    use std::os::fd::FromRawFd;
+
+    let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+    if duped < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { fs::File::from_raw_fd(duped) })
+}
+
+#[cfg(unix)]
+fn open_projection_parent_dir_at(
+    root: &fs::File,
+    rel_path: &Path,
+    create: bool,
+) -> std::io::Result<(fs::File, OsString)> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let rel_path = validate_projection_relative_path_for_io(rel_path)?;
+    let file_name = rel_path.file_name().map(OsString::from).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path has no file name",
+        )
+    })?;
+    let parent = rel_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path has no parent",
+        )
+    })?;
+    let mut dir = duplicate_dir_fd(root.as_raw_fd())?;
+    for component in parent.components() {
+        let Component::Normal(name) = component else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "non-normal projection parent component",
+            ));
+        };
+        let c_name = cstring_from_os(name)?;
+        let mut fd = unsafe {
+            libc::openat(
+                dir.as_raw_fd(),
+                c_name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            let open_error = std::io::Error::last_os_error();
+            if create && open_error.kind() == std::io::ErrorKind::NotFound {
+                let mkdir_result =
+                    unsafe { libc::mkdirat(dir.as_raw_fd(), c_name.as_ptr(), 0o700) };
+                if mkdir_result < 0 {
+                    let mkdir_error = std::io::Error::last_os_error();
+                    if mkdir_error.kind() != std::io::ErrorKind::AlreadyExists {
+                        return Err(mkdir_error);
+                    }
+                }
+                fd = unsafe {
+                    libc::openat(
+                        dir.as_raw_fd(),
+                        c_name.as_ptr(),
+                        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                    )
+                };
+            }
+        }
+        if fd < 0 {
+            return Err(map_no_follow_io_error(std::io::Error::last_os_error()));
+        }
+        let next = unsafe { fs::File::from_raw_fd(fd) };
+        let metadata = next.metadata()?;
+        if !metadata.is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "projection ancestor is not a directory",
+            ));
+        }
+        dir = next;
+    }
+    Ok((dir, file_name))
+}
+
+#[cfg(unix)]
+fn atomic_write_projection_file_at(
+    parent: &fs::File,
+    file_name: &std::ffi::OsStr,
+    content: &[u8],
+) -> std::io::Result<()> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let final_name = cstring_from_os(file_name)?;
+    let tmp_name = OsString::from(format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    let tmp_name = cstring_from_os(&tmp_name)?;
+    let write_result = (|| {
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                tmp_name.as_ptr(),
+                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+        };
+        if fd < 0 {
+            return Err(map_no_follow_io_error(std::io::Error::last_os_error()));
+        }
+        let mut file = unsafe { fs::File::from_raw_fd(fd) };
+        file.write_all(content)?;
+        file.sync_all()?;
+        drop(file);
+        let renamed = unsafe {
+            libc::renameat(
+                parent.as_raw_fd(),
+                tmp_name.as_ptr(),
+                parent.as_raw_fd(),
+                final_name.as_ptr(),
+            )
+        };
+        if renamed < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = unsafe { libc::unlinkat(parent.as_raw_fd(), tmp_name.as_ptr(), 0) };
+    }
+    write_result
+}
+
+#[cfg(unix)]
+fn cstring_from_os(value: &std::ffi::OsStr) -> std::io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(value.as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path contains nul byte",
+        )
+    })
+}
+
+#[cfg(unix)]
+fn map_no_follow_io_error(error: std::io::Error) -> std::io::Error {
+    if error.raw_os_error() == Some(libc::ELOOP) {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path contains symlink",
+        )
+    } else {
+        error
+    }
+}
+
+fn validate_projection_relative_path_for_io(path: &Path) -> std::io::Result<PathBuf> {
+    validate_projection_relative_path(path)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string()))
+}
+
+#[cfg(not(unix))]
+fn projection_abs_path_io(workspace_root: &Path, rel_path: &Path) -> std::io::Result<PathBuf> {
+    projection_abs_path(workspace_root, rel_path)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string()))
 }
 
 fn validate_existing_projection_ancestors(
@@ -1475,8 +2322,9 @@ fn validate_projection_dir_metadata(
     Ok(())
 }
 
-fn read_stable_to_string(path: &Path) -> Result<String, ClaimFileError> {
-    let (mut file, before) = open_projection_file_no_follow(path)?;
+fn read_stable_to_string(workspace_root: &Path, rel_path: &Path) -> Result<String, ClaimFileError> {
+    let rel_path = validate_projection_relative_path(rel_path)?;
+    let (mut file, before) = open_projection_file_no_follow(workspace_root, &rel_path)?;
     let mut content = String::new();
     file.read_to_string(&mut content)?;
     let after = file.metadata()?;
@@ -1493,27 +2341,51 @@ fn read_stable_to_string(path: &Path) -> Result<String, ClaimFileError> {
 }
 
 #[cfg(unix)]
-fn open_projection_file_no_follow(path: &Path) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
-    use std::os::unix::fs::OpenOptionsExt;
+fn open_projection_file_no_follow(
+    workspace_root: &Path,
+    rel_path: &Path,
+) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
+    use std::os::fd::{AsRawFd, FromRawFd};
 
-    let file = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-        .map_err(|error| {
-            if error.raw_os_error() == Some(libc::ELOOP) {
-                ClaimFileError::PathRejected("projection file is a symlink".to_string())
+    let root = open_workspace_root_dir(workspace_root).map_err(ClaimFileError::Io)?;
+    let (parent, file_name) =
+        open_projection_parent_dir_at(&root, rel_path, false).map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP)
+                || error.kind() == std::io::ErrorKind::InvalidInput
+            {
+                ClaimFileError::PathRejected(error.to_string())
             } else {
                 ClaimFileError::Io(error)
             }
         })?;
+    let file_name = cstring_from_os(&file_name).map_err(ClaimFileError::Io)?;
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            file_name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        return Err(if error.raw_os_error() == Some(libc::ELOOP) {
+            ClaimFileError::PathRejected("projection file is a symlink".to_string())
+        } else {
+            ClaimFileError::Io(error)
+        });
+    }
+    let file = unsafe { fs::File::from_raw_fd(fd) };
     let metadata = file.metadata()?;
     validate_projection_file_metadata(&metadata)?;
     Ok((file, metadata))
 }
 
 #[cfg(not(unix))]
-fn open_projection_file_no_follow(path: &Path) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
+fn open_projection_file_no_follow(
+    workspace_root: &Path,
+    rel_path: &Path,
+) -> Result<(fs::File, fs::Metadata), ClaimFileError> {
+    let path = projection_abs_path(workspace_root, rel_path)?;
     let before = fs::symlink_metadata(path)?;
     validate_projection_file_metadata(&before)?;
     let file = fs::File::open(path)?;
@@ -1677,6 +2549,12 @@ fn slug_segment(raw: &str) -> String {
     }
 }
 
+fn projection_entity_slug(raw_id: &str, entity_subject_compact: &str) -> String {
+    let display_slug = slug_segment(raw_id);
+    let identity_hash = sha256_hex(entity_subject_compact.as_bytes());
+    format!("{}-{}", display_slug, &identity_hash[..12])
+}
+
 fn trust_band_label(score: Option<f64>) -> &'static str {
     match score {
         Some(score) if score >= 0.75 => "likely_current",
@@ -1746,7 +2624,8 @@ mod tests {
     use super::*;
     use crate::db::test_utils::test_db;
     use crate::services::claims::{
-        commit_claim, record_claim_feedback, ClaimFeedbackInput, ClaimProposal, CommittedClaim,
+        commit_claim, record_claim_feedback, record_claim_feedback_for_claim_file_apply,
+        ClaimError, ClaimFeedbackInput, ClaimFileFeedbackApplyInput, ClaimProposal, CommittedClaim,
         TombstoneSpec,
     };
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
@@ -1955,6 +2834,8 @@ mod tests {
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: checksum-1
 dailyos-action: wrong_source
 dailyos-payload: {}
@@ -1966,6 +2847,8 @@ dailyos-payload: {}
 
         assert_eq!(corrections.len(), 1);
         assert_eq!(corrections[0].action, FeedbackAction::WrongSource);
+        assert_eq!(corrections[0].projected_claim_version, 3);
+        assert_eq!(corrections[0].projected_identity_hash, "identity-hash-1");
         assert_eq!(
             corrections[0]
                 .metadata
@@ -1997,6 +2880,8 @@ dailyos-payload: {}
             let markdown = format!(
                 "<!-- dailyos-claim-start -->\n\
                  dailyos-claim-id: claim-1\n\
+                 dailyos-claim-version: 3\n\
+                 dailyos-identity-hash: identity-hash-1\n\
                  dailyos-sidecar-checksum: checksum-1\n\
                  dailyos-action: {slug}\n\
                  dailyos-payload: {payload}\n\
@@ -2012,11 +2897,43 @@ dailyos-payload: {}
     }
 
     #[test]
+    fn parser_rejects_stale_claim_version_and_identity_hash() {
+        let sidecar = fixture_sidecar();
+        let stale_version = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-claim-version: 2
+dailyos-identity-hash: identity-hash-1
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: mark_false
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+        let err = parse_markdown_corrections(stale_version, &sidecar, "checksum-1").unwrap_err();
+        assert!(err.to_string().contains("stale_projection_claim_version"));
+
+        let stale_identity = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: stale-identity
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: mark_false
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+        let err = parse_markdown_corrections(stale_identity, &sidecar, "checksum-1").unwrap_err();
+        assert!(err.to_string().contains("stale_projection_identity_hash"));
+    }
+
+    #[test]
     fn parser_rejects_ambiguous_unterminated_claim_block() {
         let sidecar = fixture_sidecar();
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: checksum-1
 dailyos-action: mark_false
 dailyos-payload: {}
@@ -2033,6 +2950,8 @@ dailyos-payload: {}
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: stale
 dailyos-action: mark_false
 dailyos-payload: {}
@@ -2050,6 +2969,8 @@ dailyos-payload: {}
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: stale
 dailyos-action: mark_false
 dailyos-payload: {}
@@ -2074,6 +2995,8 @@ dailyos-payload: {}
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: checksum-1
 dailyos-action: rewrite_claim
 dailyos-payload: {}
@@ -2098,6 +3021,8 @@ dailyos-payload: {}
         let markdown = "\
 <!-- dailyos-claim-start -->
 dailyos-claim-id: claim-1
+dailyos-claim-version: 3
+dailyos-identity-hash: identity-hash-1
 dailyos-sidecar-checksum: checksum-1
 dailyos-action: none
 dailyos-payload: {}
@@ -2146,6 +3071,20 @@ dailyos-action: mark_false\n\
         .is_err());
     }
 
+    #[test]
+    fn projection_entity_slug_disambiguates_colliding_display_slugs() {
+        assert_eq!(slug_segment("acct.example"), slug_segment("acct-example"));
+
+        let dotted =
+            projection_entity_slug("acct.example", r#"{"id":"acct.example","kind":"account"}"#);
+        let dashed =
+            projection_entity_slug("acct-example", r#"{"id":"acct-example","kind":"account"}"#);
+
+        assert_ne!(dotted, dashed);
+        assert!(dotted.starts_with("acct-example-"));
+        assert!(dashed.starts_with("acct-example-"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn projection_abs_path_rejects_managed_root_symlink() {
@@ -2187,8 +3126,11 @@ dailyos-action: mark_false\n\
         )
         .expect("projection file symlink");
 
-        let err =
-            read_stable_to_string(&projection_dir.join(CLAIM_FILE_MARKDOWN_NAME)).unwrap_err();
+        let err = read_stable_to_string(
+            workspace.path(),
+            Path::new("_dailyos_claims/account/acct-1/claims.md"),
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("symlink"));
     }
@@ -2211,10 +3153,70 @@ dailyos-action: mark_false\n\
         )
         .expect("projection file hardlink");
 
-        let err =
-            read_stable_to_string(&projection_dir.join(CLAIM_FILE_MARKDOWN_NAME)).unwrap_err();
+        let err = read_stable_to_string(
+            workspace.path(),
+            Path::new("_dailyos_claims/account/acct-1/claims.md"),
+        )
+        .unwrap_err();
 
         assert!(err.to_string().contains("hard links"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_projection_files_rejects_parent_symlink() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        let account_dir = workspace
+            .path()
+            .join(CLAIM_FILE_PROJECTION_ROOT)
+            .join("account");
+        std::fs::create_dir_all(&account_dir).expect("projection account dir");
+        std::os::unix::fs::symlink(outside.path(), account_dir.join("acct-1"))
+            .expect("parent symlink");
+
+        let err = write_projection_files(
+            workspace.path(),
+            Path::new("_dailyos_claims/account/acct-1/claims.md"),
+            Path::new("_dailyos_claims/account/acct-1/claims.corrections.json"),
+            "markdown",
+            "{}",
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("symlink")
+                || err.to_string().contains("not a directory")
+                || err.to_string().contains("Not a directory")
+        );
+        assert!(
+            !outside.path().join(CLAIM_FILE_MARKDOWN_NAME).exists(),
+            "writer must not follow parent symlink outside the workspace"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_projection_files_rejects_workspace_root_symlink() {
+        let outside = tempfile::tempdir().expect("outside");
+        let link_parent = tempfile::tempdir().expect("link parent");
+        let workspace_link = link_parent.path().join("workspace-link");
+        std::os::unix::fs::symlink(outside.path(), &workspace_link).expect("workspace symlink");
+
+        let err = write_projection_files(
+            &workspace_link,
+            Path::new("_dailyos_claims/account/acct-1/claims.md"),
+            Path::new("_dailyos_claims/account/acct-1/claims.corrections.json"),
+            "markdown",
+            "{}",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("symlink"));
+        assert!(
+            !outside.path().join(CLAIM_FILE_PROJECTION_ROOT).exists(),
+            "writer must not anchor projection IO through a symlinked workspace root"
+        );
     }
 
     #[test]
@@ -2281,6 +3283,464 @@ dailyos-action: mark_false\n\
         assert_eq!(sidecar_claim.lifecycle.claim_state, "withdrawn");
         assert_eq!(sidecar_claim.lifecycle.surfacing_state, "dormant");
         assert_eq!(sidecar_claim.feedback_rows.len(), 1);
+    }
+
+    #[test]
+    fn current_projection_failures_rejects_claim_version_drift_after_render() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, fixture_claim_proposal("Version drift fixture"))
+                .expect("commit projection claim"),
+        );
+        let bundle = build_render_bundle_db(&db, r#"{"kind":"account","id":"acct-1"}"#)
+            .expect("build render bundle");
+        let edited_markdown = bundle
+            .markdown
+            .replace("dailyos-action: none", "dailyos-action: mark_false");
+        let corrections =
+            parse_markdown_corrections(&edited_markdown, &bundle.sidecar, &bundle.sidecar_checksum)
+                .expect("parse edited projection");
+        assert_eq!(corrections.len(), 1);
+
+        record_claim_feedback(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::MarkOutdated,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+        )
+        .expect("record feedback after render");
+
+        let failures = current_projection_failures_db(&db, &bundle.sidecar, &corrections)
+            .expect("check current projection");
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].claim_id.as_deref(), Some(claim_id.as_str()));
+        assert_eq!(failures[0].error_class, "stale_projection");
+    }
+
+    #[test]
+    fn correction_apply_ledger_replays_applied_reclaims_failed_and_leased_events() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, fixture_claim_proposal("Apply ledger fixture"))
+                .expect("commit projection claim"),
+        );
+        let correction = ParsedCorrection {
+            claim_id: claim_id.clone(),
+            projected_claim_version: 1,
+            projected_identity_hash: "identity-hash".to_string(),
+            action: FeedbackAction::ConfirmCurrent,
+            metadata: None,
+        };
+        let payload_hash = correction_payload_hash(&correction);
+        let apply_key =
+            correction_apply_idempotency_key("sidecar-checksum", &correction, &payload_hash);
+
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &apply_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("claim apply"),
+            CorrectionApplyState::Claimed
+        );
+        let feedback = record_claim_feedback_for_claim_file_apply(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::ConfirmCurrent,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+            ClaimFileFeedbackApplyInput {
+                expected_claim_version: correction.projected_claim_version,
+                correction_apply_key: apply_key.clone(),
+            },
+        )
+        .expect("record feedback id");
+        let stored_feedback_id: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_id
+                   FROM claim_file_correction_apply_events
+                  WHERE idempotency_key = ?1
+                    AND status = 'applied'",
+                [&apply_key],
+                |row| row.get(0),
+            )
+            .optional()
+            .expect("read applied feedback id");
+        assert_eq!(
+            stored_feedback_id.as_deref(),
+            Some(feedback.feedback_id.as_str())
+        );
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &apply_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("replay applied"),
+            CorrectionApplyState::AlreadyApplied
+        );
+
+        let failed_key = format!("{apply_key}-failed");
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &failed_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("claim failed apply"),
+            CorrectionApplyState::Claimed
+        );
+        mark_correction_apply_failed_db(&db, &failed_key, &redacted_hash("rerender failed"))
+            .expect("mark failed");
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &failed_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("reclaim failed"),
+            CorrectionApplyState::Claimed
+        );
+
+        let leased_key = format!("{apply_key}-leased");
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &leased_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("claim leased apply"),
+            CorrectionApplyState::Claimed
+        );
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &leased_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("fresh claim is in progress"),
+            CorrectionApplyState::InProgress
+        );
+        let expired_at = (Utc::now()
+            - Duration::seconds(CLAIM_FILE_CORRECTION_APPLY_LEASE_SECS + 1))
+        .to_rfc3339();
+        db.conn_ref()
+            .execute(
+                "UPDATE claim_file_correction_apply_events
+                    SET claimed_at = ?1,
+                        updated_at = ?1
+                  WHERE idempotency_key = ?2",
+                params![&expired_at, &leased_key],
+            )
+            .expect("age leased claim");
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &leased_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("expired claim is reclaimed"),
+            CorrectionApplyState::Claimed
+        );
+    }
+
+    #[test]
+    fn claim_file_feedback_apply_rejects_stale_expected_version_inside_writer_transaction() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        let claim_id = inserted_claim_id(
+            commit_claim(
+                &ctx,
+                &db,
+                fixture_claim_proposal("Atomic stale feedback fixture"),
+            )
+            .expect("commit projection claim"),
+        );
+        let correction = ParsedCorrection {
+            claim_id: claim_id.clone(),
+            projected_claim_version: 1,
+            projected_identity_hash: "identity-hash".to_string(),
+            action: FeedbackAction::ConfirmCurrent,
+            metadata: None,
+        };
+        let payload_hash = correction_payload_hash(&correction);
+        let apply_key =
+            correction_apply_idempotency_key("sidecar-checksum", &correction, &payload_hash);
+        assert_eq!(
+            claim_correction_apply_db(
+                &db,
+                &CorrectionApplyRecord {
+                    apply_key: &apply_key,
+                    sidecar_checksum: "sidecar-checksum",
+                    claim_id: &claim_id,
+                    projected_claim_version: correction.projected_claim_version,
+                    projected_identity_hash: &correction.projected_identity_hash,
+                    feedback_action: correction.action.as_str(),
+                    payload_hash: &payload_hash,
+                },
+            )
+            .expect("claim apply"),
+            CorrectionApplyState::Claimed
+        );
+        record_claim_feedback(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::MarkOutdated,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+        )
+        .expect("bump claim version after projection");
+        let before_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                   FROM claim_feedback
+                  WHERE claim_id = ?1",
+                [&claim_id],
+                |row| row.get(0),
+            )
+            .expect("feedback count before stale apply");
+
+        let err = record_claim_feedback_for_claim_file_apply(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::ConfirmCurrent,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+            ClaimFileFeedbackApplyInput {
+                expected_claim_version: 1,
+                correction_apply_key: apply_key.clone(),
+            },
+        )
+        .expect_err("stale projected version must reject inside the writer transaction");
+        assert!(matches!(
+            err,
+            ClaimError::StaleVersion {
+                claim_id: ref stale_claim_id,
+                expected: 1,
+                current: 2,
+            } if stale_claim_id == &claim_id
+        ));
+        let after_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                   FROM claim_feedback
+                  WHERE claim_id = ?1",
+                [&claim_id],
+                |row| row.get(0),
+            )
+            .expect("feedback count after stale apply");
+        assert_eq!(after_count, before_count);
+        let status: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT status
+                   FROM claim_file_correction_apply_events
+                  WHERE idempotency_key = ?1",
+                [&apply_key],
+                |row| row.get(0),
+            )
+            .expect("read apply status");
+        assert_eq!(status, "claimed");
+    }
+
+    #[test]
+    fn resumed_expired_worker_does_not_overwrite_newer_applied_correction() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        let claim_id = inserted_claim_id(
+            commit_claim(
+                &ctx,
+                &db,
+                fixture_claim_proposal("Expired worker replay fixture"),
+            )
+            .expect("commit projection claim"),
+        );
+        let correction = ParsedCorrection {
+            claim_id: claim_id.clone(),
+            projected_claim_version: 1,
+            projected_identity_hash: "identity-hash".to_string(),
+            action: FeedbackAction::ConfirmCurrent,
+            metadata: None,
+        };
+        let payload_hash = correction_payload_hash(&correction);
+        let apply_key =
+            correction_apply_idempotency_key("sidecar-checksum", &correction, &payload_hash);
+        let record = CorrectionApplyRecord {
+            apply_key: &apply_key,
+            sidecar_checksum: "sidecar-checksum",
+            claim_id: &claim_id,
+            projected_claim_version: correction.projected_claim_version,
+            projected_identity_hash: &correction.projected_identity_hash,
+            feedback_action: correction.action.as_str(),
+            payload_hash: &payload_hash,
+        };
+
+        assert_eq!(
+            claim_correction_apply_db(&db, &record).expect("worker A claims correction"),
+            CorrectionApplyState::Claimed
+        );
+        let expired_at = (Utc::now()
+            - Duration::seconds(CLAIM_FILE_CORRECTION_APPLY_LEASE_SECS + 1))
+        .to_rfc3339();
+        db.conn_ref()
+            .execute(
+                "UPDATE claim_file_correction_apply_events
+                    SET claimed_at = ?1,
+                        updated_at = ?1
+                  WHERE idempotency_key = ?2",
+                params![&expired_at, &apply_key],
+            )
+            .expect("expire worker A lease");
+        assert_eq!(
+            claim_correction_apply_db(&db, &record).expect("worker B reclaims expired correction"),
+            CorrectionApplyState::Claimed
+        );
+        let applied = record_claim_feedback_for_claim_file_apply(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::ConfirmCurrent,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+            ClaimFileFeedbackApplyInput {
+                expected_claim_version: 1,
+                correction_apply_key: apply_key.clone(),
+            },
+        )
+        .expect("worker B atomically applies no-op feedback");
+        let worker_a_err = record_claim_feedback_for_claim_file_apply(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action: FeedbackAction::ConfirmCurrent,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+            ClaimFileFeedbackApplyInput {
+                expected_claim_version: 1,
+                correction_apply_key: apply_key.clone(),
+            },
+        )
+        .expect_err("worker A cannot apply after worker B finalized the ledger");
+        assert!(
+            worker_a_err.to_string().contains("was not claimable"),
+            "unexpected worker A error: {worker_a_err}"
+        );
+
+        assert_eq!(
+            mark_correction_apply_failed_db(&db, &apply_key, &redacted_hash("worker A failed"))
+                .expect("worker A failure cleanup"),
+            CorrectionFailureMarkState::AlreadyApplied
+        );
+        let (status, feedback_id): (String, Option<String>) = db
+            .conn_ref()
+            .query_row(
+                "SELECT status, feedback_id
+                   FROM claim_file_correction_apply_events
+                  WHERE idempotency_key = ?1",
+                [&apply_key],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read final apply row");
+        assert_eq!(status, "applied");
+        assert_eq!(feedback_id.as_deref(), Some(applied.feedback_id.as_str()));
+        assert_eq!(
+            claim_correction_apply_db(&db, &record).expect("future retry reads applied"),
+            CorrectionApplyState::AlreadyApplied
+        );
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                   FROM claim_feedback
+                  WHERE claim_id = ?1",
+                [&claim_id],
+                |row| row.get(0),
+            )
+            .expect("count feedback rows");
+        assert_eq!(feedback_count, 1);
     }
 
     #[test]
@@ -2442,5 +3902,89 @@ dailyos-action: mark_false\n\
             Some(bundle.run_id.as_str())
         );
         assert!(repaired_membership_count > 0);
+    }
+
+    #[test]
+    fn projection_path_binding_rejects_same_path_for_different_subject() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        commit_claim(&ctx, &db, fixture_claim_proposal("Path binding fixture"))
+            .expect("commit projection claim");
+        let bundle = build_render_bundle_db(&db, r#"{"kind":"account","id":"acct-1"}"#)
+            .expect("build render bundle");
+
+        ensure_projection_path_binding(&db, &bundle, TEST_TS).expect("bind projection path");
+
+        let mut collision = bundle.clone();
+        collision.entity_subject_compact = r#"{"id":"acct-2","kind":"account"}"#.to_string();
+        let err = ensure_projection_path_binding(&db, &collision, TEST_TS)
+            .expect_err("same path must not bind a different subject");
+
+        assert!(err.contains("projection path collision"));
+    }
+
+    #[test]
+    fn committed_sidecar_validation_requires_recorded_run_and_claim_membership() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+        commit_claim(
+            &ctx,
+            &db,
+            fixture_claim_proposal("Committed sidecar fixture"),
+        )
+        .expect("commit projection claim");
+        let bundle = build_render_bundle_db(&db, r#"{"kind":"account","id":"acct-1"}"#)
+            .expect("build render bundle");
+
+        ensure_projection_path_binding(&db, &bundle, TEST_TS).expect("bind projection path");
+        let err = validate_committed_sidecar_projection_db(
+            &db,
+            &bundle.sidecar,
+            &bundle.sidecar_checksum,
+        )
+        .expect_err("sidecar without a committed run must not apply");
+        assert!(err.contains("committed projection run not found"));
+
+        insert_projection_run(&db, &bundle, "committed", None, None, None)
+            .expect("record committed projection");
+        let committed = validate_committed_sidecar_projection_db(
+            &db,
+            &bundle.sidecar,
+            &bundle.sidecar_checksum,
+        )
+        .expect("validate committed sidecar");
+        assert_eq!(committed.run_id, bundle.run_id);
+
+        let mut tampered_membership = bundle.sidecar.clone();
+        tampered_membership.claims[0]
+            .semantic_identity
+            .dedup_key_components_hash
+            .push_str("-tampered");
+        let err = validate_committed_sidecar_projection_db(
+            &db,
+            &tampered_membership,
+            &bundle.sidecar_checksum,
+        )
+        .expect_err("sidecar claim identity tampering must not apply");
+        assert!(err.contains("projection claim membership mismatch"));
+
+        let mut tampered_paths = bundle.sidecar.clone();
+        tampered_paths.markdown_rel_path = "_dailyos_claims/account/acct-1/claims.md".to_string();
+        tampered_paths.sidecar_rel_path =
+            "_dailyos_claims/account/acct-1/claims.corrections.json".to_string();
+        let tampered_checksum = sha256_hex(
+            serde_json::to_string_pretty(&tampered_paths)
+                .unwrap()
+                .as_bytes(),
+        );
+        let err =
+            validate_committed_sidecar_projection_db(&db, &tampered_paths, &tampered_checksum)
+                .expect_err("recomputed sidecar path tampering must not match a committed run");
+        assert!(
+            err.contains("projection path binding missing")
+                || err.contains("committed projection run not found")
+        );
     }
 }

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -1,0 +1,1881 @@
+//! Readable claim-file projection and correction apply service (DOS-628).
+//!
+//! Files under `_dailyos_claims` are projections of canonical claims. They are
+//! never source evidence, and applying edits routes through the existing
+//! receipt-level feedback path.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use abilities_runtime::abilities::feedback::FeedbackAction;
+use abilities_runtime::abilities::provenance::subject::SubjectRef as ReceiptSubjectRef;
+use abilities_runtime::sensitivity::RenderActor;
+use abilities_runtime::types::{ClaimSensitivity, ClaimSubjectRef, IntelligenceClaim};
+use chrono::Utc;
+use rusqlite::params;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::db::ActionDb;
+use crate::services::claim_receipt::contracts::{ReceiptTarget, SurfaceContext};
+use crate::services::claim_receipt::feedback::{
+    submit_claim_feedback, ClaimFeedbackRequest, ClaimFeedbackResponse, IdempotencyCache,
+};
+use crate::services::entity_intelligence::auth::{EnvelopeSet, EnvelopeView};
+use crate::services::workspace_ingestion::registry::CLAIM_FILE_PROJECTION_ROOT;
+use crate::state::AppState;
+
+pub const CLAIM_FILE_PROJECTION_VERSION: u32 = 1;
+pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_MARKDOWN_NAME: &str = "claims.md";
+pub const CLAIM_FILE_SIDECAR_NAME: &str = "claims.corrections.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClaimFileError {
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    #[error("path rejected: {0}")]
+    PathRejected(String),
+    #[error("projection failed: {0}")]
+    ProjectionFailed(String),
+    #[error("apply failed: {0}")]
+    ApplyFailed(String),
+    #[error("db: {0}")]
+    Db(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileProjectionResult {
+    pub run_id: String,
+    pub markdown_rel_path: String,
+    pub sidecar_rel_path: String,
+    pub claim_count: usize,
+    pub markdown_checksum: String,
+    pub sidecar_checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileApplyResult {
+    pub applied_count: usize,
+    pub skipped_count: usize,
+    pub failures: Vec<ClaimFileApplyFailure>,
+    pub responses: Vec<ClaimFeedbackResponse>,
+    pub rerender: Option<ClaimFileProjectionResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileApplyFailure {
+    pub claim_id: Option<String>,
+    pub error_class: String,
+    pub error_detail_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileSidecar {
+    pub schema_version: u32,
+    pub projection_version: u32,
+    pub entity_subject_ref: serde_json::Value,
+    pub entity_subject_compact: String,
+    pub markdown_rel_path: String,
+    pub sidecar_rel_path: String,
+    pub claims: Vec<ClaimFileClaim>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileClaim {
+    pub semantic_identity: ClaimSemanticIdentityV1,
+    pub runtime_claim_id: String,
+    pub runtime_claim_version: u64,
+    pub claim_text: String,
+    pub trust_band: String,
+    pub sensitivity: String,
+    pub lifecycle: ClaimFileLifecycle,
+    pub provenance_summary: ClaimFileProvenanceSummary,
+    pub feedback_rows: Vec<ClaimFileFeedbackRow>,
+    pub contradiction_edges: Vec<ClaimFileContradictionEdge>,
+    pub replay_status: ClaimFileReplayStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimSemanticIdentityV1 {
+    pub identity_version: u32,
+    pub identity_kind: String,
+    pub item_hash: String,
+    pub subject_ref_compact: String,
+    pub subject_ref: serde_json::Value,
+    pub claim_type: String,
+    pub field_path: Option<String>,
+    pub dedup_key_components_hash: String,
+    pub source_ref: Option<String>,
+    pub data_source: String,
+    pub observed_at: String,
+    pub source_asof: Option<String>,
+    pub source_content_hash: Option<String>,
+    pub runtime_claim_id: String,
+    pub runtime_claim_version: u64,
+    pub claim_state: String,
+    pub superseded_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileProvenanceSummary {
+    pub data_source: String,
+    pub source_ref: Option<String>,
+    pub source_asof: Option<String>,
+    pub observed_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileFeedbackRow {
+    pub action: String,
+    pub actor: String,
+    pub actor_id: Option<String>,
+    pub payload_json: Option<serde_json::Value>,
+    pub submitted_at: String,
+    pub applied_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileLifecycle {
+    pub claim_state: String,
+    pub surfacing_state: String,
+    pub demotion_reason: Option<String>,
+    pub retraction_reason: Option<String>,
+    pub superseded_by: Option<String>,
+    pub verification_state: String,
+    pub verification_reason: Option<String>,
+    pub needs_user_decision_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileContradictionEdge {
+    pub edge_id: String,
+    pub branch_kind: String,
+    pub role: String,
+    pub primary_runtime_claim_id: String,
+    pub contradicting_runtime_claim_id: String,
+    pub primary_semantic_identity: Option<ClaimSemanticIdentityV1>,
+    pub contradicting_semantic_identity: Option<ClaimSemanticIdentityV1>,
+    pub detected_at: String,
+    pub reconciliation_kind: Option<String>,
+    pub reconciliation_note: Option<String>,
+    pub reconciled_at: Option<String>,
+    pub winner_runtime_claim_id: Option<String>,
+    pub merged_runtime_claim_id: Option<String>,
+    pub replay_status: ClaimFileReplayStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimFileReplayStatus {
+    pub status: String,
+    pub reason: Option<String>,
+    pub last_attempted_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RenderBundle {
+    run_id: String,
+    subject_ref_json: String,
+    entity_subject_compact: String,
+    markdown_rel_path: PathBuf,
+    sidecar_rel_path: PathBuf,
+    entity_claim_invalidation_version: i64,
+    claim_watermark: String,
+    markdown: String,
+    sidecar: ClaimFileSidecar,
+    sidecar_json: String,
+    markdown_checksum: String,
+    sidecar_checksum: String,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedCorrection {
+    claim_id: String,
+    action: FeedbackAction,
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone)]
+struct FileEnvelope {
+    claim_ids: BTreeSet<String>,
+}
+
+impl EnvelopeView for FileEnvelope {
+    fn ability(&self) -> &str {
+        "claim_file_projection"
+    }
+
+    fn claim_ids(&self) -> BTreeSet<String> {
+        self.claim_ids.clone()
+    }
+
+    fn proposal_ids(&self) -> BTreeSet<String> {
+        BTreeSet::new()
+    }
+}
+
+pub async fn render_entity_claim_file(
+    state: &AppState,
+    workspace_root: PathBuf,
+    subject_ref_json: String,
+) -> Result<ClaimFileProjectionResult, ClaimFileError> {
+    let bundle = build_render_bundle(state, subject_ref_json).await?;
+    let markdown_path = projection_abs_path(&workspace_root, &bundle.markdown_rel_path)?;
+    let sidecar_path = projection_abs_path(&workspace_root, &bundle.sidecar_rel_path)?;
+
+    let write_result = write_projection_files(
+        &workspace_root,
+        &markdown_path,
+        &sidecar_path,
+        &bundle.markdown,
+        &bundle.sidecar_json,
+    );
+    record_projection_run(state, &bundle, write_result.as_ref().err()).await?;
+    write_result?;
+
+    Ok(ClaimFileProjectionResult {
+        run_id: bundle.run_id,
+        markdown_rel_path: path_to_slash_string(&bundle.markdown_rel_path),
+        sidecar_rel_path: path_to_slash_string(&bundle.sidecar_rel_path),
+        claim_count: bundle.sidecar.claims.len(),
+        markdown_checksum: bundle.markdown_checksum,
+        sidecar_checksum: bundle.sidecar_checksum,
+    })
+}
+
+pub async fn apply_claim_file_corrections(
+    state: &AppState,
+    workspace_root: PathBuf,
+    markdown_rel_path: PathBuf,
+    actor_principal_id: String,
+) -> Result<ClaimFileApplyResult, ClaimFileError> {
+    let markdown_rel_path = validate_projection_relative_path(&markdown_rel_path)?;
+    let markdown_path = projection_abs_path(&workspace_root, &markdown_rel_path)?;
+    let sidecar_rel_path = sidecar_path_for_markdown_rel(&markdown_rel_path)?;
+    let sidecar_path = projection_abs_path(&workspace_root, &sidecar_rel_path)?;
+
+    let markdown = read_stable_to_string(&markdown_path)?;
+    let sidecar_json = read_stable_to_string(&sidecar_path)?;
+    let sidecar_checksum = sha256_hex(sidecar_json.as_bytes());
+    let sidecar: ClaimFileSidecar = serde_json::from_str(&sidecar_json)?;
+    verify_sidecar_contract(&sidecar)?;
+    verify_sidecar_paths(&sidecar, &markdown_rel_path, &sidecar_rel_path)?;
+
+    let corrections = parse_markdown_corrections(&markdown, &sidecar, &sidecar_checksum)?;
+    if corrections.is_empty() {
+        return Ok(ClaimFileApplyResult {
+            applied_count: 0,
+            skipped_count: sidecar.claims.len(),
+            failures: Vec::new(),
+            responses: Vec::new(),
+            rerender: None,
+        });
+    }
+
+    let claim_ids = sidecar
+        .claims
+        .iter()
+        .map(|claim| claim.runtime_claim_id.clone())
+        .collect::<BTreeSet<_>>();
+    let envelope = FileEnvelope { claim_ids };
+    let set = EnvelopeSet::new(&envelope);
+    let actor = RenderActor::user(actor_principal_id.clone(), Some(actor_principal_id.clone()));
+    let cache = IdempotencyCache::new();
+    let mut responses = Vec::new();
+    let mut failures = Vec::new();
+
+    for correction in corrections {
+        let target = receipt_target_for_claim(&sidecar, &correction.claim_id)?;
+        let request = ClaimFeedbackRequest {
+            target,
+            action: correction.action,
+            surface: SurfaceContext::EntityDetail,
+            metadata: correction.metadata,
+            idempotency_key: None,
+        };
+        match submit_claim_feedback(state, &set, &actor, &cache, request).await {
+            Ok(response) => responses.push(response),
+            Err(error) => failures.push(ClaimFileApplyFailure {
+                claim_id: Some(correction.claim_id),
+                error_class: "feedback_rejected".to_string(),
+                error_detail_hash: redacted_hash(&error.to_string()),
+            }),
+        }
+    }
+
+    let rerender = if failures.is_empty() {
+        Some(
+            render_entity_claim_file(
+                state,
+                workspace_root,
+                serde_json::to_string(&sidecar.entity_subject_ref)?,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    Ok(ClaimFileApplyResult {
+        applied_count: responses.len(),
+        skipped_count: sidecar
+            .claims
+            .len()
+            .saturating_sub(responses.len() + failures.len()),
+        failures,
+        responses,
+        rerender,
+    })
+}
+
+async fn build_render_bundle(
+    state: &AppState,
+    subject_ref_json: String,
+) -> Result<RenderBundle, ClaimFileError> {
+    state
+        .db_read(move |db| build_render_bundle_db(db, &subject_ref_json))
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+fn build_render_bundle_db(db: &ActionDb, subject_ref_json: &str) -> Result<RenderBundle, String> {
+    let subject_value: serde_json::Value =
+        serde_json::from_str(subject_ref_json).map_err(|error| error.to_string())?;
+    let subject = abilities_runtime::types::subject_ref_from_json(&subject_value)
+        .map_err(|error| format!("subject_ref: {error}"))?;
+    let entity_subject_compact = compact_subject_label(&subject);
+    let entity_kind = supported_entity_kind_slug(&subject).ok_or_else(|| {
+        "claim file projection supports account/project/person subjects".to_string()
+    })?;
+    let entity_id = subject_id_for_path(&subject)
+        .ok_or_else(|| "claim file projection subject requires an id".to_string())?;
+    let entity_slug = slug_segment(entity_id);
+    let markdown_rel_path = PathBuf::from(CLAIM_FILE_PROJECTION_ROOT)
+        .join(entity_kind)
+        .join(entity_slug)
+        .join(CLAIM_FILE_MARKDOWN_NAME);
+    let sidecar_rel_path = PathBuf::from(CLAIM_FILE_PROJECTION_ROOT)
+        .join(entity_kind)
+        .join(slug_segment(entity_id))
+        .join(CLAIM_FILE_SIDECAR_NAME);
+
+    let mut claims = load_claims_for_projection(db, subject_ref_json, entity_kind, entity_id)?;
+    claims.sort_by(|a, b| {
+        a.claim_type
+            .cmp(&b.claim_type)
+            .then_with(|| a.field_path.cmp(&b.field_path))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let entity_claim_invalidation_version = current_entity_claim_version(db, &subject)?;
+    let claim_watermark = claim_watermark(&claims, entity_claim_invalidation_version);
+    let claim_file_claims = claims
+        .iter()
+        .map(|claim| claim_file_claim(db, claim))
+        .collect::<Result<Vec<_>, _>>()?;
+    let sidecar = ClaimFileSidecar {
+        schema_version: CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+        projection_version: CLAIM_FILE_PROJECTION_VERSION,
+        entity_subject_ref: subject_value,
+        entity_subject_compact: entity_subject_compact.clone(),
+        markdown_rel_path: path_to_slash_string(&markdown_rel_path),
+        sidecar_rel_path: path_to_slash_string(&sidecar_rel_path),
+        claims: claim_file_claims,
+    };
+    let sidecar_json = serde_json::to_string_pretty(&sidecar).map_err(|error| error.to_string())?;
+    let sidecar_checksum = sha256_hex(sidecar_json.as_bytes());
+    let markdown = render_markdown(&sidecar, &sidecar_checksum);
+    let markdown_checksum = sha256_hex(markdown.as_bytes());
+
+    Ok(RenderBundle {
+        run_id: uuid::Uuid::new_v4().to_string(),
+        subject_ref_json: subject_ref_json.to_string(),
+        entity_subject_compact,
+        markdown_rel_path,
+        sidecar_rel_path,
+        entity_claim_invalidation_version,
+        claim_watermark,
+        markdown,
+        sidecar,
+        sidecar_json,
+        markdown_checksum,
+        sidecar_checksum,
+    })
+}
+
+fn load_claims_for_projection(
+    db: &ActionDb,
+    subject_ref_json: &str,
+    entity_kind: &str,
+    entity_id: &str,
+) -> Result<Vec<IntelligenceClaim>, String> {
+    let mut claims = crate::services::claims::load_claims_active(db, subject_ref_json, None)
+        .map_err(|error| error.to_string())?;
+    let mut existing_ids = claims
+        .iter()
+        .map(|claim| claim.id.clone())
+        .collect::<BTreeSet<_>>();
+    for claim_id in correction_bearing_terminal_claim_ids(db, entity_kind, entity_id)? {
+        if !existing_ids.insert(claim_id.clone()) {
+            continue;
+        }
+        if let Some(claim) = crate::services::claims::load_claim_by_id(db.conn_ref(), &claim_id)
+            .map_err(|error| error.to_string())?
+        {
+            claims.push(claim);
+        }
+    }
+    Ok(claims)
+}
+
+fn correction_bearing_terminal_claim_ids(
+    db: &ActionDb,
+    entity_kind: &str,
+    entity_id: &str,
+) -> Result<Vec<String>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT ic.id
+             FROM intelligence_claims ic
+             WHERE json_valid(ic.subject_ref) = 1
+               AND lower(json_extract(ic.subject_ref, '$.kind')) = lower(?1)
+               AND json_extract(ic.subject_ref, '$.id') = ?2
+               AND NOT (ic.claim_state = 'active' AND ic.surfacing_state = 'active')
+               AND EXISTS (
+                   SELECT 1
+                   FROM claim_feedback cf
+                   WHERE cf.claim_id = ic.id
+               )
+             ORDER BY ic.created_at ASC, ic.id ASC",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = stmt
+        .query_map(params![entity_kind, entity_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|error| error.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|error| error.to_string())?);
+    }
+    Ok(out)
+}
+
+fn claim_file_claim(db: &ActionDb, claim: &IntelligenceClaim) -> Result<ClaimFileClaim, String> {
+    let semantic_identity = semantic_identity_for_loaded_claim(claim)?;
+    Ok(ClaimFileClaim {
+        runtime_claim_id: claim.id.clone(),
+        runtime_claim_version: claim.claim_version,
+        claim_text: claim.text.clone(),
+        trust_band: trust_band_label(claim.trust_score).to_string(),
+        sensitivity: sensitivity_label(&claim.sensitivity),
+        lifecycle: lifecycle_for_claim(claim),
+        provenance_summary: ClaimFileProvenanceSummary {
+            data_source: claim.data_source.clone(),
+            source_ref: claim.source_ref.clone(),
+            source_asof: claim.source_asof.clone(),
+            observed_at: claim.observed_at.clone(),
+        },
+        feedback_rows: load_feedback_rows(db, &claim.id)?,
+        contradiction_edges: load_contradiction_edges(db, &claim.id)?,
+        replay_status: projected_replay_status(),
+        semantic_identity,
+    })
+}
+
+fn semantic_identity_for_loaded_claim(
+    claim: &IntelligenceClaim,
+) -> Result<ClaimSemanticIdentityV1, String> {
+    let subject_value: serde_json::Value =
+        serde_json::from_str(&claim.subject_ref).map_err(|error| error.to_string())?;
+    let subject = abilities_runtime::types::subject_ref_from_json(&subject_value)
+        .map_err(|error| format!("claim subject_ref: {error}"))?;
+    let subject_ref_compact = compact_subject_label(&subject);
+    Ok(semantic_identity_for_claim(
+        claim,
+        subject_value,
+        subject_ref_compact,
+    ))
+}
+
+fn lifecycle_for_claim(claim: &IntelligenceClaim) -> ClaimFileLifecycle {
+    ClaimFileLifecycle {
+        claim_state: format!("{:?}", claim.claim_state).to_ascii_lowercase(),
+        surfacing_state: format!("{:?}", claim.surfacing_state).to_ascii_lowercase(),
+        demotion_reason: claim.demotion_reason.clone(),
+        retraction_reason: claim.retraction_reason.clone(),
+        superseded_by: claim.superseded_by.clone(),
+        verification_state: format!("{:?}", claim.verification_state).to_ascii_lowercase(),
+        verification_reason: claim.verification_reason.clone(),
+        needs_user_decision_at: claim.needs_user_decision_at.clone(),
+    }
+}
+
+fn projected_replay_status() -> ClaimFileReplayStatus {
+    ClaimFileReplayStatus {
+        status: "projected".to_string(),
+        reason: None,
+        last_attempted_at: None,
+    }
+}
+
+fn semantic_identity_for_claim(
+    claim: &IntelligenceClaim,
+    subject_ref: serde_json::Value,
+    subject_ref_compact: String,
+) -> ClaimSemanticIdentityV1 {
+    let item_hash = claim
+        .item_hash
+        .clone()
+        .unwrap_or_else(|| sha256_hex(claim.text.as_bytes()));
+    let identity_kind = if claim.claim_type == "user_note" {
+        "user_note_v1"
+    } else {
+        "claim_dedup_v1"
+    };
+    let field_path_component = claim.field_path.clone().unwrap_or_default();
+    let components = format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        item_hash, subject_ref_compact, claim.claim_type, field_path_component
+    );
+    ClaimSemanticIdentityV1 {
+        identity_version: 1,
+        identity_kind: identity_kind.to_string(),
+        item_hash,
+        subject_ref_compact,
+        subject_ref,
+        claim_type: claim.claim_type.clone(),
+        field_path: claim.field_path.clone(),
+        dedup_key_components_hash: sha256_hex(components.as_bytes()),
+        source_ref: claim.source_ref.clone(),
+        data_source: claim.data_source.clone(),
+        observed_at: claim.observed_at.clone(),
+        source_asof: claim.source_asof.clone(),
+        source_content_hash: Some(source_content_hash_for_claim(claim)),
+        runtime_claim_id: claim.id.clone(),
+        runtime_claim_version: claim.claim_version,
+        claim_state: format!("{:?}", claim.claim_state).to_ascii_lowercase(),
+        superseded_by: claim.superseded_by.clone(),
+    }
+}
+
+fn load_feedback_rows(db: &ActionDb, claim_id: &str) -> Result<Vec<ClaimFileFeedbackRow>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
+             FROM claim_feedback
+             WHERE claim_id = ?1
+             ORDER BY submitted_at ASC, id ASC",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = stmt
+        .query_map(params![claim_id], |row| {
+            let payload_raw: Option<String> = row.get(3)?;
+            Ok(ClaimFileFeedbackRow {
+                action: row.get(0)?,
+                actor: row.get(1)?,
+                actor_id: row.get(2)?,
+                payload_json: payload_raw
+                    .as_deref()
+                    .and_then(|raw| serde_json::from_str(raw).ok()),
+                submitted_at: row.get(4)?,
+                applied_at: row.get(5)?,
+            })
+        })
+        .map_err(|error| error.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|error| error.to_string())?);
+    }
+    Ok(out)
+}
+
+fn load_contradiction_edges(
+    db: &ActionDb,
+    claim_id: &str,
+) -> Result<Vec<ClaimFileContradictionEdge>, String> {
+    let mut stmt = db
+        .conn_ref()
+        .prepare(
+            "SELECT id, primary_claim_id, contradicting_claim_id, branch_kind, detected_at,
+                    reconciliation_kind, reconciliation_note, reconciled_at, winner_claim_id,
+                    merged_claim_id
+             FROM claim_contradictions
+             WHERE primary_claim_id = ?1 OR contradicting_claim_id = ?1
+             ORDER BY detected_at ASC, id ASC",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = stmt
+        .query_map(params![claim_id], |row| {
+            Ok(ContradictionEdgeRow {
+                edge_id: row.get(0)?,
+                primary_claim_id: row.get(1)?,
+                contradicting_claim_id: row.get(2)?,
+                branch_kind: row.get(3)?,
+                detected_at: row.get(4)?,
+                reconciliation_kind: row.get(5)?,
+                reconciliation_note: row.get(6)?,
+                reconciled_at: row.get(7)?,
+                winner_claim_id: row.get(8)?,
+                merged_claim_id: row.get(9)?,
+            })
+        })
+        .map_err(|error| error.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        let row = row.map_err(|error| error.to_string())?;
+        let primary_semantic_identity = semantic_identity_for_claim_id(db, &row.primary_claim_id)?;
+        let contradicting_semantic_identity =
+            semantic_identity_for_claim_id(db, &row.contradicting_claim_id)?;
+        out.push(ClaimFileContradictionEdge {
+            edge_id: row.edge_id,
+            branch_kind: row.branch_kind,
+            role: if row.primary_claim_id == claim_id {
+                "primary".to_string()
+            } else {
+                "contradicting".to_string()
+            },
+            primary_runtime_claim_id: row.primary_claim_id,
+            contradicting_runtime_claim_id: row.contradicting_claim_id,
+            primary_semantic_identity,
+            contradicting_semantic_identity,
+            detected_at: row.detected_at,
+            reconciliation_kind: row.reconciliation_kind,
+            reconciliation_note: row.reconciliation_note,
+            reconciled_at: row.reconciled_at,
+            winner_runtime_claim_id: row.winner_claim_id,
+            merged_runtime_claim_id: row.merged_claim_id,
+            replay_status: projected_replay_status(),
+        });
+    }
+    Ok(out)
+}
+
+#[derive(Debug)]
+struct ContradictionEdgeRow {
+    edge_id: String,
+    primary_claim_id: String,
+    contradicting_claim_id: String,
+    branch_kind: String,
+    detected_at: String,
+    reconciliation_kind: Option<String>,
+    reconciliation_note: Option<String>,
+    reconciled_at: Option<String>,
+    winner_claim_id: Option<String>,
+    merged_claim_id: Option<String>,
+}
+
+fn semantic_identity_for_claim_id(
+    db: &ActionDb,
+    claim_id: &str,
+) -> Result<Option<ClaimSemanticIdentityV1>, String> {
+    crate::services::claims::load_claim_by_id(db.conn_ref(), claim_id)
+        .map_err(|error| error.to_string())?
+        .as_ref()
+        .map(semantic_identity_for_loaded_claim)
+        .transpose()
+}
+
+fn render_markdown(sidecar: &ClaimFileSidecar, sidecar_checksum: &str) -> String {
+    let mut out = String::new();
+    out.push_str("# DailyOS Claims\n\n");
+    out.push_str("These files mirror canonical claim state. Edit only the dailyos-action and dailyos-payload lines inside a claim block.\n\n");
+    out.push_str(&format!(
+        "sidecar: `{}`\nsidecar_checksum: `{}`\n\n",
+        sidecar.sidecar_rel_path, sidecar_checksum
+    ));
+    for claim in &sidecar.claims {
+        out.push_str("<!-- dailyos-claim-start -->\n");
+        out.push_str(&format!("dailyos-claim-id: {}\n", claim.runtime_claim_id));
+        out.push_str(&format!(
+            "dailyos-claim-version: {}\n",
+            claim.runtime_claim_version
+        ));
+        out.push_str(&format!(
+            "dailyos-identity-hash: {}\n",
+            claim.semantic_identity.dedup_key_components_hash
+        ));
+        out.push_str(&format!("dailyos-sidecar-checksum: {}\n", sidecar_checksum));
+        out.push_str("dailyos-action: none\n");
+        out.push_str("dailyos-payload: {}\n");
+        out.push('\n');
+        out.push_str(&format!("## {}\n\n", claim.claim_text));
+        out.push_str(&format!("- Trust: `{}`\n", claim.trust_band));
+        out.push_str(&format!("- Sensitivity: `{}`\n", claim.sensitivity));
+        if claim.lifecycle.claim_state != "active" || claim.lifecycle.surfacing_state != "active" {
+            out.push_str(&format!(
+                "- Lifecycle: `{}` / `{}`\n",
+                claim.lifecycle.claim_state, claim.lifecycle.surfacing_state
+            ));
+        }
+        out.push_str(&format!(
+            "- Source: `{}` `{}`\n",
+            claim.provenance_summary.data_source,
+            claim
+                .provenance_summary
+                .source_ref
+                .as_deref()
+                .unwrap_or("source_ref_unavailable")
+        ));
+        if let Some(source_asof) = claim.provenance_summary.source_asof.as_deref() {
+            out.push_str(&format!("- Source as-of: `{source_asof}`\n"));
+        }
+        out.push_str("<!-- dailyos-claim-end -->\n\n");
+    }
+    out
+}
+
+async fn record_projection_run(
+    state: &AppState,
+    bundle: &RenderBundle,
+    write_error: Option<&std::io::Error>,
+) -> Result<(), ClaimFileError> {
+    let run = bundle.clone();
+    let status = if write_error.is_some() {
+        "failed".to_string()
+    } else {
+        "committed".to_string()
+    };
+    let error_class = write_error.map(|error| error.kind().to_string());
+    let error_detail_hash = write_error.map(|error| redacted_hash(&error.to_string()));
+    state
+        .db_write(move |db| {
+            insert_projection_run(
+                db,
+                &run,
+                &status,
+                error_class.as_deref(),
+                error_detail_hash.as_deref(),
+            )
+        })
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))?;
+    Ok(())
+}
+
+fn insert_projection_run(
+    db: &ActionDb,
+    run: &RenderBundle,
+    status: &str,
+    error_class: Option<&str>,
+    error_detail_hash: Option<&str>,
+) -> Result<(), String> {
+    let now = Utc::now().to_rfc3339();
+    db.conn_ref()
+        .execute(
+            "INSERT INTO claim_file_projection_runs (
+                id, entity_subject_ref_json, entity_subject_compact, projection_root,
+                markdown_rel_path, sidecar_rel_path, projection_version,
+                sidecar_schema_version, entity_claim_invalidation_version,
+                claim_watermark, markdown_checksum, sidecar_checksum, status,
+                error_class, error_detail_hash, attempted_at, succeeded_at, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?16, ?16)",
+            params![
+                &run.run_id,
+                &run.subject_ref_json,
+                &run.entity_subject_compact,
+                CLAIM_FILE_PROJECTION_ROOT,
+                path_to_slash_string(&run.markdown_rel_path),
+                path_to_slash_string(&run.sidecar_rel_path),
+                CLAIM_FILE_PROJECTION_VERSION,
+                CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+                run.entity_claim_invalidation_version,
+                &run.claim_watermark,
+                &run.markdown_checksum,
+                &run.sidecar_checksum,
+                status,
+                error_class,
+                error_detail_hash,
+                &now,
+                if status == "committed" { Some(now.as_str()) } else { None },
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    if status == "committed" {
+        for claim in &run.sidecar.claims {
+            let semantic_identity_json = serde_json::to_string(&claim.semantic_identity)
+                .map_err(|error| error.to_string())?;
+            db.conn_ref()
+                .execute(
+                    "INSERT INTO claim_file_projection_run_claims (
+                        run_id, claim_id, claim_version, semantic_identity_json,
+                        trust_band, sensitivity
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        &run.run_id,
+                        &claim.runtime_claim_id,
+                        claim.runtime_claim_version,
+                        semantic_identity_json,
+                        &claim.trust_band,
+                        &claim.sensitivity,
+                    ],
+                )
+                .map_err(|error| error.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+fn parse_markdown_corrections(
+    markdown: &str,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+) -> Result<Vec<ParsedCorrection>, ClaimFileError> {
+    let mut corrections = Vec::new();
+    let mut current: Option<ParsedBlock> = None;
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed == "<!-- dailyos-claim-start -->" {
+            if current.is_some() {
+                return Err(ClaimFileError::BadRequest(
+                    "nested claim block is ambiguous".to_string(),
+                ));
+            }
+            current = Some(ParsedBlock::default());
+            continue;
+        }
+        if trimmed == "<!-- dailyos-claim-end -->" {
+            if let Some(block) = current.take() {
+                if let Some(correction) = correction_from_block(block, sidecar, sidecar_checksum)? {
+                    corrections.push(correction);
+                }
+            } else {
+                return Err(ClaimFileError::BadRequest(
+                    "claim block end without start".to_string(),
+                ));
+            }
+            continue;
+        }
+        let Some(block) = current.as_mut() else {
+            continue;
+        };
+        if let Some(value) = trimmed.strip_prefix("dailyos-claim-id:") {
+            block.claim_id = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("dailyos-sidecar-checksum:") {
+            block.sidecar_checksum = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("dailyos-action:") {
+            block.action = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("dailyos-payload:") {
+            block.payload = Some(value.trim().to_string());
+        }
+    }
+    if current.is_some() {
+        return Err(ClaimFileError::BadRequest(
+            "unterminated claim block".to_string(),
+        ));
+    }
+    Ok(corrections)
+}
+
+#[derive(Debug, Default)]
+struct ParsedBlock {
+    claim_id: Option<String>,
+    sidecar_checksum: Option<String>,
+    action: Option<String>,
+    payload: Option<String>,
+}
+
+fn correction_from_block(
+    block: ParsedBlock,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+) -> Result<Option<ParsedCorrection>, ClaimFileError> {
+    let claim_id = block.claim_id.ok_or_else(|| {
+        ClaimFileError::BadRequest("claim block missing dailyos-claim-id".to_string())
+    })?;
+    let claim = sidecar
+        .claims
+        .iter()
+        .find(|claim| claim.runtime_claim_id == claim_id)
+        .ok_or_else(|| {
+            ClaimFileError::BadRequest("claim block not present in sidecar".to_string())
+        })?;
+    let block_checksum = block.sidecar_checksum.ok_or_else(|| {
+        ClaimFileError::BadRequest("claim block missing dailyos-sidecar-checksum".to_string())
+    })?;
+    if block_checksum != sidecar_checksum {
+        return Err(ClaimFileError::BadRequest("sidecar_mismatch".to_string()));
+    }
+    let action_raw = block.action.unwrap_or_else(|| "none".to_string());
+    if action_raw == "none" {
+        return Ok(None);
+    }
+    let action = feedback_action_from_slug(&action_raw)?;
+    let metadata = metadata_for_action(action, block.payload.as_deref(), claim)?;
+    Ok(Some(ParsedCorrection {
+        claim_id,
+        action,
+        metadata,
+    }))
+}
+
+fn metadata_for_action(
+    action: FeedbackAction,
+    payload: Option<&str>,
+    claim: &ClaimFileClaim,
+) -> Result<Option<serde_json::Value>, ClaimFileError> {
+    let payload_value = match payload.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(raw) => Some(serde_json::from_str::<serde_json::Value>(raw)?),
+        None => None,
+    };
+    if matches!(action, FeedbackAction::WrongSource) {
+        let mut obj = payload_value
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default();
+        if !obj.contains_key("source_content_hash") {
+            let hash = claim
+                .semantic_identity
+                .source_content_hash
+                .as_deref()
+                .ok_or_else(|| {
+                    ClaimFileError::BadRequest(
+                        "wrong_source missing source_content_hash".to_string(),
+                    )
+                })?;
+            obj.insert(
+                "source_content_hash".to_string(),
+                serde_json::Value::String(hash.to_string()),
+            );
+        }
+        return Ok(Some(serde_json::Value::Object(obj)));
+    }
+    Ok(payload_value)
+}
+
+fn feedback_action_from_slug(value: &str) -> Result<FeedbackAction, ClaimFileError> {
+    match value.trim() {
+        "confirm_current" => Ok(FeedbackAction::ConfirmCurrent),
+        "mark_outdated" => Ok(FeedbackAction::MarkOutdated),
+        "mark_false" => Ok(FeedbackAction::MarkFalse),
+        "wrong_subject" => Ok(FeedbackAction::WrongSubject),
+        "wrong_source" => Ok(FeedbackAction::WrongSource),
+        "cannot_verify" => Ok(FeedbackAction::CannotVerify),
+        "needs_nuance" => Ok(FeedbackAction::NeedsNuance),
+        other => Err(ClaimFileError::BadRequest(format!(
+            "unsupported file feedback action `{other}`"
+        ))),
+    }
+}
+
+fn receipt_target_for_claim(
+    sidecar: &ClaimFileSidecar,
+    claim_id: &str,
+) -> Result<ReceiptTarget, ClaimFileError> {
+    let claim = sidecar
+        .claims
+        .iter()
+        .find(|claim| claim.runtime_claim_id == claim_id)
+        .ok_or_else(|| ClaimFileError::BadRequest("claim not present in sidecar".to_string()))?;
+    let subject = receipt_subject_ref_from_json(&claim.semantic_identity.subject_ref)?;
+    Ok(ReceiptTarget::Claim {
+        claim_id: claim.runtime_claim_id.clone(),
+        subject,
+        field_path: claim.semantic_identity.field_path.clone(),
+    })
+}
+
+fn receipt_subject_ref_from_json(
+    value: &serde_json::Value,
+) -> Result<ReceiptSubjectRef, ClaimFileError> {
+    let subject = abilities_runtime::types::subject_ref_from_json(value)
+        .map_err(ClaimFileError::BadRequest)?;
+    Ok(match subject {
+        ClaimSubjectRef::Account { id } => ReceiptSubjectRef::Account(id),
+        ClaimSubjectRef::Project { id } => ReceiptSubjectRef::Project(id),
+        ClaimSubjectRef::Person { id } => ReceiptSubjectRef::Person(id),
+        ClaimSubjectRef::Action { id } => ReceiptSubjectRef::Action(id),
+        ClaimSubjectRef::Meeting { id } => ReceiptSubjectRef::Meeting(id),
+        ClaimSubjectRef::Global => ReceiptSubjectRef::Global,
+        ClaimSubjectRef::Multi(subjects) => ReceiptSubjectRef::Multi(
+            subjects
+                .iter()
+                .map(|subject| {
+                    let value = subject_ref_json_for_runtime(subject);
+                    receipt_subject_ref_from_json(&value)
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        ClaimSubjectRef::Email { .. } => {
+            return Err(ClaimFileError::BadRequest(
+                "email subject receipt feedback is not supported for claim files".to_string(),
+            ));
+        }
+    })
+}
+
+fn validate_projection_relative_path(path: &Path) -> Result<PathBuf, ClaimFileError> {
+    if path.is_absolute() {
+        return Err(ClaimFileError::PathRejected("absolute path".to_string()));
+    }
+    let mut components = path.components();
+    match components.next() {
+        Some(Component::Normal(root)) if root == CLAIM_FILE_PROJECTION_ROOT => {}
+        _ => {
+            return Err(ClaimFileError::PathRejected(
+                "path must be under _dailyos_claims".to_string(),
+            ))
+        }
+    }
+    for component in path.components() {
+        let Component::Normal(name) = component else {
+            return Err(ClaimFileError::PathRejected(
+                "non-normal path component".to_string(),
+            ));
+        };
+        let text = name.to_string_lossy();
+        if text.is_empty() || text == "." || text == ".." || text.contains('\0') {
+            return Err(ClaimFileError::PathRejected(
+                "unsafe path component".to_string(),
+            ));
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+fn projection_abs_path(workspace_root: &Path, rel_path: &Path) -> Result<PathBuf, ClaimFileError> {
+    let rel_path = validate_projection_relative_path(rel_path)?;
+    let canonical_root = workspace_root
+        .canonicalize()
+        .map_err(|error| ClaimFileError::PathRejected(error.to_string()))?;
+    let candidate = canonical_root.join(&rel_path);
+    validate_existing_projection_ancestors(&canonical_root, &candidate)?;
+    Ok(candidate)
+}
+
+fn sidecar_path_for_markdown_rel(path: &Path) -> Result<PathBuf, ClaimFileError> {
+    if path.file_name().and_then(|name| name.to_str()) != Some(CLAIM_FILE_MARKDOWN_NAME) {
+        return Err(ClaimFileError::PathRejected(
+            "apply path must point to claims.md".to_string(),
+        ));
+    }
+    let mut sidecar = path.to_path_buf();
+    sidecar.set_file_name(CLAIM_FILE_SIDECAR_NAME);
+    Ok(sidecar)
+}
+
+fn verify_sidecar_paths(
+    sidecar: &ClaimFileSidecar,
+    markdown_rel_path: &Path,
+    sidecar_rel_path: &Path,
+) -> Result<(), ClaimFileError> {
+    if sidecar.markdown_rel_path != path_to_slash_string(markdown_rel_path) {
+        return Err(ClaimFileError::BadRequest(
+            "sidecar markdown path mismatch".to_string(),
+        ));
+    }
+    if sidecar.sidecar_rel_path != path_to_slash_string(sidecar_rel_path) {
+        return Err(ClaimFileError::BadRequest(
+            "sidecar path mismatch".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_sidecar_contract(sidecar: &ClaimFileSidecar) -> Result<(), ClaimFileError> {
+    if sidecar.schema_version != CLAIM_FILE_SIDECAR_SCHEMA_VERSION {
+        return Err(ClaimFileError::BadRequest(
+            "unsupported sidecar schema_version".to_string(),
+        ));
+    }
+    if sidecar.projection_version != CLAIM_FILE_PROJECTION_VERSION {
+        return Err(ClaimFileError::BadRequest(
+            "unsupported claim file projection_version".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn write_projection_files(
+    workspace_root: &Path,
+    markdown_path: &Path,
+    sidecar_path: &Path,
+    markdown: &str,
+    sidecar_json: &str,
+) -> std::io::Result<()> {
+    let canonical_root = workspace_root.canonicalize()?;
+    create_projection_parent_dirs(&canonical_root, sidecar_path)?;
+    create_projection_parent_dirs(&canonical_root, markdown_path)?;
+    crate::util::atomic_write_str(sidecar_path, sidecar_json)?;
+    crate::util::atomic_write_str(markdown_path, markdown)?;
+    Ok(())
+}
+
+fn create_projection_parent_dirs(canonical_root: &Path, file_path: &Path) -> std::io::Result<()> {
+    let parent = file_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path has no parent",
+        )
+    })?;
+    let relative_parent = parent.strip_prefix(canonical_root).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection parent escapes workspace",
+        )
+    })?;
+    let mut current = canonical_root.to_path_buf();
+    for component in relative_parent.components() {
+        let Component::Normal(name) = component else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "non-normal projection parent component",
+            ));
+        };
+        current.push(name);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => validate_projection_dir_metadata(canonical_root, &current, &metadata)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&current)?;
+                let metadata = fs::symlink_metadata(&current)?;
+                validate_projection_dir_metadata(canonical_root, &current, &metadata)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn validate_existing_projection_ancestors(
+    canonical_root: &Path,
+    file_path: &Path,
+) -> Result<(), ClaimFileError> {
+    let Some(parent) = file_path.parent() else {
+        return Err(ClaimFileError::PathRejected(
+            "projection path has no parent".to_string(),
+        ));
+    };
+    let relative_parent = parent.strip_prefix(canonical_root).map_err(|_| {
+        ClaimFileError::PathRejected("projection parent escapes workspace".to_string())
+    })?;
+    let mut current = canonical_root.to_path_buf();
+    for component in relative_parent.components() {
+        let Component::Normal(name) = component else {
+            return Err(ClaimFileError::PathRejected(
+                "non-normal projection parent component".to_string(),
+            ));
+        };
+        current.push(name);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => validate_projection_dir_metadata(canonical_root, &current, &metadata)
+                .map_err(|error| ClaimFileError::PathRejected(error.to_string()))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(ClaimFileError::PathRejected(error.to_string())),
+        }
+    }
+    Ok(())
+}
+
+fn validate_projection_dir_metadata(
+    canonical_root: &Path,
+    path: &Path,
+    metadata: &fs::Metadata,
+) -> std::io::Result<()> {
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection path contains symlink",
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection ancestor is not a directory",
+        ));
+    }
+    let canonical_path = path.canonicalize()?;
+    if !canonical_path.starts_with(canonical_root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection parent escapes workspace",
+        ));
+    }
+    Ok(())
+}
+
+fn read_stable_to_string(path: &Path) -> Result<String, ClaimFileError> {
+    let before = fs::symlink_metadata(path)?;
+    validate_projection_file_metadata(&before)?;
+    let content = fs::read_to_string(path)?;
+    let after = fs::symlink_metadata(path)?;
+    validate_projection_file_metadata(&after)?;
+    if before.len() != after.len() || before.modified().ok() != after.modified().ok() {
+        return Err(ClaimFileError::PathRejected(
+            "file changed while reading; retry apply".to_string(),
+        ));
+    }
+    Ok(content)
+}
+
+fn validate_projection_file_metadata(metadata: &fs::Metadata) -> Result<(), ClaimFileError> {
+    if metadata.file_type().is_symlink() {
+        return Err(ClaimFileError::PathRejected(
+            "projection file is a symlink".to_string(),
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(ClaimFileError::PathRejected(
+            "projection path is not a file".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn current_entity_claim_version(db: &ActionDb, subject: &ClaimSubjectRef) -> Result<i64, String> {
+    let Some(kind) = subject_kind_slug(subject) else {
+        return Ok(0);
+    };
+    let Some(id) = subject_id_for_path(subject) else {
+        return Ok(0);
+    };
+    db.current_subject_claim_version(kind, id)
+        .map_err(|error| error.to_string())
+}
+
+fn claim_watermark(claims: &[IntelligenceClaim], entity_claim_version: i64) -> String {
+    let mut entries = claims
+        .iter()
+        .map(|claim| format!("{}:{}", claim.id, claim.claim_version))
+        .collect::<Vec<_>>();
+    entries.sort();
+    entries.push(format!("entity_claim_version:{entity_claim_version}"));
+    sha256_hex(entries.join("\n").as_bytes())
+}
+
+fn compact_subject_label(subject: &ClaimSubjectRef) -> String {
+    match subject {
+        ClaimSubjectRef::Account { id } => format!("account:{id}"),
+        ClaimSubjectRef::Project { id } => format!("project:{id}"),
+        ClaimSubjectRef::Person { id } => format!("person:{id}"),
+        ClaimSubjectRef::Action { id } => format!("action:{id}"),
+        ClaimSubjectRef::Meeting { id } => format!("meeting:{id}"),
+        ClaimSubjectRef::Email { id } => format!("email:{id}"),
+        ClaimSubjectRef::Global => "global".to_string(),
+        ClaimSubjectRef::Multi(subjects) => {
+            let mut parts = subjects
+                .iter()
+                .map(compact_subject_label)
+                .collect::<Vec<_>>();
+            parts.sort();
+            format!("multi:{}", parts.join("|"))
+        }
+    }
+}
+
+fn subject_kind_slug(subject: &ClaimSubjectRef) -> Option<&'static str> {
+    match subject {
+        ClaimSubjectRef::Account { .. } => Some("account"),
+        ClaimSubjectRef::Project { .. } => Some("project"),
+        ClaimSubjectRef::Person { .. } => Some("person"),
+        ClaimSubjectRef::Action { .. } => Some("action"),
+        ClaimSubjectRef::Meeting { .. } => Some("meeting"),
+        ClaimSubjectRef::Email { .. } => Some("email"),
+        ClaimSubjectRef::Global | ClaimSubjectRef::Multi(_) => None,
+    }
+}
+
+fn supported_entity_kind_slug(subject: &ClaimSubjectRef) -> Option<&'static str> {
+    match subject {
+        ClaimSubjectRef::Account { .. } => Some("account"),
+        ClaimSubjectRef::Project { .. } => Some("project"),
+        ClaimSubjectRef::Person { .. } => Some("person"),
+        _ => None,
+    }
+}
+
+fn subject_id_for_path(subject: &ClaimSubjectRef) -> Option<&str> {
+    match subject {
+        ClaimSubjectRef::Account { id }
+        | ClaimSubjectRef::Project { id }
+        | ClaimSubjectRef::Person { id }
+        | ClaimSubjectRef::Action { id }
+        | ClaimSubjectRef::Meeting { id }
+        | ClaimSubjectRef::Email { id } => Some(id.as_str()),
+        ClaimSubjectRef::Global | ClaimSubjectRef::Multi(_) => None,
+    }
+}
+
+fn subject_ref_json_for_runtime(subject: &ClaimSubjectRef) -> serde_json::Value {
+    match subject {
+        ClaimSubjectRef::Account { id } => serde_json::json!({"kind": "account", "id": id}),
+        ClaimSubjectRef::Project { id } => serde_json::json!({"kind": "project", "id": id}),
+        ClaimSubjectRef::Person { id } => serde_json::json!({"kind": "person", "id": id}),
+        ClaimSubjectRef::Action { id } => serde_json::json!({"kind": "action", "id": id}),
+        ClaimSubjectRef::Meeting { id } => serde_json::json!({"kind": "meeting", "id": id}),
+        ClaimSubjectRef::Email { id } => serde_json::json!({"kind": "email", "id": id}),
+        ClaimSubjectRef::Global => serde_json::json!({"kind": "global"}),
+        ClaimSubjectRef::Multi(subjects) => serde_json::json!({
+            "kind": "multi",
+            "subjects": subjects.iter().map(subject_ref_json_for_runtime).collect::<Vec<_>>()
+        }),
+    }
+}
+
+fn slug_segment(raw: &str) -> String {
+    let mut out = String::new();
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if ch == '-' || ch == '_' || ch == ' ' || ch == '.' {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "entity".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn trust_band_label(score: Option<f64>) -> &'static str {
+    match score {
+        Some(score) if score >= 0.75 => "likely_current",
+        Some(score) if score >= 0.45 => "use_with_caution",
+        _ => "needs_verification",
+    }
+}
+
+fn sensitivity_label(sensitivity: &ClaimSensitivity) -> String {
+    serde_json::to_value(sensitivity)
+        .ok()
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| format!("{sensitivity:?}").to_ascii_lowercase())
+}
+
+fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(claim.data_source.as_bytes());
+    hasher.update([0x1f]);
+    if let Some(source_ref) = claim.source_ref.as_deref() {
+        hasher.update(source_ref.as_bytes());
+    }
+    hasher.update([0x1f]);
+    if let Some(item_hash) = claim.item_hash.as_deref() {
+        hasher.update(item_hash.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn path_to_slash_string(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn redacted_hash(value: &str) -> String {
+    sha256_hex(value.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+    use crate::services::claims::{
+        commit_claim, record_claim_feedback, ClaimFeedbackInput, ClaimProposal, CommittedClaim,
+        TombstoneSpec,
+    };
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use abilities_runtime::sensitivity::ClaimVerificationState;
+    use abilities_runtime::types::{ClaimState, SurfacingState, TemporalScope};
+
+    const TEST_TS: &str = "2026-06-02T12:00:00Z";
+
+    fn fixture_sidecar() -> ClaimFileSidecar {
+        let subject = serde_json::json!({"kind": "account", "id": "acct-1"});
+        ClaimFileSidecar {
+            schema_version: CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+            projection_version: CLAIM_FILE_PROJECTION_VERSION,
+            entity_subject_ref: subject.clone(),
+            entity_subject_compact: "account:acct-1".to_string(),
+            markdown_rel_path: "_dailyos_claims/account/acct-1/claims.md".to_string(),
+            sidecar_rel_path: "_dailyos_claims/account/acct-1/claims.corrections.json".to_string(),
+            claims: vec![ClaimFileClaim {
+                semantic_identity: ClaimSemanticIdentityV1 {
+                    identity_version: 1,
+                    identity_kind: "claim_dedup_v1".to_string(),
+                    item_hash: "item-hash-1".to_string(),
+                    subject_ref_compact: "account:acct-1".to_string(),
+                    subject_ref: subject,
+                    claim_type: "risk".to_string(),
+                    field_path: Some("health.risk".to_string()),
+                    dedup_key_components_hash: "identity-hash-1".to_string(),
+                    source_ref: Some("fixture://source-1".to_string()),
+                    data_source: "unit_test".to_string(),
+                    observed_at: "2026-06-02T12:00:00Z".to_string(),
+                    source_asof: Some("2026-06-02T12:00:00Z".to_string()),
+                    source_content_hash: Some("abcdef0123456789".to_string()),
+                    runtime_claim_id: "claim-1".to_string(),
+                    runtime_claim_version: 3,
+                    claim_state: "active".to_string(),
+                    superseded_by: None,
+                },
+                runtime_claim_id: "claim-1".to_string(),
+                runtime_claim_version: 3,
+                claim_text: "Renewal risk is elevated".to_string(),
+                trust_band: "likely_current".to_string(),
+                sensitivity: "internal".to_string(),
+                lifecycle: ClaimFileLifecycle {
+                    claim_state: "active".to_string(),
+                    surfacing_state: "active".to_string(),
+                    demotion_reason: None,
+                    retraction_reason: None,
+                    superseded_by: None,
+                    verification_state: "active".to_string(),
+                    verification_reason: None,
+                    needs_user_decision_at: None,
+                },
+                provenance_summary: ClaimFileProvenanceSummary {
+                    data_source: "unit_test".to_string(),
+                    source_ref: Some("fixture://source-1".to_string()),
+                    source_asof: Some("2026-06-02T12:00:00Z".to_string()),
+                    observed_at: "2026-06-02T12:00:00Z".to_string(),
+                },
+                feedback_rows: Vec::new(),
+                contradiction_edges: Vec::new(),
+                replay_status: projected_replay_status(),
+            }],
+        }
+    }
+
+    fn fixture_intelligence_claim(
+        claim_type: &str,
+        field_path: Option<&str>,
+        item_hash: Option<&str>,
+    ) -> IntelligenceClaim {
+        IntelligenceClaim {
+            id: "claim-identity-1".to_string(),
+            claim_version: 7,
+            subject_ref: serde_json::json!({"kind": "account", "id": "acct-1"}).to_string(),
+            claim_type: claim_type.to_string(),
+            field_path: field_path.map(ToString::to_string),
+            topic_key: None,
+            text: "Identity fixture claim".to_string(),
+            dedup_key: "dedup-fixture".to_string(),
+            item_hash: item_hash.map(ToString::to_string),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: Some("fixture://source-identity".to_string()),
+            source_asof: Some("2026-06-02T12:00:00Z".to_string()),
+            observed_at: "2026-06-02T12:00:00Z".to_string(),
+            created_at: "2026-06-02T12:00:00Z".to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            claim_state: ClaimState::Active,
+            surfacing_state: SurfacingState::Active,
+            demotion_reason: None,
+            reactivated_at: None,
+            retraction_reason: None,
+            expires_at: None,
+            superseded_by: None,
+            trust_score: Some(0.8),
+            trust_computed_at: None,
+            trust_version: None,
+            thread_id: None,
+            temporal_scope: TemporalScope::State,
+            sensitivity: ClaimSensitivity::Internal,
+            verification_state: ClaimVerificationState::Active,
+            verification_reason: None,
+            needs_user_decision_at: None,
+        }
+    }
+
+    fn test_context_parts() -> (FixedClock, SeedableRng, ExternalClients) {
+        let now = chrono::DateTime::parse_from_rfc3339(TEST_TS)
+            .expect("test timestamp")
+            .with_timezone(&Utc);
+        (
+            FixedClock::new(now),
+            SeedableRng::new(7),
+            ExternalClients::default(),
+        )
+    }
+
+    fn test_live_context<'a>(
+        clock: &'a FixedClock,
+        rng: &'a SeedableRng,
+        external: &'a ExternalClients,
+    ) -> ServiceContext<'a> {
+        ServiceContext::test_live(clock, rng, external)
+    }
+
+    fn fixture_claim_proposal(text: &str) -> ClaimProposal {
+        ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: r#"{"kind":"account","id":"acct-1"}"#.to_string(),
+            claim_type: "risk".to_string(),
+            field_path: Some("health.risk".to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: Some("fixture://source".to_string()),
+            source_asof: Some(TEST_TS.to_string()),
+            observed_at: TEST_TS.to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        }
+    }
+
+    fn inserted_claim_id(result: CommittedClaim) -> String {
+        match result {
+            CommittedClaim::Inserted { claim } | CommittedClaim::Tombstoned { claim } => claim.id,
+            other => panic!("expected inserted/tombstoned claim, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sidecar_serialization_round_trips_contract_fields() {
+        let sidecar = fixture_sidecar();
+        let json = serde_json::to_string_pretty(&sidecar).expect("serialize sidecar");
+        let decoded: ClaimFileSidecar = serde_json::from_str(&json).expect("decode sidecar");
+
+        assert_eq!(decoded.schema_version, CLAIM_FILE_SIDECAR_SCHEMA_VERSION);
+        assert_eq!(decoded.projection_version, CLAIM_FILE_PROJECTION_VERSION);
+        assert_eq!(
+            decoded.claims[0].semantic_identity.identity_kind,
+            "claim_dedup_v1"
+        );
+        assert_eq!(decoded.claims[0].runtime_claim_id, "claim-1");
+        assert_eq!(decoded.claims[0].lifecycle.claim_state, "active");
+        assert_eq!(decoded.claims[0].replay_status.status, "projected");
+        assert!(decoded.claims[0].contradiction_edges.is_empty());
+    }
+
+    #[test]
+    fn sidecar_contract_rejects_unsupported_versions() {
+        let mut sidecar = fixture_sidecar();
+        sidecar.schema_version = CLAIM_FILE_SIDECAR_SCHEMA_VERSION + 1;
+        let err = verify_sidecar_contract(&sidecar).unwrap_err();
+        assert!(err.to_string().contains("sidecar schema_version"));
+
+        let mut sidecar = fixture_sidecar();
+        sidecar.projection_version = CLAIM_FILE_PROJECTION_VERSION + 1;
+        let err = verify_sidecar_contract(&sidecar).unwrap_err();
+        assert!(err.to_string().contains("projection_version"));
+    }
+
+    #[test]
+    fn parser_ignores_arbitrary_prose_without_structured_claim_blocks() {
+        let sidecar = fixture_sidecar();
+        let corrections = parse_markdown_corrections(
+            "This prose mentions claim-1 and says it is false, but it is not a bounded edit block.",
+            &sidecar,
+            "checksum",
+        )
+        .expect("parse arbitrary prose");
+
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn parser_maps_structured_wrong_source_to_feedback_metadata() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: wrong_source
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+
+        let corrections =
+            parse_markdown_corrections(markdown, &sidecar, "checksum-1").expect("parse");
+
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].action, FeedbackAction::WrongSource);
+        assert_eq!(
+            corrections[0]
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("source_content_hash")),
+            Some(&serde_json::json!("abcdef0123456789"))
+        );
+    }
+
+    #[test]
+    fn parser_maps_supported_structured_actions() {
+        let sidecar = fixture_sidecar();
+        for (slug, expected, payload) in [
+            ("confirm_current", FeedbackAction::ConfirmCurrent, "{}"),
+            ("mark_outdated", FeedbackAction::MarkOutdated, "{}"),
+            ("mark_false", FeedbackAction::MarkFalse, "{}"),
+            ("cannot_verify", FeedbackAction::CannotVerify, "{}"),
+            (
+                "wrong_subject",
+                FeedbackAction::WrongSubject,
+                "{\"corrected_subject_ref\":{\"kind\":\"project\",\"id\":\"proj-2\"}}",
+            ),
+            (
+                "needs_nuance",
+                FeedbackAction::NeedsNuance,
+                "{\"corrected_text\":\"Needs account-specific nuance.\"}",
+            ),
+        ] {
+            let markdown = format!(
+                "<!-- dailyos-claim-start -->\n\
+                 dailyos-claim-id: claim-1\n\
+                 dailyos-sidecar-checksum: checksum-1\n\
+                 dailyos-action: {slug}\n\
+                 dailyos-payload: {payload}\n\
+                 <!-- dailyos-claim-end -->\n"
+            );
+
+            let corrections =
+                parse_markdown_corrections(&markdown, &sidecar, "checksum-1").expect("parse");
+
+            assert_eq!(corrections.len(), 1, "{slug} should map one correction");
+            assert_eq!(corrections[0].action, expected, "{slug} action maps");
+        }
+    }
+
+    #[test]
+    fn parser_rejects_ambiguous_unterminated_claim_block() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: checksum-1
+dailyos-action: mark_false
+dailyos-payload: {}
+";
+
+        let err = parse_markdown_corrections(markdown, &sidecar, "checksum-1").unwrap_err();
+
+        assert!(err.to_string().contains("unterminated claim block"));
+    }
+
+    #[test]
+    fn parser_rejects_sidecar_checksum_mismatch() {
+        let sidecar = fixture_sidecar();
+        let markdown = "\
+<!-- dailyos-claim-start -->
+dailyos-claim-id: claim-1
+dailyos-sidecar-checksum: stale
+dailyos-action: mark_false
+dailyos-payload: {}
+<!-- dailyos-claim-end -->
+";
+
+        let err = parse_markdown_corrections(markdown, &sidecar, "current").unwrap_err();
+
+        assert!(err.to_string().contains("sidecar_mismatch"));
+    }
+
+    #[test]
+    fn projection_path_validator_rejects_non_managed_roots_and_traversal() {
+        assert!(validate_projection_relative_path(Path::new(
+            "_dailyos_claims/account/acct-1/claims.md"
+        ))
+        .is_ok());
+        assert!(validate_projection_relative_path(Path::new("Accounts/acct-1/claims.md")).is_err());
+        assert!(validate_projection_relative_path(Path::new(
+            "_dailyos_claims/../Accounts/acct-1.md"
+        ))
+        .is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn projection_abs_path_rejects_managed_root_symlink() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(
+            outside.path(),
+            workspace.path().join(CLAIM_FILE_PROJECTION_ROOT),
+        )
+        .expect("symlink projection root");
+
+        let err = projection_abs_path(
+            workspace.path(),
+            Path::new("_dailyos_claims/account/acct-1/claims.md"),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("symlink"));
+        assert!(
+            !outside.path().join("account").exists(),
+            "projection path resolution must not create directories through the symlink"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_stable_to_string_rejects_projection_file_symlink() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::NamedTempFile::new().expect("outside file");
+        let projection_dir = workspace
+            .path()
+            .join(CLAIM_FILE_PROJECTION_ROOT)
+            .join("account")
+            .join("acct-1");
+        std::fs::create_dir_all(&projection_dir).expect("projection dir");
+        std::os::unix::fs::symlink(
+            outside.path(),
+            projection_dir.join(CLAIM_FILE_MARKDOWN_NAME),
+        )
+        .expect("projection file symlink");
+
+        let err =
+            read_stable_to_string(&projection_dir.join(CLAIM_FILE_MARKDOWN_NAME)).unwrap_err();
+
+        assert!(err.to_string().contains("symlink"));
+    }
+
+    #[test]
+    fn projection_loader_preserves_feedback_bearing_terminal_claims() {
+        let db = test_db();
+        let (clock, rng, external) = test_context_parts();
+        let ctx = test_live_context(&clock, &rng, &external);
+
+        let active_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, fixture_claim_proposal("Active projection claim"))
+                .expect("commit active claim"),
+        );
+        let withdrawn_with_feedback_id = inserted_claim_id(
+            commit_claim(
+                &ctx,
+                &db,
+                fixture_claim_proposal("Terminal projection claim with feedback"),
+            )
+            .expect("commit feedback-bearing claim"),
+        );
+        record_claim_feedback(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: withdrawn_with_feedback_id.clone(),
+                action: FeedbackAction::MarkFalse,
+                actor: "user".to_string(),
+                actor_id: Some("user".to_string()),
+                payload_json: None,
+            },
+        )
+        .expect("record feedback");
+
+        let mut tombstone = fixture_claim_proposal("Terminal projection claim without feedback");
+        tombstone.tombstone = Some(TombstoneSpec {
+            retraction_reason: "user_marked_false".to_string(),
+            expires_at: None,
+        });
+        let withdrawn_without_feedback_id =
+            inserted_claim_id(commit_claim(&ctx, &db, tombstone).expect("commit tombstone claim"));
+
+        let claims = load_claims_for_projection(
+            &db,
+            r#"{"kind":"account","id":"acct-1"}"#,
+            "account",
+            "acct-1",
+        )
+        .expect("load projection claims");
+        let ids = claims
+            .iter()
+            .map(|claim| claim.id.as_str())
+            .collect::<BTreeSet<_>>();
+
+        assert!(ids.contains(active_claim_id.as_str()));
+        assert!(ids.contains(withdrawn_with_feedback_id.as_str()));
+        assert!(!ids.contains(withdrawn_without_feedback_id.as_str()));
+
+        let terminal_claim = claims
+            .iter()
+            .find(|claim| claim.id == withdrawn_with_feedback_id)
+            .expect("terminal claim included");
+        let sidecar_claim = claim_file_claim(&db, terminal_claim).expect("sidecar claim");
+
+        assert_eq!(sidecar_claim.lifecycle.claim_state, "withdrawn");
+        assert_eq!(sidecar_claim.lifecycle.surfacing_state, "dormant");
+        assert_eq!(sidecar_claim.feedback_rows.len(), 1);
+    }
+
+    #[test]
+    fn projection_subject_kind_is_limited_to_account_project_person() {
+        assert_eq!(
+            supported_entity_kind_slug(&ClaimSubjectRef::Account {
+                id: "acct-1".to_string()
+            }),
+            Some("account")
+        );
+        assert_eq!(
+            supported_entity_kind_slug(&ClaimSubjectRef::Project {
+                id: "proj-1".to_string()
+            }),
+            Some("project")
+        );
+        assert_eq!(
+            supported_entity_kind_slug(&ClaimSubjectRef::Person {
+                id: "person-1".to_string()
+            }),
+            Some("person")
+        );
+        assert_eq!(
+            supported_entity_kind_slug(&ClaimSubjectRef::Action {
+                id: "action-1".to_string()
+            }),
+            None
+        );
+        assert_eq!(supported_entity_kind_slug(&ClaimSubjectRef::Global), None);
+    }
+
+    #[test]
+    fn semantic_identity_hashes_compute_dedup_key_components() {
+        let claim = fixture_intelligence_claim("risk", Some("health.risk"), Some("item-hash-1"));
+        let identity = semantic_identity_for_claim(
+            &claim,
+            serde_json::json!({"kind": "account", "id": "acct-1"}),
+            "account:acct-1".to_string(),
+        );
+        let expected_components = "item-hash-1\u{1f}account:acct-1\u{1f}risk\u{1f}health.risk";
+
+        assert_eq!(identity.identity_kind, "claim_dedup_v1");
+        assert_eq!(
+            identity.dedup_key_components_hash,
+            sha256_hex(expected_components.as_bytes())
+        );
+        assert_eq!(identity.runtime_claim_version, 7);
+    }
+
+    #[test]
+    fn user_note_identity_uses_user_note_kind() {
+        let claim = fixture_intelligence_claim("user_note", None, Some("note-hash-1"));
+        let identity = semantic_identity_for_claim(
+            &claim,
+            serde_json::json!({"kind": "account", "id": "acct-1"}),
+            "account:acct-1".to_string(),
+        );
+
+        assert_eq!(identity.identity_kind, "user_note_v1");
+        assert_eq!(identity.item_hash, "note-hash-1");
+    }
+}

--- a/src-tauri/src/services/claim_receipt/feedback.rs
+++ b/src-tauri/src/services/claim_receipt/feedback.rs
@@ -9,7 +9,8 @@
 //!    (`claim_receipt::auth::can_surface_for`). `Actor::Agent` collapses to
 //!    deny at every surface in v1.4.4 (AC-8.13).
 //! 3. Validates per-action metadata against the ADR-0123 §1 variant field
-//!    schema verbatim — `WrongSubject.corrected_to`, `WrongSource.source_content_hash`
+//!    schema plus the DOS-628 canonical bridge — `WrongSubject.corrected_subject_ref`
+//!    (with legacy `corrected_to` accepted), `WrongSource.source_content_hash`
 //!    (ADR-0131 canonicalization, NOT an index), `NeedsNuance.corrected_text`,
 //!    `CannotVerify.note`, `SurfaceInappropriate.surface`, `NotRelevantHere.invocation_id`
 //!    (AC-8.10 / AC-8.11).
@@ -39,7 +40,7 @@ use sha2::{Digest, Sha256};
 
 use abilities_runtime::abilities::feedback::FeedbackAction;
 use abilities_runtime::abilities::provenance::field::FieldPath;
-use abilities_runtime::abilities::provenance::subject::SubjectRef;
+use abilities_runtime::abilities::provenance::subject::SubjectRef as ReceiptSubjectRef;
 use abilities_runtime::sensitivity::{RenderActor, RenderSurface};
 use abilities_runtime::types::{ClaimSensitivity, IntelligenceClaim};
 
@@ -495,16 +496,28 @@ fn validate_and_sanitize_metadata(
             // No required metadata. Optional fields accepted as-is.
         }
         FeedbackAction::WrongSubject => {
-            // Optional `corrected_to: SubjectRef`. ADR-0123 §1 verbatim name.
-            if let Some(value) = sanitized_metadata
-                .as_ref()
-                .and_then(|m| m.get("corrected_to"))
-            {
-                serde_json::from_value::<SubjectRef>(value.clone()).map_err(|error| {
-                    FeedbackError::BadRequest(format!(
-                        "wrong_subject.corrected_to must decode as SubjectRef: {error}"
-                    ))
+            if let Some(metadata) = sanitized_metadata.as_mut() {
+                let obj = metadata.as_object_mut().ok_or_else(|| {
+                    FeedbackError::BadRequest(
+                        "wrong_subject metadata must be a JSON object".to_string(),
+                    )
                 })?;
+                let canonical = obj
+                    .get("corrected_subject_ref")
+                    .map(normalize_wrong_subject_ref)
+                    .transpose()?;
+                let legacy = obj
+                    .get("corrected_to")
+                    .map(normalize_wrong_subject_ref)
+                    .transpose()?;
+                if canonical.is_some() && legacy.is_some() && canonical != legacy {
+                    return Err(FeedbackError::BadRequest(
+                        "wrong_subject corrected_to and corrected_subject_ref disagree".to_string(),
+                    ));
+                }
+                if let Some(value) = canonical.or(legacy) {
+                    obj.insert("corrected_subject_ref".to_string(), value);
+                }
             }
         }
         FeedbackAction::WrongSource => {
@@ -644,7 +657,7 @@ fn validate_and_sanitize_metadata(
                 )
             })?;
             // Deep-decode to enforce the SubjectRef shape per ADR-0125.
-            serde_json::from_value::<SubjectRef>(target_value).map_err(|error| {
+            serde_json::from_value::<ReceiptSubjectRef>(target_value).map_err(|error| {
                 FeedbackError::BadRequest(format!(
                     "merge_intent.merge_target must decode as SubjectRef: {error}"
                 ))
@@ -684,12 +697,67 @@ fn validate_and_sanitize_metadata(
     })
 }
 
+fn normalize_wrong_subject_ref(
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, FeedbackError> {
+    let materialized = if let Some(raw) = value.as_str() {
+        serde_json::from_str::<serde_json::Value>(raw).map_err(|error| {
+            FeedbackError::BadRequest(format!(
+                "wrong_subject.corrected_subject_ref string must contain JSON SubjectRef: {error}"
+            ))
+        })?
+    } else {
+        value.clone()
+    };
+    if crate::services::claims::subject_ref_from_json(&materialized).is_ok() {
+        return Ok(materialized);
+    }
+    let receipt_subject =
+        serde_json::from_value::<ReceiptSubjectRef>(materialized).map_err(|error| {
+            FeedbackError::BadRequest(format!(
+                "wrong_subject.corrected_subject_ref must decode as SubjectRef: {error}"
+            ))
+        })?;
+    let normalized = receipt_subject_ref_to_claim_json(&receipt_subject)?;
+    crate::services::claims::subject_ref_from_json(&normalized).map_err(|error| {
+        FeedbackError::BadRequest(format!(
+            "wrong_subject.corrected_subject_ref must decode as claim SubjectRef: {error}"
+        ))
+    })?;
+    Ok(normalized)
+}
+
+fn receipt_subject_ref_to_claim_json(
+    subject: &ReceiptSubjectRef,
+) -> Result<serde_json::Value, FeedbackError> {
+    Ok(match subject {
+        ReceiptSubjectRef::Account(id) => serde_json::json!({"kind": "account", "id": id}),
+        ReceiptSubjectRef::Project(id) => serde_json::json!({"kind": "project", "id": id}),
+        ReceiptSubjectRef::Person(id) => serde_json::json!({"kind": "person", "id": id}),
+        ReceiptSubjectRef::Action(id) => serde_json::json!({"kind": "action", "id": id}),
+        ReceiptSubjectRef::Meeting(id) => serde_json::json!({"kind": "meeting", "id": id}),
+        ReceiptSubjectRef::Global => serde_json::json!({"kind": "global"}),
+        ReceiptSubjectRef::Multi(subjects) => {
+            let subjects = subjects
+                .iter()
+                .map(receipt_subject_ref_to_claim_json)
+                .collect::<Result<Vec<_>, _>>()?;
+            serde_json::json!({"kind": "multi", "subjects": subjects})
+        }
+        ReceiptSubjectRef::User(_) | ReceiptSubjectRef::Unknown => {
+            return Err(FeedbackError::BadRequest(
+                "wrong_subject.corrected_subject_ref must target a claim subject".to_string(),
+            ));
+        }
+    })
+}
+
 fn allowed_keys_for(action: FeedbackAction) -> &'static [&'static str] {
     match action {
         FeedbackAction::ConfirmCurrent => &[],
         FeedbackAction::MarkOutdated => &["last_known_true_at"],
         FeedbackAction::MarkFalse => &["corrected_value"],
-        FeedbackAction::WrongSubject => &["corrected_to"],
+        FeedbackAction::WrongSubject => &["corrected_to", "corrected_subject_ref"],
         FeedbackAction::WrongSource => &["source_content_hash", "source_index"],
         FeedbackAction::CannotVerify => &["note"],
         FeedbackAction::NeedsNuance => &["corrected_text"],
@@ -956,7 +1024,7 @@ mod tests {
     fn claim_target(id: &str) -> ReceiptTarget {
         ReceiptTarget::Claim {
             claim_id: id.to_string(),
-            subject: SubjectRef::Account("acct-1".to_string()),
+            subject: ReceiptSubjectRef::Account("acct-1".to_string()),
             field_path: Some("health.risk".to_string()),
         }
     }
@@ -976,14 +1044,33 @@ mod tests {
             validate_and_sanitize_metadata(action, None).expect("no metadata required");
         }
 
-        // WrongSubject: optional corrected_to.
+        // WrongSubject: optional corrected_subject_ref; legacy corrected_to bridges to it.
         validate_and_sanitize_metadata(FeedbackAction::WrongSubject, None)
             .expect("wrong_subject metadata is optional");
-        validate_and_sanitize_metadata(
+        let canonical_wrong_subject = validate_and_sanitize_metadata(
+            FeedbackAction::WrongSubject,
+            Some(&serde_json::json!({"corrected_subject_ref": {"account": "acct-2"}})),
+        )
+        .expect("wrong_subject with corrected_subject_ref");
+        assert_eq!(
+            canonical_wrong_subject
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("corrected_subject_ref")),
+            Some(&serde_json::json!({"kind": "account", "id": "acct-2"}))
+        );
+        let legacy_wrong_subject = validate_and_sanitize_metadata(
             FeedbackAction::WrongSubject,
             Some(&serde_json::json!({"corrected_to": {"account": "acct-2"}})),
         )
-        .expect("wrong_subject with corrected_to");
+        .expect("wrong_subject with legacy corrected_to");
+        assert_eq!(
+            legacy_wrong_subject
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("corrected_subject_ref")),
+            Some(&serde_json::json!({"kind": "account", "id": "acct-2"}))
+        );
 
         // WrongSource: required source_content_hash (ADR-0123 §1 verbatim).
         let err = validate_and_sanitize_metadata(FeedbackAction::WrongSource, None).unwrap_err();
@@ -1126,7 +1213,7 @@ mod tests {
 
     #[test]
     fn rejects_intended_subject_ref_alias_for_wrong_subject() {
-        // ADR-0123 §1 verbatim: the field is corrected_to, not intended_subject_ref.
+        // DOS-628 canonicalizes on corrected_subject_ref; do not accept freeform aliases.
         let err = validate_and_sanitize_metadata(
             FeedbackAction::WrongSubject,
             Some(&serde_json::json!({"intended_subject_ref": {"account": "acct-2"}})),
@@ -1135,6 +1222,19 @@ mod tests {
         assert!(
             matches!(err, FeedbackError::BadRequest(message) if message.contains("intended_subject_ref"))
         );
+    }
+
+    #[test]
+    fn rejects_disagreeing_wrong_subject_aliases() {
+        let err = validate_and_sanitize_metadata(
+            FeedbackAction::WrongSubject,
+            Some(&serde_json::json!({
+                "corrected_to": {"account": "acct-2"},
+                "corrected_subject_ref": {"account": "acct-3"}
+            })),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FeedbackError::BadRequest(message) if message.contains("disagree")));
     }
 
     #[test]

--- a/src-tauri/src/services/claim_receipt/feedback.rs
+++ b/src-tauri/src/services/claim_receipt/feedback.rs
@@ -9,7 +9,7 @@
 //!    (`claim_receipt::auth::can_surface_for`). `Actor::Agent` collapses to
 //!    deny at every surface in v1.4.4 (AC-8.13).
 //! 3. Validates per-action metadata against the ADR-0123 §1 variant field
-//!    schema plus the DOS-628 canonical bridge — `WrongSubject.corrected_subject_ref`
+//!    schema plus the claim-file canonical bridge — `WrongSubject.corrected_subject_ref`
 //!    (with legacy `corrected_to` accepted), `WrongSource.source_content_hash`
 //!    (ADR-0131 canonicalization, NOT an index), `NeedsNuance.corrected_text`,
 //!    `CannotVerify.note`, `SurfaceInappropriate.surface`, `NotRelevantHere.invocation_id`
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     fn rejects_intended_subject_ref_alias_for_wrong_subject() {
-        // DOS-628 canonicalizes on corrected_subject_ref; do not accept freeform aliases.
+        // Claim-file feedback canonicalizes on corrected_subject_ref; do not accept aliases.
         let err = validate_and_sanitize_metadata(
             FeedbackAction::WrongSubject,
             Some(&serde_json::json!({"intended_subject_ref": {"account": "acct-2"}})),

--- a/src-tauri/src/services/claim_receipt/feedback.rs
+++ b/src-tauri/src/services/claim_receipt/feedback.rs
@@ -47,7 +47,10 @@ use abilities_runtime::types::{ClaimSensitivity, IntelligenceClaim};
 use crate::services::claim_receipt::auth::{can_surface_for, AuthError};
 use crate::services::claim_receipt::contracts::{ClaimReceipt, ReceiptTarget, SurfaceContext};
 use crate::services::claim_receipt::render::{render_receipt_for, RenderError};
-use crate::services::claims::{record_claim_feedback, ClaimError, ClaimFeedbackInput};
+use crate::services::claims::{
+    record_claim_feedback, record_claim_feedback_for_claim_file_apply, ClaimError,
+    ClaimFeedbackInput, ClaimFileFeedbackApplyInput,
+};
 use crate::services::entity_intelligence::auth::{
     validate_envelope_target, EnvelopeSet, TargetBindingError,
 };
@@ -97,6 +100,18 @@ pub struct ClaimFeedbackResponse {
     pub repair_queued: bool,
     pub sanitizer_warnings: Vec<SanitizerWarning>,
     pub replayed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimFileFeedbackApplyCommit {
+    pub expected_claim_version: u64,
+    pub correction_apply_key: String,
+}
+
+#[derive(Debug, Clone)]
+enum FeedbackPersistence {
+    Default,
+    ClaimFileApply(ClaimFileFeedbackApplyCommit),
 }
 
 // ---------------------------------------------------------------------------
@@ -238,6 +253,44 @@ pub async fn submit_claim_feedback(
     cache: &IdempotencyCache,
     request: ClaimFeedbackRequest,
 ) -> Result<ClaimFeedbackResponse, FeedbackError> {
+    submit_claim_feedback_with_persistence(
+        state,
+        envelope_set,
+        actor,
+        cache,
+        request,
+        FeedbackPersistence::Default,
+    )
+    .await
+}
+
+pub async fn submit_claim_feedback_for_claim_file_apply(
+    state: &AppState,
+    envelope_set: &EnvelopeSet<'_>,
+    actor: &RenderActor,
+    cache: &IdempotencyCache,
+    request: ClaimFeedbackRequest,
+    apply: ClaimFileFeedbackApplyCommit,
+) -> Result<ClaimFeedbackResponse, FeedbackError> {
+    submit_claim_feedback_with_persistence(
+        state,
+        envelope_set,
+        actor,
+        cache,
+        request,
+        FeedbackPersistence::ClaimFileApply(apply),
+    )
+    .await
+}
+
+async fn submit_claim_feedback_with_persistence(
+    state: &AppState,
+    envelope_set: &EnvelopeSet<'_>,
+    actor: &RenderActor,
+    cache: &IdempotencyCache,
+    request: ClaimFeedbackRequest,
+    persistence: FeedbackPersistence,
+) -> Result<ClaimFeedbackResponse, FeedbackError> {
     // AC-8.2: caller-supplied idempotency keys are not accepted.
     if request.idempotency_key.is_some() {
         return Err(FeedbackError::CallerSuppliedIdempotencyKey);
@@ -354,7 +407,23 @@ pub async fn submit_claim_feedback(
             let external = crate::services::context::ExternalClients::default();
             let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
                 .with_actor("user");
-            record_claim_feedback(&ctx, db, input).map_err(|error| error.to_string())
+            match persistence {
+                FeedbackPersistence::Default => {
+                    record_claim_feedback(&ctx, db, input).map_err(|error| error.to_string())
+                }
+                FeedbackPersistence::ClaimFileApply(apply) => {
+                    record_claim_feedback_for_claim_file_apply(
+                        &ctx,
+                        db,
+                        input,
+                        ClaimFileFeedbackApplyInput {
+                            expected_claim_version: apply.expected_claim_version,
+                            correction_apply_key: apply.correction_apply_key,
+                        },
+                    )
+                    .map_err(|error| error.to_string())
+                }
+            }
         })
         .await
         .map_err(|message| FeedbackError::Storage(anyhow::anyhow!(message)))?;

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -245,6 +245,12 @@ pub struct ClaimFeedbackOutcome {
     pub repair_job_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ClaimFileFeedbackApplyInput {
+    pub expected_claim_version: u64,
+    pub correction_apply_key: String,
+}
+
 /// Claim-generation contract boundary.
 ///
 /// Implementation note: this cites and accepts the W0-A enrichment refactor
@@ -7196,6 +7202,24 @@ pub fn record_claim_feedback(
     db: &ActionDb,
     input: ClaimFeedbackInput,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    record_claim_feedback_with_apply_commit(ctx, db, input, None)
+}
+
+pub fn record_claim_feedback_for_claim_file_apply(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: ClaimFeedbackInput,
+    apply: ClaimFileFeedbackApplyInput,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    record_claim_feedback_with_apply_commit(ctx, db, input, Some(apply))
+}
+
+fn record_claim_feedback_with_apply_commit(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: ClaimFeedbackInput,
+    claim_file_apply: Option<ClaimFileFeedbackApplyInput>,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
 
@@ -7212,6 +7236,15 @@ pub fn record_claim_feedback(
         let now = ctx.clock.now().to_rfc3339();
         let claim = load_claim_by_id(tx.conn_ref(), &input.claim_id)?
             .ok_or_else(|| ClaimError::UnknownClaimId(input.claim_id.clone()))?;
+        if let Some(apply) = claim_file_apply.as_ref() {
+            if claim.claim_version != apply.expected_claim_version {
+                return Err(ClaimError::StaleVersion {
+                    claim_id: input.claim_id.clone(),
+                    expected: apply.expected_claim_version,
+                    current: claim.claim_version,
+                });
+            }
+        }
         validate_feedback_actor(&input.actor)?;
         let metadata = feedback_metadata_for_claim(&claim, &input, metadata.clone())?;
         let subject_value: serde_json::Value = serde_json::from_str(&claim.subject_ref)?;
@@ -7350,6 +7383,24 @@ pub fn record_claim_feedback(
         bump_invalidation_for_claim_id(tx, &input.claim_id)?;
         let repair_job_id =
             targeted_repair_enqueue_job(ctx, tx, &claim, &feedback_id, metadata.repair)?;
+        if let Some(apply) = claim_file_apply.as_ref() {
+            let updated = tx.conn_ref().execute(
+                "UPDATE claim_file_correction_apply_events
+                    SET status = 'applied',
+                        feedback_id = ?1,
+                        applied_at = ?2,
+                        updated_at = ?2
+                  WHERE idempotency_key = ?3
+                    AND status = 'claimed'",
+                params![&feedback_id, &now, &apply.correction_apply_key],
+            )?;
+            if updated != 1 {
+                return Err(ClaimError::Transaction(format!(
+                    "claim file correction apply event {} was not claimable",
+                    apply.correction_apply_key
+                )));
+            }
+        }
         let verification_state_after = enum_to_db(&new_verification_state)?;
 
         Ok(ClaimFeedbackWriteOutcome {

--- a/src-tauri/src/services/context.rs
+++ b/src-tauri/src/services/context.rs
@@ -7,9 +7,11 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    path::PathBuf,
     sync::Arc,
 };
 
+use abilities_runtime::abilities::claim_files::contracts as runtime_claim_files;
 use abilities_runtime::abilities::recommendations::contracts as runtime_salience;
 use abilities_runtime::abilities::trust::TrustBand;
 
@@ -66,6 +68,7 @@ pub struct LiveRecommendationFeedbackWriter;
 pub struct LiveSourceManagementActionHandler {
     signal_engine: Option<Arc<crate::signals::propagation::PropagationEngine>>,
 }
+pub struct LiveClaimFileOperations;
 pub struct LiveEntityContextClaimReader;
 pub struct LiveAccountCompositionSnapshotReader;
 pub struct LiveProjectCompositionSnapshotReader;
@@ -136,6 +139,7 @@ pub fn attach_live_workspace_readers_with_signal_engine(
         .with_workspace_intake(Arc::new(
             crate::services::workspace_ingestion::workspace_intake_impl::IngestPipelineWorkspaceIntake::from_config_or_empty_with_signal_engine(signal_engine),
         ))
+        .with_claim_file_operations(Arc::new(LiveClaimFileOperations))
 }
 
 impl EntityContextReadHandle for LiveEntityContextReader {
@@ -546,6 +550,129 @@ impl SourceManagementActionHandle for LiveSourceManagementActionHandler {
                 ))
             })?
         })
+    }
+}
+
+impl ClaimFileOperationHandle for LiveClaimFileOperations {
+    fn render_entity_claim_file<'a>(
+        &'a self,
+        request: ClaimFileRenderRequest,
+    ) -> ClaimFileRenderFuture<'a> {
+        Box::pin(async move {
+            let workspace_root = configured_claim_file_workspace_root()?;
+            let subject_ref_json =
+                serde_json::to_string(&request.input.subject_ref).map_err(|error| {
+                    runtime_claim_files::ClaimFileOperationError::InvalidRequest(error.to_string())
+                })?;
+            let state = crate::state::AppState::new();
+            let result = crate::services::claim_files::render_entity_claim_file(
+                &state,
+                workspace_root,
+                subject_ref_json,
+            )
+            .await
+            .map_err(claim_file_error_to_runtime)?;
+            Ok(claim_file_projection_result_to_runtime(result))
+        })
+    }
+
+    fn apply_claim_file_corrections<'a>(
+        &'a self,
+        request: ClaimFileApplyRequest,
+    ) -> ClaimFileApplyFuture<'a> {
+        Box::pin(async move {
+            let workspace_root = configured_claim_file_workspace_root()?;
+            let state = crate::state::AppState::new();
+            let result = crate::services::claim_files::apply_claim_file_corrections(
+                &state,
+                workspace_root,
+                PathBuf::from(request.input.markdown_rel_path),
+                request.actor_principal_id,
+            )
+            .await
+            .map_err(claim_file_error_to_runtime)?;
+            claim_file_apply_result_to_runtime(result)
+        })
+    }
+}
+
+fn configured_claim_file_workspace_root(
+) -> Result<PathBuf, runtime_claim_files::ClaimFileOperationError> {
+    let config = crate::state::load_config().map_err(|error| {
+        runtime_claim_files::ClaimFileOperationError::OperationFailed(error.to_string())
+    })?;
+    let workspace_path = config.workspace_path.trim();
+    if workspace_path.is_empty() {
+        return Err(
+            runtime_claim_files::ClaimFileOperationError::InvalidRequest(
+                "workspace path is not configured".to_string(),
+            ),
+        );
+    }
+    Ok(PathBuf::from(workspace_path))
+}
+
+fn claim_file_projection_result_to_runtime(
+    result: crate::services::claim_files::ClaimFileProjectionResult,
+) -> runtime_claim_files::ClaimFileProjectionResult {
+    runtime_claim_files::ClaimFileProjectionResult {
+        run_id: result.run_id,
+        markdown_rel_path: result.markdown_rel_path,
+        sidecar_rel_path: result.sidecar_rel_path,
+        claim_count: result.claim_count,
+        markdown_checksum: result.markdown_checksum,
+        sidecar_checksum: result.sidecar_checksum,
+    }
+}
+
+fn claim_file_apply_result_to_runtime(
+    result: crate::services::claim_files::ClaimFileApplyResult,
+) -> Result<runtime_claim_files::ClaimFileApplyResult, runtime_claim_files::ClaimFileOperationError>
+{
+    let responses = result
+        .responses
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            runtime_claim_files::ClaimFileOperationError::OperationFailed(error.to_string())
+        })?;
+    Ok(runtime_claim_files::ClaimFileApplyResult {
+        applied_count: result.applied_count,
+        skipped_count: result.skipped_count,
+        failures: result
+            .failures
+            .into_iter()
+            .map(|failure| runtime_claim_files::ClaimFileApplyFailure {
+                claim_id: failure.claim_id,
+                error_class: failure.error_class,
+                error_detail_hash: failure.error_detail_hash,
+            })
+            .collect(),
+        responses,
+        rerender: result.rerender.map(claim_file_projection_result_to_runtime),
+    })
+}
+
+fn claim_file_error_to_runtime(
+    error: crate::services::claim_files::ClaimFileError,
+) -> runtime_claim_files::ClaimFileOperationError {
+    match error {
+        crate::services::claim_files::ClaimFileError::BadRequest(message)
+        | crate::services::claim_files::ClaimFileError::PathRejected(message) => {
+            runtime_claim_files::ClaimFileOperationError::InvalidRequest(message)
+        }
+        crate::services::claim_files::ClaimFileError::Json(error) => {
+            runtime_claim_files::ClaimFileOperationError::InvalidRequest(error.to_string())
+        }
+        crate::services::claim_files::ClaimFileError::ProjectionFailed(message)
+        | crate::services::claim_files::ClaimFileError::ApplyFailed(message)
+        | crate::services::claim_files::ClaimFileError::Db(message) => {
+            runtime_claim_files::ClaimFileOperationError::OperationFailed(message)
+        }
+        crate::services::claim_files::ClaimFileError::Io(error) => {
+            runtime_claim_files::ClaimFileOperationError::OperationFailed(error.to_string())
+        }
     }
 }
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod account_fact_claims;
 pub mod accounts;
 pub mod action_claims;
 pub mod actions;
+pub mod claim_files;
 pub mod claim_receipt;
 pub mod claim_review_queue;
 pub mod claims;

--- a/src-tauri/src/services/workspace_backfill.rs
+++ b/src-tauri/src/services/workspace_backfill.rs
@@ -32,7 +32,7 @@ use crate::services::workspace_ingestion::pipeline::{
     file_id_from_identity, EntityRef, DEFAULT_MAX_FILE_BYTES,
 };
 use crate::services::workspace_ingestion::registry::{
-    WorkspaceCategoryRegistry, WorkspaceSourceRegistry,
+    is_claim_file_projection_root_path, WorkspaceCategoryRegistry, WorkspaceSourceRegistry,
 };
 use crate::services::workspace_ingestion::signals::WorkspaceSignalEmitter;
 use crate::signals::propagation::{default_engine, PropagationEngine};
@@ -478,6 +478,9 @@ fn eligibility_skip_reason(relative_path: &Path) -> Option<&'static str> {
     if root == "Internal" {
         return Some("internal_path");
     }
+    if is_claim_file_projection_root_path(relative_path) {
+        return Some("managed_output_root");
+    }
     if root.starts_with('_') && root != "_inbox" {
         return Some("managed_root");
     }
@@ -528,6 +531,9 @@ fn candidate_from_relative_path(
     .map_err(|reason| match reason {
         crate::services::workspace_ingestion::contracts::RejectionReason::PathTraversalAttempt => {
             "path_traversal_attempt".to_string()
+        }
+        crate::services::workspace_ingestion::contracts::RejectionReason::ManagedOutputRoot => {
+            "managed_output_root".to_string()
         }
         crate::services::workspace_ingestion::contracts::RejectionReason::SymlinkRefused => {
             "symlink_refused".to_string()
@@ -1498,11 +1504,19 @@ mod tests {
         let temp = TempDir::new().expect("temp");
         seed_account(db.conn_ref(), temp.path());
         std::fs::create_dir_all(temp.path().join("_archive")).expect("managed root");
+        std::fs::create_dir_all(temp.path().join("_dailyos_claims/account/example"))
+            .expect("claim projection root");
         let account_notes = temp.path().join("Accounts/ExampleCo/notes");
 
         std::fs::write(account_notes.join(".hidden.md"), "hidden").expect("hidden file");
         std::fs::write(temp.path().join("_archive/source.md"), "managed root")
             .expect("managed root file");
+        std::fs::write(
+            temp.path()
+                .join("_dailyos_claims/account/example/claims.md"),
+            "claim projection",
+        )
+        .expect("claim projection markdown");
         std::fs::write(temp.path().join("CLAUDE.md"), "managed").expect("managed file");
         std::fs::write(account_notes.join("dashboard.json"), "{}").expect("generated file");
         std::fs::write(account_notes.join("archive.zip"), "unsupported").expect("unsupported file");
@@ -1542,6 +1556,7 @@ mod tests {
         for (reason, expected_count) in [
             ("hidden_path", 1),
             ("managed_root", 1),
+            ("managed_output_root", 1),
             ("managed_file", 1),
             ("generated_file", 1),
             ("unsupported_format", 1),

--- a/src-tauri/src/services/workspace_ingestion/contracts.rs
+++ b/src-tauri/src/services/workspace_ingestion/contracts.rs
@@ -130,6 +130,7 @@ fn is_valid_slug_shape(s: &str) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RejectionReason {
     PathTraversalAttempt,
+    ManagedOutputRoot,
     SymlinkRefused,
     SymlinkRaced,
     OutsideWorkspace,

--- a/src-tauri/src/services/workspace_ingestion/registry.rs
+++ b/src-tauri/src/services/workspace_ingestion/registry.rs
@@ -53,6 +53,13 @@ use crate::entity::EntityType;
 /// only, max 32 chars, must start with a letter, allows digits/underscore/hyphen.
 /// Per L0 V1.3 §6.
 pub const SLUG_REGEX: &str = r"^[a-z][a-z0-9_-]{0,31}$";
+pub const CLAIM_FILE_PROJECTION_ROOT: &str = "_dailyos_claims";
+
+pub fn is_claim_file_projection_root_path(path: &Path) -> bool {
+    path.components().next().is_some_and(|component| {
+        component.as_os_str() == std::ffi::OsStr::new(CLAIM_FILE_PROJECTION_ROOT)
+    })
+}
 
 /// Validation error: caller-provided category is not registered for the entity type.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -214,6 +221,9 @@ impl WorkspaceSourceRegistry {
                     return Err(RejectionReason::PathTraversalAttempt);
                 }
             }
+            if !path.is_absolute() && is_claim_file_projection_root_path(path) {
+                return Err(RejectionReason::ManagedOutputRoot);
+            }
 
             // Resolve the input path relative to workspace_root if it's relative.
             let candidate = if path.is_absolute() {
@@ -226,6 +236,13 @@ impl WorkspaceSourceRegistry {
             let canonical_root = workspace_root
                 .canonicalize()
                 .map_err(|_| RejectionReason::OutsideWorkspace)?;
+            for lexical_root in [workspace_root, canonical_root.as_path()] {
+                if let Ok(relative_path) = candidate.strip_prefix(lexical_root) {
+                    if is_claim_file_projection_root_path(relative_path) {
+                        return Err(RejectionReason::ManagedOutputRoot);
+                    }
+                }
+            }
             let canonical_path = match candidate.canonicalize() {
                 Ok(p) => p,
                 Err(e) => {
@@ -241,6 +258,11 @@ impl WorkspaceSourceRegistry {
             }
             if !canonical_path.starts_with(&canonical_root) {
                 return Err(RejectionReason::OutsideWorkspace);
+            }
+            if let Ok(relative_path) = canonical_path.strip_prefix(&canonical_root) {
+                if is_claim_file_projection_root_path(relative_path) {
+                    return Err(RejectionReason::ManagedOutputRoot);
+                }
             }
 
             // Step 3: lstat canonical_path; record (dev, ino) + check cross-device.
@@ -907,6 +929,56 @@ mod tests {
         )
         .expect_err("ADS colon");
         assert!(matches!(err, RejectionReason::PathTraversalAttempt));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_validated_rejects_claim_file_projection_root_before_open() {
+        let ws = make_workspace();
+        let projected = ws.path().join(CLAIM_FILE_PROJECTION_ROOT).join("account");
+        fs::create_dir_all(&projected).expect("mkdir");
+        fs::write(projected.join("claims.md"), b"managed output").expect("write projection");
+
+        let err = WorkspaceSourceRegistry::open_validated(
+            ws.path(),
+            std::path::Path::new("_dailyos_claims/account/claims.md"),
+        )
+        .expect_err("managed projection root");
+        assert!(matches!(err, RejectionReason::ManagedOutputRoot));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_validated_rejects_claim_file_projection_root_before_symlink_resolution() {
+        let ws = make_workspace();
+        let accounts = ws.path().join("Accounts");
+        fs::create_dir_all(&accounts).expect("mkdir accounts");
+        fs::write(accounts.join("claims.md"), b"source through managed alias").expect("write file");
+        std::os::unix::fs::symlink(&accounts, ws.path().join(CLAIM_FILE_PROJECTION_ROOT))
+            .expect("symlink managed root");
+
+        let err = WorkspaceSourceRegistry::open_validated(
+            ws.path(),
+            std::path::Path::new("_dailyos_claims/claims.md"),
+        )
+        .expect_err("managed projection root must be lexical, not canonical");
+
+        assert!(matches!(err, RejectionReason::ManagedOutputRoot));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_validated_still_accepts_inbox_root() {
+        let ws = make_workspace();
+        let inbox = ws.path().join("_inbox");
+        fs::create_dir_all(&inbox).expect("mkdir");
+        fs::write(inbox.join("source.md"), b"inbox source").expect("write inbox");
+
+        WorkspaceSourceRegistry::open_validated(
+            ws.path(),
+            std::path::Path::new("_inbox/source.md"),
+        )
+        .expect("_inbox remains source-intake eligible");
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/services/workspace_ingestion/signals.rs
+++ b/src-tauri/src/services/workspace_ingestion/signals.rs
@@ -345,6 +345,7 @@ fn serialize_payload<T: Serialize>(
 pub fn rejection_reason_code(reason: &RejectionReason) -> &'static str {
     match reason {
         RejectionReason::PathTraversalAttempt => "path_traversal_attempt",
+        RejectionReason::ManagedOutputRoot => "managed_output_root",
         RejectionReason::SymlinkRefused => "symlink_refused",
         RejectionReason::SymlinkRaced => "symlink_raced",
         RejectionReason::OutsideWorkspace => "outside_workspace",

--- a/src-tauri/src/services/workspace_ingestion/workspace_intake_impl.rs
+++ b/src-tauri/src/services/workspace_ingestion/workspace_intake_impl.rs
@@ -34,7 +34,10 @@ use super::pipeline::{file_id_from_identity, EntityRef, FileIdError, IngestError
 use super::registry::{ResolvePathError, WorkspaceCategoryRegistry};
 use super::signals::emit_pre_pipeline_rejection;
 use super::wiring::build_pipeline;
-use super::{registry::WorkspaceSourceRegistry, runs::IngestionMode};
+use super::{
+    registry::{is_claim_file_projection_root_path, WorkspaceSourceRegistry},
+    runs::IngestionMode,
+};
 
 const PLACEMENT_RATE_LIMIT_MAX: i64 = 200;
 const PLACEMENT_RATE_LIMIT_WINDOW_SECONDS: i64 = 60 * 60;
@@ -296,6 +299,7 @@ fn is_valid_path_segment_slug(slug: &str) -> bool {
 fn intake_error_from_rejection(reason: RejectionReason) -> WorkspaceIntakeError {
     match reason {
         RejectionReason::PathTraversalAttempt => WorkspaceIntakeError::PathTraversalAttempt,
+        RejectionReason::ManagedOutputRoot => WorkspaceIntakeError::ManagedOutputRoot,
         RejectionReason::OutsideWorkspace => WorkspaceIntakeError::OutsideWorkspace,
         RejectionReason::SymlinkRaced | RejectionReason::SymlinkRefused => {
             WorkspaceIntakeError::SymlinkRaced
@@ -1720,6 +1724,12 @@ fn validate_relative_components_io(path: &Path) -> io::Result<()> {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "absolute path rejected",
+        ));
+    }
+    if is_claim_file_projection_root_path(path) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "managed output root rejected",
         ));
     }
     for component in path.components() {

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -2,6 +2,27 @@
   "schema_version": 1,
   "abilities": [
     {
+      "name": "apply_claim_file_corrections",
+      "description": "",
+      "category": "maintenance",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "submit.claim_file_corrections"
+      ],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "side_effect",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
       "name": "claim_receipt",
       "description": "",
       "category": "read",
@@ -433,6 +454,27 @@
         "runtime"
       ],
       "required_scopes": [],
+      "mcp_exposure": "none",
+      "client_side_executable": false,
+      "idempotency_class": "side_effect",
+      "composition_kind": {
+        "produces_blocks": false,
+        "block_types": []
+      }
+    },
+    {
+      "name": "render_entity_claim_file",
+      "description": "",
+      "category": "maintenance",
+      "annotations": {},
+      "wp_permission": "none",
+      "allowed_actors": [
+        "user",
+        "surface_client"
+      ],
+      "required_scopes": [
+        "write.claim_files"
+      ],
       "mcp_exposure": "none",
       "client_side_executable": false,
       "idempotency_class": "side_effect",

--- a/tools/dailyos-abilities.json
+++ b/tools/dailyos-abilities.json
@@ -8,12 +8,9 @@
       "annotations": {},
       "wp_permission": "none",
       "allowed_actors": [
-        "user",
-        "surface_client"
+        "user"
       ],
-      "required_scopes": [
-        "submit.claim_file_corrections"
-      ],
+      "required_scopes": [],
       "mcp_exposure": "none",
       "client_side_executable": false,
       "idempotency_class": "side_effect",
@@ -469,12 +466,9 @@
       "annotations": {},
       "wp_permission": "none",
       "allowed_actors": [
-        "user",
-        "surface_client"
+        "user"
       ],
-      "required_scopes": [
-        "write.claim_files"
-      ],
+      "required_scopes": [],
       "mcp_exposure": "none",
       "client_side_executable": false,
       "idempotency_class": "side_effect",


### PR DESCRIPTION
<!-- protocol-doc: dailyos-pr-template -->

## Linear ticket

DOS-628

## Summary

Implements readable claim-file projections for v1.4.9 W3. Canonical claims can now render into `_dailyos_claims/.../claims.md` with a structured correction sidecar, and edited correction blocks apply back through the existing claim receipt feedback path instead of becoming source evidence.

## What changed

- Added `claim_files` service support for rendering account/project/person claim files, sidecars, semantic identity, lifecycle, provenance summaries, contradiction edges, feedback rows, projection checksums, and correction parsing.
- Added hidden runtime abilities for `render_entity_claim_file` and `apply_claim_file_corrections`, wired through the live `ServiceContext` without adding handwritten Tauri commands.
- Added v280/v281 projection ledger migrations for projection runs and run-claim membership.
- Extended WrongSubject receipt metadata to canonical `corrected_subject_ref` while preserving legacy `corrected_to` input.
- Excluded `_dailyos_claims` from workspace ingestion, explicit workspace intake, and workspace backfill, including lexical managed-root rejection before symlink resolution.
- Hardened apply reads to reject unsupported sidecar versions, sidecar checksum drift, traversal, managed-root symlinks, symlinked projection files, hardlinked projection files, and post-feedback rerender failures that should not make a successful correction retriable.
- Regenerated `tools/dailyos-abilities.json` so the committed ability inventory matches the live registry.
- Added a devtools schema-impact note for the service-owned projection ledgers.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `pnpm tsc --noEmit`
- [x] `cargo test --lib claim_files`
- [x] `cargo test --lib open_validated_rejects_claim_file_projection_root`
- [x] `cargo test --lib test_mock_data_insert_statements_match_current_schema`
- [x] `cargo test -p abilities-runtime claim_files`
- [x] `cargo test --test dos217_surface_drift_lint_test`
- [x] `cargo test --test dos7_d4_lint_test`
- [x] `scripts/check_no_ephemeral_issue_refs_in_comments.sh`
- [x] `scripts/check_ability_inventory.sh`
- [x] `git diff --check`
- [x] GitHub checks on PR #436: `L2 / config-fence`, `L2 / validate-pr-template`, `L2 / l2-summary`, `lint-and-checks`, `frontend`

## Definition of Done

- [x] Acceptance criteria validated against real service paths.
- [x] End-to-end flow implemented: claim substrate -> projection files -> structured correction blocks -> receipt feedback -> rerender.
- [x] No Tauri command surface drift.
- [x] Managed projection outputs are excluded from all workspace ingestion paths.
- [x] No implementation stubs or unfinished-work deferrals introduced.

## L2 status

Initial external `/codex review` was blocked by local approval policy for repository-diff transfer, so the branch started with a local bounded L2 pass. After the blocking findings were fixed, a focused Codex L2 recheck passed against the four reviewed findings:

- machine-parsed correction block no longer includes display-only claim/provenance text
- sidecar `subject_ref_compact` now matches canonical claim dedup semantics
- projection-file reads reject symlink and hardlink races using stable file-handle metadata
- correction feedback success is not converted into a retriable failure when rerender fails

Latest code-touching commits carry `L2-status: passed`; the original docs-only L0 commit carries `L2-status: n-a-doc-only`.

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field above is set false): _none_

**Exemption rationale**:

Security review applies because this implementation defines filesystem boundaries, claim write-back, managed-output ingestion fences, sidecar validation, and ability scope policy.

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [x] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

---

Generated with Codex.
