### PR TITLE
DOS-832 L1a: replay claim-file corrections

### DIFF
--- a/.docs/plans/dos-832/dos-832-l0-packet.md
+++ b/.docs/plans/dos-832/dos-832-l0-packet.md
@@ -4,8 +4,8 @@
 **Issue:** [DOS-832](https://linear.app/a8c/issue/DOS-832)  
 **Author date:** 2026-06-03  
 **Tier:** Tier 3 (markdown-only)  
-**Scope tier:** Wave-coupled substrate. L0 requires `/codex challenge` equivalent, `ce-feasibility-reviewer`, `ce-security-lens-reviewer`, and mandatory K-in. External `/codex challenge` is not recorded in this draft; local adversarial document review is the substitute unless the external run is explicitly approved.
-**Status:** Draft for L0 review.
+**Scope tier:** Wave-coupled substrate. L0 requires `/codex challenge` or a project-approved equivalent, `ce-feasibility-reviewer`, `ce-security-lens-reviewer`, and mandatory K-in. Local adversarial document review may harden the draft, but it does not make the packet L0-approved on its own.
+**Status:** Draft for L0 review; not approved until the adversarial, feasibility, security-lens, and K-in verdicts are recorded.
 
 ---
 
@@ -294,7 +294,7 @@ pnpm tsc --noEmit
 - **K-in:** `ce-learnings-researcher` completed; findings folded into §1-§6.
 - **Feasibility:** `ce-feasibility-reviewer` required to verify this can be built from current source registration, ingestion, claim, feedback, and DB-mode services.
 - **Security:** `ce-security-lens-reviewer` required because DOS-832 touches filesystem trust boundaries, Live destructive operation, recovery docs, exported DB copies, and sensitive correction data.
-- **Adversarial doc review:** local substitute for external `/codex challenge` unless external review is explicitly approved.
+- **Adversarial review:** external `/codex challenge` or a project-approved equivalent is required for formal L0 approval. If the external run is unavailable, record the failure and keep the packet in draft/not-approved status; local adversarial review is only an input to hardening edits.
 
 Approval requires unanimous pass or explicit L6 decision on any residual release gate.
 
@@ -318,7 +318,7 @@ Approval requires unanimous pass or explicit L6 decision on any residual release
 
 ## §9 Definition of Done
 
-- L0 packet passes K-in, feasibility, security-lens, and adversarial review.
+- L0 packet passes K-in, feasibility, security-lens, and external/project-approved adversarial review.
 - L1 implementation either waits for DOS-628 or remains explicitly non-releaseable until DOS-628 sidecar semantics exist.
 - Fresh-schema rebuild succeeds in Replica mode with generic fixtures and real-workspace PII-free proof.
 - Correction replay proves typed feedback, tombstone, contradiction, and ambiguity behavior.

--- a/.docs/plans/dos-832/dos-832-l0-packet.md
+++ b/.docs/plans/dos-832/dos-832-l0-packet.md
@@ -28,7 +28,7 @@
 - SQLCipher retirement is an ADR-0092 amendment path, not ADR-0136.
 - There is no in-place decrypt/sentinel migration in DOS-831.
 - Existing encrypted-looking active DBs fail loud into storage-health/rebuild guidance.
-- Current schema head is v276; next free slot is v277.
+- At L0 drafting, current schema head was v276 and the next free slot was v277. The stacked L1 implementation now sits above W3's v280/v281 claim-file projection migrations, so DOS-832 replay journal schema uses v282.
 - Writer-priority lane language is stale; ADR-0133 owns FIFO writer/gate responsibility.
 
 **Authority precondition:** DOS-832 implementation does not begin from the stale local wave-plan text. Before L1, either DOS-831 PR #434 (or an equivalent wave-plan/ADR correction) is merged into the branch, or this packet remains a draft and the first L1 task is to rebase/apply those authority corrections. A packet note pointing at an unavailable PR is not sufficient for shipping implementation.
@@ -107,7 +107,7 @@ The rebuild path creates a fresh database at schema head, then replays canonical
 The intended phases:
 
 1. **Plan:** resolve workspace root, DB mode, target DB path, existing DB health, and source inventory. Produce a PII-safe summary using handles/counts/reason codes.
-2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev`; reserve `v277+` only if L1 adds rebuild-run schema).
+2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev` at L0; v281 after W3 stacking; reserve `v282+` if L1 adds rebuild-run schema after W3).
 3. **Canonical entity seed:** run the existing entity JSON sync for `Accounts`, `Projects`, and `People` through `WorkspaceSourceRegistry::open_validated` or a rebuild-owned bounded-open helper with the same traversal, symlink, race, workspace-escape, size, and hardlink protections, while preserving the fact that this is only the entity seed layer.
 4. **Source registration:** reuse/extend `workspace_backfill` to register workspace files and entity links. It remains privacy-aware and resumable.
 5. **Source ingestion:** run the workspace ingestion pipeline over registered eligible files. Claims must enter through `commit_claim` with `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, `observed_at`, temporal scope, sensitivity, and provenance intact.
@@ -122,7 +122,7 @@ Implementation shape:
 - Existing entity JSON read paths in `accounts`, `projects`, `people`, `entity_io`, and `db_backup` are either bypassed by the rebuild reader or refactored behind the bounded-open helper for rebuild use. L1 must include a static/code-review proof that rebuild cannot ingest account/project/person JSON from symlinks, outside-workspace paths, race-swapped files, oversize inputs, or hardlinks rejected by `open_validated`.
 - Rebuild orchestration, source registration, ingestion, re-enrichment, correction replay, cutover, queue pause/drain/resume, verification, and failure/rollback phases emit ADR-0120 `InvocationRecord`s. Rebuild/replay run state stores or correlates `invocation_id` / `caused_by_invocation_id` where the row answers "what invocation caused this."
 - Pause/drain background intelligence queues before Live replacement or long writer-exclusive phases, then resume or requeue pending work. Rebuild cannot race normal startup/background writers.
-- Add durable rebuild/replay run state if the existing `workspace_backfill_runs` tables are insufficient. If new schema is required, reserve from v277 upward and update the wave plan after DOS-831's corrections merge.
+- Add durable rebuild/replay run state if the existing `workspace_backfill_runs` tables are insufficient. If new schema is required, reserve from the next free slot above the stacked schema head and update the wave plan after DOS-831's corrections merge.
 
 ### §2.2 Canonical Inputs
 
@@ -360,7 +360,7 @@ Approval requires unanimous pass or explicit L6 decision on any residual release
 | `/codex challenge` | APPROVE | Final rerun approved after verifying debug trace, Live cutover reopen-path coverage, ADR-0120 observability, ADR-0094/0098 audit events, entity seed trust boundary, correction replay, source-time determinism, and release gates. Evidence: `CODEX_DOS832_FINAL2_ERR=/tmp/codex-dos832-final2-err-EJJPzG`; tokens used: 710,957. |
 | `ce-security-lens-reviewer` | APPROVE | Approved after entity JSON seed reads were bound to the workspace trust boundary, cutover gates covered DB/service reopen paths, and sidecar/export audit/security obligations were explicit. |
 | `ce-feasibility-reviewer` | APPROVE | Approved after process-wide cutover gate, scoped reopen token, queue pause/drain/resume semantics, service ownership, and current-code reopen paths were named. |
-| `ce-data-migrations-reviewer` | APPROVE | Approved schema/data-integrity posture: fresh-schema replay, v277+ reservation only if new run state is required, no raw claim copy, replay idempotency, and invocation correlation where applicable. |
+| `ce-data-migrations-reviewer` | APPROVE | Approved schema/data-integrity posture: fresh-schema replay, next-free-slot reservation only if new run state is required, no raw claim copy, replay idempotency, and invocation correlation where applicable. |
 | `ce-learnings-researcher` | APPROVE | Confirmed prior substrate is represented: ADR-0120, ADR-0094/0098, ADR-0048, ADR-0107/0098, ADR-0123/0126/0131, ADR-0133, ADR-0110, and documented claim-producer/runtime trust audit and DB lock-storm learnings. |
 
 Cycle notes:

--- a/.docs/plans/dos-832/dos-832-l0-packet.md
+++ b/.docs/plans/dos-832/dos-832-l0-packet.md
@@ -1,0 +1,326 @@
+# DOS-832 L0 Packet — First-Class Rebuild From Canonical Workspace Inputs
+
+**Version:** v1.4.9 · W1b storage hardening  
+**Issue:** [DOS-832](https://linear.app/a8c/issue/DOS-832)  
+**Author date:** 2026-06-03  
+**Tier:** Tier 3 (markdown-only)  
+**Scope tier:** Wave-coupled substrate. L0 requires `/codex challenge` equivalent, `ce-feasibility-reviewer`, `ce-security-lens-reviewer`, and mandatory K-in. External `/codex challenge` is not recorded in this draft; local adversarial document review is the substitute unless the external run is explicitly approved.
+**Status:** Draft for L0 review.
+
+---
+
+## §0 Origination + Boundary
+
+**Origination class:** Debug-driven. DOS-832 comes from the 2026-05-28/29 storage-loss recovery path and the v1.4.9 storage reset program. The existing manual recovery shape was "delete/recreate/re-enrich until the app works." This packet turns that into a first-class, repeatable, auditable rebuild path.
+
+**Critical dependency:** DOS-832 is not a generic import script and not a W1-only feature. The v1.4.9 wave plan routes correction-preserving rebuild through W3/DOS-628's structured corrections sidecar. DOS-832 can design and implement source inventory, fresh-schema orchestration, source registration, ingestion replay, and Replica proof now, but **the correction-preserving release gate cannot pass until DOS-628 defines and ships the sidecar projection contract**.
+
+**Branch-note:** this branch is based on `public/dev`, whose `.docs/plans/v1.4.9-waves.md` still contains stale W1b text: ADR-0136, split-build decrypt/sentinel migration, v273/v274 migration slots, and "writer-priority lane." DOS-831 PR #434 corrects those assumptions. DOS-832 consumes the corrected assumptions:
+
+- SQLCipher retirement is an ADR-0092 amendment path, not ADR-0136.
+- There is no in-place decrypt/sentinel migration in DOS-831.
+- Existing encrypted-looking active DBs fail loud into storage-health/rebuild guidance.
+- Current schema head is v276; next free slot is v277.
+- Writer-priority lane language is stale; ADR-0133 owns FIFO writer/gate responsibility.
+
+**Authority precondition:** DOS-832 implementation does not begin from the stale local wave-plan text. Before L1, either DOS-831 PR #434 (or an equivalent wave-plan/ADR correction) is merged into the branch, or this packet remains a draft and the first L1 task is to rebase/apply those authority corrections. A packet note pointing at an unavailable PR is not sufficient for shipping implementation.
+
+### Trust Topology
+
+- Local-to-local, single-user machine trust boundary.
+- Rebuild operates on local workspace files and the local app DB only.
+- Rebuild output can contain claims, provenance, trust bands, signal state, and feedback history; therefore DOS-832 runs the full Intelligence Loop integration check.
+- Real-workspace validation may run locally, but committed fixtures, docs, logs, PR text, and test output must be PII-free.
+
+---
+
+## §1 What Exists
+
+### §1.1 Existing Rebuild Is Insufficient
+
+`src-tauri/src/db_backup.rs::rebuild_from_filesystem` scans `Accounts/*/dashboard.json`, `Projects/*/dashboard.json`, and `People/*/person.json`, then syncs accounts, projects, and people. Its own doc comment names the known gaps: email enrichment state, meeting history, and action source references can be lost. It does not rebuild the claim substrate, provenance, trust inputs, workspace source lifecycle, embeddings, signals, invalidation jobs, claim feedback, or contradictions.
+
+ADR-0048 accurately described that older safety net in February 2026, but it now conflicts with v1.4.9's correction-preserving rebuild goal. DOS-832 must update ADR-0048 Principle 4 to distinguish:
+
+- legacy partial rebuild from entity JSON; and
+- first-class intelligence rebuild from canonical workspace inputs plus re-enrichment plus correction replay.
+
+### §1.2 Workspace Source Substrate Exists
+
+The v1.4.5 workspace ingestion substrate already provides the pieces DOS-832 should consume:
+
+- `WorkspaceSourceRegistry::open_validated` is the workspace file trust boundary and guards traversal, symlinks, races, workspace escape, size, and unsupported formats.
+- `workspace_file_lifecycle` stores source provenance (`source_type`, `data_source`, `source_asof`, lifecycle state, entity link, content hash, category).
+- `workspace_source_registry` and `workspace_category_registry` define typed `DataSource::WorkspaceFile { kind }` categories.
+- `document_ingestion_runs` provides per-file/content/mode ingestion idempotency.
+- `document_entity_links` records source-to-entity attribution and tombstones.
+- `workspace_backfill` already scans the workspace, computes PII-safe handles, detects duplicate content, records resumable state, and registers sources. It intentionally does **not** create claims.
+
+### §1.3 Claim + Correction Substrate Exists
+
+Rebuild must reuse the shipped claim services:
+
+- `services::claims::commit_claim` is the only intelligence-claim writer. It computes canonical subject identity, item hash, semantic `compute_dedup_key`, trust initialization, same-meaning merge, tombstone PRE-GATE, contradiction forks, claim edges, version events, and invalidation bumps.
+- `services::claims::record_claim_feedback` is the typed correction writer. It records append-only `claim_feedback`, updates verification/lifecycle state, emits version events, tombstones edges where appropriate, bumps invalidation, and queues targeted repair.
+- `claim_receipt::feedback` is already a receipt-shaped, sensitivity-gated, idempotency-aware caller for feedback.
+
+DOS-832 must not raw-copy `intelligence_claims`, raw-insert `claim_feedback`, preserve old claim IDs as a correctness assumption, or update claim lifecycle columns directly.
+
+### §1.4 DB Mode + Writer Discipline Exists
+
+DB-mode isolation exists in `ActionDb`: non-release defaults to Replica, `DbMode::Replica` resolves to `dailyos-replica.db`, and structural prod-open denial forbids production DB opens outside Live. Maintenance binaries already use explicit Live opt-in patterns.
+
+ADR-0133 owns writer queue responsibility: no fresh mutating DB connections to "avoid starving foreground," no priority in the gate, no DB guards across `.await`, and mutations route through the service/writer path. DOS-832 is write-heavy and must consume this substrate.
+
+### §1.5 Current-Code Blockers
+
+Current `public/dev` is not yet a plain-SQLite rebuild target. `ActionDb` still detects plaintext DB files and migrates them to SQLCipher through `migrate_to_encrypted`. Therefore:
+
+- DOS-832's plain-SQLite fresh-install proof is gated on DOS-831 L1 landing the storage-mode change.
+- Until then, DOS-832 L1 may prove orchestration in Replica/current-encrypted mode, but it cannot claim the final plain-SQLite recovery AC.
+- The packet remains release-gated with DOS-831: encrypted-looking active stores fail loud into storage-health/rebuild guidance, but the plain rebuild target must not be marked complete while auto-encrypt paths still exist.
+
+Meeting history, email enrichment cache state, and action source-reference repair are the historical gaps that motivated DOS-832. This packet does **not** claim a lossless clone of every legacy SQLite table. L1 must either name a canonical input/producer and verification metric for each of those categories or report it as out-of-scope/degraded in the rebuild result. User-facing proof must say "reconstructed intelligence substrate" unless those categories are covered explicitly.
+
+---
+
+## §2 Target Shape
+
+### §2.1 Rebuild Is Fresh-Schema Replay, Not Migration
+
+The rebuild path creates a fresh database at schema head, then replays canonical inputs into it. It does not:
+
+- mutate a damaged/encrypted source DB in place;
+- convert cipher to plain;
+- repair arbitrary corruption inside the source DB;
+- copy claim rows by ID from an old DB;
+- treat generated markdown as canonical truth.
+
+The intended phases:
+
+1. **Plan:** resolve workspace root, DB mode, target DB path, existing DB health, and source inventory. Produce a PII-safe summary using handles/counts/reason codes.
+2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev`; reserve `v277+` only if L1 adds rebuild-run schema).
+3. **Canonical entity seed:** run the existing entity JSON sync for `Accounts`, `Projects`, and `People`, while preserving the fact that this is only the entity seed layer.
+4. **Source registration:** reuse/extend `workspace_backfill` to register workspace files and entity links. It remains privacy-aware and resumable.
+5. **Source ingestion:** run the workspace ingestion pipeline over registered eligible files. Claims must enter through `commit_claim` with `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, `observed_at`, temporal scope, sensitivity, and provenance intact.
+6. **Re-enrichment:** run existing claim/enrichment producers needed to reproduce entities, claims, provenance, trust inputs, salience, embeddings, and derived context. Any producer newly invoked by rebuild must pass the runtime-wide trust audit in `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md`.
+7. **Correction replay:** after DOS-628/W3 supplies the corrections sidecar, match regenerated claims by semantic content identity and replay typed corrections through `record_claim_feedback`.
+8. **Verification:** compare source inventory, entity counts, claim counts by type/state/trust band, correction replay outcomes, orphaned sidecar entries, and surface smoke checks. No PII in committed proof.
+
+Implementation shape:
+
+- Add a `services::rebuild` owner. Commands and maintenance binaries only parse/validate options and invoke the service.
+- Pause/drain background intelligence queues before Live replacement or long writer-exclusive phases, then resume or requeue pending work. Rebuild cannot race normal startup/background writers.
+- Add durable rebuild/replay run state if the existing `workspace_backfill_runs` tables are insufficient. If new schema is required, reserve from v277 upward and update the wave plan after DOS-831's corrections merge.
+
+### §2.2 Canonical Inputs
+
+Canonical inputs are:
+
+- workspace JSON where ADRs define it as durable structured state (`dashboard.json`, `person.json`, project/account equivalents);
+- governed workspace files opened through `WorkspaceSourceRegistry::open_validated`;
+- source registry/lifecycle metadata derived from those files and source kinds;
+- DOS-628 corrections sidecar once shipped.
+
+Derived replay outputs are not canonical inputs. L1 must inventory each producer before implementation:
+
+| Producer family | Canonical inputs | Derived outputs | Verification metric |
+| --- | --- | --- | --- |
+| Entity JSON sync | account/project/person JSON | entity rows, tracker paths, basic relationships | counts by entity type, archived/internal exclusions, tracker-path parity |
+| Workspace registration/ingestion | validated workspace files + source metadata | lifecycle rows, entity links, workspace-backed claims | file counts by source kind/category, claim counts by type/source, source-time confidence counts |
+| Re-enrichment/trust/salience | canonical entities, workspace sources, service evidence, AI runtime output | claims, trust inputs/bands, salience, embeddings, derived contexts | counts by producer/claim type/trust band, provenance completeness, invalidation/recompute markers |
+| Correction replay | DOS-628 sidecar events | feedback rows, claim lifecycle/verification changes, contradiction/supersession state | applied/skipped/orphaned counts by stable event id and reason |
+
+Non-canonical inputs:
+
+- generated markdown as a source of database truth;
+- old DB row IDs;
+- old runtime `dedup_key` values copied verbatim;
+- re-enrichment outputs treated as authority instead of derived results;
+- logs, proof output, or human-only summaries.
+
+`source_asof` resolution must be deterministic. Existing public intake/backfill paths derive `source_asof` from file mtime; that is not enough for replay proof. DOS-832 L1 must define a source-time resolver with explicit precedence:
+
+1. persisted lifecycle/source metadata or canonical source sidecar timestamp when available;
+2. source-native timestamp inside canonical JSON when the ADR for that file type names it;
+3. filesystem mtime only as `filesystem_unverified`, with that confidence recorded in the report.
+
+Rebuild time is never a substitute for source time.
+
+### §2.3 Correction Replay Contract
+
+DOS-832 consumes the v1.4.9 rebuild decision:
+
+- W3/DOS-628 projects a structured `corrections` sidecar keyed by content-derived semantic identity in the `compute_dedup_key(item_hash, subject_ref_compact, claim_type, field_path)` shape.
+- Rebuild re-enriches first, producing fresh claim UUIDs.
+- Replay resolves sidecar entries to regenerated claims by semantic identity.
+- Non-unique matches are disambiguated by `source_ref` and `observed_at`.
+- Ambiguous or missing matches become **orphaned replay entries** in the report; they are never guessed, silently dropped, or wired to the wrong claim.
+- Tombstones, dormant/withdrawn state, contradictions, supersession, and typed `FeedbackAction` semantics are preserved by replaying through `services::claims`, not by raw SQL.
+- Replay must never resurrect a tombstoned claim or write around PRE-GATE.
+- Feedback replay uses the same user-correction actor semantics accepted by `record_claim_feedback`; non-user replay actors require an explicit writer extension in the sidecar/replay L0 before implementation.
+- DOS-628 sidecar events must expose a stable `correction_event_id` or equivalent replay key. DOS-832's replay journal claims that key before calling any feedback/claim mutation service.
+- DOS-832 uses a named `services::claims` replay helper for sidecar events that are not expressible as a plain `record_claim_feedback` call. The helper owns contradiction/supersession reconciliation, endpoint resolution, idempotency, orphaning, and internal calls to `record_claim_feedback` / `commit_claim` / existing reconciliation routines. It is the only place where sidecar edge semantics enter the claim substrate.
+- Replay has its own durable journal: restarted rebuilds must not duplicate feedback rows, repair jobs, contradiction edges, or supersession effects.
+
+The exact sidecar schema and key derivation are owned jointly by DOS-628 and DOS-832 L0/L1. DOS-832 cannot pass its full AC without that contract.
+
+### §2.4 Operator Boundary
+
+Default posture:
+
+- `--dry-run` and Replica rebuild proof are first-class.
+- Live destructive replacement requires explicit Live mode plus an explicit operator flag.
+- Existing active DB replacement must create a restore point and validate storage health before and after.
+- Live replacement uses a DB-service cutover protocol, not a blind file copy: block new readers/writers, pause/drain background queues, close/drop the active DB pool, checkpoint/handle WAL, stage the rebuilt DB, atomically swap, remove stale WAL/SHM, harden permissions, validate, then reopen.
+- If an encrypted-looking active DB is present after DOS-831, the app fails loud and routes to storage-health rebuild/restore guidance; it does not run an in-place decrypt repair.
+- Exported DB copies are plaintext egress after DOS-831 and must use destination-boundary warnings and restrictive permissions where possible.
+
+### §2.5 Sensitive Artifacts
+
+The DOS-628 corrections sidecar and DOS-832 replay journal are sensitive local artifacts. They can contain claim feedback actions, wrong-source/wrong-subject metadata, nuance text, tombstone/supersession state, and contradiction references.
+
+Security contract:
+
+- Sidecars live only under the configured workspace or DailyOS app-support recovery directory; arbitrary output paths are rejected unless the operator explicitly chooses an export destination.
+- Sidecar and replay-journal files are classified at least `confidential`; user-authored free text inherits higher sensitivity when the source claim requires it.
+- Files are written with owner-only permissions where supported.
+- Reports/logs use handles, counts, hashes, reason codes, and sensitivity labels; they do not include raw correction text, entity names, absolute local paths, or source payloads.
+- Retention is explicit: after successful replay, the sidecar is retained only if it is part of the durable DOS-628 projection contract; transient replay journals are pruned or marked completed according to the operator policy. Failed/orphaned entries retain only the minimum data needed for safe retry.
+- Exporting a sidecar follows the same destination-boundary warning and evidence-governance rules as exported DB copies.
+
+---
+
+## §3 Acceptance Criteria
+
+**AC1 — Fresh intelligence-substrate proof.** Starting from an empty target DB at schema head, rebuild reproduces the reconstructable intelligence substrate from canonical workspace inputs plus service re-enrichment: accounts, projects, people, workspace sources, entity links, claims, provenance, trust-band inputs, salience/derived context needed by covered shipped surfaces, and source lifecycle state. Meeting history, email enrichment cache state, and action source references are either covered by named canonical producers and verification counts or explicitly reported as degraded/out-of-scope.
+
+**AC2 — Correction preservation.** With a DOS-628 corrections sidecar containing representative feedback, demotions/tombstones, contradictions, supersession, stable replay IDs, and a deliberate ambiguous match, rebuild replays corrections through the named `services::claims` replay helper. Regenerated claims reflect the correction state; ambiguous entries are reported as orphans.
+
+**AC3 — No raw claim copy.** Tests and static review show rebuild does not copy old `intelligence_claims` rows, old claim IDs, raw `claim_feedback`, or old runtime `dedup_key` values as authoritative state. All claim production flows through `commit_claim`; all correction replay flows through `record_claim_feedback` or its receipt-layer wrapper.
+
+**AC4 — Source/provenance fidelity.** Rebuilt claims preserve `DataSource`, `source_ref`, knowable `source_asof`, `observed_at`, provenance JSON, temporal scope, sensitivity, and trust inputs. Rebuild time is not used as source time unless the source truly has no earlier timestamp and the report marks the confidence accordingly.
+
+**AC5 — DB-mode safety.** Dry-run and Replica proof cannot open or mutate the production DB. Live replacement refuses unless DB mode is Live and an explicit operator flag is present. Existing DB replacement creates a restore point and validates storage health.
+
+**AC6 — Exported DB egress.** Exported DB copies after DOS-831 are treated as plaintext egress: the UI/operator flow shows an explicit warning, destination handling avoids leaking absolute paths or source details into logs, and owner-only permissions are applied where supported.
+
+**AC7 — Correction sidecar security.** DOS-628 sidecars and DOS-832 replay journals have a classified storage/retention contract: bounded path, owner-only permissions where supported, no raw correction/source payloads in logs or reports, explicit retention/prune behavior, and safe orphan retry metadata.
+
+**AC8 — Live cutover exclusivity.** Live destructive replacement blocks new readers/writers, pauses/drains background queues, closes/drops the active DB service/pool, stages and atomically swaps the rebuilt DB, cleans WAL/SHM, validates the replacement, and reopens service access. Failure restores the prior DB or leaves a clear restore point.
+
+**AC9 — Single-writer/service boundary.** Rebuild writes route through service-owned mutation paths and the writer discipline. No command handler or maintenance bin directly mutates tables outside services. No fresh mutating DB connection is introduced to bypass the writer path.
+
+**AC10 — Resumability and observability.** Long rebuilds are resumable by durable run state. The run report uses PII-safe handles/counts/reason codes and records failures for source registration, ingestion, enrichment, correction replay, and verification. Replay resume is idempotent across process restarts by claiming stable sidecar event IDs before mutation.
+
+**AC11 — ADR + docs.** ADR-0048 Principle 4 is amended to describe first-class intelligence rebuild and its dependency on correction sidecars. Operator recovery docs explain dry-run, Replica proof, Live cutover, encrypted-looking DB failure, sidecar retention, plaintext export warnings, and restoration.
+
+**AC12 — Gates.** Focused tests plus full gates pass:
+
+```bash
+cargo clippy -- -D warnings
+cargo test
+pnpm tsc --noEmit
+```
+
+---
+
+## §4 Intelligence Loop Integration Check
+
+1. **Claim model:** Rebuild produces claims, not display-only rows. Existing claim types and `ClaimProposal` metadata remain authoritative. New rebuild-run metadata is operational, not a claim, unless L1 introduces a user-visible assertion about rebuild health.
+2. **Provenance + trust:** Producers must pass full provenance and trust inputs into `commit_claim`. Trust recomputation/audit covers source lifecycle, freshness, corroboration, contradiction, correction state, sensitivity, and verification state. Rebuild must not seed arbitrary trust scores.
+3. **Signals + invalidation:** Rebuild must emit or reconstitute the signals needed for source ingestion, claim commits, feedback replay, targeted repair, trust recompute, and surface invalidation. A rebuilt DB with stale rendered surfaces is not accepted.
+4. **Runtime + surfaces:** Tauri and MCP read the rebuilt DB through existing services and sensitivity gates. `build_intelligence_context()`, account/project/person contexts, workspace graph reads, and claim receipt routes must behave against the rebuilt store. Meeting prep/readiness surfaces are included only where their canonical source inputs/producers are covered; otherwise rebuild proof must show an explicit source-gap/degraded state rather than silent stale output.
+5. **Feedback loop:** User corrections survive by structured sidecar replay into `claim_feedback` and claim lifecycle state. New feedback after rebuild continues through the same services and source-reliability/trust inputs. Sidecar storage and replay logs preserve the correction loop without exposing raw sensitive correction text.
+
+---
+
+## §5 Scope Boundaries
+
+In scope:
+
+- L0 design for full correction-preserving rebuild.
+- Reuse/extension of workspace backfill, workspace ingestion, claim producers, correction replay, and run reporting.
+- ADR-0048 amendment requirement.
+- Replica-first and Live-cutover operator guard design.
+
+Out of scope:
+
+- In-place cipher/plain migration or corruption repair.
+- Re-authoring DOS-628 sidecar schema inside DOS-832.
+- New claim mutation API parallel to `commit_claim` / `record_claim_feedback`.
+- New source-of-truth model where generated markdown becomes canonical.
+- Customer-specific fixtures or committed real-workspace proof.
+- MCP auth/transport changes from W2.
+
+---
+
+## §6 Test Plan
+
+Focused L1 tests:
+
+- Unit tests for rebuild plan/source inventory skip reasons and PII-safe report shape.
+- Replica-mode test proving production DB path denial.
+- Workspace source registration integration test reusing existing generic fixtures.
+- Deterministic `source_asof` precedence test where file mtime changes but canonical source metadata keeps the same provenance timestamp.
+- Ingestion replay test proving claims enter through `commit_claim` and carry `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, provenance, and sensitivity.
+- Producer-inventory test or fixture proof that each claimed derived output has named canonical inputs, produced tables/claims, trust/provenance behavior, and verification counts.
+- Correction replay test using generic sidecar fixtures with stable replay IDs for confirm/current, false/outdated, wrong subject/source, nuance, surface inappropriate, not relevant, contradiction, supersession, tombstone, unknown claim ID, and ambiguous/non-unique endpoints.
+- Idempotency/resume test that claims sidecar event IDs before mutation and restarts after source registration, ingestion, enrichment, and correction replay without duplicate claims, feedback, repair jobs, or replay effects.
+- Queue pause/drain/resume and DB-service close/drop/reopen test for Live cutover phases.
+- Exported DB copy test for warning state, destination-boundary handling, owner-only permissions where supported, and no raw destination/path/source details in logs.
+- Sidecar/replay-journal security test for bounded path, owner-only permissions where supported, report redaction, orphan metadata shape, and retention/prune behavior.
+- Storage-health test for encrypted-looking / unreadable active DB guidance.
+- Operator CLI/command tests for dry-run, apply, resume, and Live refusal.
+
+Real-data proof:
+
+- Run locally against the real workspace in Replica mode.
+- Commit only aggregate PII-free counts and pass/fail summaries.
+- Any committed proof record follows `.docs/evals/evaluation-evidence-contract.md` and `.docs/evals/fixture-governance.md`: repo-relative paths, input hashes, privacy metadata, and no customer data, identity maps, private payload paths, or absolute local paths.
+
+Full gates:
+
+```bash
+cargo clippy -- -D warnings
+cargo test
+pnpm tsc --noEmit
+```
+
+---
+
+## §7 L0 Reviewer Dispatch
+
+- **K-in:** `ce-learnings-researcher` completed; findings folded into §1-§6.
+- **Feasibility:** `ce-feasibility-reviewer` required to verify this can be built from current source registration, ingestion, claim, feedback, and DB-mode services.
+- **Security:** `ce-security-lens-reviewer` required because DOS-832 touches filesystem trust boundaries, Live destructive operation, recovery docs, exported DB copies, and sensitive correction data.
+- **Adversarial doc review:** local substitute for external `/codex challenge` unless external review is explicitly approved.
+
+Approval requires unanimous pass or explicit L6 decision on any residual release gate.
+
+---
+
+## §8 K-In Findings Folded
+
+- `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md`: any rebuild/backfill that produces claims must audit producer path, provenance, trust inputs, recompute trigger, and surface behavior.
+- `docs/solutions/architecture-patterns/db-lock-storm-class-2026-05-27.md`: rebuild touches write-heavy paths; consume ADR-0133 writer discipline, no fresh writer connections, no locks across `.await`.
+- `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`: search by substrate primitives. DOS-832 extends existing workspace ingestion/claim feedback substrate rather than inventing a new import/correction system.
+- `.docs/evals/evaluation-evidence-contract.md` and `.docs/evals/fixture-governance.md`: real-data proof must be PII-free, repo-relative, hash-bound, and lintable.
+- Security L0 cycle: exported DB copies, correction sidecars/replay journals, and Live file-swap exclusivity are explicit AC/test surfaces, not posture-only bullets.
+- Adversarial L0 cycle: DOS-831 authority correction is a precondition, derived producer outputs are not canonical inputs, legacy rebuild gaps are either covered or reported as degraded, and correction replay requires stable event IDs plus a named `services::claims` replay helper.
+- ADR-0048: current rebuild principle is partial and must be amended.
+- ADR-0107: `DataSource::WorkspaceFile { kind }` exists and sets file-derived facts as reference posture.
+- ADR-0123/0126: corrections are typed feedback against immutable claim core; no direct claim mutation.
+- ADR-0131: canonicalization/dedup must respect tombstone shadowing and ambiguity.
+- ADR-0133: writer queue owns serialization and telemetry, not priority lanes or extra connections.
+
+---
+
+## §9 Definition of Done
+
+- L0 packet passes K-in, feasibility, security-lens, and adversarial review.
+- L1 implementation either waits for DOS-628 or remains explicitly non-releaseable until DOS-628 sidecar semantics exist.
+- Fresh-schema rebuild succeeds in Replica mode with generic fixtures and real-workspace PII-free proof.
+- Correction replay proves typed feedback, tombstone, contradiction, and ambiguity behavior.
+- ADR-0048 and operator docs are updated.
+- Full gates pass.

--- a/.docs/plans/dos-832/dos-832-l0-packet.md
+++ b/.docs/plans/dos-832/dos-832-l0-packet.md
@@ -5,13 +5,21 @@
 **Author date:** 2026-06-03  
 **Tier:** Tier 3 (markdown-only)  
 **Scope tier:** Wave-coupled substrate. L0 requires `/codex challenge` or a project-approved equivalent, `ce-feasibility-reviewer`, `ce-security-lens-reviewer`, and mandatory K-in. Local adversarial document review may harden the draft, but it does not make the packet L0-approved on its own.
-**Status:** Draft for L0 review; not approved until the adversarial, feasibility, security-lens, and K-in verdicts are recorded.
+**Status:** L0 approved on 2026-06-04 CDT after unanimous adversarial, feasibility, security-lens, data/migrations, and K-in review.
 
 ---
 
 ## §0 Origination + Boundary
 
 **Origination class:** Debug-driven. DOS-832 comes from the 2026-05-28/29 storage-loss recovery path and the v1.4.9 storage reset program. The existing manual recovery shape was "delete/recreate/re-enrich until the app works." This packet turns that into a first-class, repeatable, auditable rebuild path.
+
+**Debug trace:**
+
+- **Incident symptom:** the v1.4.9 wave plan records the trigger as the "2026-05-28 production DB-loss incident (dev-workflow `pkill` on a hot WAL writer; root-caused in PR #416, isolation in DOS-820/821/822)." The user-visible recovery symptom was an app that could only be brought back by recreating local state and rerunning enrichment, with correction history not guaranteed to survive.
+- **Source call path:** dev/test workflow killed a process while DB writes and WAL state were active; recovery then fell back to storage reset and `db_backup::rebuild_from_filesystem`, which calls account/project/person workspace sync from `src-tauri/src/db_backup.rs:545-554`.
+- **Suspected failure points:** pre-W1 single-writer ownership allowed unsafe writer/process interaction around a hot DB; the legacy rebuild fallback is partial by design (`src-tauri/src/db_backup.rs:533-544`) and cannot recover claim substrate, provenance, feedback, contradictions, source lifecycle, embeddings, or invalidation state.
+- **Rejected hypotheses:** the fix is not in-place cipher/plain migration, row-ID copy from an old DB, generated markdown as database authority, or a broader multi-user trust model. DOS-831 owns storage-mode retirement; DOS-820/821/822/DOS-758/DOS-823 own DB ownership and Replica isolation; DOS-832 owns the first-class rebuild after those guards exist.
+- **AC intersection:** AC1/AC1a replace the partial entity-only fallback with validated canonical input replay; AC2/AC3 preserve corrections through claim services instead of row copy; AC4/AC10 prove provenance, signals, and replay idempotency; AC5/AC8/AC9 prevent recovery from racing normal DB writers/readers while swapping Live storage.
 
 **Critical dependency:** DOS-832 is not a generic import script and not a W1-only feature. The v1.4.9 wave plan routes correction-preserving rebuild through W3/DOS-628's structured corrections sidecar. DOS-832 can design and implement source inventory, fresh-schema orchestration, source registration, ingestion replay, and Replica proof now, but **the correction-preserving release gate cannot pass until DOS-628 defines and ships the sidecar projection contract**.
 
@@ -100,16 +108,19 @@ The intended phases:
 
 1. **Plan:** resolve workspace root, DB mode, target DB path, existing DB health, and source inventory. Produce a PII-safe summary using handles/counts/reason codes.
 2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev`; reserve `v277+` only if L1 adds rebuild-run schema).
-3. **Canonical entity seed:** run the existing entity JSON sync for `Accounts`, `Projects`, and `People`, while preserving the fact that this is only the entity seed layer.
+3. **Canonical entity seed:** run the existing entity JSON sync for `Accounts`, `Projects`, and `People` through `WorkspaceSourceRegistry::open_validated` or a rebuild-owned bounded-open helper with the same traversal, symlink, race, workspace-escape, size, and hardlink protections, while preserving the fact that this is only the entity seed layer.
 4. **Source registration:** reuse/extend `workspace_backfill` to register workspace files and entity links. It remains privacy-aware and resumable.
 5. **Source ingestion:** run the workspace ingestion pipeline over registered eligible files. Claims must enter through `commit_claim` with `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, `observed_at`, temporal scope, sensitivity, and provenance intact.
-6. **Re-enrichment:** run existing claim/enrichment producers needed to reproduce entities, claims, provenance, trust inputs, salience, embeddings, and derived context. Any producer newly invoked by rebuild must pass the runtime-wide trust audit in `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md`.
+6. **Re-enrichment:** run existing claim/enrichment producers needed to reproduce entities, claims, provenance, trust inputs, salience, embeddings, and derived context. Any producer newly invoked by rebuild must pass the runtime-wide trust audit in `docs/solutions/architecture-patterns/claim-producers-require-runtime-wide-trust-audit-2026-05-22.md` and the ADR-0120 invocation-record contract.
 7. **Correction replay:** after DOS-628/W3 supplies the corrections sidecar, match regenerated claims by semantic content identity and replay typed corrections through `record_claim_feedback`.
-8. **Verification:** compare source inventory, entity counts, claim counts by type/state/trust band, correction replay outcomes, orphaned sidecar entries, and surface smoke checks. No PII in committed proof.
+8. **Verification:** compare source inventory, entity counts, claim counts by type/state/trust band, correction replay outcomes, orphaned sidecar entries, invocation/audit counters, and surface smoke checks. No PII in committed proof.
 
 Implementation shape:
 
 - Add a `services::rebuild` owner. Commands and maintenance binaries only parse/validate options and invoke the service.
+- Add a rebuild-owned entity seed reader under `services::rebuild` for account, project, and person JSON. It may wrap the existing entity sync services, but rebuild seed reads must not use direct `std::fs::read_dir` / `read_to_string` over `Accounts`, `Projects`, or `People` paths unless the path has first crossed the same validated workspace boundary as workspace ingestion.
+- Existing entity JSON read paths in `accounts`, `projects`, `people`, `entity_io`, and `db_backup` are either bypassed by the rebuild reader or refactored behind the bounded-open helper for rebuild use. L1 must include a static/code-review proof that rebuild cannot ingest account/project/person JSON from symlinks, outside-workspace paths, race-swapped files, oversize inputs, or hardlinks rejected by `open_validated`.
+- Rebuild orchestration, source registration, ingestion, re-enrichment, correction replay, cutover, queue pause/drain/resume, verification, and failure/rollback phases emit ADR-0120 `InvocationRecord`s. Rebuild/replay run state stores or correlates `invocation_id` / `caused_by_invocation_id` where the row answers "what invocation caused this."
 - Pause/drain background intelligence queues before Live replacement or long writer-exclusive phases, then resume or requeue pending work. Rebuild cannot race normal startup/background writers.
 - Add durable rebuild/replay run state if the existing `workspace_backfill_runs` tables are insufficient. If new schema is required, reserve from v277 upward and update the wave plan after DOS-831's corrections merge.
 
@@ -117,7 +128,7 @@ Implementation shape:
 
 Canonical inputs are:
 
-- workspace JSON where ADRs define it as durable structured state (`dashboard.json`, `person.json`, project/account equivalents);
+- workspace JSON where ADRs define it as durable structured state (`dashboard.json`, `person.json`, project/account equivalents), opened through `WorkspaceSourceRegistry::open_validated` or the rebuild-owned equivalent bounded-open helper;
 - governed workspace files opened through `WorkspaceSourceRegistry::open_validated`;
 - source registry/lifecycle metadata derived from those files and source kinds;
 - DOS-628 corrections sidecar once shipped.
@@ -126,7 +137,7 @@ Derived replay outputs are not canonical inputs. L1 must inventory each producer
 
 | Producer family | Canonical inputs | Derived outputs | Verification metric |
 | --- | --- | --- | --- |
-| Entity JSON sync | account/project/person JSON | entity rows, tracker paths, basic relationships | counts by entity type, archived/internal exclusions, tracker-path parity |
+| Entity JSON sync | validated account/project/person JSON | entity rows, tracker paths, basic relationships | counts by entity type, archived/internal exclusions, tracker-path parity, trust-boundary rejection counts |
 | Workspace registration/ingestion | validated workspace files + source metadata | lifecycle rows, entity links, workspace-backed claims | file counts by source kind/category, claim counts by type/source, source-time confidence counts |
 | Re-enrichment/trust/salience | canonical entities, workspace sources, service evidence, AI runtime output | claims, trust inputs/bands, salience, embeddings, derived contexts | counts by producer/claim type/trust band, provenance completeness, invalidation/recompute markers |
 | Correction replay | DOS-628 sidecar events | feedback rows, claim lifecycle/verification changes, contradiction/supersession state | applied/skipped/orphaned counts by stable event id and reason |
@@ -173,8 +184,10 @@ Default posture:
 - Live destructive replacement requires explicit Live mode plus an explicit operator flag.
 - Existing active DB replacement must create a restore point and validate storage health before and after.
 - Live replacement uses a DB-service cutover protocol, not a blind file copy: block new readers/writers, pause/drain background queues, close/drop the active DB pool, checkpoint/handle WAL, stage the rebuilt DB, atomically swap, remove stale WAL/SHM, harden permissions, validate, then reopen.
+- Live replacement owns a process-wide cutover gate under `services::rebuild` (name flexible in L1, semantics fixed). While active, the gate covers pooled app access (`AppState::db_read`, `AppState::db_write`), app service reopen paths (`AppState::init_db_service`, `reinit_db_service`, `recover_db_service_after_access_error`, recovery/restore command reopen paths), direct DB open paths (`ActionDb::open`, `open_at`, `open_readonly`, `open_for_inspection`, test/maintenance direct-open wrappers), and raw service lifecycle paths (`DbService::open`, `open_at`, `install_global`, `uninstall_global`). New opens/reopens/installs during the gate must block behind the gate or fail with a typed `RebuildCutoverInProgress` error; they must not silently create a fresh legacy connection or install a new pool while the cutover owner has dropped service access.
+- Only the rebuild cutover owner may reopen or install service access while the gate is active, and only by holding a scoped cutover token after replacement validation passes. The cutover sequence is: acquire the process-wide gate token; mark the rebuild run as `cutover_in_progress`; emit an ADR-0120 invocation span for the cutover root; reject or queue new read/write/open/reopen/install attempts; pause and drain all DB-writing or DB-reading processors involved in intelligence freshness (`IntelligenceQueue`, `EmbeddingQueue`, `MeetingPrepQueue`, workspace ingestion/backfill workers, source processors, enrichment processors, and any claim-feedback repair queue touched by replay); wait for in-flight work to finish or snapshot and requeue it with reason-coded status; close/drop the global DB service and active pools; checkpoint/flush WAL; stage and atomically swap the rebuilt DB; remove stale WAL/SHM; validate schema/storage health/proof counters through a plain-SQLite reader; reinstall/reopen DB services through the scoped token; resume queues and requeue claimed-but-unfinished jobs. Failure reopens the original DB from the restore point where possible through the scoped token, resumes queues, and leaves a PII-safe operator report with the restore path handle and failed phase.
 - If an encrypted-looking active DB is present after DOS-831, the app fails loud and routes to storage-health rebuild/restore guidance; it does not run an in-place decrypt repair.
-- Exported DB copies are plaintext egress after DOS-831 and must use destination-boundary warnings and restrictive permissions where possible.
+- Exported DB copies are plaintext egress after DOS-831 and must use destination-boundary warnings, restrictive permissions where possible, and an append-only PII-safe audit event per ADR-0094/ADR-0098. Audit details use counts/categories/result, export kind, sensitivity labels, and destination handles, never absolute paths or raw content.
 
 ### §2.5 Sensitive Artifacts
 
@@ -187,13 +200,15 @@ Security contract:
 - Files are written with owner-only permissions where supported.
 - Reports/logs use handles, counts, hashes, reason codes, and sensitivity labels; they do not include raw correction text, entity names, absolute local paths, or source payloads.
 - Retention is explicit: after successful replay, the sidecar is retained only if it is part of the durable DOS-628 projection contract; transient replay journals are pruned or marked completed according to the operator policy. Failed/orphaned entries retain only the minimum data needed for safe retry.
-- Exporting a sidecar follows the same destination-boundary warning and evidence-governance rules as exported DB copies.
+- Exporting a sidecar follows the same destination-boundary warning, evidence-governance, owner-only permission, and append-only audit-event rules as exported DB copies.
 
 ---
 
 ## §3 Acceptance Criteria
 
 **AC1 — Fresh intelligence-substrate proof.** Starting from an empty target DB at schema head, rebuild reproduces the reconstructable intelligence substrate from canonical workspace inputs plus service re-enrichment: accounts, projects, people, workspace sources, entity links, claims, provenance, trust-band inputs, salience/derived context needed by covered shipped surfaces, and source lifecycle state. Meeting history, email enrichment cache state, and action source references are either covered by named canonical producers and verification counts or explicitly reported as degraded/out-of-scope.
+
+**AC1a — Entity seed trust boundary.** Account, project, and person JSON seed reads cross `WorkspaceSourceRegistry::open_validated` or an equivalent rebuild-owned bounded-open helper before parsing. Tests reject symlink escapes, outside-workspace paths, race-swapped files, oversize inputs, and hardlinks that the workspace ingestion boundary rejects.
 
 **AC2 — Correction preservation.** With a DOS-628 corrections sidecar containing representative feedback, demotions/tombstones, contradictions, supersession, stable replay IDs, and a deliberate ambiguous match, rebuild replays corrections through the named `services::claims` replay helper. Regenerated claims reflect the correction state; ambiguous entries are reported as orphans.
 
@@ -203,15 +218,15 @@ Security contract:
 
 **AC5 — DB-mode safety.** Dry-run and Replica proof cannot open or mutate the production DB. Live replacement refuses unless DB mode is Live and an explicit operator flag is present. Existing DB replacement creates a restore point and validates storage health.
 
-**AC6 — Exported DB egress.** Exported DB copies after DOS-831 are treated as plaintext egress: the UI/operator flow shows an explicit warning, destination handling avoids leaking absolute paths or source details into logs, and owner-only permissions are applied where supported.
+**AC6 — Exported DB egress.** Exported DB copies after DOS-831 are treated as plaintext egress: the UI/operator flow shows an explicit warning, destination handling avoids leaking absolute paths or source details into logs, owner-only permissions are applied where supported, and an append-only ADR-0094/ADR-0098 audit event is written with export kind, counts/categories/result, sensitivity labels, and a destination handle. The audit event never stores raw content, customer/entity names, correction text, or absolute local paths.
 
-**AC7 — Correction sidecar security.** DOS-628 sidecars and DOS-832 replay journals have a classified storage/retention contract: bounded path, owner-only permissions where supported, no raw correction/source payloads in logs or reports, explicit retention/prune behavior, and safe orphan retry metadata.
+**AC7 — Correction sidecar security.** DOS-628 sidecars and DOS-832 replay journals have a classified storage/retention contract: bounded path, owner-only permissions where supported, no raw correction/source payloads in logs or reports, append-only audit events for sidecar export/retention/prune outcomes, explicit retention/prune behavior, and safe orphan retry metadata.
 
-**AC8 — Live cutover exclusivity.** Live destructive replacement blocks new readers/writers, pauses/drains background queues, closes/drops the active DB service/pool, stages and atomically swaps the rebuilt DB, cleans WAL/SHM, validates the replacement, and reopens service access. Failure restores the prior DB or leaves a clear restore point.
+**AC8 — Live cutover exclusivity.** Live destructive replacement blocks new readers/writers, direct DB open paths, and service reopen/install paths, including `AppState::db_read`, `AppState::db_write`, `AppState::init_db_service`, `reinit_db_service`, `recover_db_service_after_access_error`, recovery/restore command reopen paths, `ActionDb::open`, `open_at`, `open_readonly`, `open_for_inspection`, `DbService::open`, `open_at`, `install_global`, `uninstall_global`, and the legacy fallback after global uninstall. The cutover gate pauses/drains named background queues/processors (`IntelligenceQueue`, `EmbeddingQueue`, `MeetingPrepQueue`, workspace ingestion/backfill, source processing, enrichment, and replay/repair workers), records in-flight work behavior, closes/drops the active DB service/pool, stages and atomically swaps the rebuilt DB, cleans WAL/SHM, validates the replacement through a plain-SQLite reader, and reopens service access only through a rebuild-owned scoped cutover token. New opens/reopens/installs during cutover block or fail with typed `RebuildCutoverInProgress`; they do not create fresh legacy connections or install a new pool. Failure restores the prior DB or leaves a clear restore point and resumes or safely reports queued work.
 
 **AC9 — Single-writer/service boundary.** Rebuild writes route through service-owned mutation paths and the writer discipline. No command handler or maintenance bin directly mutates tables outside services. No fresh mutating DB connection is introduced to bypass the writer path.
 
-**AC10 — Resumability and observability.** Long rebuilds are resumable by durable run state. The run report uses PII-safe handles/counts/reason codes and records failures for source registration, ingestion, enrichment, correction replay, and verification. Replay resume is idempotent across process restarts by claiming stable sidecar event IDs before mutation.
+**AC10 — Resumability and observability.** Long rebuilds are resumable by durable run state. `services::rebuild`, cutover, queue pause/drain/resume, source registration, ingestion, re-enrichment, correction replay, replay helpers, verification, rollback, and export/retention operations emit ADR-0120 `InvocationRecord`s and propagate `invocation_id` / `caused_by_invocation_id` into rebuild/replay run state and any new correlateable storage where applicable. The run report uses PII-safe handles/counts/reason codes and records failures for source registration, ingestion, enrichment, correction replay, cutover, export/audit emission, and verification. Replay resume is idempotent across process restarts by claiming stable sidecar event IDs before mutation.
 
 **AC11 — ADR + docs.** ADR-0048 Principle 4 is amended to describe first-class intelligence rebuild and its dependency on correction sidecars. Operator recovery docs explain dry-run, Replica proof, Live cutover, encrypted-looking DB failure, sidecar retention, plaintext export warnings, and restoration.
 
@@ -229,7 +244,7 @@ pnpm tsc --noEmit
 
 1. **Claim model:** Rebuild produces claims, not display-only rows. Existing claim types and `ClaimProposal` metadata remain authoritative. New rebuild-run metadata is operational, not a claim, unless L1 introduces a user-visible assertion about rebuild health.
 2. **Provenance + trust:** Producers must pass full provenance and trust inputs into `commit_claim`. Trust recomputation/audit covers source lifecycle, freshness, corroboration, contradiction, correction state, sensitivity, and verification state. Rebuild must not seed arbitrary trust scores.
-3. **Signals + invalidation:** Rebuild must emit or reconstitute the signals needed for source ingestion, claim commits, feedback replay, targeted repair, trust recompute, and surface invalidation. A rebuilt DB with stale rendered surfaces is not accepted.
+3. **Signals + invalidation:** Rebuild must emit or reconstitute the signals needed for source ingestion, claim commits, feedback replay, targeted repair, trust recompute, and surface invalidation. Signal and claim rows caused by rebuild carry ADR-0120 invocation correlation where applicable. A rebuilt DB with stale rendered surfaces is not accepted.
 4. **Runtime + surfaces:** Tauri and MCP read the rebuilt DB through existing services and sensitivity gates. `build_intelligence_context()`, account/project/person contexts, workspace graph reads, and claim receipt routes must behave against the rebuilt store. Meeting prep/readiness surfaces are included only where their canonical source inputs/producers are covered; otherwise rebuild proof must show an explicit source-gap/degraded state rather than silent stale output.
 5. **Feedback loop:** User corrections survive by structured sidecar replay into `claim_feedback` and claim lifecycle state. New feedback after rebuild continues through the same services and source-reliability/trust inputs. Sidecar storage and replay logs preserve the correction loop without exposing raw sensitive correction text.
 
@@ -261,15 +276,19 @@ Focused L1 tests:
 
 - Unit tests for rebuild plan/source inventory skip reasons and PII-safe report shape.
 - Replica-mode test proving production DB path denial.
+- Entity seed reader tests proving account/project/person JSON reads use the validated workspace boundary and reject symlink escapes, outside-workspace paths, race-swapped files, oversize inputs, and hardlinks rejected by `open_validated`.
 - Workspace source registration integration test reusing existing generic fixtures.
 - Deterministic `source_asof` precedence test where file mtime changes but canonical source metadata keeps the same provenance timestamp.
 - Ingestion replay test proving claims enter through `commit_claim` and carry `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, provenance, and sensitivity.
 - Producer-inventory test or fixture proof that each claimed derived output has named canonical inputs, produced tables/claims, trust/provenance behavior, and verification counts.
 - Correction replay test using generic sidecar fixtures with stable replay IDs for confirm/current, false/outdated, wrong subject/source, nuance, surface inappropriate, not relevant, contradiction, supersession, tombstone, unknown claim ID, and ambiguous/non-unique endpoints.
 - Idempotency/resume test that claims sidecar event IDs before mutation and restarts after source registration, ingestion, enrichment, and correction replay without duplicate claims, feedback, repair jobs, or replay effects.
-- Queue pause/drain/resume and DB-service close/drop/reopen test for Live cutover phases.
-- Exported DB copy test for warning state, destination-boundary handling, owner-only permissions where supported, and no raw destination/path/source details in logs.
-- Sidecar/replay-journal security test for bounded path, owner-only permissions where supported, report redaction, orphan metadata shape, and retention/prune behavior.
+- ADR-0120 observability test proving rebuild orchestration, cutover, queue pause/drain/resume, source registration/ingestion, re-enrichment, correction replay, replay helper, verification, rollback, and export/retention phases emit invocation records and propagate `invocation_id` / `caused_by_invocation_id` into rebuild/replay run state where applicable.
+- Process-wide Live cutover test that holds the rebuild gate while `AppState::db_read`, `AppState::db_write`, `AppState::init_db_service`, `reinit_db_service`, `recover_db_service_after_access_error`, recovery/restore command reopen paths, `ActionDb::open`, `open_at`, `open_readonly`, `open_for_inspection`, `DbService::open`, `open_at`, `install_global`, `uninstall_global`, and the legacy fallback after global uninstall attempt access; each blocks or returns typed `RebuildCutoverInProgress`, never a fresh legacy connection or new installed pool.
+- Scoped cutover-token test proving only the rebuild cutover owner can reopen/install DB service access while the gate is active, and only after replacement validation passes or rollback begins.
+- Queue pause/drain/resume and DB-service close/drop/reopen test for Live cutover phases covering `IntelligenceQueue`, `EmbeddingQueue`, `MeetingPrepQueue`, workspace ingestion/backfill, source processing, enrichment, and replay/repair workers, including in-flight completion/requeue behavior.
+- Exported DB copy test for warning state, destination-boundary handling, owner-only permissions where supported, append-only PII-safe audit event shape, and no raw destination/path/source details in logs.
+- Sidecar/replay-journal security test for bounded path, owner-only permissions where supported, append-only PII-safe audit event shape for export/retention/prune, report redaction, orphan metadata shape, and retention/prune behavior.
 - Storage-health test for encrypted-looking / unreadable active DB guidance.
 - Operator CLI/command tests for dry-run, apply, resume, and Live refusal.
 
@@ -306,7 +325,12 @@ Approval requires unanimous pass or explicit L6 decision on any residual release
 - `docs/solutions/architecture-patterns/db-lock-storm-class-2026-05-27.md`: rebuild touches write-heavy paths; consume ADR-0133 writer discipline, no fresh writer connections, no locks across `.await`.
 - `docs/solutions/workflow-issues/k-in-grep-substrate-type-not-proposed-name-2026-05-19.md`: search by substrate primitives. DOS-832 extends existing workspace ingestion/claim feedback substrate rather than inventing a new import/correction system.
 - `.docs/evals/evaluation-evidence-contract.md` and `.docs/evals/fixture-governance.md`: real-data proof must be PII-free, repo-relative, hash-bound, and lintable.
+- ADR-0120: rebuild is a service/background-worker/projection orchestration path, so it emits invocation records and propagates invocation correlation through signals, claims, run state, replay, and verification storage where applicable.
+- ADR-0094 + ADR-0098 Principle 4: exported DB copies and sidecar exports are data export events and require append-only, PII-safe audit records with counts/categories/result and destination handles.
 - Security L0 cycle: exported DB copies, correction sidecars/replay journals, and Live file-swap exclusivity are explicit AC/test surfaces, not posture-only bullets.
+- Security L0 cycle: entity JSON seed reads are part of the workspace filesystem trust boundary. Rebuild cannot make `dashboard.json` / `person.json` canonical while bypassing `WorkspaceSourceRegistry::open_validated` or an equivalent bounded-open helper.
+- Feasibility L0 cycle: Live cutover exclusivity must bind both pooled service access and direct `ActionDb::open*` fallback paths, including behavior after `DbService::uninstall_global`, with named queue/processor pause-drain-resume semantics.
+- Adversarial L0 cycle: debug-driven packets require a symptom-to-failure trace, and Live cutover must also bind `AppState::init_db_service` / `reinit_db_service`, recovery reopen paths, raw `DbService::open/open_at`, and `install_global` so service access cannot be reinstalled during the swap window.
 - Adversarial L0 cycle: DOS-831 authority correction is a precondition, derived producer outputs are not canonical inputs, legacy rebuild gaps are either covered or reported as degraded, and correction replay requires stable event IDs plus a named `services::claims` replay helper.
 - ADR-0048: current rebuild principle is partial and must be amended.
 - ADR-0107: `DataSource::WorkspaceFile { kind }` exists and sets file-derived facts as reference posture.
@@ -324,3 +348,24 @@ Approval requires unanimous pass or explicit L6 decision on any residual release
 - Correction replay proves typed feedback, tombstone, contradiction, and ambiguity behavior.
 - ADR-0048 and operator docs are updated.
 - Full gates pass.
+
+---
+
+## §10 L0 Review Verdict
+
+**Final verdict:** APPROVE. DOS-832 is L0-approved for L1 implementation, subject to the DOS-831 authority precondition and DOS-628 correction-sidecar release gate already stated in §0/§2.3.
+
+| Lane | Final verdict | Notes |
+| --- | --- | --- |
+| `/codex challenge` | APPROVE | Final rerun approved after verifying debug trace, Live cutover reopen-path coverage, ADR-0120 observability, ADR-0094/0098 audit events, entity seed trust boundary, correction replay, source-time determinism, and release gates. Evidence: `CODEX_DOS832_FINAL2_ERR=/tmp/codex-dos832-final2-err-EJJPzG`; tokens used: 710,957. |
+| `ce-security-lens-reviewer` | APPROVE | Approved after entity JSON seed reads were bound to the workspace trust boundary, cutover gates covered DB/service reopen paths, and sidecar/export audit/security obligations were explicit. |
+| `ce-feasibility-reviewer` | APPROVE | Approved after process-wide cutover gate, scoped reopen token, queue pause/drain/resume semantics, service ownership, and current-code reopen paths were named. |
+| `ce-data-migrations-reviewer` | APPROVE | Approved schema/data-integrity posture: fresh-schema replay, v277+ reservation only if new run state is required, no raw claim copy, replay idempotency, and invocation correlation where applicable. |
+| `ce-learnings-researcher` | APPROVE | Confirmed prior substrate is represented: ADR-0120, ADR-0094/0098, ADR-0048, ADR-0107/0098, ADR-0123/0126/0131, ADR-0133, ADR-0110, and documented claim-producer/runtime trust audit and DB lock-storm learnings. |
+
+Cycle notes:
+
+- Cycle 1 blockers: security required entity JSON seed reads to use the workspace trust boundary; feasibility required process-wide Live cutover gating across pooled and direct DB open paths.
+- Cycle 2 blocker: adversarial review required a debug-driven symptom-to-failure trace and explicit gating for `AppState::init_db_service` / `reinit_db_service` plus raw `DbService::open/open_at/install_global` paths.
+- Cycle 3 blocker: K-in required ADR-0120 invocation observability and ADR-0094/0098 append-only audit events for exported DB copies and sidecar export/retention/prune operations.
+- Cycle 4 result: all lanes approved the revised packet.

--- a/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
+++ b/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
@@ -1,0 +1,116 @@
+# DOS-832 L1a Proof Bundle -- Current-Encrypted Replica Correction Replay
+
+**Issue:** DOS-832
+**Branch:** `codex/v1.4.9-w1-dos832-l1`
+**Date:** 2026-06-05
+**Scope:** L1a substrate proof only. This proves replay of W3 claim-file sidecar feedback into freshly regenerated claim IDs in the current encrypted/Replica-compatible schema. It does not claim final plain-SQLite rebuild, Live cutover, or full DOS-832 release completion.
+
+## Verdict
+
+**L1a pass, bounded.**
+
+The branch proves the correction-replay core that DOS-832 can honestly validate before DOS-831 lands:
+
+- W3 sidecar feedback rows now carry a stable `feedbackId` replay key.
+- Legacy v1 sidecars without `feedbackId` replay through a deterministic derived key so old sidecars remain readable without pretending they had durable source IDs.
+- DOS-832 resolves sidecar entries by rebuild-stable semantic identity, not old runtime claim UUID.
+- v2 replay requires source-content hash provenance before mutation.
+- Replay claims the stable sidecar event in a durable journal before calling the claim feedback service.
+- Feedback replay goes through `services::claims`, not raw `claim_feedback` inserts.
+- Re-running the replay does not duplicate feedback rows.
+- Same event ID with changed feedback content is rejected.
+- Missing stable replay IDs are rejected before mutation.
+- Duplicate stable replay IDs are rejected before mutation.
+- Unsupported sidecar schema versions are rejected before mutation.
+- Missing, provenance-mismatched, or ambiguous semantic matches are represented as orphan outcomes, not guessed.
+- Service-invalid feedback rows are marked `failed` in the replay journal and do not abort later independent rows.
+- Stable replay event IDs cannot be retargeted after applied, failed, or orphaned terminal journal outcomes.
+- Partial v282 journal rows from an interrupted old-shape migration are repaired before replay continues.
+
+## Explicit Non-Claims
+
+These remain unproven by this L1a slice:
+
+- Plain-SQLite fresh recovery after DOS-831.
+- Live destructive replacement and cutover exclusivity.
+- Entity JSON seed trust-boundary replay.
+- Full source registration, ingestion, re-enrichment, salience, embeddings, and derived-context rebuild.
+- Supersession and contradiction edge replay beyond sidecar serialization of semantic endpoint identities.
+- Operator recovery docs and ADR-0048 amendment.
+- Real-workspace end-to-end rebuild.
+
+The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverProven: false` to keep these boundaries machine-visible.
+
+## Implementation Evidence
+
+### Schema
+
+- Added migration `v282_dos_832_rebuild_replay_journal`.
+- Added `claim_feedback.replay_event_id` plus a unique partial index for replay idempotency.
+- Added `rebuild_correction_replay_events` with status-coded replay outcomes:
+  - `claimed`
+  - `applied`
+  - `already_applied`
+  - `orphan_missing`
+  - `orphan_ambiguous`
+  - `failed`
+- Journal rows persist a canonical feedback-content hash so replay can reject event-ID reuse with changed feedback content.
+- Registered v282 through the idempotent multi-statement migration helper so schema-version record gaps can retry without duplicate-column failure.
+- v282 includes an explicit idempotent repair for partial old-shape journal tables missing `feedback_content_hash`.
+- Bumped claim-file sidecar schema version to `2` because stable `feedbackId` is now part of the replay contract.
+
+### Services
+
+- Added `services::rebuild::replay_claim_file_sidecar_corrections`.
+- Added `services::claims::record_claim_feedback_replay`.
+- Existing `record_claim_feedback` now delegates through a shared internal writer path; replay adds only stable-event idempotency and does not bypass actor or feedback validation.
+- `claim_files` sidecar serialization now includes stable feedback row IDs and semantic identities for supersession/contradiction endpoints.
+
+## Intelligence Loop Check
+
+1. **Claim model:** Replay does not create display-only data. It targets regenerated claim rows and writes typed claim feedback through the claim service.
+2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source-content hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
+3. **Signals + invalidation:** Replay uses the same `record_claim_feedback` path, so existing feedback signals, version events, invalidation bumps, and repair-job coalescing remain active.
+4. **Runtime + surfaces:** The L1a helper is service-owned and callable by future rebuild orchestration. It does not expose a user-visible surface yet.
+5. **Feedback loop:** User feedback rows replay as typed `FeedbackAction` events with existing claim-service behavior; duplicates are suppressed by stable event ID.
+
+## Validation
+
+Commands run from the DOS-832 worktree:
+
+```bash
+src-tauri/scripts/check_migrations_transactional.sh
+cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture
+cargo fmt --manifest-path src-tauri/Cargo.toml
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+cargo test --manifest-path src-tauri/Cargo.toml --lib
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- Migration wrapper check: passed.
+- Focused DOS-832 replay tests: 18 passed.
+- Claim-file tests: 18 passed.
+- Claim feedback tests: 23 passed.
+- v282 migration regressions: 2 passed.
+- Clippy: passed with `-D warnings`.
+- Full Rust lib suite: 3181 passed, 0 failed, 11 ignored.
+- Full Cargo suite: passed, including integration tests and doc tests.
+- TypeScript: passed.
+- Diff hygiene: passed.
+- Note: full Cargo emitted two pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; `cargo clippy -- -D warnings` passed.
+
+## L2 Inputs
+
+The next L2 reviewer should focus on these risk areas:
+
+- Whether replay-event claiming is sufficiently atomic for the current single-writer/local topology.
+- Whether the sidecar stable `feedbackId` contract belongs in W3/DOS-628 before DOS-832 merges, or whether the stacked DOS-832 branch may extend the W3 sidecar contract.
+- Whether the L1a proof boundary is acceptable for PR scope, given the full DOS-832 packet still requires DOS-831 and broader rebuild orchestration.
+- Whether supersession/contradiction endpoint semantic identities are enough as contract plumbing while actual edge replay remains out of this slice.

--- a/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
+++ b/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
@@ -14,11 +14,12 @@ The branch proves the correction-replay core that DOS-832 can honestly validate 
 - W3 sidecar feedback rows now carry a stable `feedbackId` replay key.
 - Legacy v1 sidecars without `feedbackId` replay through a deterministic derived key so old sidecars remain readable without pretending they had durable source IDs.
 - DOS-832 resolves sidecar entries by rebuild-stable semantic identity, not old runtime claim UUID.
-- v2 replay requires source-content hash provenance before mutation.
+- v2 replay requires the sidecar source identity hash before mutation. This hash binds `data_source`, `source_ref`, and `item_hash`; it is not proof of the full projection-file contents.
 - Replay claims the stable sidecar event in a durable journal before calling the claim feedback service.
 - Feedback replay goes through `services::claims`, not raw `claim_feedback` inserts.
 - Re-running the replay does not duplicate feedback rows.
-- Same event ID with changed feedback content is rejected.
+- Replay preserves the original sidecar feedback `submitted_at` rather than rewriting it to rebuild time.
+- Same event ID with changed feedback content or `submitted_at` is rejected.
 - Missing stable replay IDs are rejected before mutation.
 - Duplicate stable replay IDs are rejected before mutation.
 - Unsupported sidecar schema versions are rejected before mutation.
@@ -54,7 +55,7 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
   - `orphan_missing`
   - `orphan_ambiguous`
   - `failed`
-- Journal rows persist a canonical feedback-content hash so replay can reject event-ID reuse with changed feedback content.
+- Journal rows persist a canonical feedback-content hash, including `submitted_at`, so replay can reject event-ID reuse with changed feedback content or historical feedback time.
 - Registered v282 through the idempotent multi-statement migration helper so schema-version record gaps can retry without duplicate-column failure.
 - v282 includes an explicit idempotent repair for partial old-shape journal tables missing `feedback_content_hash`.
 - Bumped claim-file sidecar schema version to `2` because stable `feedbackId` is now part of the replay contract.
@@ -69,7 +70,7 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
 ## Intelligence Loop Check
 
 1. **Claim model:** Replay does not create display-only data. It targets regenerated claim rows and writes typed claim feedback through the claim service.
-2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source-content hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
+2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source identity hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
 3. **Signals + invalidation:** Replay uses the same `record_claim_feedback` path, so existing feedback signals, version events, invalidation bumps, and repair-job coalescing remain active.
 4. **Runtime + surfaces:** The L1a helper is service-owned and callable by future rebuild orchestration. It does not expose a user-visible surface yet.
 5. **Feedback loop:** User feedback rows replay as typed `FeedbackAction` events with existing claim-service behavior; duplicates are suppressed by stable event ID.
@@ -82,7 +83,7 @@ Commands run from the DOS-832 worktree:
 src-tauri/scripts/check_migrations_transactional.sh
 cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture
-cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback_replay --lib -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture
 cargo fmt --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
@@ -95,15 +96,16 @@ git diff --check
 Results:
 
 - Migration wrapper check: passed.
-- Focused DOS-832 replay tests: 18 passed.
+- Focused DOS-832 replay tests: 19 passed.
 - Claim-file tests: 18 passed.
-- Claim feedback tests: 23 passed.
+- Claim feedback replay tests: 5 passed.
 - v282 migration regressions: 2 passed.
 - Clippy: passed with `-D warnings`.
-- Full Rust lib suite: 3181 passed, 0 failed, 11 ignored.
+- Full Rust lib suite: 3183 passed, 0 failed, 11 ignored.
 - Full Cargo suite: passed, including integration tests and doc tests.
 - TypeScript: passed.
 - Diff hygiene: passed.
+- Focused remediation re-review: adversarial reviewer PASS; data-migration reviewer PASS.
 - Note: full Cargo emitted two pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; `cargo clippy -- -D warnings` passed.
 
 ## L2 Inputs

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -23,6 +23,9 @@
 //! Claim file projection ledgers follow the same rule: they are service-owned
 //! operational receipts produced by claim-file render/apply abilities, not
 //! static mock fixture data.
+//! Rebuild correction replay journals follow the same rule: they are
+//! service-owned recovery receipts produced by rebuild replay, not static mock
+//! fixture data or user-facing demo content.
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1128,6 +1128,13 @@ const MIGRATIONS: &[Migration] = &[
         version: 281,
         sql: include_str!("migrations/281_claim_file_projection_run_claims.sql"),
     },
+    // v1.4.9 DOS-832 — correction replay idempotency journal. This is
+    // intentionally above W3's v280/v281 head so databases that already
+    // applied DOS-628 still receive the replay schema.
+    Migration::Fn {
+        version: 282,
+        apply: migrate_v282_dos_832_rebuild_replay_journal,
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -2954,6 +2961,14 @@ fn migrate_v271_recommendation_surfacing(conn: &Connection) -> Result<(), Migrat
         conn,
         include_str!("migrations/271_recommendation_surfacing.sql"),
         "v1.4.6 W2-A recommendation surfacing policy and decision audit",
+    )
+}
+
+fn migrate_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), MigrationError> {
+    apply_idempotent_sql_migration(
+        conn,
+        include_str!("migrations/282_dos_832_rebuild_replay_journal.sql"),
+        "v1.4.9 DOS-832 rebuild replay journal",
     )
 }
 
@@ -7588,6 +7603,95 @@ mod tests {
             current_version(&conn).expect("current version") >= 281,
             "schema version is at least v281"
         );
+    }
+
+    #[test]
+    fn migration_282_applies_rebuild_replay_journal_after_w3_v281() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "DROP INDEX IF EXISTS idx_claim_feedback_replay_event;
+             DROP INDEX IF EXISTS idx_rebuild_replay_events_run_status;
+             DROP INDEX IF EXISTS idx_rebuild_replay_events_resolved_claim;
+             DROP TABLE IF EXISTS rebuild_correction_replay_events;
+             ALTER TABLE claim_feedback DROP COLUMN replay_event_id;
+             DELETE FROM schema_version WHERE version >= 282;
+             INSERT OR IGNORE INTO schema_version (version) VALUES (281);",
+        )
+        .expect("simulate W3-at-v281 database before DOS-832");
+        assert_eq!(current_version(&conn).expect("current version"), 281);
+        assert!(!table_columns(&conn, "claim_feedback")
+            .expect("claim_feedback columns")
+            .contains("replay_event_id"));
+
+        let applied = run_migrations(&conn).expect("apply DOS-832 v282");
+
+        assert!(applied >= 1, "v282 migration should apply");
+        assert!(
+            current_version(&conn).expect("current version") >= 282,
+            "schema version is at least v282"
+        );
+        assert!(table_columns(&conn, "claim_feedback")
+            .expect("claim_feedback columns")
+            .contains("replay_event_id"));
+        assert!(table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay event columns")
+            .contains("feedback_content_hash"));
+        assert!(
+            table_exists(&conn, "rebuild_correction_replay_events").expect("replay table exists")
+        );
+        for index_name in [
+            "idx_claim_feedback_replay_event",
+            "idx_rebuild_replay_events_run_status",
+            "idx_rebuild_replay_events_resolved_claim",
+        ] {
+            assert!(
+                index_exists(&conn, index_name).expect("query replay index"),
+                "{index_name} exists"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_282_repairs_replay_journal_content_hash_gap() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "ALTER TABLE rebuild_correction_replay_events DROP COLUMN feedback_content_hash;
+             INSERT INTO rebuild_correction_replay_events (
+                sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                semantic_identity_hash, applied_feedback_id, attempt_count, claimed_at,
+                applied_at, updated_at
+             ) VALUES (
+                'legacy-event', 'run-1', 2, 'runtime-claim-1', 'claim-1',
+                'cannot_verify', 'claimed', NULL, NULL, 'semantic-hash', NULL,
+                1, '2026-06-05T12:00:00Z', NULL, '2026-06-05T12:00:00Z'
+             );
+             DELETE FROM schema_version WHERE version >= 282;
+             INSERT OR IGNORE INTO schema_version (version) VALUES (281);",
+        )
+        .expect("simulate partial v282 replay journal");
+        assert_eq!(current_version(&conn).expect("current version"), 281);
+        assert!(!table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns")
+            .contains("feedback_content_hash"));
+
+        run_migrations(&conn).expect("repair v282 replay journal");
+
+        assert!(table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns")
+            .contains("feedback_content_hash"));
+        let content_hash: String = conn
+            .query_row(
+                "SELECT feedback_content_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = 'legacy-event'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired content hash");
+        assert_eq!(content_hash, "legacy-v282-unset");
     }
 
     #[test]

--- a/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
+++ b/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
@@ -1,0 +1,41 @@
+ALTER TABLE claim_feedback
+    ADD COLUMN replay_event_id TEXT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claim_feedback_replay_event
+    ON claim_feedback(replay_event_id)
+    WHERE replay_event_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS rebuild_correction_replay_events (
+    sidecar_event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    sidecar_schema_version INTEGER NOT NULL,
+    source_runtime_claim_id TEXT NOT NULL,
+    resolved_claim_id TEXT,
+    action TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN (
+        'claimed',
+        'applied',
+        'already_applied',
+        'orphan_missing',
+        'orphan_ambiguous',
+        'failed'
+    )),
+    reason_code TEXT,
+    reason_detail_hash TEXT,
+    semantic_identity_hash TEXT NOT NULL,
+    feedback_content_hash TEXT NOT NULL,
+    applied_feedback_id TEXT REFERENCES claim_feedback(id),
+    attempt_count INTEGER NOT NULL DEFAULT 1,
+    claimed_at TEXT NOT NULL,
+    applied_at TEXT,
+    updated_at TEXT NOT NULL
+);
+
+ALTER TABLE rebuild_correction_replay_events
+    ADD COLUMN feedback_content_hash TEXT NOT NULL DEFAULT 'legacy-v282-unset';
+
+CREATE INDEX IF NOT EXISTS idx_rebuild_replay_events_run_status
+    ON rebuild_correction_replay_events(run_id, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_rebuild_replay_events_resolved_claim
+    ON rebuild_correction_replay_events(resolved_claim_id, status);

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -30,7 +30,8 @@ use crate::services::workspace_ingestion::registry::CLAIM_FILE_PROJECTION_ROOT;
 use crate::state::AppState;
 
 pub const CLAIM_FILE_PROJECTION_VERSION: u32 = 1;
-pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 2;
 pub const CLAIM_FILE_MARKDOWN_NAME: &str = "claims.md";
 pub const CLAIM_FILE_SIDECAR_NAME: &str = "claims.corrections.json";
 
@@ -106,6 +107,7 @@ pub struct ClaimFileClaim {
     pub provenance_summary: ClaimFileProvenanceSummary,
     pub feedback_rows: Vec<ClaimFileFeedbackRow>,
     pub contradiction_edges: Vec<ClaimFileContradictionEdge>,
+    pub superseded_by_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub replay_status: ClaimFileReplayStatus,
 }
 
@@ -143,6 +145,8 @@ pub struct ClaimFileProvenanceSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaimFileFeedbackRow {
+    #[serde(default)]
+    pub feedback_id: String,
     pub action: String,
     pub actor: String,
     pub actor_id: Option<String>,
@@ -179,7 +183,9 @@ pub struct ClaimFileContradictionEdge {
     pub reconciliation_note: Option<String>,
     pub reconciled_at: Option<String>,
     pub winner_runtime_claim_id: Option<String>,
+    pub winner_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub merged_runtime_claim_id: Option<String>,
+    pub merged_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub replay_status: ClaimFileReplayStatus,
 }
 
@@ -506,12 +512,18 @@ fn claim_file_claim(db: &ActionDb, claim: &IntelligenceClaim) -> Result<ClaimFil
         },
         feedback_rows: load_feedback_rows(db, &claim.id)?,
         contradiction_edges: load_contradiction_edges(db, &claim.id)?,
+        superseded_by_semantic_identity: claim
+            .superseded_by
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten(),
         replay_status: projected_replay_status(),
         semantic_identity,
     })
 }
 
-fn semantic_identity_for_loaded_claim(
+pub(crate) fn semantic_identity_for_loaded_claim(
     claim: &IntelligenceClaim,
 ) -> Result<ClaimSemanticIdentityV1, String> {
     let subject_value: serde_json::Value =
@@ -591,7 +603,7 @@ fn load_feedback_rows(db: &ActionDb, claim_id: &str) -> Result<Vec<ClaimFileFeed
     let mut stmt = db
         .conn_ref()
         .prepare(
-            "SELECT feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
+            "SELECT id, feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
              FROM claim_feedback
              WHERE claim_id = ?1
              ORDER BY submitted_at ASC, id ASC",
@@ -599,16 +611,17 @@ fn load_feedback_rows(db: &ActionDb, claim_id: &str) -> Result<Vec<ClaimFileFeed
         .map_err(|error| error.to_string())?;
     let rows = stmt
         .query_map(params![claim_id], |row| {
-            let payload_raw: Option<String> = row.get(3)?;
+            let payload_raw: Option<String> = row.get(4)?;
             Ok(ClaimFileFeedbackRow {
-                action: row.get(0)?,
-                actor: row.get(1)?,
-                actor_id: row.get(2)?,
+                feedback_id: row.get(0)?,
+                action: row.get(1)?,
+                actor: row.get(2)?,
+                actor_id: row.get(3)?,
                 payload_json: payload_raw
                     .as_deref()
                     .and_then(|raw| serde_json::from_str(raw).ok()),
-                submitted_at: row.get(4)?,
-                applied_at: row.get(5)?,
+                submitted_at: row.get(5)?,
+                applied_at: row.get(6)?,
             })
         })
         .map_err(|error| error.to_string())?;
@@ -656,6 +669,18 @@ fn load_contradiction_edges(
         let primary_semantic_identity = semantic_identity_for_claim_id(db, &row.primary_claim_id)?;
         let contradicting_semantic_identity =
             semantic_identity_for_claim_id(db, &row.contradicting_claim_id)?;
+        let winner_semantic_identity = row
+            .winner_claim_id
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten();
+        let merged_semantic_identity = row
+            .merged_claim_id
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten();
         out.push(ClaimFileContradictionEdge {
             edge_id: row.edge_id,
             branch_kind: row.branch_kind,
@@ -673,7 +698,9 @@ fn load_contradiction_edges(
             reconciliation_note: row.reconciliation_note,
             reconciled_at: row.reconciled_at,
             winner_runtime_claim_id: row.winner_claim_id,
+            winner_semantic_identity,
             merged_runtime_claim_id: row.merged_claim_id,
+            merged_semantic_identity,
             replay_status: projected_replay_status(),
         });
     }
@@ -1120,7 +1147,10 @@ fn verify_sidecar_paths(
 }
 
 fn verify_sidecar_contract(sidecar: &ClaimFileSidecar) -> Result<(), ClaimFileError> {
-    if sidecar.schema_version != CLAIM_FILE_SIDECAR_SCHEMA_VERSION {
+    if !matches!(
+        sidecar.schema_version,
+        CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION | CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+    ) {
         return Err(ClaimFileError::BadRequest(
             "unsupported sidecar schema_version".to_string(),
         ));
@@ -1457,7 +1487,7 @@ fn sensitivity_label(sensitivity: &ClaimSensitivity) -> String {
         .unwrap_or_else(|| format!("{sensitivity:?}").to_ascii_lowercase())
 }
 
-fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
+pub(crate) fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
     let mut hasher = Sha256::new();
     hasher.update(claim.data_source.as_bytes());
     hasher.update([0x1f]);
@@ -1572,6 +1602,7 @@ mod tests {
                 },
                 feedback_rows: Vec::new(),
                 contradiction_edges: Vec::new(),
+                superseded_by_semantic_identity: None,
                 replay_status: projected_replay_status(),
             }],
         }
@@ -1671,11 +1702,21 @@ mod tests {
 
     #[test]
     fn sidecar_serialization_round_trips_contract_fields() {
-        let sidecar = fixture_sidecar();
+        let mut sidecar = fixture_sidecar();
+        sidecar.claims[0].feedback_rows.push(ClaimFileFeedbackRow {
+            feedback_id: "feedback-1".to_string(),
+            action: "cannot_verify".to_string(),
+            actor: "user".to_string(),
+            actor_id: Some("user-fixture".to_string()),
+            payload_json: None,
+            submitted_at: TEST_TS.to_string(),
+            applied_at: None,
+        });
         let json = serde_json::to_string_pretty(&sidecar).expect("serialize sidecar");
         let decoded: ClaimFileSidecar = serde_json::from_str(&json).expect("decode sidecar");
 
         assert_eq!(decoded.schema_version, CLAIM_FILE_SIDECAR_SCHEMA_VERSION);
+        assert_eq!(CLAIM_FILE_SIDECAR_SCHEMA_VERSION, 2);
         assert_eq!(decoded.projection_version, CLAIM_FILE_PROJECTION_VERSION);
         assert_eq!(
             decoded.claims[0].semantic_identity.identity_kind,
@@ -1684,7 +1725,39 @@ mod tests {
         assert_eq!(decoded.claims[0].runtime_claim_id, "claim-1");
         assert_eq!(decoded.claims[0].lifecycle.claim_state, "active");
         assert_eq!(decoded.claims[0].replay_status.status, "projected");
+        assert_eq!(decoded.claims[0].feedback_rows[0].feedback_id, "feedback-1");
+        assert!(json.contains("\"feedbackId\""));
         assert!(decoded.claims[0].contradiction_edges.is_empty());
+    }
+
+    #[test]
+    fn legacy_v1_sidecar_deserializes_without_feedback_id() {
+        let mut sidecar = fixture_sidecar();
+        sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+        sidecar.claims[0].feedback_rows.push(ClaimFileFeedbackRow {
+            feedback_id: String::new(),
+            action: "cannot_verify".to_string(),
+            actor: "user".to_string(),
+            actor_id: Some("user-fixture".to_string()),
+            payload_json: None,
+            submitted_at: TEST_TS.to_string(),
+            applied_at: None,
+        });
+        let mut json = serde_json::to_value(&sidecar).expect("serialize sidecar");
+        let feedback = json
+            .pointer_mut("/claims/0/feedbackRows/0")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("feedback object");
+        feedback.remove("feedbackId");
+        let decoded: ClaimFileSidecar =
+            serde_json::from_value(json).expect("decode legacy sidecar");
+
+        assert_eq!(
+            decoded.schema_version,
+            CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION
+        );
+        assert_eq!(decoded.claims[0].feedback_rows[0].feedback_id, "");
+        verify_sidecar_contract(&decoded).expect("v1 sidecar remains readable");
     }
 
     #[test]
@@ -1951,7 +2024,7 @@ dailyos-action: mark_false\n\
             )
             .expect("commit feedback-bearing claim"),
         );
-        record_claim_feedback(
+        let feedback_outcome = record_claim_feedback(
             &ctx,
             &db,
             ClaimFeedbackInput {
@@ -1997,6 +2070,13 @@ dailyos-action: mark_false\n\
         assert_eq!(sidecar_claim.lifecycle.claim_state, "withdrawn");
         assert_eq!(sidecar_claim.lifecycle.surfacing_state, "dormant");
         assert_eq!(sidecar_claim.feedback_rows.len(), 1);
+        assert_eq!(
+            sidecar_claim.feedback_rows[0].feedback_id,
+            feedback_outcome.feedback_id
+        );
+        let json = serde_json::to_string(&sidecar_claim).expect("serialize sidecar claim");
+        assert!(json.contains("\"feedbackId\""));
+        assert!(json.contains(&feedback_outcome.feedback_id));
     }
 
     #[test]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -239,6 +239,7 @@ pub struct ClaimFeedbackInput {
 pub struct ClaimFeedbackReplayInput {
     pub feedback: ClaimFeedbackInput,
     pub replay_event_id: String,
+    pub submitted_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -249,6 +250,12 @@ pub struct ClaimFeedbackOutcome {
     pub new_verification_state: ClaimVerificationState,
     pub applied_at_pending: bool,
     pub repair_job_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ClaimFeedbackReplayWrite {
+    event_id: String,
+    submitted_at: String,
 }
 
 /// Claim-generation contract boundary.
@@ -5567,7 +5574,9 @@ pub(crate) fn claim_feedback_replay_content_hash(
     actor: &str,
     actor_id: Option<&str>,
     payload_json: Option<&str>,
+    submitted_at: &str,
 ) -> Result<String, ClaimError> {
+    let submitted_at = normalize_replay_submitted_at(submitted_at)?;
     let canonical_payload = payload_json
         .map(|payload| {
             serde_json::from_str::<serde_json::Value>(payload)
@@ -5581,8 +5590,22 @@ pub(crate) fn claim_feedback_replay_content_hash(
     update_hash_part(&mut hasher, Some(action.as_str()));
     update_hash_part(&mut hasher, Some(actor));
     update_hash_part(&mut hasher, actor_id);
+    update_hash_part(&mut hasher, Some(&submitted_at));
     update_hash_part(&mut hasher, canonical_payload.as_deref());
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn normalize_replay_submitted_at(value: &str) -> Result<String, ClaimError> {
+    let submitted_at = value.trim();
+    if submitted_at.is_empty() {
+        return Err(ClaimError::InvalidFeedback(
+            "replay submitted_at is required for correction replay".to_string(),
+        ));
+    }
+    DateTime::parse_from_rfc3339(submitted_at).map_err(|error| {
+        ClaimError::InvalidFeedback(format!("replay submitted_at must be RFC3339: {error}"))
+    })?;
+    Ok(submitted_at.to_string())
 }
 
 fn update_hash_part(hasher: &mut Sha256, value: Option<&str>) {
@@ -7279,14 +7302,18 @@ pub fn record_claim_feedback_replay(
             "replay_event_id is required for correction replay".to_string(),
         ));
     }
-    record_claim_feedback_inner(ctx, db, input.feedback, Some(replay_event_id.to_string()))
+    let replay = ClaimFeedbackReplayWrite {
+        event_id: replay_event_id.to_string(),
+        submitted_at: normalize_replay_submitted_at(&input.submitted_at)?,
+    };
+    record_claim_feedback_inner(ctx, db, input.feedback, Some(replay))
 }
 
 fn record_claim_feedback_inner(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     input: ClaimFeedbackInput,
-    replay_event_id: Option<String>,
+    replay: Option<ClaimFeedbackReplayWrite>,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
@@ -7294,8 +7321,8 @@ fn record_claim_feedback_inner(
     let metadata = feedback_semantics(input.action);
     validate_feedback_payload(&input, &metadata)?;
 
-    if let Some(replay_event_id) = replay_event_id.as_deref() {
-        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay_event_id)? {
+    if let Some(replay) = replay.as_ref() {
+        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay)? {
             return Ok(outcome);
         }
     }
@@ -7308,6 +7335,9 @@ fn record_claim_feedback_inner(
 
     let write = with_claim_transaction(db, |tx| {
         let now = ctx.clock.now().to_rfc3339();
+        let feedback_effect_at = replay
+            .as_ref()
+            .map_or(now.as_str(), |replay| replay.submitted_at.as_str());
         let claim = load_claim_by_id(tx.conn_ref(), &input.claim_id)?
             .ok_or_else(|| ClaimError::UnknownClaimId(input.claim_id.clone()))?;
         validate_feedback_actor(&input.actor)?;
@@ -7318,7 +7348,7 @@ fn record_claim_feedback_inner(
         let verification_state_before = enum_to_db(&claim.verification_state)?;
 
         let feedback_id = uuid::Uuid::new_v4().to_string();
-        if let Some(replay_event_id) = replay_event_id.as_deref() {
+        if let Some(replay) = replay.as_ref() {
             let inserted = tx.conn_ref().execute(
                 "INSERT OR IGNORE INTO claim_feedback (
                     id, claim_id, feedback_type, actor, actor_id, payload_json,
@@ -7331,19 +7361,19 @@ fn record_claim_feedback_inner(
                     &input.actor,
                     input.actor_id.as_deref(),
                     input.payload_json.as_deref(),
-                    &now,
-                    replay_event_id,
+                    &replay.submitted_at,
+                    &replay.event_id,
                 ],
             )?;
             if inserted == 0 {
                 mark_mutation_attempt_committed_noop(tx, mutation_guard.attempt(), &now)?;
-                let outcome =
-                    existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay_event_id)?
-                        .ok_or_else(|| {
-                            ClaimError::InvalidFeedback(format!(
-                                "replay_event_id insert collided without readable feedback row: {replay_event_id}"
-                            ))
-                        })?;
+                let outcome = existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay)?
+                    .ok_or_else(|| {
+                        ClaimError::InvalidFeedback(format!(
+                            "replay_event_id insert collided without readable feedback row: {}",
+                            replay.event_id
+                        ))
+                    })?;
                 return Ok(ClaimFeedbackWriteResult::ExistingReplay(outcome));
             }
         } else {
@@ -7365,7 +7395,7 @@ fn record_claim_feedback_inner(
         }
 
         let (new_verification_state, verification_reason, needs_user_decision_at) =
-            verification_update_for_feedback(&claim, input.action, &now);
+            verification_update_for_feedback(&claim, input.action, feedback_effect_at);
         let lifecycle_update = lifecycle_update_for_feedback(&claim, input.action, metadata.render);
         let lifecycle_changed = lifecycle_update != LifecycleUpdate::from_claim(&claim);
         let verification_changed = new_verification_state != claim.verification_state
@@ -7439,7 +7469,7 @@ fn record_claim_feedback_inner(
             ClaimState::Tombstoned | ClaimState::Withdrawn
         ) || lifecycle_update.surfacing_state == SurfacingState::Dormant
         {
-            mark_claim_edges_tombstoned(tx, &input.claim_id, &now)?;
+            mark_claim_edges_tombstoned(tx, &input.claim_id, feedback_effect_at)?;
         }
 
         // Bump claim_version + emit version_events when feedback actually
@@ -7511,22 +7541,22 @@ fn record_claim_feedback_inner(
 fn existing_feedback_replay_outcome(
     db: &ActionDb,
     input: &ClaimFeedbackInput,
-    replay_event_id: &str,
+    replay: &ClaimFeedbackReplayWrite,
 ) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
-    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay_event_id)
+    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay)
 }
 
 fn existing_feedback_replay_outcome_conn(
     conn: &Connection,
     input: &ClaimFeedbackInput,
-    replay_event_id: &str,
+    replay: &ClaimFeedbackReplayWrite,
 ) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
     let existing = conn
         .query_row(
-            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json
+            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at
              FROM claim_feedback
              WHERE replay_event_id = ?1",
-            params![replay_event_id],
+            params![&replay.event_id],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -7535,17 +7565,20 @@ fn existing_feedback_replay_outcome_conn(
                     row.get::<_, String>(3)?,
                     row.get::<_, Option<String>>(4)?,
                     row.get::<_, Option<String>>(5)?,
+                    row.get::<_, String>(6)?,
                 ))
             },
         )
         .optional()?;
-    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json)) = existing
+    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at)) =
+        existing
     else {
         return Ok(None);
     };
     if claim_id != input.claim_id || feedback_type != input.action.as_str() {
         return Err(ClaimError::InvalidFeedback(format!(
-            "replay_event_id already applied to different feedback target: {replay_event_id}"
+            "replay_event_id already applied to different feedback target: {}",
+            replay.event_id
         )));
     }
     let existing_content_hash = claim_feedback_replay_content_hash(
@@ -7553,16 +7586,19 @@ fn existing_feedback_replay_outcome_conn(
         &actor,
         actor_id.as_deref(),
         payload_json.as_deref(),
+        &submitted_at,
     )?;
     let input_content_hash = claim_feedback_replay_content_hash(
         input.action,
         &input.actor,
         input.actor_id.as_deref(),
         input.payload_json.as_deref(),
+        &replay.submitted_at,
     )?;
     if existing_content_hash != input_content_hash {
         return Err(ClaimError::InvalidFeedback(format!(
-            "replay_event_id already applied with different feedback content: {replay_event_id}"
+            "replay_event_id already applied with different feedback content: {}",
+            replay.event_id
         )));
     }
     let claim = load_claim_by_id(conn, &claim_id)?
@@ -11411,6 +11447,7 @@ mod tests {
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
 
     const TS: &str = "2026-05-02T12:00:00+00:00";
+    const REPLAY_TS: &str = "2026-04-01T09:15:00+00:00";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
 
     fn register_canonical_embedding_fixtures() {
@@ -13509,6 +13546,17 @@ mod tests {
             actor: "user".to_string(),
             actor_id: Some("user-fixture".to_string()),
             payload_json: feedback_payload_for(action),
+        }
+    }
+
+    fn replay_input(
+        feedback: ClaimFeedbackInput,
+        replay_event_id: &str,
+    ) -> ClaimFeedbackReplayInput {
+        ClaimFeedbackReplayInput {
+            feedback,
+            replay_event_id: replay_event_id.to_string(),
+            submitted_at: REPLAY_TS.to_string(),
         }
     }
 
@@ -16861,19 +16909,19 @@ mod tests {
         let first = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
         let second = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
 
@@ -16891,6 +16939,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(feedback_count, 1);
+        let submitted_at: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(submitted_at, REPLAY_TS);
         assert_eq!(repair_job_count(&db, &claim_id), 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
     }
@@ -16912,20 +16969,20 @@ mod tests {
         record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
 
         let err = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .expect_err("replay event must not retarget a different claim");
 
@@ -16965,24 +17022,9 @@ mod tests {
                 .to_string(),
         );
 
-        record_claim_feedback_replay(
-            &ctx,
-            &db,
-            ClaimFeedbackReplayInput {
-                feedback: first,
-                replay_event_id: replay_event_id.to_string(),
-            },
-        )
-        .unwrap();
-        let err = record_claim_feedback_replay(
-            &ctx,
-            &db,
-            ClaimFeedbackReplayInput {
-                feedback: second,
-                replay_event_id: replay_event_id.to_string(),
-            },
-        )
-        .expect_err("same replay event must not hide changed payload");
+        record_claim_feedback_replay(&ctx, &db, replay_input(first, replay_event_id)).unwrap();
+        let err = record_claim_feedback_replay(&ctx, &db, replay_input(second, replay_event_id))
+            .expect_err("same replay event must not hide changed payload");
 
         assert!(
             matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
@@ -16997,6 +17039,48 @@ mod tests {
             .unwrap();
         assert_eq!(feedback_count, 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_submitted_at_change() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay timestamp")).unwrap());
+        let replay_event_id = "replay-event-submitted-at-1";
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
+        )
+        .unwrap();
+        let mut changed_timestamp = replay_input(
+            feedback_input(&claim_id, FeedbackAction::CannotVerify),
+            replay_event_id,
+        );
+        changed_timestamp.submitted_at = "2026-04-02T09:15:00+00:00".to_string();
+
+        let err = record_claim_feedback_replay(&ctx, &db, changed_timestamp)
+            .expect_err("same replay event must not hide changed submitted_at");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
+        );
+        let submitted_at: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(submitted_at, REPLAY_TS);
     }
 
     #[test]
@@ -17029,10 +17113,10 @@ mod tests {
         let outcome = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: "replay-event-race-1".to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                "replay-event-race-1",
+            ),
         )
         .unwrap();
 

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -236,6 +236,12 @@ pub struct ClaimFeedbackInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimFeedbackReplayInput {
+    pub feedback: ClaimFeedbackInput,
+    pub replay_event_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClaimFeedbackOutcome {
     pub feedback_id: String,
     pub claim_id: String,
@@ -5556,6 +5562,64 @@ fn validate_feedback_actor(actor: &str) -> Result<(), ClaimError> {
     }
 }
 
+pub(crate) fn claim_feedback_replay_content_hash(
+    action: FeedbackAction,
+    actor: &str,
+    actor_id: Option<&str>,
+    payload_json: Option<&str>,
+) -> Result<String, ClaimError> {
+    let canonical_payload = payload_json
+        .map(|payload| {
+            serde_json::from_str::<serde_json::Value>(payload)
+                .map_err(|error| {
+                    ClaimError::InvalidFeedback(format!("payload_json must be valid JSON: {error}"))
+                })
+                .map(|value| canonical_json_string(&value))
+        })
+        .transpose()?;
+    let mut hasher = Sha256::new();
+    update_hash_part(&mut hasher, Some(action.as_str()));
+    update_hash_part(&mut hasher, Some(actor));
+    update_hash_part(&mut hasher, actor_id);
+    update_hash_part(&mut hasher, canonical_payload.as_deref());
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn update_hash_part(hasher: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            hasher.update(b"1:");
+            hasher.update(value.len().to_string().as_bytes());
+            hasher.update(b":");
+            hasher.update(value.as_bytes());
+        }
+        None => hasher.update(b"0:"),
+    }
+    hasher.update([0x1f]);
+}
+
+fn canonical_json_string(value: &serde_json::Value) -> String {
+    serde_json::to_string(&canonical_json_value(value)).expect("canonical JSON serializes")
+}
+
+fn canonical_json_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(canonical_json_value).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(key, _)| *key);
+            let mut out = serde_json::Map::new();
+            for (key, value) in entries {
+                out.insert(key.clone(), canonical_json_value(value));
+            }
+            serde_json::Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
 fn validate_feedback_payload(
     input: &ClaimFeedbackInput,
     metadata: &ClaimFeedbackMetadata,
@@ -7191,16 +7255,50 @@ struct ClaimFeedbackWriteOutcome {
     verification_state_after: String,
 }
 
+enum ClaimFeedbackWriteResult {
+    Written(ClaimFeedbackWriteOutcome),
+    ExistingReplay(ClaimFeedbackOutcome),
+}
+
 pub fn record_claim_feedback(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     input: ClaimFeedbackInput,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    record_claim_feedback_inner(ctx, db, input, None)
+}
+
+pub fn record_claim_feedback_replay(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: ClaimFeedbackReplayInput,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    let replay_event_id = input.replay_event_id.trim();
+    if replay_event_id.is_empty() {
+        return Err(ClaimError::InvalidFeedback(
+            "replay_event_id is required for correction replay".to_string(),
+        ));
+    }
+    record_claim_feedback_inner(ctx, db, input.feedback, Some(replay_event_id.to_string()))
+}
+
+fn record_claim_feedback_inner(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: ClaimFeedbackInput,
+    replay_event_id: Option<String>,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
 
     let metadata = feedback_semantics(input.action);
     validate_feedback_payload(&input, &metadata)?;
+
+    if let Some(replay_event_id) = replay_event_id.as_deref() {
+        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay_event_id)? {
+            return Ok(outcome);
+        }
+    }
 
     // Feedback mutates assertion-relevant columns on intelligence_claims
     // (verification_state, lifecycle). Reserve a MutationGuard so the
@@ -7220,21 +7318,51 @@ pub fn record_claim_feedback(
         let verification_state_before = enum_to_db(&claim.verification_state)?;
 
         let feedback_id = uuid::Uuid::new_v4().to_string();
-        tx.conn_ref().execute(
-            "INSERT INTO claim_feedback (
-                id, claim_id, feedback_type, actor, actor_id, payload_json,
-                submitted_at, applied_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
-            params![
-                &feedback_id,
-                &input.claim_id,
-                input.action.as_str(),
-                &input.actor,
-                input.actor_id.as_deref(),
-                input.payload_json.as_deref(),
-                &now,
-            ],
-        )?;
+        if let Some(replay_event_id) = replay_event_id.as_deref() {
+            let inserted = tx.conn_ref().execute(
+                "INSERT OR IGNORE INTO claim_feedback (
+                    id, claim_id, feedback_type, actor, actor_id, payload_json,
+                    submitted_at, applied_at, replay_event_id
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8)",
+                params![
+                    &feedback_id,
+                    &input.claim_id,
+                    input.action.as_str(),
+                    &input.actor,
+                    input.actor_id.as_deref(),
+                    input.payload_json.as_deref(),
+                    &now,
+                    replay_event_id,
+                ],
+            )?;
+            if inserted == 0 {
+                mark_mutation_attempt_committed_noop(tx, mutation_guard.attempt(), &now)?;
+                let outcome =
+                    existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay_event_id)?
+                        .ok_or_else(|| {
+                            ClaimError::InvalidFeedback(format!(
+                                "replay_event_id insert collided without readable feedback row: {replay_event_id}"
+                            ))
+                        })?;
+                return Ok(ClaimFeedbackWriteResult::ExistingReplay(outcome));
+            }
+        } else {
+            tx.conn_ref().execute(
+                "INSERT INTO claim_feedback (
+                    id, claim_id, feedback_type, actor, actor_id, payload_json,
+                    submitted_at, applied_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+                params![
+                    &feedback_id,
+                    &input.claim_id,
+                    input.action.as_str(),
+                    &input.actor,
+                    input.actor_id.as_deref(),
+                    input.payload_json.as_deref(),
+                    &now,
+                ],
+            )?;
+        }
 
         let (new_verification_state, verification_reason, needs_user_decision_at) =
             verification_update_for_feedback(&claim, input.action, &now);
@@ -7352,26 +7480,112 @@ pub fn record_claim_feedback(
             targeted_repair_enqueue_job(ctx, tx, &claim, &feedback_id, metadata.repair)?;
         let verification_state_after = enum_to_db(&new_verification_state)?;
 
-        Ok(ClaimFeedbackWriteOutcome {
-            outcome: ClaimFeedbackOutcome {
-                feedback_id,
-                claim_id: input.claim_id.clone(),
-                action: input.action,
-                new_verification_state,
-                applied_at_pending: true,
-                repair_job_id,
+        Ok(ClaimFeedbackWriteResult::Written(
+            ClaimFeedbackWriteOutcome {
+                outcome: ClaimFeedbackOutcome {
+                    feedback_id,
+                    claim_id: input.claim_id.clone(),
+                    action: input.action,
+                    new_verification_state,
+                    applied_at_pending: true,
+                    repair_job_id,
+                },
+                signal_entity_type,
+                signal_entity_id,
+                verification_state_before,
+                verification_state_after,
             },
-            signal_entity_type,
-            signal_entity_id,
-            verification_state_before,
-            verification_state_after,
-        })
+        ))
     })?;
 
     mutation_guard.mark_completed();
-    emit_claim_feedback_signals(ctx, db, &write);
+    match write {
+        ClaimFeedbackWriteResult::ExistingReplay(outcome) => Ok(outcome),
+        ClaimFeedbackWriteResult::Written(write) => {
+            emit_claim_feedback_signals(ctx, db, &write);
+            Ok(write.outcome)
+        }
+    }
+}
 
-    Ok(write.outcome)
+fn existing_feedback_replay_outcome(
+    db: &ActionDb,
+    input: &ClaimFeedbackInput,
+    replay_event_id: &str,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay_event_id)
+}
+
+fn existing_feedback_replay_outcome_conn(
+    conn: &Connection,
+    input: &ClaimFeedbackInput,
+    replay_event_id: &str,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    let existing = conn
+        .query_row(
+            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json
+             FROM claim_feedback
+             WHERE replay_event_id = ?1",
+            params![replay_event_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json)) = existing
+    else {
+        return Ok(None);
+    };
+    if claim_id != input.claim_id || feedback_type != input.action.as_str() {
+        return Err(ClaimError::InvalidFeedback(format!(
+            "replay_event_id already applied to different feedback target: {replay_event_id}"
+        )));
+    }
+    let existing_content_hash = claim_feedback_replay_content_hash(
+        input.action,
+        &actor,
+        actor_id.as_deref(),
+        payload_json.as_deref(),
+    )?;
+    let input_content_hash = claim_feedback_replay_content_hash(
+        input.action,
+        &input.actor,
+        input.actor_id.as_deref(),
+        input.payload_json.as_deref(),
+    )?;
+    if existing_content_hash != input_content_hash {
+        return Err(ClaimError::InvalidFeedback(format!(
+            "replay_event_id already applied with different feedback content: {replay_event_id}"
+        )));
+    }
+    let claim = load_claim_by_id(conn, &claim_id)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(claim_id.clone()))?;
+    let repair_job_id = conn
+        .query_row(
+            "SELECT id
+             FROM claim_repair_job
+             WHERE feedback_id = ?1
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1",
+            params![&feedback_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(Some(ClaimFeedbackOutcome {
+        feedback_id,
+        claim_id,
+        action: input.action,
+        new_verification_state: claim.verification_state,
+        applied_at_pending: false,
+        repair_job_id,
+    }))
 }
 
 pub fn targeted_repair_claim_generation_budget(ability_id: &str) -> Option<ClaimGenerationBudget> {
@@ -16632,6 +16846,209 @@ mod tests {
         let (_, _, _, _, _, raw_signal_count) =
             first_invalidation_job(&db, TARGETED_REPAIR_OPERATION);
         assert_eq!(raw_signal_count, 2);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_is_idempotent() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay event")).unwrap());
+        let replay_event_id = "replay-event-idempotent-1";
+
+        let first = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+        let second = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(second.feedback_id, first.feedback_id);
+        assert_eq!(second.claim_id, first.claim_id);
+        assert_eq!(second.action, FeedbackAction::CannotVerify);
+        assert!(first.applied_at_pending);
+        assert!(!second.applied_at_pending);
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(repair_job_count(&db, &claim_id), 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_retarget() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Risk replay first target")).unwrap(),
+        );
+        let mut second_proposal = proposal("Risk replay second target");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id = inserted_claim_id(commit_claim(&ctx, &db, second_proposal).unwrap());
+        let replay_event_id = "replay-event-retarget-1";
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .expect_err("replay event must not retarget a different claim");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("already applied to different feedback target"))
+        );
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(repair_job_count(&db, &second_claim_id), 0);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_content_change() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay payload")).unwrap());
+        let replay_event_id = "replay-event-content-1";
+        let mut first = feedback_input(&claim_id, FeedbackAction::NeedsNuance);
+        first.payload_json = Some(
+            serde_json::json!({ "corrected_text": "Risk is limited to the pilot group" })
+                .to_string(),
+        );
+        let mut second = feedback_input(&claim_id, FeedbackAction::NeedsNuance);
+        second.payload_json = Some(
+            serde_json::json!({ "corrected_text": "Risk is limited to the renewal window" })
+                .to_string(),
+        );
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: first,
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+        let err = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: second,
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .expect_err("same replay event must not hide changed payload");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
+        );
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_race_collision_re_reads_existing_row() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay race")).unwrap());
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER claim_feedback_replay_race
+                 BEFORE INSERT ON claim_feedback
+                 WHEN NEW.replay_event_id = 'replay-event-race-1'
+                   AND NEW.id != 'feedback-race-existing'
+                 BEGIN
+                   INSERT INTO claim_feedback (
+                     id, claim_id, feedback_type, actor, actor_id, payload_json,
+                     submitted_at, applied_at, replay_event_id
+                   ) VALUES (
+                     'feedback-race-existing', NEW.claim_id, NEW.feedback_type,
+                     NEW.actor, NEW.actor_id, NEW.payload_json, NEW.submitted_at,
+                     NULL, NEW.replay_event_id
+                   );
+                 END;",
+            )
+            .unwrap();
+
+        let outcome = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: "replay-event-race-1".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(outcome.feedback_id, "feedback-race-existing");
+        assert!(!outcome.applied_at_pending);
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = 'replay-event-race-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 0);
+        assert_eq!(repair_job_count(&db, &claim_id), 0);
     }
 
     #[test]

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -48,6 +48,7 @@ pub mod mutations;
 pub mod people;
 pub mod projection_signing;
 pub mod projects;
+pub mod rebuild;
 pub mod recommendations;
 pub mod reports;
 pub mod runtime_evidence_backfill;

--- a/src-tauri/src/services/rebuild.rs
+++ b/src-tauri/src/services/rebuild.rs
@@ -1,0 +1,1687 @@
+//! First-class rebuild helpers for DOS-832.
+//!
+//! This module owns rebuild replay planning and reporting. The L1a slice is
+//! deliberately scoped to current-encrypted/Replica proof: it replays W3 claim
+//! file correction sidecars through the claim service, and it records which
+//! storage/cutover claims remain unproven until DOS-831 lands.
+
+use std::collections::HashSet;
+
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::abilities::feedback::FeedbackAction;
+use crate::db::ActionDb;
+use crate::services::claim_files::{
+    semantic_identity_for_loaded_claim, source_content_hash_for_claim, ClaimFileClaim,
+    ClaimFileFeedbackRow, ClaimFileSidecar, ClaimSemanticIdentityV1,
+    CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+};
+use crate::services::claims::{
+    claim_feedback_replay_content_hash, load_claim_by_id, record_claim_feedback_replay,
+    ClaimFeedbackInput, ClaimFeedbackReplayInput,
+};
+use crate::services::context::ServiceContext;
+
+const LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH: &str = "legacy-v282-unset";
+
+#[derive(Debug, thiserror::Error)]
+pub enum RebuildError {
+    #[error("invalid sidecar: {0}")]
+    InvalidSidecar(String),
+    #[error("claim replay failed: {0}")]
+    ClaimReplay(String),
+    #[error("db: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayEventStatus {
+    Applied,
+    AlreadyApplied,
+    OrphanMissing,
+    OrphanAmbiguous,
+    Failed,
+}
+
+impl ReplayEventStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::AlreadyApplied => "already_applied",
+            Self::OrphanMissing => "orphan_missing",
+            Self::OrphanAmbiguous => "orphan_ambiguous",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayEventOutcome {
+    pub sidecar_event_id: String,
+    pub source_runtime_claim_id: String,
+    pub resolved_claim_id: Option<String>,
+    pub action: String,
+    pub status: ReplayEventStatus,
+    pub reason_code: Option<String>,
+    pub applied_feedback_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectionReplayReport {
+    pub run_id: String,
+    pub sidecar_schema_version: u32,
+    pub applied_count: usize,
+    pub already_applied_count: usize,
+    pub orphaned_count: usize,
+    pub failed_count: usize,
+    pub events: Vec<ReplayEventOutcome>,
+    pub plain_sqlite_recovery_proven: bool,
+    pub live_cutover_proven: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Resolution {
+    Resolved(String),
+    Missing,
+    Ambiguous { candidate_count: usize },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReplayScope<'a> {
+    run_id: &'a str,
+    sidecar_schema_version: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SidecarClaimRef<'a> {
+    runtime_claim_id: &'a str,
+    identity: &'a ClaimSemanticIdentityV1,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SidecarFeedbackRef<'a> {
+    row: &'a ClaimFileFeedbackRow,
+    event_id: &'a str,
+    action: FeedbackAction,
+}
+
+struct ClaimReplayJournalInput<'a> {
+    scope: ReplayScope<'a>,
+    source_claim: SidecarClaimRef<'a>,
+    resolved_claim_id: Option<&'a str>,
+    sidecar_event_id: &'a str,
+    action: &'a str,
+    reason_code: Option<&'a str>,
+    feedback_content_hash: &'a str,
+}
+
+#[derive(Debug, Clone)]
+struct ExistingReplayEvent {
+    sidecar_schema_version: u32,
+    source_runtime_claim_id: String,
+    resolved_claim_id: Option<String>,
+    action: String,
+    status: String,
+    reason_code: Option<String>,
+    semantic_identity_hash: String,
+    feedback_content_hash: String,
+    applied_feedback_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReplayEventClaim {
+    Claimed,
+    ExistingTerminal {
+        status: ReplayEventStatus,
+        reason_code: Option<String>,
+        applied_feedback_id: Option<String>,
+    },
+}
+
+pub fn replay_claim_file_sidecar_corrections(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    run_id: &str,
+    sidecar: &ClaimFileSidecar,
+) -> Result<CorrectionReplayReport, RebuildError> {
+    if run_id.trim().is_empty() {
+        return Err(RebuildError::InvalidSidecar(
+            "run_id is required for rebuild replay".to_string(),
+        ));
+    }
+    validate_replay_sidecar(sidecar)?;
+
+    let scope = ReplayScope {
+        run_id,
+        sidecar_schema_version: sidecar.schema_version,
+    };
+    let mut events = Vec::new();
+    for claim in &sidecar.claims {
+        let resolution = resolve_claim_by_semantic_identity(db, &claim.semantic_identity)?;
+        let source_claim = SidecarClaimRef {
+            runtime_claim_id: &claim.runtime_claim_id,
+            identity: &claim.semantic_identity,
+        };
+        for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            let action = feedback_action_from_slug(&feedback.action)?;
+            let sidecar_event_id =
+                sidecar_feedback_event_id(sidecar, claim, feedback, feedback_index)?;
+            let feedback_ref = SidecarFeedbackRef {
+                row: feedback,
+                event_id: &sidecar_event_id,
+                action,
+            };
+            let event = match &resolution {
+                Resolution::Resolved(claim_id) => {
+                    replay_feedback_event(ctx, db, scope, source_claim, claim_id, feedback_ref)?
+                }
+                Resolution::Missing => record_orphan_replay_event(
+                    db,
+                    scope,
+                    source_claim,
+                    feedback_ref,
+                    ReplayEventStatus::OrphanMissing,
+                    "semantic_identity_missing",
+                )?,
+                Resolution::Ambiguous { candidate_count } => record_orphan_replay_event(
+                    db,
+                    scope,
+                    source_claim,
+                    feedback_ref,
+                    ReplayEventStatus::OrphanAmbiguous,
+                    &format!("semantic_identity_ambiguous_{candidate_count}"),
+                )?,
+            };
+            events.push(event);
+        }
+    }
+
+    let applied_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::Applied)
+        .count();
+    let already_applied_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::AlreadyApplied)
+        .count();
+    let orphaned_count = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.status,
+                ReplayEventStatus::OrphanMissing | ReplayEventStatus::OrphanAmbiguous
+            )
+        })
+        .count();
+    let failed_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::Failed)
+        .count();
+
+    Ok(CorrectionReplayReport {
+        run_id: run_id.to_string(),
+        sidecar_schema_version: sidecar.schema_version,
+        applied_count,
+        already_applied_count,
+        orphaned_count,
+        failed_count,
+        events,
+        plain_sqlite_recovery_proven: false,
+        live_cutover_proven: false,
+    })
+}
+
+fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildError> {
+    if !matches!(
+        sidecar.schema_version,
+        CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION | CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+    ) {
+        return Err(RebuildError::InvalidSidecar(
+            "unsupported sidecar schema_version".to_string(),
+        ));
+    }
+    let mut feedback_ids = HashSet::new();
+    for claim in &sidecar.claims {
+        if claim
+            .semantic_identity
+            .source_content_hash
+            .as_deref()
+            .is_none_or(str::is_empty)
+        {
+            return Err(RebuildError::InvalidSidecar(
+                "sidecar semantic identity missing source_content_hash".to_string(),
+            ));
+        }
+        for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            if sidecar.schema_version == CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+                && feedback.feedback_id.trim().is_empty()
+            {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row missing stable feedback_id".to_string(),
+                ));
+            }
+            let event_id = sidecar_feedback_event_id(sidecar, claim, feedback, feedback_index)?;
+            if !feedback_ids.insert(event_id) {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row reused stable feedback_id".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sidecar_feedback_event_id(
+    sidecar: &ClaimFileSidecar,
+    claim: &ClaimFileClaim,
+    feedback: &ClaimFileFeedbackRow,
+    feedback_index: usize,
+) -> Result<String, RebuildError> {
+    let explicit = feedback.feedback_id.trim();
+    if !explicit.is_empty() {
+        return Ok(explicit.to_string());
+    }
+    if sidecar.schema_version != CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar feedback row missing stable feedback_id".to_string(),
+        ));
+    }
+    let action = feedback_action_from_slug(&feedback.action)?;
+    let payload_json = feedback_payload_json(feedback)?;
+    let content_hash = feedback_content_hash(feedback, action, payload_json.as_deref())?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"dailyos-claim-file-feedback-v1");
+    hasher.update([0x1f]);
+    hasher.update(claim.runtime_claim_id.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(claim.runtime_claim_version.to_string().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(claim.semantic_identity.dedup_key_components_hash.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(feedback_index.to_string().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(feedback.submitted_at.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(content_hash.as_bytes());
+    Ok(format!("legacy-v1:{:x}", hasher.finalize()))
+}
+
+fn feedback_payload_json(feedback: &ClaimFileFeedbackRow) -> Result<Option<String>, RebuildError> {
+    feedback
+        .payload_json
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(RebuildError::Json)
+}
+
+fn feedback_content_hash(
+    feedback: &ClaimFileFeedbackRow,
+    action: FeedbackAction,
+    payload_json: Option<&str>,
+) -> Result<String, RebuildError> {
+    claim_feedback_replay_content_hash(
+        action,
+        &feedback.actor,
+        feedback.actor_id.as_deref(),
+        payload_json,
+    )
+    .map_err(|error| RebuildError::InvalidSidecar(error.to_string()))
+}
+
+fn replay_feedback_event(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    scope: ReplayScope<'_>,
+    source_claim: SidecarClaimRef<'_>,
+    resolved_claim_id: &str,
+    feedback: SidecarFeedbackRef<'_>,
+) -> Result<ReplayEventOutcome, RebuildError> {
+    let payload_json = feedback_payload_json(feedback.row)?;
+    let content_hash =
+        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    if let ReplayEventClaim::ExistingTerminal {
+        status,
+        reason_code,
+        applied_feedback_id,
+    } = claim_replay_event(
+        db,
+        ClaimReplayJournalInput {
+            scope,
+            source_claim,
+            resolved_claim_id: Some(resolved_claim_id),
+            sidecar_event_id: feedback.event_id,
+            action: &feedback.row.action,
+            reason_code: None,
+            feedback_content_hash: &content_hash,
+        },
+    )? {
+        return Ok(ReplayEventOutcome {
+            sidecar_event_id: feedback.event_id.to_string(),
+            source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+            resolved_claim_id: Some(resolved_claim_id.to_string()),
+            action: feedback.row.action.clone(),
+            status,
+            reason_code,
+            applied_feedback_id,
+        });
+    }
+
+    let outcome = match record_claim_feedback_replay(
+        ctx,
+        db,
+        ClaimFeedbackReplayInput {
+            feedback: ClaimFeedbackInput {
+                claim_id: resolved_claim_id.to_string(),
+                action: feedback.action,
+                actor: feedback.row.actor.clone(),
+                actor_id: feedback.row.actor_id.clone(),
+                payload_json,
+            },
+            replay_event_id: feedback.event_id.to_string(),
+        },
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let reason_code = "claim_feedback_replay_failed";
+            let reason_detail_hash = reason_detail_hash(&error.to_string());
+            mark_replay_event_terminal(
+                db,
+                feedback.event_id,
+                ReplayEventStatus::Failed.as_str(),
+                Some(reason_code),
+                Some(&reason_detail_hash),
+                None,
+            )?;
+            return Ok(ReplayEventOutcome {
+                sidecar_event_id: feedback.event_id.to_string(),
+                source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+                resolved_claim_id: Some(resolved_claim_id.to_string()),
+                action: feedback.row.action.clone(),
+                status: ReplayEventStatus::Failed,
+                reason_code: Some(reason_code.to_string()),
+                applied_feedback_id: None,
+            });
+        }
+    };
+
+    let status = if outcome.applied_at_pending {
+        ReplayEventStatus::Applied
+    } else {
+        ReplayEventStatus::AlreadyApplied
+    };
+    mark_replay_event_terminal(
+        db,
+        feedback.event_id,
+        status.as_str(),
+        None,
+        None,
+        Some(&outcome.feedback_id),
+    )?;
+    Ok(ReplayEventOutcome {
+        sidecar_event_id: feedback.event_id.to_string(),
+        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+        resolved_claim_id: Some(resolved_claim_id.to_string()),
+        action: feedback.row.action.clone(),
+        status,
+        reason_code: None,
+        applied_feedback_id: Some(outcome.feedback_id),
+    })
+}
+
+fn record_orphan_replay_event(
+    db: &ActionDb,
+    scope: ReplayScope<'_>,
+    source_claim: SidecarClaimRef<'_>,
+    feedback: SidecarFeedbackRef<'_>,
+    status: ReplayEventStatus,
+    reason_code: &str,
+) -> Result<ReplayEventOutcome, RebuildError> {
+    let payload_json = feedback_payload_json(feedback.row)?;
+    let content_hash =
+        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    if let ReplayEventClaim::ExistingTerminal {
+        status,
+        reason_code,
+        applied_feedback_id,
+    } = claim_replay_event(
+        db,
+        ClaimReplayJournalInput {
+            scope,
+            source_claim,
+            resolved_claim_id: None,
+            sidecar_event_id: feedback.event_id,
+            action: &feedback.row.action,
+            reason_code: Some(reason_code),
+            feedback_content_hash: &content_hash,
+        },
+    )? {
+        return Ok(ReplayEventOutcome {
+            sidecar_event_id: feedback.event_id.to_string(),
+            source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+            resolved_claim_id: None,
+            action: feedback.row.action.clone(),
+            status,
+            reason_code,
+            applied_feedback_id,
+        });
+    }
+    mark_replay_event_terminal(
+        db,
+        feedback.event_id,
+        status.as_str(),
+        Some(reason_code),
+        None,
+        None,
+    )?;
+    Ok(ReplayEventOutcome {
+        sidecar_event_id: feedback.event_id.to_string(),
+        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+        resolved_claim_id: None,
+        action: feedback.row.action.clone(),
+        status,
+        reason_code: Some(reason_code.to_string()),
+        applied_feedback_id: None,
+    })
+}
+
+fn resolve_claim_by_semantic_identity(
+    db: &ActionDb,
+    identity: &ClaimSemanticIdentityV1,
+) -> Result<Resolution, RebuildError> {
+    let subject_kind = identity
+        .subject_ref
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            RebuildError::InvalidSidecar("semantic identity missing subject kind".to_string())
+        })?;
+    let subject_id = identity
+        .subject_ref
+        .get("id")
+        .and_then(serde_json::Value::as_str);
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT id
+         FROM intelligence_claims
+         WHERE claim_type = ?1
+           AND COALESCE(field_path, '') = COALESCE(?2, '')
+           AND json_valid(subject_ref) = 1
+           AND lower(json_extract(subject_ref, '$.kind')) = lower(?3)
+           AND (?4 IS NULL OR json_extract(subject_ref, '$.id') = ?4)
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            &identity.claim_type,
+            identity.field_path.as_deref(),
+            subject_kind,
+            subject_id,
+        ],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut candidates = Vec::new();
+    for row in rows {
+        let claim_id = row?;
+        if let Some(claim) = load_claim_by_id(db.conn_ref(), &claim_id)
+            .map_err(|error| RebuildError::ClaimReplay(error.to_string()))?
+        {
+            let candidate_identity =
+                semantic_identity_for_loaded_claim(&claim).map_err(RebuildError::ClaimReplay)?;
+            if candidate_identity.dedup_key_components_hash == identity.dedup_key_components_hash {
+                candidates.push((claim_id, claim));
+            }
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(Resolution::Missing);
+    }
+    if candidates.len() == 1 {
+        let (claim_id, claim) = candidates.remove(0);
+        return if claim_matches_identity_provenance(&claim, identity) {
+            Ok(Resolution::Resolved(claim_id))
+        } else {
+            Ok(Resolution::Missing)
+        };
+    }
+
+    let narrowed = candidates
+        .iter()
+        .filter(|(_, claim)| claim_matches_identity_provenance(claim, identity))
+        .collect::<Vec<_>>();
+    if narrowed.len() == 1 {
+        return Ok(Resolution::Resolved(narrowed[0].0.clone()));
+    }
+    if narrowed.is_empty() {
+        return Ok(Resolution::Missing);
+    }
+
+    Ok(Resolution::Ambiguous {
+        candidate_count: narrowed.len(),
+    })
+}
+
+fn read_existing_replay_event(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+) -> Result<Option<ExistingReplayEvent>, RebuildError> {
+    db.conn_ref()
+        .query_row(
+            "SELECT sidecar_schema_version, source_runtime_claim_id, resolved_claim_id,
+                    action, status, reason_code, semantic_identity_hash,
+                    feedback_content_hash, applied_feedback_id
+             FROM rebuild_correction_replay_events
+             WHERE sidecar_event_id = ?1",
+            params![sidecar_event_id],
+            |row| {
+                let schema_version = row.get::<_, i64>(0)?;
+                Ok(ExistingReplayEvent {
+                    sidecar_schema_version: schema_version as u32,
+                    source_runtime_claim_id: row.get(1)?,
+                    resolved_claim_id: row.get(2)?,
+                    action: row.get(3)?,
+                    status: row.get(4)?,
+                    reason_code: row.get(5)?,
+                    semantic_identity_hash: row.get(6)?,
+                    feedback_content_hash: row.get(7)?,
+                    applied_feedback_id: row.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(RebuildError::Db)
+}
+
+fn claim_replay_event(
+    db: &ActionDb,
+    input: ClaimReplayJournalInput<'_>,
+) -> Result<ReplayEventClaim, RebuildError> {
+    if let Some(existing) = read_existing_replay_event(db, input.sidecar_event_id)? {
+        validate_existing_replay_event(&existing, &input)?;
+        repair_claimed_legacy_content_hash(db, &existing, &input)?;
+        increment_claimed_attempt_count(db, input.sidecar_event_id)?;
+        return replay_event_claim_from_existing(existing);
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let inserted = db.conn_ref().execute(
+        "INSERT INTO rebuild_correction_replay_events (
+            sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+            resolved_claim_id, action, status, reason_code, semantic_identity_hash,
+            feedback_content_hash, attempt_count, claimed_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', ?7, ?8, ?9, 1, ?10, ?10)
+         ON CONFLICT(sidecar_event_id) DO NOTHING",
+        params![
+            input.sidecar_event_id,
+            input.scope.run_id,
+            input.scope.sidecar_schema_version as i64,
+            input.source_claim.runtime_claim_id,
+            input.resolved_claim_id,
+            input.action,
+            input.reason_code,
+            &input.source_claim.identity.dedup_key_components_hash,
+            input.feedback_content_hash,
+            &now,
+        ],
+    )?;
+    let existing = read_existing_replay_event(db, input.sidecar_event_id)?.ok_or_else(|| {
+        RebuildError::InvalidSidecar("replay event claim was not persisted".to_string())
+    })?;
+    validate_existing_replay_event(&existing, &input)?;
+    repair_claimed_legacy_content_hash(db, &existing, &input)?;
+    if inserted == 0 {
+        increment_claimed_attempt_count(db, input.sidecar_event_id)?;
+    }
+    replay_event_claim_from_existing(existing)
+}
+
+fn increment_claimed_attempt_count(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+) -> Result<(), RebuildError> {
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET attempt_count = attempt_count + 1,
+             updated_at = ?1
+         WHERE sidecar_event_id = ?2
+           AND status = 'claimed'",
+        params![Utc::now().to_rfc3339(), sidecar_event_id],
+    )?;
+    Ok(())
+}
+
+fn validate_existing_replay_event(
+    existing: &ExistingReplayEvent,
+    input: &ClaimReplayJournalInput<'_>,
+) -> Result<(), RebuildError> {
+    if existing.sidecar_schema_version != input.scope.sidecar_schema_version
+        || existing.source_runtime_claim_id != input.source_claim.runtime_claim_id
+        || existing.resolved_claim_id.as_deref() != input.resolved_claim_id
+        || existing.action != input.action
+        || existing.semantic_identity_hash != input.source_claim.identity.dedup_key_components_hash
+    {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different target or feedback content"
+                .to_string(),
+        ));
+    }
+    let content_hash_matches = existing.feedback_content_hash == input.feedback_content_hash
+        || (existing.status == "claimed"
+            && existing.feedback_content_hash == LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+    if !content_hash_matches {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different target or feedback content"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn repair_claimed_legacy_content_hash(
+    db: &ActionDb,
+    existing: &ExistingReplayEvent,
+    input: &ClaimReplayJournalInput<'_>,
+) -> Result<(), RebuildError> {
+    if existing.status != "claimed"
+        || existing.feedback_content_hash != LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH
+    {
+        return Ok(());
+    }
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET feedback_content_hash = ?1,
+             updated_at = ?2
+         WHERE sidecar_event_id = ?3
+           AND status = 'claimed'
+           AND feedback_content_hash = ?4",
+        params![
+            input.feedback_content_hash,
+            Utc::now().to_rfc3339(),
+            input.sidecar_event_id,
+            LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+        ],
+    )?;
+    Ok(())
+}
+
+fn replay_event_claim_from_existing(
+    existing: ExistingReplayEvent,
+) -> Result<ReplayEventClaim, RebuildError> {
+    Ok(match existing.status.as_str() {
+        "claimed" => ReplayEventClaim::Claimed,
+        "applied" | "already_applied" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::AlreadyApplied,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "orphan_missing" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::OrphanMissing,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "orphan_ambiguous" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::OrphanAmbiguous,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "failed" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::Failed,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        other => {
+            return Err(RebuildError::InvalidSidecar(format!(
+                "unknown replay event status `{other}`"
+            )))
+        }
+    })
+}
+
+fn mark_replay_event_terminal(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+    status: &str,
+    reason_code: Option<&str>,
+    reason_detail_hash: Option<&str>,
+    applied_feedback_id: Option<&str>,
+) -> Result<(), RebuildError> {
+    let now = Utc::now().to_rfc3339();
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET status = ?1,
+             reason_code = COALESCE(?2, reason_code),
+             reason_detail_hash = COALESCE(?3, reason_detail_hash),
+             applied_feedback_id = COALESCE(?4, applied_feedback_id),
+             applied_at = CASE WHEN ?1 IN ('applied', 'already_applied') THEN ?5 ELSE applied_at END,
+             updated_at = ?5
+         WHERE sidecar_event_id = ?6
+           AND NOT (
+             status IN ('applied', 'already_applied')
+             AND ?1 = 'failed'
+           )",
+        params![
+            status,
+            reason_code,
+            reason_detail_hash,
+            applied_feedback_id,
+            &now,
+            sidecar_event_id
+        ],
+    )?;
+    Ok(())
+}
+
+fn claim_matches_identity_provenance(
+    claim: &abilities_runtime::types::IntelligenceClaim,
+    identity: &ClaimSemanticIdentityV1,
+) -> bool {
+    claim.source_ref == identity.source_ref
+        && claim.data_source == identity.data_source
+        && claim.observed_at == identity.observed_at
+        && claim.source_asof == identity.source_asof
+        && identity
+            .source_content_hash
+            .as_deref()
+            .is_some_and(|hash| !hash.is_empty() && source_content_hash_for_claim(claim) == hash)
+}
+
+fn reason_detail_hash(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn feedback_action_from_slug(value: &str) -> Result<FeedbackAction, RebuildError> {
+    match value.trim() {
+        "confirm_current" => Ok(FeedbackAction::ConfirmCurrent),
+        "mark_outdated" => Ok(FeedbackAction::MarkOutdated),
+        "mark_false" => Ok(FeedbackAction::MarkFalse),
+        "wrong_subject" => Ok(FeedbackAction::WrongSubject),
+        "wrong_source" => Ok(FeedbackAction::WrongSource),
+        "cannot_verify" => Ok(FeedbackAction::CannotVerify),
+        "needs_nuance" => Ok(FeedbackAction::NeedsNuance),
+        "surface_inappropriate" => Ok(FeedbackAction::SurfaceInappropriate),
+        "not_relevant_here" => Ok(FeedbackAction::NotRelevantHere),
+        "merge_intent" => Ok(FeedbackAction::MergeIntent),
+        other => Err(RebuildError::InvalidSidecar(format!(
+            "unsupported feedback action `{other}`"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+    use crate::services::claim_files::{
+        ClaimFileClaim, ClaimFileContradictionEdge, ClaimFileLifecycle, ClaimFileProvenanceSummary,
+        ClaimFileReplayStatus, CLAIM_FILE_PROJECTION_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+    };
+    use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim, TombstoneSpec};
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
+
+    const TS: &str = "2026-06-05T12:00:00Z";
+    const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
+
+    fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
+        let now = chrono::DateTime::parse_from_rfc3339(TS)
+            .expect("timestamp")
+            .with_timezone(&Utc);
+        (
+            FixedClock::new(now),
+            SeedableRng::new(9),
+            ExternalClients::default(),
+        )
+    }
+
+    fn proposal(text: &str) -> ClaimProposal {
+        ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: SUBJECT.to_string(),
+            claim_type: "risk".to_string(),
+            field_path: Some("health.risk".to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: Some("fixture://source-1".to_string()),
+            source_asof: Some(TS.to_string()),
+            observed_at: TS.to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        }
+    }
+
+    fn inserted_claim_id(outcome: CommittedClaim) -> String {
+        match outcome {
+            CommittedClaim::Inserted { claim }
+            | CommittedClaim::Reinforced { claim, .. }
+            | CommittedClaim::Tombstoned { claim } => claim.id,
+            CommittedClaim::Forked { new_claim_id, .. } => new_claim_id,
+        }
+    }
+
+    fn seed_account(db: &ActionDb) {
+        db.conn_ref()
+            .execute(
+                "INSERT INTO accounts (id, name, updated_at) VALUES (?1, ?2, ?3)",
+                params!["acct-1", "Account 1", TS],
+            )
+            .expect("seed account");
+    }
+
+    fn replay_status() -> ClaimFileReplayStatus {
+        ClaimFileReplayStatus {
+            status: "projected".to_string(),
+            reason: None,
+            last_attempted_at: None,
+        }
+    }
+
+    fn sidecar_for_claim(
+        db: &ActionDb,
+        fresh_claim_id: &str,
+        source_runtime_claim_id: &str,
+        feedback_id: &str,
+    ) -> ClaimFileSidecar {
+        let fresh_claim = load_claim_by_id(db.conn_ref(), fresh_claim_id)
+            .expect("load claim")
+            .expect("claim exists");
+        let mut identity =
+            semantic_identity_for_loaded_claim(&fresh_claim).expect("semantic identity");
+        identity.runtime_claim_id = source_runtime_claim_id.to_string();
+        identity.runtime_claim_version = 4;
+        let subject = serde_json::json!({"kind":"account","id":"acct-1"});
+        ClaimFileSidecar {
+            schema_version: CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+            projection_version: CLAIM_FILE_PROJECTION_VERSION,
+            entity_subject_ref: subject,
+            entity_subject_compact: r#"{"id":"acct-1","kind":"account"}"#.to_string(),
+            markdown_rel_path: "_dailyos_claims/account/acct-1/claims.md".to_string(),
+            sidecar_rel_path: "_dailyos_claims/account/acct-1/claims.corrections.json".to_string(),
+            claims: vec![ClaimFileClaim {
+                semantic_identity: identity,
+                runtime_claim_id: source_runtime_claim_id.to_string(),
+                runtime_claim_version: 4,
+                claim_text: "Renewal risk is elevated".to_string(),
+                trust_band: "likely_current".to_string(),
+                sensitivity: "internal".to_string(),
+                lifecycle: ClaimFileLifecycle {
+                    claim_state: "active".to_string(),
+                    surfacing_state: "active".to_string(),
+                    demotion_reason: None,
+                    retraction_reason: None,
+                    superseded_by: None,
+                    verification_state: "active".to_string(),
+                    verification_reason: None,
+                    needs_user_decision_at: None,
+                },
+                provenance_summary: ClaimFileProvenanceSummary {
+                    data_source: "unit_test".to_string(),
+                    source_ref: Some("fixture://source-1".to_string()),
+                    source_asof: Some(TS.to_string()),
+                    observed_at: TS.to_string(),
+                },
+                feedback_rows: vec![ClaimFileFeedbackRow {
+                    feedback_id: feedback_id.to_string(),
+                    action: "cannot_verify".to_string(),
+                    actor: "user".to_string(),
+                    actor_id: Some("user-fixture".to_string()),
+                    payload_json: None,
+                    submitted_at: TS.to_string(),
+                    applied_at: None,
+                }],
+                contradiction_edges: Vec::<ClaimFileContradictionEdge>::new(),
+                superseded_by_semantic_identity: None,
+                replay_status: replay_status(),
+            }],
+        }
+    }
+
+    fn feedback_count_for_replay(db: &ActionDb, replay_event_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("count replay feedback")
+    }
+
+    fn replay_journal_count(db: &ActionDb) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM rebuild_correction_replay_events",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count replay journal")
+    }
+
+    fn replay_journal_status_and_reason(
+        db: &ActionDb,
+        replay_event_id: &str,
+    ) -> (String, Option<String>, Option<String>) {
+        db.conn_ref()
+            .query_row(
+                "SELECT status, reason_code, reason_detail_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = ?1",
+                params![replay_event_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read replay journal status")
+    }
+
+    fn replay_journal_resolved_claim_id(db: &ActionDb, replay_event_id: &str) -> Option<String> {
+        db.conn_ref()
+            .query_row(
+                "SELECT resolved_claim_id
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("read replay journal target")
+    }
+
+    fn claim_verification_state_and_version(db: &ActionDb, claim_id: &str) -> (String, i64) {
+        db.conn_ref()
+            .query_row(
+                "SELECT verification_state, claim_version
+                 FROM intelligence_claims
+                 WHERE id = ?1",
+                params![claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read claim verification state")
+    }
+
+    fn targeted_repair_job_count(db: &ActionDb, claim_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM invalidation_jobs
+                 WHERE job_kind = ?1
+                   AND json_extract(payload_json, '$.claim_id') = ?2",
+                params![crate::db::invalidation_jobs::KIND_TARGETED_REPAIR, claim_id],
+                |row| row.get(0),
+            )
+            .expect("count targeted repair jobs")
+    }
+
+    #[test]
+    fn dos832_replay_sidecar_resolves_fresh_claim_by_semantic_identity_not_runtime_uuid() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-1",
+        );
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 1);
+        assert!(!report.plain_sqlite_recovery_proven);
+        assert!(!report.live_cutover_proven);
+        assert_eq!(
+            report.events[0].source_runtime_claim_id,
+            "old-runtime-claim-id"
+        );
+        assert_eq!(
+            report.events[0].resolved_claim_id.as_deref(),
+            Some(fresh_claim_id.as_str())
+        );
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-1"), 1);
+        let (verification_state, claim_version) =
+            claim_verification_state_and_version(&db, &fresh_claim_id);
+        assert_eq!(verification_state, "contested");
+        assert_eq!(claim_version, 2);
+        assert_eq!(targeted_repair_job_count(&db, &fresh_claim_id), 1);
+    }
+
+    #[test]
+    fn dos832_replay_claims_event_id_before_mutation_and_survives_restart() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-2",
+        );
+
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        let second = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("second replay");
+
+        assert_eq!(second.applied_count, 0);
+        assert_eq!(second.already_applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-2"), 1);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "old-feedback-2");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+    }
+
+    #[test]
+    fn dos832_replay_derives_event_id_for_legacy_v1_sidecar_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
+        sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay legacy sidecar");
+
+        assert_eq!(report.applied_count, 1);
+        assert!(report.events[0].sidecar_event_id.starts_with("legacy-v1:"));
+        assert_eq!(
+            feedback_count_for_replay(&db, &report.events[0].sidecar_event_id),
+            1
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_v2_sidecar_without_source_content_hash() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "missing-source-hash-feedback",
+        );
+        sidecar.claims[0].semantic_identity.source_content_hash = None;
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("v2 sidecar without source hash must reject");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("source_content_hash"))
+        );
+        assert_eq!(
+            feedback_count_for_replay(&db, "missing-source-hash-feedback"),
+            0
+        );
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_same_event_id_with_changed_feedback_content() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut first_sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "payload-event",
+        );
+        first_sidecar.claims[0].feedback_rows[0].action = "needs_nuance".to_string();
+        first_sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "corrected_text": "Risk is limited to the pilot group" }));
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let mut second_sidecar = first_sidecar;
+        second_sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "corrected_text": "Risk is limited to the renewal window" }));
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("same replay id must not hide changed payload");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "payload-event"), 1);
+    }
+
+    #[test]
+    fn dos832_replay_failed_terminal_update_cannot_overwrite_applied() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "applied-event",
+        );
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
+
+        mark_replay_event_terminal(
+            &db,
+            "applied-event",
+            ReplayEventStatus::Failed.as_str(),
+            Some("late_failure"),
+            Some("late-failure-detail"),
+            None,
+        )
+        .expect("late failed mark is ignored");
+
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "applied-event");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+        assert_eq!(detail_hash, None);
+    }
+
+    #[test]
+    fn dos832_replay_repairs_partial_v282_claimed_content_hash_gap() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "partial-v282-event",
+        );
+        let sidecar_claim = &sidecar.claims[0];
+        let feedback = &sidecar_claim.feedback_rows[0];
+        db.conn_ref()
+            .execute(
+                "INSERT INTO rebuild_correction_replay_events (
+                    sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                    resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                    semantic_identity_hash, feedback_content_hash, applied_feedback_id,
+                    attempt_count, claimed_at, applied_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', NULL, NULL, ?7, ?8, NULL, 1, ?9, NULL, ?9)",
+                params![
+                    &feedback.feedback_id,
+                    "run-before-crash",
+                    sidecar.schema_version as i64,
+                    &sidecar_claim.runtime_claim_id,
+                    &fresh_claim_id,
+                    &feedback.action,
+                    &sidecar_claim.semantic_identity.dedup_key_components_hash,
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    TS,
+                ],
+            )
+            .expect("insert partial v282 claimed row");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay repaired claimed row");
+
+        assert_eq!(report.applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "partial-v282-event"), 1);
+        let repaired_hash: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = 'partial-v282-event'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired hash");
+        assert_ne!(repaired_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+        let (status, _, _) = replay_journal_status_and_reason(&db, "partial-v282-event");
+        assert_eq!(status, "applied");
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_claimed_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &first_claim_id,
+            "old-runtime-claim-id",
+            "claimed-event",
+        );
+        let first_claim = &first_sidecar.claims[0];
+        let first_feedback = &first_claim.feedback_rows[0];
+        let action = feedback_action_from_slug(&first_feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(first_feedback).expect("payload json");
+        let content_hash = feedback_content_hash(first_feedback, action, payload_json.as_deref())
+            .expect("content hash");
+        let source_claim = SidecarClaimRef {
+            runtime_claim_id: &first_claim.runtime_claim_id,
+            identity: &first_claim.semantic_identity,
+        };
+        let claim = claim_replay_event(
+            &db,
+            ClaimReplayJournalInput {
+                scope: ReplayScope {
+                    run_id: "run-1",
+                    sidecar_schema_version: first_sidecar.schema_version,
+                },
+                source_claim,
+                resolved_claim_id: Some(first_claim_id.as_str()),
+                sidecar_event_id: "claimed-event",
+                action: &first_feedback.action,
+                reason_code: None,
+                feedback_content_hash: &content_hash,
+            },
+        )
+        .expect("claim replay event");
+        assert_eq!(claim, ReplayEventClaim::Claimed);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar = sidecar_for_claim(
+            &db,
+            &second_claim_id,
+            "other-runtime-claim-id",
+            "claimed-event",
+        );
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("claimed event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "claimed-event"), 0);
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "claimed-event").as_deref(),
+            Some(first_claim_id.as_str())
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_sidecar_feedback_without_stable_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("missing event id must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, ""), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_unsupported_sidecar_schema_before_writes() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-schema",
+        );
+        sidecar.schema_version = CLAIM_FILE_SIDECAR_SCHEMA_VERSION + 1;
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("unsupported sidecar schema must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-schema"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_duplicate_feedback_ids_before_writes() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "dupe-feedback",
+        );
+        let duplicate_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        sidecar.claims[0].feedback_rows.push(duplicate_feedback);
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("duplicate event id must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, "dupe-feedback"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_orphans_when_semantic_identity_is_missing() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "missing-feedback",
+        );
+        sidecar.claims[0]
+            .semantic_identity
+            .dedup_key_components_hash = "missing-semantic-identity".to_string();
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanMissing);
+        assert_eq!(
+            report.events[0].reason_code.as_deref(),
+            Some("semantic_identity_missing")
+        );
+        assert_eq!(feedback_count_for_replay(&db, "missing-feedback"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "missing-feedback");
+        assert_eq!(status, "orphan_missing");
+        assert_eq!(reason_code.as_deref(), Some("semantic_identity_missing"));
+    }
+
+    #[test]
+    fn dos832_replay_orphans_single_candidate_when_provenance_mismatches() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "source-mismatch-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "source_ref": "fixture://source-1" }));
+        sidecar.claims[0].semantic_identity.source_ref = Some("fixture://source-2".to_string());
+        sidecar.claims[0].semantic_identity.source_asof = Some("2026-06-05T13:00:00Z".to_string());
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanMissing);
+        assert_eq!(
+            feedback_count_for_replay(&db, "source-mismatch-feedback"),
+            0
+        );
+    }
+
+    #[test]
+    fn dos832_replay_orphans_ambiguous_semantic_identity_without_mutating_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut tombstone = proposal("Renewal risk is elevated");
+        tombstone.tombstone = Some(TombstoneSpec {
+            retraction_reason: "test tombstone shadow".to_string(),
+            expires_at: None,
+        });
+        let tombstone_id =
+            inserted_claim_id(commit_claim(&ctx, &db, tombstone).expect("commit tombstone claim"));
+        assert_ne!(fresh_claim_id, tombstone_id);
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "ambiguous-feedback",
+        );
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanAmbiguous);
+        assert_eq!(
+            report.events[0].reason_code.as_deref(),
+            Some("semantic_identity_ambiguous_2")
+        );
+        assert_eq!(feedback_count_for_replay(&db, "ambiguous-feedback"), 0);
+    }
+
+    #[test]
+    fn dos832_replay_marks_invalid_feedback_failed_and_continues() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "invalid-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        let mut valid_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        valid_feedback.feedback_id = "valid-feedback-after-failure".to_string();
+        valid_feedback.action = "cannot_verify".to_string();
+        sidecar.claims[0].feedback_rows.push(valid_feedback);
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(report.applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "invalid-feedback"), 0);
+        assert_eq!(
+            feedback_count_for_replay(&db, "valid-feedback-after-failure"),
+            1
+        );
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "invalid-feedback");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert!(detail_hash.is_some_and(|hash| hash.len() == 64));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_failed_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut failed_sidecar =
+            sidecar_for_claim(&db, &first_claim_id, "old-runtime-claim-id", "event-1");
+        failed_sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        let first_report =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &failed_sidecar)
+                .expect("first replay fails terminally");
+        assert_eq!(first_report.failed_count, 1);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar =
+            sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-1");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("failed event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "event-1"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "event-1");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "event-1").as_deref(),
+            Some(first_claim_id.as_str())
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_orphaned_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut orphan_sidecar =
+            sidecar_for_claim(&db, &first_claim_id, "old-runtime-claim-id", "event-2");
+        orphan_sidecar.claims[0]
+            .semantic_identity
+            .dedup_key_components_hash = "missing-semantic-identity".to_string();
+        let first_report =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &orphan_sidecar)
+                .expect("first replay orphans");
+        assert_eq!(first_report.orphaned_count, 1);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar =
+            sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-2");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("orphaned event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "event-2"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "event-2");
+        assert_eq!(status, "orphan_missing");
+        assert_eq!(reason_code.as_deref(), Some("semantic_identity_missing"));
+        assert_eq!(replay_journal_resolved_claim_id(&db, "event-2"), None);
+    }
+
+    #[test]
+    fn dos832_replay_terminal_status_must_match_original_target() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &first_claim_id,
+            "old-runtime-claim-id",
+            "reused-feedback",
+        );
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let second_sidecar = sidecar_for_claim(
+            &db,
+            &second_claim_id,
+            "other-runtime-claim-id",
+            "reused-feedback",
+        );
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("reused terminal event id must reject target mismatch");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "reused-feedback"), 1);
+    }
+}

--- a/src-tauri/src/services/rebuild.rs
+++ b/src-tauri/src/services/rebuild.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -262,6 +262,7 @@ fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildErro
             ));
         }
         for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            validate_feedback_submitted_at(&feedback.submitted_at)?;
             if sidecar.schema_version == CLAIM_FILE_SIDECAR_SCHEMA_VERSION
                 && feedback.feedback_id.trim().is_empty()
             {
@@ -334,8 +335,23 @@ fn feedback_content_hash(
         &feedback.actor,
         feedback.actor_id.as_deref(),
         payload_json,
+        &feedback.submitted_at,
     )
     .map_err(|error| RebuildError::InvalidSidecar(error.to_string()))
+}
+
+fn validate_feedback_submitted_at(submitted_at: &str) -> Result<(), RebuildError> {
+    if submitted_at.trim().is_empty() {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar feedback row missing submitted_at".to_string(),
+        ));
+    }
+    DateTime::parse_from_rfc3339(submitted_at.trim()).map_err(|error| {
+        RebuildError::InvalidSidecar(format!(
+            "sidecar feedback row submitted_at must be RFC3339: {error}"
+        ))
+    })?;
+    Ok(())
 }
 
 fn replay_feedback_event(
@@ -388,6 +404,7 @@ fn replay_feedback_event(
                 payload_json,
             },
             replay_event_id: feedback.event_id.to_string(),
+            submitted_at: feedback.row.submitted_at.clone(),
         },
     ) {
         Ok(outcome) => outcome,
@@ -831,6 +848,7 @@ mod tests {
     use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
 
     const TS: &str = "2026-06-05T12:00:00Z";
+    const REPLAYED_FEEDBACK_TS: &str = "2026-05-01T08:30:00Z";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
 
     fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
@@ -974,6 +992,16 @@ mod tests {
             .expect("count replay journal")
     }
 
+    fn feedback_submitted_at_for_replay(db: &ActionDb, replay_event_id: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("read replay feedback submitted_at")
+    }
+
     fn replay_journal_status_and_reason(
         db: &ActionDb,
         replay_event_id: &str,
@@ -1036,12 +1064,13 @@ mod tests {
             commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
                 .expect("commit fresh claim"),
         );
-        let sidecar = sidecar_for_claim(
+        let mut sidecar = sidecar_for_claim(
             &db,
             &fresh_claim_id,
             "old-runtime-claim-id",
             "old-feedback-1",
         );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
 
         let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
             .expect("replay sidecar");
@@ -1058,6 +1087,10 @@ mod tests {
             Some(fresh_claim_id.as_str())
         );
         assert_eq!(feedback_count_for_replay(&db, "old-feedback-1"), 1);
+        assert_eq!(
+            feedback_submitted_at_for_replay(&db, "old-feedback-1"),
+            REPLAYED_FEEDBACK_TS
+        );
         let (verification_state, claim_version) =
             claim_verification_state_and_version(&db, &fresh_claim_id);
         assert_eq!(verification_state, "contested");
@@ -1181,6 +1214,40 @@ mod tests {
             matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
         );
         assert_eq!(feedback_count_for_replay(&db, "payload-event"), 1);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_same_event_id_with_changed_submitted_at() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut first_sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "submitted-at-event",
+        );
+        first_sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let mut second_sidecar = first_sidecar;
+        second_sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-02T08:30:00Z".to_string();
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("same replay id must not hide changed submitted_at");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
+        );
+        assert_eq!(
+            feedback_submitted_at_for_replay(&db, "submitted-at-event"),
+            REPLAYED_FEEDBACK_TS
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds the DOS-832 L1a correction-replay service for W3 claim-file sidecar feedback.
- Resolves regenerated claims by semantic identity and provenance instead of old runtime UUIDs.
- Adds v282 replay journal schema, stable sidecar feedback IDs, idempotent claim-feedback replay, and partial-v282 repair coverage.
- Records a bounded proof bundle for current encrypted/Replica-compatible replay only.

## Stack

This PR is stacked on `codex/v1.4.9-w3-dos628` / PR #436 because the replay path depends on W3 claim-file projection sidecars and migrations v280/v281. It intentionally does not claim final plain-SQLite rebuild or Live cutover completion.

## Validation

- `src-tauri/scripts/check_migrations_transactional.sh`
- `cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback --lib -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture`
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm tsc --noEmit`
- `git diff --check`

Full Cargo rerun passed after one isolated timing-sensitive benchmark failure passed on rerun and in the full rerun.
