### PR TITLE
DOS-832 L1a: replay claim-file corrections

### DIFF
--- a/.docs/plans/dos-832/dos-832-l0-packet.md
+++ b/.docs/plans/dos-832/dos-832-l0-packet.md
@@ -28,7 +28,7 @@
 - SQLCipher retirement is an ADR-0092 amendment path, not ADR-0136.
 - There is no in-place decrypt/sentinel migration in DOS-831.
 - Existing encrypted-looking active DBs fail loud into storage-health/rebuild guidance.
-- Current schema head is v276; next free slot is v277.
+- At L0 drafting, current schema head was v276 and the next free slot was v277. The stacked L1 implementation now sits above W3's v280/v281 claim-file projection migrations, so DOS-832 replay journal schema uses v282.
 - Writer-priority lane language is stale; ADR-0133 owns FIFO writer/gate responsibility.
 
 **Authority precondition:** DOS-832 implementation does not begin from the stale local wave-plan text. Before L1, either DOS-831 PR #434 (or an equivalent wave-plan/ADR correction) is merged into the branch, or this packet remains a draft and the first L1 task is to rebase/apply those authority corrections. A packet note pointing at an unavailable PR is not sufficient for shipping implementation.
@@ -107,7 +107,7 @@ The rebuild path creates a fresh database at schema head, then replays canonical
 The intended phases:
 
 1. **Plan:** resolve workspace root, DB mode, target DB path, existing DB health, and source inventory. Produce a PII-safe summary using handles/counts/reason codes.
-2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev`; reserve `v277+` only if L1 adds rebuild-run schema).
+2. **Fresh schema:** create or open the target rebuild DB and run migrations to head (`v276` on current `dev` at L0; v281 after W3 stacking; reserve `v282+` if L1 adds rebuild-run schema after W3).
 3. **Canonical entity seed:** run the existing entity JSON sync for `Accounts`, `Projects`, and `People` through `WorkspaceSourceRegistry::open_validated` or a rebuild-owned bounded-open helper with the same traversal, symlink, race, workspace-escape, size, and hardlink protections, while preserving the fact that this is only the entity seed layer.
 4. **Source registration:** reuse/extend `workspace_backfill` to register workspace files and entity links. It remains privacy-aware and resumable.
 5. **Source ingestion:** run the workspace ingestion pipeline over registered eligible files. Claims must enter through `commit_claim` with `DataSource::WorkspaceFile`, `source_ref`, `source_asof`, `observed_at`, temporal scope, sensitivity, and provenance intact.
@@ -367,6 +367,7 @@ Approval requires unanimous pass or explicit L6 decision on any residual release
 | `/codex challenge` | APPROVE | Re-review blockers were interprocess cutover lock, degraded source-time semantics, replay coverage/anchor gate, crash-consistent cutover manifest/startup recovery, lock transition, WAL checkpoint owner, and structured replay payload. Cycle 4 passed. |
 | `ce-security-lens-reviewer` | APPROVE | Approved entity JSON seed trust boundary, cutover gates, sidecar/export audit/security obligations, and DOS-831/DOS-628 gates across re-review cycles. |
 | `ce-feasibility-reviewer` | APPROVE | Re-review blockers were implementable invocation-correlation adapter, minimum sidecar contract, worker-control registry, concrete producer matrix, and named source-time resolver. Cycle 4 passed. |
+| `ce-data-migrations-reviewer` | APPROVE | Approved schema/data-integrity posture: fresh-schema replay, next-free-slot reservation only if new run state is required, no raw claim copy, replay idempotency, and invocation correlation where applicable. |
 | `ce-learnings-researcher` | APPROVE | Confirmed prior substrate is represented: ADR-0120, ADR-0094/0098, ADR-0048, ADR-0107/0098, ADR-0123/0126/0131, ADR-0133, ADR-0110, and documented claim-producer/runtime trust audit and DB lock-storm learnings. |
 
 Cycle notes:

--- a/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
+++ b/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
@@ -1,0 +1,116 @@
+# DOS-832 L1a Proof Bundle -- Current-Encrypted Replica Correction Replay
+
+**Issue:** DOS-832
+**Branch:** `codex/v1.4.9-w1-dos832-l1`
+**Date:** 2026-06-05
+**Scope:** L1a substrate proof only. This proves replay of W3 claim-file sidecar feedback into freshly regenerated claim IDs in the current encrypted/Replica-compatible schema. It does not claim final plain-SQLite rebuild, Live cutover, or full DOS-832 release completion.
+
+## Verdict
+
+**L1a pass, bounded.**
+
+The branch proves the correction-replay core that DOS-832 can honestly validate before DOS-831 lands:
+
+- W3 sidecar feedback rows now carry a stable `feedbackId` replay key.
+- Legacy v1 sidecars without `feedbackId` replay through a deterministic derived key so old sidecars remain readable without pretending they had durable source IDs.
+- DOS-832 resolves sidecar entries by rebuild-stable semantic identity, not old runtime claim UUID.
+- v2 replay requires source-content hash provenance before mutation.
+- Replay claims the stable sidecar event in a durable journal before calling the claim feedback service.
+- Feedback replay goes through `services::claims`, not raw `claim_feedback` inserts.
+- Re-running the replay does not duplicate feedback rows.
+- Same event ID with changed feedback content is rejected.
+- Missing stable replay IDs are rejected before mutation.
+- Duplicate stable replay IDs are rejected before mutation.
+- Unsupported sidecar schema versions are rejected before mutation.
+- Missing, provenance-mismatched, or ambiguous semantic matches are represented as orphan outcomes, not guessed.
+- Service-invalid feedback rows are marked `failed` in the replay journal and do not abort later independent rows.
+- Stable replay event IDs cannot be retargeted after applied, failed, or orphaned terminal journal outcomes.
+- Partial v282 journal rows from an interrupted old-shape migration are repaired before replay continues.
+
+## Explicit Non-Claims
+
+These remain unproven by this L1a slice:
+
+- Plain-SQLite fresh recovery after DOS-831.
+- Live destructive replacement and cutover exclusivity.
+- Entity JSON seed trust-boundary replay.
+- Full source registration, ingestion, re-enrichment, salience, embeddings, and derived-context rebuild.
+- Supersession and contradiction edge replay beyond sidecar serialization of semantic endpoint identities.
+- Operator recovery docs and ADR-0048 amendment.
+- Real-workspace end-to-end rebuild.
+
+The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverProven: false` to keep these boundaries machine-visible.
+
+## Implementation Evidence
+
+### Schema
+
+- Added migration `v282_dos_832_rebuild_replay_journal`.
+- Added `claim_feedback.replay_event_id` plus a unique partial index for replay idempotency.
+- Added `rebuild_correction_replay_events` with status-coded replay outcomes:
+  - `claimed`
+  - `applied`
+  - `already_applied`
+  - `orphan_missing`
+  - `orphan_ambiguous`
+  - `failed`
+- Journal rows persist a canonical feedback-content hash so replay can reject event-ID reuse with changed feedback content.
+- Registered v282 through the idempotent multi-statement migration helper so schema-version record gaps can retry without duplicate-column failure.
+- v282 includes an explicit idempotent repair for partial old-shape journal tables missing `feedback_content_hash`.
+- Bumped claim-file sidecar schema version to `2` because stable `feedbackId` is now part of the replay contract.
+
+### Services
+
+- Added `services::rebuild::replay_claim_file_sidecar_corrections`.
+- Added `services::claims::record_claim_feedback_replay`.
+- Existing `record_claim_feedback` now delegates through a shared internal writer path; replay adds only stable-event idempotency and does not bypass actor or feedback validation.
+- `claim_files` sidecar serialization now includes stable feedback row IDs and semantic identities for supersession/contradiction endpoints.
+
+## Intelligence Loop Check
+
+1. **Claim model:** Replay does not create display-only data. It targets regenerated claim rows and writes typed claim feedback through the claim service.
+2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source-content hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
+3. **Signals + invalidation:** Replay uses the same `record_claim_feedback` path, so existing feedback signals, version events, invalidation bumps, and repair-job coalescing remain active.
+4. **Runtime + surfaces:** The L1a helper is service-owned and callable by future rebuild orchestration. It does not expose a user-visible surface yet.
+5. **Feedback loop:** User feedback rows replay as typed `FeedbackAction` events with existing claim-service behavior; duplicates are suppressed by stable event ID.
+
+## Validation
+
+Commands run from the DOS-832 worktree:
+
+```bash
+src-tauri/scripts/check_migrations_transactional.sh
+cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture
+cargo fmt --manifest-path src-tauri/Cargo.toml
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+cargo test --manifest-path src-tauri/Cargo.toml --lib
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- Migration wrapper check: passed.
+- Focused DOS-832 replay tests: 18 passed.
+- Claim-file tests: 18 passed.
+- Claim feedback tests: 23 passed.
+- v282 migration regressions: 2 passed.
+- Clippy: passed with `-D warnings`.
+- Full Rust lib suite: 3181 passed, 0 failed, 11 ignored.
+- Full Cargo suite: passed, including integration tests and doc tests.
+- TypeScript: passed.
+- Diff hygiene: passed.
+- Note: full Cargo emitted two pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; `cargo clippy -- -D warnings` passed.
+
+## L2 Inputs
+
+The next L2 reviewer should focus on these risk areas:
+
+- Whether replay-event claiming is sufficiently atomic for the current single-writer/local topology.
+- Whether the sidecar stable `feedbackId` contract belongs in W3/DOS-628 before DOS-832 merges, or whether the stacked DOS-832 branch may extend the W3 sidecar contract.
+- Whether the L1a proof boundary is acceptable for PR scope, given the full DOS-832 packet still requires DOS-831 and broader rebuild orchestration.
+- Whether supersession/contradiction endpoint semantic identities are enough as contract plumbing while actual edge replay remains out of this slice.

--- a/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
+++ b/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
@@ -14,11 +14,12 @@ The branch proves the correction-replay core that DOS-832 can honestly validate 
 - W3 sidecar feedback rows now carry a stable `feedbackId` replay key.
 - Legacy v1 sidecars without `feedbackId` replay through a deterministic derived key so old sidecars remain readable without pretending they had durable source IDs.
 - DOS-832 resolves sidecar entries by rebuild-stable semantic identity, not old runtime claim UUID.
-- v2 replay requires source-content hash provenance before mutation.
+- v2 replay requires the sidecar source identity hash before mutation. This hash binds `data_source`, `source_ref`, and `item_hash`; it is not proof of the full projection-file contents.
 - Replay claims the stable sidecar event in a durable journal before calling the claim feedback service.
 - Feedback replay goes through `services::claims`, not raw `claim_feedback` inserts.
 - Re-running the replay does not duplicate feedback rows.
-- Same event ID with changed feedback content is rejected.
+- Replay preserves the original sidecar feedback `submitted_at` rather than rewriting it to rebuild time.
+- Same event ID with changed feedback content or `submitted_at` is rejected.
 - Missing stable replay IDs are rejected before mutation.
 - Duplicate stable replay IDs are rejected before mutation.
 - Unsupported sidecar schema versions are rejected before mutation.
@@ -54,7 +55,7 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
   - `orphan_missing`
   - `orphan_ambiguous`
   - `failed`
-- Journal rows persist a canonical feedback-content hash so replay can reject event-ID reuse with changed feedback content.
+- Journal rows persist a canonical feedback-content hash, including `submitted_at`, so replay can reject event-ID reuse with changed feedback content or historical feedback time.
 - Registered v282 through the idempotent multi-statement migration helper so schema-version record gaps can retry without duplicate-column failure.
 - v282 includes an explicit idempotent repair for partial old-shape journal tables missing `feedback_content_hash`.
 - Bumped claim-file sidecar schema version to `2` because stable `feedbackId` is now part of the replay contract.
@@ -69,7 +70,7 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
 ## Intelligence Loop Check
 
 1. **Claim model:** Replay does not create display-only data. It targets regenerated claim rows and writes typed claim feedback through the claim service.
-2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source-content hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
+2. **Provenance + trust:** Sidecar semantic identity retains subject, claim type, field path, source ref, source-asof, observed-at, and source identity hash for matching. Replay requires the regenerated claim to match those provenance fields before applying feedback. Trust movement remains owned by the claim feedback writer and repair queue.
 3. **Signals + invalidation:** Replay uses the same `record_claim_feedback` path, so existing feedback signals, version events, invalidation bumps, and repair-job coalescing remain active.
 4. **Runtime + surfaces:** The L1a helper is service-owned and callable by future rebuild orchestration. It does not expose a user-visible surface yet.
 5. **Feedback loop:** User feedback rows replay as typed `FeedbackAction` events with existing claim-service behavior; duplicates are suppressed by stable event ID.
@@ -82,7 +83,7 @@ Commands run from the DOS-832 worktree:
 src-tauri/scripts/check_migrations_transactional.sh
 cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture
-cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback --lib -- --nocapture
+cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback_replay --lib -- --nocapture
 cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture
 cargo fmt --manifest-path src-tauri/Cargo.toml
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
@@ -95,15 +96,16 @@ git diff --check
 Results:
 
 - Migration wrapper check: passed.
-- Focused DOS-832 replay tests: 18 passed.
+- Focused DOS-832 replay tests: 19 passed.
 - Claim-file tests: 18 passed.
-- Claim feedback tests: 23 passed.
+- Claim feedback replay tests: 5 passed.
 - v282 migration regressions: 2 passed.
 - Clippy: passed with `-D warnings`.
-- Full Rust lib suite: 3181 passed, 0 failed, 11 ignored.
+- Full Rust lib suite: 3183 passed, 0 failed, 11 ignored.
 - Full Cargo suite: passed, including integration tests and doc tests.
 - TypeScript: passed.
 - Diff hygiene: passed.
+- Focused remediation re-review: adversarial reviewer PASS; data-migration reviewer PASS.
 - Note: full Cargo emitted two pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; `cargo clippy -- -D warnings` passed.
 
 ## L2 Inputs

--- a/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
+++ b/.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md
@@ -1,8 +1,8 @@
 # DOS-832 L1a Proof Bundle -- Current-Encrypted Replica Correction Replay
 
 **Issue:** DOS-832
-**Branch:** `codex/v1.4.9-w1-dos832-l1`
-**Date:** 2026-06-05
+**Branch:** `codex/v1.4.9-w1-dos832-l1-rebased`
+**Date:** 2026-06-06
 **Scope:** L1a substrate proof only. This proves replay of W3 claim-file sidecar feedback into freshly regenerated claim IDs in the current encrypted/Replica-compatible schema. It does not claim final plain-SQLite rebuild, Live cutover, or full DOS-832 release completion.
 
 ## Verdict
@@ -15,18 +15,27 @@ The branch proves the correction-replay core that DOS-832 can honestly validate 
 - Legacy v1 sidecars without `feedbackId` replay through a deterministic derived key so old sidecars remain readable without pretending they had durable source IDs.
 - DOS-832 resolves sidecar entries by rebuild-stable semantic identity, not old runtime claim UUID.
 - v2 replay requires the sidecar source identity hash before mutation. This hash binds `data_source`, `source_ref`, and `item_hash`; it is not proof of the full projection-file contents.
+- Replay now authenticates the sidecar against a committed projection-run ledger before mutation, including checksum binding for the replayed sidecar payload.
 - Replay claims the stable sidecar event in a durable journal before calling the claim feedback service.
 - Feedback replay goes through `services::claims`, not raw `claim_feedback` inserts.
+- Feedback signal rows are persisted inside the feedback transaction, so crash-after-write retry paths do not silently lose feedback signals.
+- Missing feedback signals are repaired on idempotent replay and claim-file apply paths before a replay is considered recovered.
 - Re-running the replay does not duplicate feedback rows.
 - Replay preserves the original sidecar feedback `submitted_at` rather than rewriting it to rebuild time.
+- Sidecar feedback older than an existing claim feedback watermark is rejected as stale before mutation; same-sidecar stale exclusions only apply when durable replay feedback matches the sidecar event action and content hash.
 - Same event ID with changed feedback content or `submitted_at` is rejected.
+- Same event ID collision against a different claim, action, or content is failed without attaching the wrong durable feedback row.
 - Missing stable replay IDs are rejected before mutation.
 - Duplicate stable replay IDs are rejected before mutation.
+- Unsupported feedback actions are rejected during sidecar preflight, before any earlier row can mutate.
 - Unsupported sidecar schema versions are rejected before mutation.
 - Missing, provenance-mismatched, or ambiguous semantic matches are represented as orphan outcomes, not guessed.
-- Service-invalid feedback rows are marked `failed` in the replay journal and do not abort later independent rows.
+- Recoverable orphan rows can be reclaimed only by the same sidecar/event once a later rebuild resolves the semantic claim match. Migrated legacy orphan placeholders keep checksum-neutral behavior because the original checksum is unknowable, but terminal rows still bind canonical feedback content.
+- Deterministic service-invalid feedback rows are marked `failed` in the replay journal and do not abort later independent rows.
+- Retryable service failures remain `claimed` so the same sidecar/event can be retried instead of being permanently terminal.
 - Stable replay event IDs cannot be retargeted after applied, failed, or orphaned terminal journal outcomes.
 - Partial v282 journal rows from an interrupted old-shape migration are repaired before replay continues.
+- A follow-up v283 repair migration covers databases that already recorded the draft v282 migration before the journal shape was completed.
 
 ## Explicit Non-Claims
 
@@ -47,6 +56,7 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
 ### Schema
 
 - Added migration `v282_dos_832_rebuild_replay_journal`.
+- Added migration `v283_dos_832_rebuild_replay_journal_repair`.
 - Added `claim_feedback.replay_event_id` plus a unique partial index for replay idempotency.
 - Added `rebuild_correction_replay_events` with status-coded replay outcomes:
   - `claimed`
@@ -56,8 +66,10 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
   - `orphan_ambiguous`
   - `failed`
 - Journal rows persist a canonical feedback-content hash, including `submitted_at`, so replay can reject event-ID reuse with changed feedback content or historical feedback time.
+- Journal rows persist a sidecar checksum for new replay events, so replay cannot bind an event from one sidecar payload to another sidecar payload after authorization. Rows migrated with `legacy-v283-unset` keep checksum-neutral semantics because the original checksum was not recorded; terminal content hash still binds the feedback payload.
 - Registered v282 through the idempotent multi-statement migration helper so schema-version record gaps can retry without duplicate-column failure.
 - v282 includes an explicit idempotent repair for partial old-shape journal tables missing `feedback_content_hash`.
+- v283 reruns the replay-journal repair path for databases that already recorded v282 before `feedback_content_hash` and `sidecar_checksum` existed.
 - Bumped claim-file sidecar schema version to `2` because stable `feedbackId` is now part of the replay contract.
 
 ### Services
@@ -66,6 +78,8 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
 - Added `services::claims::record_claim_feedback_replay`.
 - Existing `record_claim_feedback` now delegates through a shared internal writer path; replay adds only stable-event idempotency and does not bypass actor or feedback validation.
 - `claim_files` sidecar serialization now includes stable feedback row IDs and semantic identities for supersession/contradiction endpoints.
+- Replay validates sidecars against the committed projection run before claim matching or feedback mutation.
+- Existing feedback replay events now repair missing feedback signals through the service layer before continuing.
 
 ## Intelligence Loop Check
 
@@ -77,42 +91,40 @@ The runtime report returns `plainSqliteRecoveryProven: false` and `liveCutoverPr
 
 ## Validation
 
-Commands run from the DOS-832 worktree:
+Final commands run from the DOS-832 worktree after the Cycle 16 remediation:
 
 ```bash
-src-tauri/scripts/check_migrations_transactional.sh
-cargo test --manifest-path src-tauri/Cargo.toml services::rebuild --lib -- --nocapture
-cargo test --manifest-path src-tauri/Cargo.toml services::claim_files --lib -- --nocapture
-cargo test --manifest-path src-tauri/Cargo.toml record_claim_feedback_replay --lib -- --nocapture
-cargo test --manifest-path src-tauri/Cargo.toml migration_282 --lib -- --nocapture
 cargo fmt --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml --lib dos832_replay_rejects_unsupported_later_feedback_action_before_writes
+cargo test --manifest-path src-tauri/Cargo.toml --lib dos832_replay_mismatched_sidecar_event_does_not_mask_stale_later_row
+cargo test --manifest-path src-tauri/Cargo.toml --lib migrated_orphan
+cargo test --manifest-path src-tauri/Cargo.toml --lib dos832
+cargo test --manifest-path src-tauri/Cargo.toml --lib apply_claim_file_corrections_repairs_signal_for_already_applied_feedback
+cargo test --manifest-path src-tauri/Cargo.toml --lib record_claim_feedback_replay_event
+cargo test --manifest-path src-tauri/Cargo.toml --test dos7_d4_lint_test
 cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
-cargo test --manifest-path src-tauri/Cargo.toml --lib
-cargo test --manifest-path src-tauri/Cargo.toml
-pnpm tsc --noEmit
 git diff --check
 ```
 
 Results:
 
-- Migration wrapper check: passed.
-- Focused DOS-832 replay tests: 19 passed.
-- Claim-file tests: 18 passed.
-- Claim feedback replay tests: 5 passed.
-- v282 migration regressions: 2 passed.
+- Unsupported later feedback action preflight regression: 1 passed.
+- Mismatched sidecar event stale-watermark regression: 1 passed.
+- Migrated orphan placeholder regressions: 2 passed.
+- Focused DOS-832 replay suite: 43 passed.
+- Claim-file already-applied signal repair regression: 1 passed.
+- Claim feedback replay idempotency suite: 6 passed.
+- DOS7/D4 lint suite: 28 passed.
 - Clippy: passed with `-D warnings`.
-- Full Rust lib suite: 3183 passed, 0 failed, 11 ignored.
-- Full Cargo suite: passed, including integration tests and doc tests.
-- TypeScript: passed.
 - Diff hygiene: passed.
-- Focused remediation re-review: adversarial reviewer PASS; data-migration reviewer PASS.
-- Note: full Cargo emitted two pre-existing unused-import warnings in `tests/dos567_fixture_backfill_and_composition_versions.rs`; `cargo clippy -- -D warnings` passed.
 
-## L2 Inputs
+## L2 Review Cycles
 
-The next L2 reviewer should focus on these risk areas:
+The L2 remediation ran adversarial review cycles across five subagents: data migrations, reliability, testing, security, and adversarial review. All five passed on Cycle 16.
 
-- Whether replay-event claiming is sufficiently atomic for the current single-writer/local topology.
-- Whether the sidecar stable `feedbackId` contract belongs in W3/DOS-628 before DOS-832 merges, or whether the stacked DOS-832 branch may extend the W3 sidecar contract.
-- Whether the L1a proof boundary is acceptable for PR scope, given the full DOS-832 packet still requires DOS-831 and broader rebuild orchestration.
-- Whether supersession/contradiction endpoint semantic identities are enough as contract plumbing while actual edge replay remains out of this slice.
+- Cycle 11 found missing mismatch proof, missing claimed-legacy signal repair, and terminal checksum rebinding. Fixed with content/action/claim collision tests, recovery signal repair, and legacy checksum-neutral terminal handling.
+- Cycle 12 found content-hash adoption and signal-repair failure ordering gaps. Fixed by requiring content-hash equality for fallback recovery, preserving legacy checksums, and proving retryability after transient signal repair failures.
+- Cycle 13 found pre-terminal content hash mutation and migrated orphan placeholder validation gaps. Fixed by moving content-hash writes into terminal updates and allowing recoverable migrated orphans through validation.
+- Cycle 14 found orphan reclaim pre-binding. Fixed by making orphan reclaim set only `claimed`/`resolved_claim_id`; terminalization owns content binding while legacy checksum placeholders remain neutral by policy.
+- Cycle 15 found sidecar-wide stale exclusions and malformed later feedback action partial writes. Fixed with content-aware stale exclusions and action preflight.
+- Cycle 16 verdict: data migrations PASS; reliability PASS; testing PASS; security PASS; adversarial PASS.

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -25,7 +25,8 @@
 //! by claim-file render/apply abilities, not static mock fixture data.
 //! Rebuild correction replay journals follow the same rule: they are
 //! service-owned recovery receipts produced by rebuild replay, not static mock
-//! fixture data or user-facing demo content.
+//! fixture data or user-facing demo content. The replay-journal checksum repair
+//! preserves that receipt-only contract and does not add a seedable surface.
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.

--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -23,6 +23,9 @@
 //! Claim file projection ledgers, path bindings, and correction apply events
 //! follow the same rule: they are service-owned operational receipts produced
 //! by claim-file render/apply abilities, not static mock fixture data.
+//! Rebuild correction replay journals follow the same rule: they are
+//! service-owned recovery receipts produced by rebuild replay, not static mock
+//! fixture data or user-facing demo content.
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1128,12 +1128,18 @@ const MIGRATIONS: &[Migration] = &[
         version: 281,
         sql: include_str!("migrations/281_claim_file_projection_run_claims.sql"),
     },
-    // v1.4.9 DOS-832 — correction replay idempotency journal. This is
-    // intentionally above W3's v280/v281 head so databases that already
-    // applied DOS-628 still receive the replay schema.
+    // Correction replay idempotency journal. This is intentionally above the
+    // readable claim-file projection head so databases that already applied
+    // the projection migrations still receive the replay schema.
     Migration::Fn {
         version: 282,
         apply: migrate_v282_dos_832_rebuild_replay_journal,
+    },
+    // Replay-journal repair for local draft builds that could record the
+    // journal migration before the final content-hash column repair.
+    Migration::Fn {
+        version: 283,
+        apply: migrate_v283_dos_832_rebuild_replay_journal_repair,
     },
 ];
 
@@ -2599,6 +2605,10 @@ fn verify_required_schema(conn: &Connection) -> Result<(), String> {
         }
     }
 
+    if version >= 282 {
+        verify_v282_dos_832_rebuild_replay_journal(conn)?;
+    }
+
     Ok(())
 }
 
@@ -2965,6 +2975,16 @@ fn migrate_v271_recommendation_surfacing(conn: &Connection) -> Result<(), Migrat
 }
 
 fn migrate_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), MigrationError> {
+    repair_v282_dos_832_rebuild_replay_journal(conn)
+}
+
+fn migrate_v283_dos_832_rebuild_replay_journal_repair(
+    conn: &Connection,
+) -> Result<(), MigrationError> {
+    repair_v282_dos_832_rebuild_replay_journal(conn)
+}
+
+fn repair_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), MigrationError> {
     apply_idempotent_sql_migration(
         conn,
         include_str!("migrations/282_dos_832_rebuild_replay_journal.sql"),
@@ -2980,6 +3000,70 @@ fn migrate_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), 
         .map_err(|e| {
             format!("Failed to repair v282 replay journal feedback_content_hash column: {e}")
         })?;
+    }
+    let columns = table_columns(conn, "rebuild_correction_replay_events")?;
+    if !columns.contains("sidecar_checksum") {
+        conn.execute_batch(
+            "ALTER TABLE rebuild_correction_replay_events
+                ADD COLUMN sidecar_checksum TEXT NOT NULL DEFAULT 'legacy-v283-unset';",
+        )
+        .map_err(|e| {
+            format!("Failed to repair v282 replay journal sidecar_checksum column: {e}")
+        })?;
+    }
+
+    Ok(())
+}
+
+fn verify_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), MigrationError> {
+    let claim_feedback_columns = table_columns(conn, "claim_feedback")?;
+    if !claim_feedback_columns.contains("replay_event_id") {
+        return Err(
+            "Schema integrity check failed: missing column claim_feedback.replay_event_id"
+                .to_string(),
+        );
+    }
+
+    if !table_exists(conn, "rebuild_correction_replay_events")? {
+        return Err(
+            "Schema integrity check failed: missing required table 'rebuild_correction_replay_events'"
+                .to_string(),
+        );
+    }
+
+    let replay_columns = table_columns(conn, "rebuild_correction_replay_events")?;
+    for col in [
+        "sidecar_event_id",
+        "run_id",
+        "sidecar_checksum",
+        "sidecar_schema_version",
+        "source_runtime_claim_id",
+        "resolved_claim_id",
+        "action",
+        "status",
+        "semantic_identity_hash",
+        "feedback_content_hash",
+        "attempt_count",
+        "claimed_at",
+        "updated_at",
+    ] {
+        if !replay_columns.contains(col) {
+            return Err(format!(
+                "Schema integrity check failed: missing column rebuild_correction_replay_events.{col}"
+            ));
+        }
+    }
+
+    for index_name in [
+        "idx_claim_feedback_replay_event",
+        "idx_rebuild_replay_events_run_status",
+        "idx_rebuild_replay_events_resolved_claim",
+    ] {
+        if !index_exists(conn, index_name)? {
+            return Err(format!(
+                "Schema integrity check failed: missing required index '{index_name}'"
+            ));
+        }
     }
 
     Ok(())
@@ -7716,6 +7800,53 @@ mod tests {
             )
             .expect("read repaired content hash");
         assert_eq!(content_hash, "legacy-v282-unset");
+    }
+
+    #[test]
+    fn migration_283_repairs_replay_journal_when_draft_v282_already_recorded() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "ALTER TABLE rebuild_correction_replay_events DROP COLUMN feedback_content_hash;
+             ALTER TABLE rebuild_correction_replay_events DROP COLUMN sidecar_checksum;
+             INSERT INTO rebuild_correction_replay_events (
+                sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                semantic_identity_hash, applied_feedback_id, attempt_count, claimed_at,
+                applied_at, updated_at
+             ) VALUES (
+                'draft-v282-event', 'run-1', 2, 'runtime-claim-1', 'claim-1',
+                'cannot_verify', 'claimed', NULL, NULL, 'semantic-hash', NULL,
+                1, '2026-06-05T12:00:00Z', NULL, '2026-06-05T12:00:00Z'
+             );
+             DELETE FROM schema_version WHERE version >= 283;
+             INSERT OR IGNORE INTO schema_version (version) VALUES (282);",
+        )
+        .expect("simulate draft v282 already recorded");
+        assert_eq!(current_version(&conn).expect("current version"), 282);
+        let columns = table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns before repair");
+        assert!(!columns.contains("feedback_content_hash"));
+        assert!(!columns.contains("sidecar_checksum"));
+
+        run_migrations(&conn).expect("repair already-recorded draft v282");
+
+        let columns = table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns after repair");
+        assert!(columns.contains("feedback_content_hash"));
+        assert!(columns.contains("sidecar_checksum"));
+        let repaired: (String, String) = conn
+            .query_row(
+                "SELECT feedback_content_hash, sidecar_checksum
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = 'draft-v282-event'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read repaired replay row");
+        assert_eq!(repaired.0, "legacy-v282-unset");
+        assert_eq!(repaired.1, "legacy-v283-unset");
+        verify_required_schema(&conn).expect("v282 replay invariants pass after repair");
     }
 
     #[test]

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1128,6 +1128,13 @@ const MIGRATIONS: &[Migration] = &[
         version: 281,
         sql: include_str!("migrations/281_claim_file_projection_run_claims.sql"),
     },
+    // v1.4.9 DOS-832 — correction replay idempotency journal. This is
+    // intentionally above W3's v280/v281 head so databases that already
+    // applied DOS-628 still receive the replay schema.
+    Migration::Fn {
+        version: 282,
+        apply: migrate_v282_dos_832_rebuild_replay_journal,
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;
@@ -2955,6 +2962,27 @@ fn migrate_v271_recommendation_surfacing(conn: &Connection) -> Result<(), Migrat
         include_str!("migrations/271_recommendation_surfacing.sql"),
         "v1.4.6 W2-A recommendation surfacing policy and decision audit",
     )
+}
+
+fn migrate_v282_dos_832_rebuild_replay_journal(conn: &Connection) -> Result<(), MigrationError> {
+    apply_idempotent_sql_migration(
+        conn,
+        include_str!("migrations/282_dos_832_rebuild_replay_journal.sql"),
+        "v1.4.9 DOS-832 rebuild replay journal",
+    )?;
+
+    let columns = table_columns(conn, "rebuild_correction_replay_events")?;
+    if !columns.contains("feedback_content_hash") {
+        conn.execute_batch(
+            "ALTER TABLE rebuild_correction_replay_events
+                ADD COLUMN feedback_content_hash TEXT NOT NULL DEFAULT 'legacy-v282-unset';",
+        )
+        .map_err(|e| {
+            format!("Failed to repair v282 replay journal feedback_content_hash column: {e}")
+        })?;
+    }
+
+    Ok(())
 }
 
 fn migrate_v273_recommendation_w2_shape_repair(conn: &Connection) -> Result<(), MigrationError> {
@@ -7599,6 +7627,95 @@ mod tests {
             current_version(&conn).expect("current version") >= 281,
             "schema version is at least v281"
         );
+    }
+
+    #[test]
+    fn migration_282_applies_rebuild_replay_journal_after_w3_v281() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "DROP INDEX IF EXISTS idx_claim_feedback_replay_event;
+             DROP INDEX IF EXISTS idx_rebuild_replay_events_run_status;
+             DROP INDEX IF EXISTS idx_rebuild_replay_events_resolved_claim;
+             DROP TABLE IF EXISTS rebuild_correction_replay_events;
+             ALTER TABLE claim_feedback DROP COLUMN replay_event_id;
+             DELETE FROM schema_version WHERE version >= 282;
+             INSERT OR IGNORE INTO schema_version (version) VALUES (281);",
+        )
+        .expect("simulate W3-at-v281 database before DOS-832");
+        assert_eq!(current_version(&conn).expect("current version"), 281);
+        assert!(!table_columns(&conn, "claim_feedback")
+            .expect("claim_feedback columns")
+            .contains("replay_event_id"));
+
+        let applied = run_migrations(&conn).expect("apply DOS-832 v282");
+
+        assert!(applied >= 1, "v282 migration should apply");
+        assert!(
+            current_version(&conn).expect("current version") >= 282,
+            "schema version is at least v282"
+        );
+        assert!(table_columns(&conn, "claim_feedback")
+            .expect("claim_feedback columns")
+            .contains("replay_event_id"));
+        assert!(table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay event columns")
+            .contains("feedback_content_hash"));
+        assert!(
+            table_exists(&conn, "rebuild_correction_replay_events").expect("replay table exists")
+        );
+        for index_name in [
+            "idx_claim_feedback_replay_event",
+            "idx_rebuild_replay_events_run_status",
+            "idx_rebuild_replay_events_resolved_claim",
+        ] {
+            assert!(
+                index_exists(&conn, index_name).expect("query replay index"),
+                "{index_name} exists"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_282_repairs_replay_journal_content_hash_gap() {
+        let conn = mem_db();
+        run_migrations(&conn).expect("build current schema");
+        conn.execute_batch(
+            "ALTER TABLE rebuild_correction_replay_events DROP COLUMN feedback_content_hash;
+             INSERT INTO rebuild_correction_replay_events (
+                sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                semantic_identity_hash, applied_feedback_id, attempt_count, claimed_at,
+                applied_at, updated_at
+             ) VALUES (
+                'legacy-event', 'run-1', 2, 'runtime-claim-1', 'claim-1',
+                'cannot_verify', 'claimed', NULL, NULL, 'semantic-hash', NULL,
+                1, '2026-06-05T12:00:00Z', NULL, '2026-06-05T12:00:00Z'
+             );
+             DELETE FROM schema_version WHERE version >= 282;
+             INSERT OR IGNORE INTO schema_version (version) VALUES (281);",
+        )
+        .expect("simulate partial v282 replay journal");
+        assert_eq!(current_version(&conn).expect("current version"), 281);
+        assert!(!table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns")
+            .contains("feedback_content_hash"));
+
+        run_migrations(&conn).expect("repair v282 replay journal");
+
+        assert!(table_columns(&conn, "rebuild_correction_replay_events")
+            .expect("replay columns")
+            .contains("feedback_content_hash"));
+        let content_hash: String = conn
+            .query_row(
+                "SELECT feedback_content_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = 'legacy-event'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired content hash");
+        assert_eq!(content_hash, "legacy-v282-unset");
     }
 
     #[test]

--- a/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
+++ b/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
@@ -1,0 +1,38 @@
+ALTER TABLE claim_feedback
+    ADD COLUMN replay_event_id TEXT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claim_feedback_replay_event
+    ON claim_feedback(replay_event_id)
+    WHERE replay_event_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS rebuild_correction_replay_events (
+    sidecar_event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    sidecar_schema_version INTEGER NOT NULL,
+    source_runtime_claim_id TEXT NOT NULL,
+    resolved_claim_id TEXT,
+    action TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN (
+        'claimed',
+        'applied',
+        'already_applied',
+        'orphan_missing',
+        'orphan_ambiguous',
+        'failed'
+    )),
+    reason_code TEXT,
+    reason_detail_hash TEXT,
+    semantic_identity_hash TEXT NOT NULL,
+    feedback_content_hash TEXT NOT NULL,
+    applied_feedback_id TEXT REFERENCES claim_feedback(id),
+    attempt_count INTEGER NOT NULL DEFAULT 1,
+    claimed_at TEXT NOT NULL,
+    applied_at TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rebuild_replay_events_run_status
+    ON rebuild_correction_replay_events(run_id, status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_rebuild_replay_events_resolved_claim
+    ON rebuild_correction_replay_events(resolved_claim_id, status);

--- a/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
+++ b/src-tauri/src/migrations/282_dos_832_rebuild_replay_journal.sql
@@ -8,6 +8,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_claim_feedback_replay_event
 CREATE TABLE IF NOT EXISTS rebuild_correction_replay_events (
     sidecar_event_id TEXT PRIMARY KEY,
     run_id TEXT NOT NULL,
+    sidecar_checksum TEXT NOT NULL DEFAULT 'legacy-v283-unset',
     sidecar_schema_version INTEGER NOT NULL,
     source_runtime_claim_id TEXT NOT NULL,
     resolved_claim_id TEXT,

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -32,7 +32,8 @@ use crate::services::workspace_ingestion::registry::CLAIM_FILE_PROJECTION_ROOT;
 use crate::state::AppState;
 
 pub const CLAIM_FILE_PROJECTION_VERSION: u32 = 1;
-pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_FILE_SIDECAR_SCHEMA_VERSION: u32 = 2;
 pub const CLAIM_FILE_MARKDOWN_NAME: &str = "claims.md";
 pub const CLAIM_FILE_SIDECAR_NAME: &str = "claims.corrections.json";
 const CLAIM_FILE_CORRECTION_APPLY_LEASE_SECS: i64 = 300;
@@ -124,6 +125,7 @@ pub struct ClaimFileClaim {
     pub provenance_summary: ClaimFileProvenanceSummary,
     pub feedback_rows: Vec<ClaimFileFeedbackRow>,
     pub contradiction_edges: Vec<ClaimFileContradictionEdge>,
+    pub superseded_by_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub replay_status: ClaimFileReplayStatus,
 }
 
@@ -162,6 +164,8 @@ pub struct ClaimFileProvenanceSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaimFileFeedbackRow {
+    #[serde(default)]
+    pub feedback_id: String,
     pub action: String,
     pub actor: String,
     pub actor_id: Option<String>,
@@ -198,7 +202,9 @@ pub struct ClaimFileContradictionEdge {
     pub reconciliation_note: Option<String>,
     pub reconciled_at: Option<String>,
     pub winner_runtime_claim_id: Option<String>,
+    pub winner_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub merged_runtime_claim_id: Option<String>,
+    pub merged_semantic_identity: Option<ClaimSemanticIdentityV1>,
     pub replay_status: ClaimFileReplayStatus,
 }
 
@@ -672,12 +678,18 @@ fn claim_file_claim(db: &ActionDb, claim: &IntelligenceClaim) -> Result<ClaimFil
         },
         feedback_rows: load_feedback_rows(db, &claim.id)?,
         contradiction_edges: load_contradiction_edges(db, &claim.id)?,
+        superseded_by_semantic_identity: claim
+            .superseded_by
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten(),
         replay_status: projected_replay_status(),
         semantic_identity,
     })
 }
 
-fn semantic_identity_for_loaded_claim(
+pub(crate) fn semantic_identity_for_loaded_claim(
     claim: &IntelligenceClaim,
 ) -> Result<ClaimSemanticIdentityV1, String> {
     let subject_value: serde_json::Value =
@@ -768,7 +780,7 @@ fn load_feedback_rows(db: &ActionDb, claim_id: &str) -> Result<Vec<ClaimFileFeed
     let mut stmt = db
         .conn_ref()
         .prepare(
-            "SELECT feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
+            "SELECT id, feedback_type, actor, actor_id, payload_json, submitted_at, applied_at
              FROM claim_feedback
              WHERE claim_id = ?1
              ORDER BY submitted_at ASC, id ASC",
@@ -776,16 +788,17 @@ fn load_feedback_rows(db: &ActionDb, claim_id: &str) -> Result<Vec<ClaimFileFeed
         .map_err(|error| error.to_string())?;
     let rows = stmt
         .query_map(params![claim_id], |row| {
-            let payload_raw: Option<String> = row.get(3)?;
+            let payload_raw: Option<String> = row.get(4)?;
             Ok(ClaimFileFeedbackRow {
-                action: row.get(0)?,
-                actor: row.get(1)?,
-                actor_id: row.get(2)?,
+                feedback_id: row.get(0)?,
+                action: row.get(1)?,
+                actor: row.get(2)?,
+                actor_id: row.get(3)?,
                 payload_json: payload_raw
                     .as_deref()
                     .and_then(|raw| serde_json::from_str(raw).ok()),
-                submitted_at: row.get(4)?,
-                applied_at: row.get(5)?,
+                submitted_at: row.get(5)?,
+                applied_at: row.get(6)?,
             })
         })
         .map_err(|error| error.to_string())?;
@@ -833,6 +846,18 @@ fn load_contradiction_edges(
         let primary_semantic_identity = semantic_identity_for_claim_id(db, &row.primary_claim_id)?;
         let contradicting_semantic_identity =
             semantic_identity_for_claim_id(db, &row.contradicting_claim_id)?;
+        let winner_semantic_identity = row
+            .winner_claim_id
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten();
+        let merged_semantic_identity = row
+            .merged_claim_id
+            .as_deref()
+            .map(|claim_id| semantic_identity_for_claim_id(db, claim_id))
+            .transpose()?
+            .flatten();
         out.push(ClaimFileContradictionEdge {
             edge_id: row.edge_id,
             branch_kind: row.branch_kind,
@@ -850,7 +875,9 @@ fn load_contradiction_edges(
             reconciliation_note: row.reconciliation_note,
             reconciled_at: row.reconciled_at,
             winner_runtime_claim_id: row.winner_claim_id,
+            winner_semantic_identity,
             merged_runtime_claim_id: row.merged_claim_id,
+            merged_semantic_identity,
             replay_status: projected_replay_status(),
         });
     }
@@ -1910,7 +1937,10 @@ fn verify_sidecar_paths(
 }
 
 fn verify_sidecar_contract(sidecar: &ClaimFileSidecar) -> Result<(), ClaimFileError> {
-    if sidecar.schema_version != CLAIM_FILE_SIDECAR_SCHEMA_VERSION {
+    if !matches!(
+        sidecar.schema_version,
+        CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION | CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+    ) {
         return Err(ClaimFileError::BadRequest(
             "unsupported sidecar schema_version".to_string(),
         ));
@@ -2570,7 +2600,7 @@ fn sensitivity_label(sensitivity: &ClaimSensitivity) -> String {
         .unwrap_or_else(|| format!("{sensitivity:?}").to_ascii_lowercase())
 }
 
-fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
+pub(crate) fn source_content_hash_for_claim(claim: &IntelligenceClaim) -> String {
     let mut hasher = Sha256::new();
     hasher.update(claim.data_source.as_bytes());
     hasher.update([0x1f]);
@@ -2687,6 +2717,7 @@ mod tests {
                 },
                 feedback_rows: Vec::new(),
                 contradiction_edges: Vec::new(),
+                superseded_by_semantic_identity: None,
                 replay_status: projected_replay_status(),
             }],
         }
@@ -2786,11 +2817,21 @@ mod tests {
 
     #[test]
     fn sidecar_serialization_round_trips_contract_fields() {
-        let sidecar = fixture_sidecar();
+        let mut sidecar = fixture_sidecar();
+        sidecar.claims[0].feedback_rows.push(ClaimFileFeedbackRow {
+            feedback_id: "feedback-1".to_string(),
+            action: "cannot_verify".to_string(),
+            actor: "user".to_string(),
+            actor_id: Some("user-fixture".to_string()),
+            payload_json: None,
+            submitted_at: TEST_TS.to_string(),
+            applied_at: None,
+        });
         let json = serde_json::to_string_pretty(&sidecar).expect("serialize sidecar");
         let decoded: ClaimFileSidecar = serde_json::from_str(&json).expect("decode sidecar");
 
         assert_eq!(decoded.schema_version, CLAIM_FILE_SIDECAR_SCHEMA_VERSION);
+        assert_eq!(CLAIM_FILE_SIDECAR_SCHEMA_VERSION, 2);
         assert_eq!(decoded.projection_version, CLAIM_FILE_PROJECTION_VERSION);
         assert_eq!(
             decoded.claims[0].semantic_identity.identity_kind,
@@ -2799,7 +2840,39 @@ mod tests {
         assert_eq!(decoded.claims[0].runtime_claim_id, "claim-1");
         assert_eq!(decoded.claims[0].lifecycle.claim_state, "active");
         assert_eq!(decoded.claims[0].replay_status.status, "projected");
+        assert_eq!(decoded.claims[0].feedback_rows[0].feedback_id, "feedback-1");
+        assert!(json.contains("\"feedbackId\""));
         assert!(decoded.claims[0].contradiction_edges.is_empty());
+    }
+
+    #[test]
+    fn legacy_v1_sidecar_deserializes_without_feedback_id() {
+        let mut sidecar = fixture_sidecar();
+        sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+        sidecar.claims[0].feedback_rows.push(ClaimFileFeedbackRow {
+            feedback_id: String::new(),
+            action: "cannot_verify".to_string(),
+            actor: "user".to_string(),
+            actor_id: Some("user-fixture".to_string()),
+            payload_json: None,
+            submitted_at: TEST_TS.to_string(),
+            applied_at: None,
+        });
+        let mut json = serde_json::to_value(&sidecar).expect("serialize sidecar");
+        let feedback = json
+            .pointer_mut("/claims/0/feedbackRows/0")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("feedback object");
+        feedback.remove("feedbackId");
+        let decoded: ClaimFileSidecar =
+            serde_json::from_value(json).expect("decode legacy sidecar");
+
+        assert_eq!(
+            decoded.schema_version,
+            CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION
+        );
+        assert_eq!(decoded.claims[0].feedback_rows[0].feedback_id, "");
+        verify_sidecar_contract(&decoded).expect("v1 sidecar remains readable");
     }
 
     #[test]
@@ -3237,7 +3310,7 @@ dailyos-action: mark_false\n\
             )
             .expect("commit feedback-bearing claim"),
         );
-        record_claim_feedback(
+        let feedback_outcome = record_claim_feedback(
             &ctx,
             &db,
             ClaimFeedbackInput {
@@ -3283,6 +3356,13 @@ dailyos-action: mark_false\n\
         assert_eq!(sidecar_claim.lifecycle.claim_state, "withdrawn");
         assert_eq!(sidecar_claim.lifecycle.surfacing_state, "dormant");
         assert_eq!(sidecar_claim.feedback_rows.len(), 1);
+        assert_eq!(
+            sidecar_claim.feedback_rows[0].feedback_id,
+            feedback_outcome.feedback_id
+        );
+        let json = serde_json::to_string(&sidecar_claim).expect("serialize sidecar claim");
+        assert!(json.contains("\"feedbackId\""));
+        assert!(json.contains(&feedback_outcome.feedback_id));
     }
 
     #[test]

--- a/src-tauri/src/services/claim_files.rs
+++ b/src-tauri/src/services/claim_files.rs
@@ -27,6 +27,7 @@ use crate::services::claim_receipt::feedback::{
     submit_claim_feedback_for_claim_file_apply, ClaimFeedbackRequest, ClaimFeedbackResponse,
     ClaimFileFeedbackApplyCommit, IdempotencyCache,
 };
+use crate::services::claims::repair_claim_feedback_recorded_signal;
 use crate::services::entity_intelligence::auth::{EnvelopeSet, EnvelopeView};
 use crate::services::workspace_ingestion::registry::CLAIM_FILE_PROJECTION_ROOT;
 use crate::state::AppState;
@@ -164,7 +165,7 @@ pub struct ClaimFileProvenanceSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaimFileFeedbackRow {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub feedback_id: String,
     pub action: String,
     pub actor: String,
@@ -244,7 +245,7 @@ struct ParsedCorrection {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CorrectionApplyState {
     Claimed,
-    AlreadyApplied,
+    AlreadyApplied { feedback_id: Option<String> },
     InProgress,
 }
 
@@ -265,8 +266,8 @@ struct CorrectionApplyRecord<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct CommittedProjectionRun {
-    run_id: String,
+pub(crate) struct CommittedProjectionRun {
+    pub run_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -435,7 +436,12 @@ pub async fn apply_claim_file_corrections(
         )
         .await?
         {
-            CorrectionApplyState::AlreadyApplied => continue,
+            CorrectionApplyState::AlreadyApplied { feedback_id } => {
+                if let Some(feedback_id) = feedback_id {
+                    repair_claim_file_feedback_signal(state, feedback_id).await?;
+                }
+                continue;
+            }
             CorrectionApplyState::InProgress => {
                 failures.push(ClaimFileApplyFailure {
                     claim_id: Some(correction.claim_id),
@@ -1097,6 +1103,28 @@ fn validate_committed_sidecar_projection_db(
     sidecar: &ClaimFileSidecar,
     sidecar_checksum: &str,
 ) -> Result<CommittedProjectionRun, String> {
+    validate_sidecar_projection_db(
+        db,
+        sidecar,
+        sidecar_checksum,
+        CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+    )
+}
+
+pub(crate) fn validate_replay_sidecar_projection_db(
+    db: &ActionDb,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+) -> Result<CommittedProjectionRun, String> {
+    validate_sidecar_projection_db(db, sidecar, sidecar_checksum, sidecar.schema_version)
+}
+
+fn validate_sidecar_projection_db(
+    db: &ActionDb,
+    sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
+    expected_sidecar_schema_version: u32,
+) -> Result<CommittedProjectionRun, String> {
     let binding: Option<(String, String)> = db
         .conn_ref()
         .query_row(
@@ -1139,7 +1167,7 @@ fn validate_committed_sidecar_projection_db(
                 sidecar_checksum,
                 CLAIM_FILE_PROJECTION_ROOT,
                 CLAIM_FILE_PROJECTION_VERSION,
-                CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+                expected_sidecar_schema_version,
             ],
             |row| row.get(0),
         )
@@ -1660,20 +1688,20 @@ fn claim_correction_apply_db(
         return Ok(CorrectionApplyState::Claimed);
     }
 
-    let (status, claimed_at): (String, String) = db
+    let (status, claimed_at, feedback_id): (String, String, Option<String>) = db
         .conn_ref()
         .query_row(
-            "SELECT status, claimed_at
+            "SELECT status, claimed_at, feedback_id
               FROM claim_file_correction_apply_events
               WHERE idempotency_key = ?1",
             [record.apply_key],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .optional()
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "correction apply event missing after insert conflict".to_string())?;
     match status.as_str() {
-        "applied" => Ok(CorrectionApplyState::AlreadyApplied),
+        "applied" => Ok(CorrectionApplyState::AlreadyApplied { feedback_id }),
         "claimed" => {
             if correction_apply_claim_expired(&claimed_at, now)? {
                 db.conn_ref()
@@ -1719,6 +1747,24 @@ async fn mark_correction_apply_failed(
     let error_detail_hash = redacted_hash(error_detail);
     state
         .db_write(move |db| mark_correction_apply_failed_db(db, &apply_key, &error_detail_hash))
+        .await
+        .map_err(|error| ClaimFileError::Db(error.to_string()))
+}
+
+async fn repair_claim_file_feedback_signal(
+    state: &AppState,
+    feedback_id: String,
+) -> Result<(), ClaimFileError> {
+    state
+        .db_write(move |db| {
+            let clock = crate::services::context::SystemClock;
+            let rng = crate::services::context::SystemRng;
+            let external = crate::services::context::ExternalClients::default();
+            let ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &external)
+                .with_actor("user");
+            repair_claim_feedback_recorded_signal(&ctx, db, &feedback_id)
+                .map_err(|error| error.to_string())
+        })
         .await
         .map_err(|error| ClaimFileError::Db(error.to_string()))
 }
@@ -2815,6 +2861,12 @@ mod tests {
         }
     }
 
+    fn claim_feedback_recorded_signal_id_for_test(feedback_id: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(format!("claim-feedback:{feedback_id}:recorded").as_bytes());
+        format!("sig-once-{:x}", hasher.finalize())
+    }
+
     #[test]
     fn sidecar_serialization_round_trips_contract_fields() {
         let mut sidecar = fixture_sidecar();
@@ -3487,7 +3539,9 @@ dailyos-action: mark_false\n\
                 },
             )
             .expect("replay applied"),
-            CorrectionApplyState::AlreadyApplied
+            CorrectionApplyState::AlreadyApplied {
+                feedback_id: Some(feedback.feedback_id.clone())
+            }
         );
 
         let failed_key = format!("{apply_key}-failed");
@@ -3586,6 +3640,199 @@ dailyos-action: mark_false\n\
             )
             .expect("expired claim is reclaimed"),
             CorrectionApplyState::Claimed
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_claim_file_corrections_repairs_signal_for_already_applied_feedback() {
+        let db_dir = tempfile::tempdir().expect("db dir");
+        let db_path = db_dir.path().join("dailyos.db");
+        let db_service =
+            crate::db_service::DbService::open_at_with_fixture_provider_for_tests(db_path)
+                .await
+                .expect("open test db service");
+        let state = AppState::test_with_db_service(db_service);
+        let workspace = tempfile::tempdir().expect("workspace");
+        let _claim_id = state
+            .db_write(|db| {
+                let (clock, rng, external) = test_context_parts();
+                let ctx = test_live_context(&clock, &rng, &external);
+                commit_claim(
+                    &ctx,
+                    db,
+                    fixture_claim_proposal("Public apply signal repair fixture"),
+                )
+                .map(inserted_claim_id)
+                .map_err(|error| error.to_string())
+            })
+            .await
+            .expect("seed projection claim");
+
+        let projection = render_entity_claim_file(
+            &state,
+            workspace.path().to_path_buf(),
+            r#"{"kind":"account","id":"acct-1"}"#.to_string(),
+        )
+        .await
+        .expect("render projection");
+        let markdown_rel_path = PathBuf::from(&projection.markdown_rel_path);
+        let sidecar_rel_path =
+            sidecar_path_for_markdown_rel(&markdown_rel_path).expect("sidecar path");
+        let markdown_path = workspace.path().join(&markdown_rel_path);
+        let sidecar_path = workspace.path().join(&sidecar_rel_path);
+        let original_sidecar_json =
+            std::fs::read_to_string(&sidecar_path).expect("read original sidecar");
+        let edited_markdown = std::fs::read_to_string(&markdown_path)
+            .expect("read markdown")
+            .replace("dailyos-action: none", "dailyos-action: cannot_verify");
+        assert!(edited_markdown.contains("dailyos-action: cannot_verify"));
+        std::fs::write(&markdown_path, &edited_markdown).expect("write edited markdown");
+
+        let sidecar: ClaimFileSidecar =
+            serde_json::from_str(&original_sidecar_json).expect("decode original sidecar");
+        let corrections =
+            parse_markdown_corrections(&edited_markdown, &sidecar, &projection.sidecar_checksum)
+                .expect("parse edited correction");
+        assert_eq!(corrections.len(), 1);
+        let correction = corrections[0].clone();
+        let payload_hash = correction_payload_hash(&correction);
+        let apply_key = correction_apply_idempotency_key(
+            &projection.sidecar_checksum,
+            &correction,
+            &payload_hash,
+        );
+        let feedback_id = {
+            let sidecar_checksum = projection.sidecar_checksum.clone();
+            let apply_key = apply_key.clone();
+            let payload_hash = payload_hash.clone();
+            state
+                .db_write(move |db| {
+                    let apply_state = claim_correction_apply_db(
+                        db,
+                        &CorrectionApplyRecord {
+                            apply_key: &apply_key,
+                            sidecar_checksum: &sidecar_checksum,
+                            claim_id: &correction.claim_id,
+                            projected_claim_version: correction.projected_claim_version,
+                            projected_identity_hash: &correction.projected_identity_hash,
+                            feedback_action: correction.action.as_str(),
+                            payload_hash: &payload_hash,
+                        },
+                    )?;
+                    if apply_state != CorrectionApplyState::Claimed {
+                        return Err(format!("expected claimed apply state, got {apply_state:?}"));
+                    }
+                    let (clock, rng, external) = test_context_parts();
+                    let ctx = test_live_context(&clock, &rng, &external);
+                    record_claim_feedback_for_claim_file_apply(
+                        &ctx,
+                        db,
+                        ClaimFeedbackInput {
+                            claim_id: correction.claim_id.clone(),
+                            action: correction.action,
+                            actor: "user".to_string(),
+                            actor_id: Some("user-fixture".to_string()),
+                            payload_json: correction
+                                .metadata
+                                .as_ref()
+                                .map(|value| value.to_string()),
+                        },
+                        ClaimFileFeedbackApplyInput {
+                            expected_claim_version: correction.projected_claim_version,
+                            correction_apply_key: apply_key,
+                        },
+                    )
+                    .map(|outcome| outcome.feedback_id)
+                    .map_err(|error| error.to_string())
+                })
+                .await
+                .expect("seed applied correction")
+        };
+        let recorded_signal_id = claim_feedback_recorded_signal_id_for_test(&feedback_id);
+        let signal_count = {
+            let recorded_signal_id = recorded_signal_id.clone();
+            state
+                .db_write(move |db| {
+                    db.conn_ref()
+                        .query_row(
+                            "SELECT count(*) FROM signal_events WHERE id = ?1",
+                            params![&recorded_signal_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .map_err(|error| error.to_string())
+                })
+                .await
+                .expect("count recorded signal")
+        };
+        assert_eq!(signal_count, 1);
+        {
+            let recorded_signal_id = recorded_signal_id.clone();
+            state
+                .db_write(move |db| {
+                    db.conn_ref()
+                        .execute(
+                            "DELETE FROM signal_events WHERE id = ?1",
+                            params![&recorded_signal_id],
+                        )
+                        .map(|_| ())
+                        .map_err(|error| error.to_string())
+                })
+                .await
+                .expect("delete recorded signal");
+        }
+
+        std::fs::write(&markdown_path, &edited_markdown).expect("restore edited markdown");
+        std::fs::write(&sidecar_path, &original_sidecar_json).expect("restore original sidecar");
+        let second = apply_claim_file_corrections(
+            &state,
+            workspace.path().to_path_buf(),
+            markdown_rel_path,
+            "user-fixture".to_string(),
+        )
+        .await
+        .expect("second apply");
+
+        assert_eq!(second.applied_count, 0);
+        assert!(second.failures.is_empty());
+        let (feedback_count, signal_count, repaired_payload) = {
+            let feedback_id = feedback_id.clone();
+            let recorded_signal_id = recorded_signal_id.clone();
+            state
+                .db_write(move |db| {
+                    let feedback_count = db
+                        .conn_ref()
+                        .query_row(
+                            "SELECT count(*) FROM claim_feedback WHERE id = ?1",
+                            params![&feedback_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .map_err(|error| error.to_string())?;
+                    let signal_count = db
+                        .conn_ref()
+                        .query_row(
+                            "SELECT count(*) FROM signal_events WHERE id = ?1",
+                            params![&recorded_signal_id],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .map_err(|error| error.to_string())?;
+                    let repaired_payload = db
+                        .conn_ref()
+                        .query_row(
+                            "SELECT value FROM signal_events WHERE id = ?1",
+                            params![&recorded_signal_id],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .map_err(|error| error.to_string())?;
+                    Ok((feedback_count, signal_count, repaired_payload))
+                })
+                .await
+                .expect("read repair proof")
+        };
+        assert_eq!(feedback_count, 1);
+        assert_eq!(signal_count, 1);
+        assert!(
+            repaired_payload.contains("\"recovered\":true"),
+            "AlreadyApplied branch must repair the missing recorded-feedback signal"
         );
     }
 
@@ -3808,7 +4055,9 @@ dailyos-action: mark_false\n\
         assert_eq!(feedback_id.as_deref(), Some(applied.feedback_id.as_str()));
         assert_eq!(
             claim_correction_apply_db(&db, &record).expect("future retry reads applied"),
-            CorrectionApplyState::AlreadyApplied
+            CorrectionApplyState::AlreadyApplied {
+                feedback_id: Some(applied.feedback_id.clone())
+            }
         );
         let feedback_count: i64 = db
             .conn_ref()
@@ -4036,6 +4285,14 @@ dailyos-action: mark_false\n\
         )
         .expect("validate committed sidecar");
         assert_eq!(committed.run_id, bundle.run_id);
+
+        let err = validate_committed_sidecar_projection_db(
+            &db,
+            &bundle.sidecar,
+            "wrong-sidecar-checksum",
+        )
+        .expect_err("checksum mismatch must not match a committed run");
+        assert!(err.contains("committed projection run not found"));
 
         let mut tampered_membership = bundle.sidecar.clone();
         tampered_membership.claims[0]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -239,6 +239,7 @@ pub struct ClaimFeedbackInput {
 pub struct ClaimFeedbackReplayInput {
     pub feedback: ClaimFeedbackInput,
     pub replay_event_id: String,
+    pub submitted_at: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -255,6 +256,12 @@ pub struct ClaimFeedbackOutcome {
 pub struct ClaimFileFeedbackApplyInput {
     pub expected_claim_version: u64,
     pub correction_apply_key: String,
+}
+
+#[derive(Debug, Clone)]
+struct ClaimFeedbackReplayWrite {
+    event_id: String,
+    submitted_at: String,
 }
 
 /// Claim-generation contract boundary.
@@ -5573,7 +5580,9 @@ pub(crate) fn claim_feedback_replay_content_hash(
     actor: &str,
     actor_id: Option<&str>,
     payload_json: Option<&str>,
+    submitted_at: &str,
 ) -> Result<String, ClaimError> {
+    let submitted_at = normalize_replay_submitted_at(submitted_at)?;
     let canonical_payload = payload_json
         .map(|payload| {
             serde_json::from_str::<serde_json::Value>(payload)
@@ -5587,8 +5596,22 @@ pub(crate) fn claim_feedback_replay_content_hash(
     update_hash_part(&mut hasher, Some(action.as_str()));
     update_hash_part(&mut hasher, Some(actor));
     update_hash_part(&mut hasher, actor_id);
+    update_hash_part(&mut hasher, Some(&submitted_at));
     update_hash_part(&mut hasher, canonical_payload.as_deref());
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn normalize_replay_submitted_at(value: &str) -> Result<String, ClaimError> {
+    let submitted_at = value.trim();
+    if submitted_at.is_empty() {
+        return Err(ClaimError::InvalidFeedback(
+            "replay submitted_at is required for correction replay".to_string(),
+        ));
+    }
+    DateTime::parse_from_rfc3339(submitted_at).map_err(|error| {
+        ClaimError::InvalidFeedback(format!("replay submitted_at must be RFC3339: {error}"))
+    })?;
+    Ok(submitted_at.to_string())
 }
 
 fn update_hash_part(hasher: &mut Sha256, value: Option<&str>) {
@@ -7294,7 +7317,11 @@ pub fn record_claim_feedback_replay(
             "replay_event_id is required for correction replay".to_string(),
         ));
     }
-    record_claim_feedback_inner(ctx, db, input.feedback, None, Some(replay_event_id.to_string()))
+    let replay = ClaimFeedbackReplayWrite {
+        event_id: replay_event_id.to_string(),
+        submitted_at: normalize_replay_submitted_at(&input.submitted_at)?,
+    };
+    record_claim_feedback_inner(ctx, db, input.feedback, None, Some(replay))
 }
 
 fn record_claim_feedback_inner(
@@ -7302,7 +7329,7 @@ fn record_claim_feedback_inner(
     db: &ActionDb,
     input: ClaimFeedbackInput,
     claim_file_apply: Option<ClaimFileFeedbackApplyInput>,
-    replay_event_id: Option<String>,
+    replay: Option<ClaimFeedbackReplayWrite>,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
@@ -7310,8 +7337,8 @@ fn record_claim_feedback_inner(
     let metadata = feedback_semantics(input.action);
     validate_feedback_payload(&input, &metadata)?;
 
-    if let Some(replay_event_id) = replay_event_id.as_deref() {
-        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay_event_id)? {
+    if let Some(replay) = replay.as_ref() {
+        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay)? {
             return Ok(outcome);
         }
     }
@@ -7324,6 +7351,9 @@ fn record_claim_feedback_inner(
 
     let write = with_claim_transaction(db, |tx| {
         let now = ctx.clock.now().to_rfc3339();
+        let feedback_effect_at = replay
+            .as_ref()
+            .map_or(now.as_str(), |replay| replay.submitted_at.as_str());
         let claim = load_claim_by_id(tx.conn_ref(), &input.claim_id)?
             .ok_or_else(|| ClaimError::UnknownClaimId(input.claim_id.clone()))?;
         if let Some(apply) = claim_file_apply.as_ref() {
@@ -7343,7 +7373,7 @@ fn record_claim_feedback_inner(
         let verification_state_before = enum_to_db(&claim.verification_state)?;
 
         let feedback_id = uuid::Uuid::new_v4().to_string();
-        if let Some(replay_event_id) = replay_event_id.as_deref() {
+        if let Some(replay) = replay.as_ref() {
             let inserted = tx.conn_ref().execute(
                 "INSERT OR IGNORE INTO claim_feedback (
                     id, claim_id, feedback_type, actor, actor_id, payload_json,
@@ -7356,19 +7386,19 @@ fn record_claim_feedback_inner(
                     &input.actor,
                     input.actor_id.as_deref(),
                     input.payload_json.as_deref(),
-                    &now,
-                    replay_event_id,
+                    &replay.submitted_at,
+                    &replay.event_id,
                 ],
             )?;
             if inserted == 0 {
                 mark_mutation_attempt_committed_noop(tx, mutation_guard.attempt(), &now)?;
-                let outcome =
-                    existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay_event_id)?
-                        .ok_or_else(|| {
-                            ClaimError::InvalidFeedback(format!(
-                                "replay_event_id insert collided without readable feedback row: {replay_event_id}"
-                            ))
-                        })?;
+                let outcome = existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay)?
+                    .ok_or_else(|| {
+                        ClaimError::InvalidFeedback(format!(
+                            "replay_event_id insert collided without readable feedback row: {}",
+                            replay.event_id
+                        ))
+                    })?;
                 return Ok(ClaimFeedbackWriteResult::ExistingReplay(outcome));
             }
         } else {
@@ -7390,7 +7420,7 @@ fn record_claim_feedback_inner(
         }
 
         let (new_verification_state, verification_reason, needs_user_decision_at) =
-            verification_update_for_feedback(&claim, input.action, &now);
+            verification_update_for_feedback(&claim, input.action, feedback_effect_at);
         let lifecycle_update = lifecycle_update_for_feedback(&claim, input.action, metadata.render);
         let lifecycle_changed = lifecycle_update != LifecycleUpdate::from_claim(&claim);
         let verification_changed = new_verification_state != claim.verification_state
@@ -7464,7 +7494,7 @@ fn record_claim_feedback_inner(
             ClaimState::Tombstoned | ClaimState::Withdrawn
         ) || lifecycle_update.surfacing_state == SurfacingState::Dormant
         {
-            mark_claim_edges_tombstoned(tx, &input.claim_id, &now)?;
+            mark_claim_edges_tombstoned(tx, &input.claim_id, feedback_effect_at)?;
         }
 
         // Bump claim_version + emit version_events when feedback actually
@@ -7554,22 +7584,22 @@ fn record_claim_feedback_inner(
 fn existing_feedback_replay_outcome(
     db: &ActionDb,
     input: &ClaimFeedbackInput,
-    replay_event_id: &str,
+    replay: &ClaimFeedbackReplayWrite,
 ) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
-    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay_event_id)
+    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay)
 }
 
 fn existing_feedback_replay_outcome_conn(
     conn: &Connection,
     input: &ClaimFeedbackInput,
-    replay_event_id: &str,
+    replay: &ClaimFeedbackReplayWrite,
 ) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
     let existing = conn
         .query_row(
-            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json
+            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at
              FROM claim_feedback
              WHERE replay_event_id = ?1",
-            params![replay_event_id],
+            params![&replay.event_id],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -7578,17 +7608,20 @@ fn existing_feedback_replay_outcome_conn(
                     row.get::<_, String>(3)?,
                     row.get::<_, Option<String>>(4)?,
                     row.get::<_, Option<String>>(5)?,
+                    row.get::<_, String>(6)?,
                 ))
             },
         )
         .optional()?;
-    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json)) = existing
+    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at)) =
+        existing
     else {
         return Ok(None);
     };
     if claim_id != input.claim_id || feedback_type != input.action.as_str() {
         return Err(ClaimError::InvalidFeedback(format!(
-            "replay_event_id already applied to different feedback target: {replay_event_id}"
+            "replay_event_id already applied to different feedback target: {}",
+            replay.event_id
         )));
     }
     let existing_content_hash = claim_feedback_replay_content_hash(
@@ -7596,16 +7629,19 @@ fn existing_feedback_replay_outcome_conn(
         &actor,
         actor_id.as_deref(),
         payload_json.as_deref(),
+        &submitted_at,
     )?;
     let input_content_hash = claim_feedback_replay_content_hash(
         input.action,
         &input.actor,
         input.actor_id.as_deref(),
         input.payload_json.as_deref(),
+        &replay.submitted_at,
     )?;
     if existing_content_hash != input_content_hash {
         return Err(ClaimError::InvalidFeedback(format!(
-            "replay_event_id already applied with different feedback content: {replay_event_id}"
+            "replay_event_id already applied with different feedback content: {}",
+            replay.event_id
         )));
     }
     let claim = load_claim_by_id(conn, &claim_id)?
@@ -11454,6 +11490,7 @@ mod tests {
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng};
 
     const TS: &str = "2026-05-02T12:00:00+00:00";
+    const REPLAY_TS: &str = "2026-04-01T09:15:00+00:00";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
 
     fn register_canonical_embedding_fixtures() {
@@ -13552,6 +13589,17 @@ mod tests {
             actor: "user".to_string(),
             actor_id: Some("user-fixture".to_string()),
             payload_json: feedback_payload_for(action),
+        }
+    }
+
+    fn replay_input(
+        feedback: ClaimFeedbackInput,
+        replay_event_id: &str,
+    ) -> ClaimFeedbackReplayInput {
+        ClaimFeedbackReplayInput {
+            feedback,
+            replay_event_id: replay_event_id.to_string(),
+            submitted_at: REPLAY_TS.to_string(),
         }
     }
 
@@ -16904,19 +16952,19 @@ mod tests {
         let first = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
         let second = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
 
@@ -16934,6 +16982,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(feedback_count, 1);
+        let submitted_at: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(submitted_at, REPLAY_TS);
         assert_eq!(repair_job_count(&db, &claim_id), 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
     }
@@ -16955,20 +17012,20 @@ mod tests {
         record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .unwrap();
 
         let err = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: replay_event_id.to_string(),
-            },
+            replay_input(
+                feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
         )
         .expect_err("replay event must not retarget a different claim");
 
@@ -17008,24 +17065,9 @@ mod tests {
                 .to_string(),
         );
 
-        record_claim_feedback_replay(
-            &ctx,
-            &db,
-            ClaimFeedbackReplayInput {
-                feedback: first,
-                replay_event_id: replay_event_id.to_string(),
-            },
-        )
-        .unwrap();
-        let err = record_claim_feedback_replay(
-            &ctx,
-            &db,
-            ClaimFeedbackReplayInput {
-                feedback: second,
-                replay_event_id: replay_event_id.to_string(),
-            },
-        )
-        .expect_err("same replay event must not hide changed payload");
+        record_claim_feedback_replay(&ctx, &db, replay_input(first, replay_event_id)).unwrap();
+        let err = record_claim_feedback_replay(&ctx, &db, replay_input(second, replay_event_id))
+            .expect_err("same replay event must not hide changed payload");
 
         assert!(
             matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
@@ -17040,6 +17082,48 @@ mod tests {
             .unwrap();
         assert_eq!(feedback_count, 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_submitted_at_change() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay timestamp")).unwrap());
+        let replay_event_id = "replay-event-submitted-at-1";
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id,
+            ),
+        )
+        .unwrap();
+        let mut changed_timestamp = replay_input(
+            feedback_input(&claim_id, FeedbackAction::CannotVerify),
+            replay_event_id,
+        );
+        changed_timestamp.submitted_at = "2026-04-02T09:15:00+00:00".to_string();
+
+        let err = record_claim_feedback_replay(&ctx, &db, changed_timestamp)
+            .expect_err("same replay event must not hide changed submitted_at");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
+        );
+        let submitted_at: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(submitted_at, REPLAY_TS);
     }
 
     #[test]
@@ -17072,10 +17156,10 @@ mod tests {
         let outcome = record_claim_feedback_replay(
             &ctx,
             &db,
-            ClaimFeedbackReplayInput {
-                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
-                replay_event_id: "replay-event-race-1".to_string(),
-            },
+            replay_input(
+                feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                "replay-event-race-1",
+            ),
         )
         .unwrap();
 

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -236,6 +236,12 @@ pub struct ClaimFeedbackInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimFeedbackReplayInput {
+    pub feedback: ClaimFeedbackInput,
+    pub replay_event_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClaimFeedbackOutcome {
     pub feedback_id: String,
     pub claim_id: String,
@@ -5562,6 +5568,64 @@ fn validate_feedback_actor(actor: &str) -> Result<(), ClaimError> {
     }
 }
 
+pub(crate) fn claim_feedback_replay_content_hash(
+    action: FeedbackAction,
+    actor: &str,
+    actor_id: Option<&str>,
+    payload_json: Option<&str>,
+) -> Result<String, ClaimError> {
+    let canonical_payload = payload_json
+        .map(|payload| {
+            serde_json::from_str::<serde_json::Value>(payload)
+                .map_err(|error| {
+                    ClaimError::InvalidFeedback(format!("payload_json must be valid JSON: {error}"))
+                })
+                .map(|value| canonical_json_string(&value))
+        })
+        .transpose()?;
+    let mut hasher = Sha256::new();
+    update_hash_part(&mut hasher, Some(action.as_str()));
+    update_hash_part(&mut hasher, Some(actor));
+    update_hash_part(&mut hasher, actor_id);
+    update_hash_part(&mut hasher, canonical_payload.as_deref());
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn update_hash_part(hasher: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            hasher.update(b"1:");
+            hasher.update(value.len().to_string().as_bytes());
+            hasher.update(b":");
+            hasher.update(value.as_bytes());
+        }
+        None => hasher.update(b"0:"),
+    }
+    hasher.update([0x1f]);
+}
+
+fn canonical_json_string(value: &serde_json::Value) -> String {
+    serde_json::to_string(&canonical_json_value(value)).expect("canonical JSON serializes")
+}
+
+fn canonical_json_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(canonical_json_value).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(key, _)| *key);
+            let mut out = serde_json::Map::new();
+            for (key, value) in entries {
+                out.insert(key.clone(), canonical_json_value(value));
+            }
+            serde_json::Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
 fn validate_feedback_payload(
     input: &ClaimFeedbackInput,
     metadata: &ClaimFeedbackMetadata,
@@ -7197,12 +7261,17 @@ struct ClaimFeedbackWriteOutcome {
     verification_state_after: String,
 }
 
+enum ClaimFeedbackWriteResult {
+    Written(ClaimFeedbackWriteOutcome),
+    ExistingReplay(ClaimFeedbackOutcome),
+}
+
 pub fn record_claim_feedback(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     input: ClaimFeedbackInput,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
-    record_claim_feedback_with_apply_commit(ctx, db, input, None)
+    record_claim_feedback_inner(ctx, db, input, None, None)
 }
 
 pub fn record_claim_feedback_for_claim_file_apply(
@@ -7211,20 +7280,41 @@ pub fn record_claim_feedback_for_claim_file_apply(
     input: ClaimFeedbackInput,
     apply: ClaimFileFeedbackApplyInput,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
-    record_claim_feedback_with_apply_commit(ctx, db, input, Some(apply))
+    record_claim_feedback_inner(ctx, db, input, Some(apply), None)
 }
 
-fn record_claim_feedback_with_apply_commit(
+pub fn record_claim_feedback_replay(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    input: ClaimFeedbackReplayInput,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    let replay_event_id = input.replay_event_id.trim();
+    if replay_event_id.is_empty() {
+        return Err(ClaimError::InvalidFeedback(
+            "replay_event_id is required for correction replay".to_string(),
+        ));
+    }
+    record_claim_feedback_inner(ctx, db, input.feedback, None, Some(replay_event_id.to_string()))
+}
+
+fn record_claim_feedback_inner(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     input: ClaimFeedbackInput,
     claim_file_apply: Option<ClaimFileFeedbackApplyInput>,
+    replay_event_id: Option<String>,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
     ctx.check_mutation_allowed()
         .map_err(|e| ClaimError::Mode(e.to_string()))?;
 
     let metadata = feedback_semantics(input.action);
     validate_feedback_payload(&input, &metadata)?;
+
+    if let Some(replay_event_id) = replay_event_id.as_deref() {
+        if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay_event_id)? {
+            return Ok(outcome);
+        }
+    }
 
     // Feedback mutates assertion-relevant columns on intelligence_claims
     // (verification_state, lifecycle). Reserve a MutationGuard so the
@@ -7253,21 +7343,51 @@ fn record_claim_feedback_with_apply_commit(
         let verification_state_before = enum_to_db(&claim.verification_state)?;
 
         let feedback_id = uuid::Uuid::new_v4().to_string();
-        tx.conn_ref().execute(
-            "INSERT INTO claim_feedback (
-                id, claim_id, feedback_type, actor, actor_id, payload_json,
-                submitted_at, applied_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
-            params![
-                &feedback_id,
-                &input.claim_id,
-                input.action.as_str(),
-                &input.actor,
-                input.actor_id.as_deref(),
-                input.payload_json.as_deref(),
-                &now,
-            ],
-        )?;
+        if let Some(replay_event_id) = replay_event_id.as_deref() {
+            let inserted = tx.conn_ref().execute(
+                "INSERT OR IGNORE INTO claim_feedback (
+                    id, claim_id, feedback_type, actor, actor_id, payload_json,
+                    submitted_at, applied_at, replay_event_id
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8)",
+                params![
+                    &feedback_id,
+                    &input.claim_id,
+                    input.action.as_str(),
+                    &input.actor,
+                    input.actor_id.as_deref(),
+                    input.payload_json.as_deref(),
+                    &now,
+                    replay_event_id,
+                ],
+            )?;
+            if inserted == 0 {
+                mark_mutation_attempt_committed_noop(tx, mutation_guard.attempt(), &now)?;
+                let outcome =
+                    existing_feedback_replay_outcome_conn(tx.conn_ref(), &input, replay_event_id)?
+                        .ok_or_else(|| {
+                            ClaimError::InvalidFeedback(format!(
+                                "replay_event_id insert collided without readable feedback row: {replay_event_id}"
+                            ))
+                        })?;
+                return Ok(ClaimFeedbackWriteResult::ExistingReplay(outcome));
+            }
+        } else {
+            tx.conn_ref().execute(
+                "INSERT INTO claim_feedback (
+                    id, claim_id, feedback_type, actor, actor_id, payload_json,
+                    submitted_at, applied_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+                params![
+                    &feedback_id,
+                    &input.claim_id,
+                    input.action.as_str(),
+                    &input.actor,
+                    input.actor_id.as_deref(),
+                    input.payload_json.as_deref(),
+                    &now,
+                ],
+            )?;
+        }
 
         let (new_verification_state, verification_reason, needs_user_decision_at) =
             verification_update_for_feedback(&claim, input.action, &now);
@@ -7403,26 +7523,112 @@ fn record_claim_feedback_with_apply_commit(
         }
         let verification_state_after = enum_to_db(&new_verification_state)?;
 
-        Ok(ClaimFeedbackWriteOutcome {
-            outcome: ClaimFeedbackOutcome {
-                feedback_id,
-                claim_id: input.claim_id.clone(),
-                action: input.action,
-                new_verification_state,
-                applied_at_pending: true,
-                repair_job_id,
+        Ok(ClaimFeedbackWriteResult::Written(
+            ClaimFeedbackWriteOutcome {
+                outcome: ClaimFeedbackOutcome {
+                    feedback_id,
+                    claim_id: input.claim_id.clone(),
+                    action: input.action,
+                    new_verification_state,
+                    applied_at_pending: true,
+                    repair_job_id,
+                },
+                signal_entity_type,
+                signal_entity_id,
+                verification_state_before,
+                verification_state_after,
             },
-            signal_entity_type,
-            signal_entity_id,
-            verification_state_before,
-            verification_state_after,
-        })
+        ))
     })?;
 
     mutation_guard.mark_completed();
-    emit_claim_feedback_signals(ctx, db, &write);
+    match write {
+        ClaimFeedbackWriteResult::ExistingReplay(outcome) => Ok(outcome),
+        ClaimFeedbackWriteResult::Written(write) => {
+            emit_claim_feedback_signals(ctx, db, &write);
+            Ok(write.outcome)
+        }
+    }
+}
 
-    Ok(write.outcome)
+fn existing_feedback_replay_outcome(
+    db: &ActionDb,
+    input: &ClaimFeedbackInput,
+    replay_event_id: &str,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    existing_feedback_replay_outcome_conn(db.conn_ref(), input, replay_event_id)
+}
+
+fn existing_feedback_replay_outcome_conn(
+    conn: &Connection,
+    input: &ClaimFeedbackInput,
+    replay_event_id: &str,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    let existing = conn
+        .query_row(
+            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json
+             FROM claim_feedback
+             WHERE replay_event_id = ?1",
+            params![replay_event_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json)) = existing
+    else {
+        return Ok(None);
+    };
+    if claim_id != input.claim_id || feedback_type != input.action.as_str() {
+        return Err(ClaimError::InvalidFeedback(format!(
+            "replay_event_id already applied to different feedback target: {replay_event_id}"
+        )));
+    }
+    let existing_content_hash = claim_feedback_replay_content_hash(
+        input.action,
+        &actor,
+        actor_id.as_deref(),
+        payload_json.as_deref(),
+    )?;
+    let input_content_hash = claim_feedback_replay_content_hash(
+        input.action,
+        &input.actor,
+        input.actor_id.as_deref(),
+        input.payload_json.as_deref(),
+    )?;
+    if existing_content_hash != input_content_hash {
+        return Err(ClaimError::InvalidFeedback(format!(
+            "replay_event_id already applied with different feedback content: {replay_event_id}"
+        )));
+    }
+    let claim = load_claim_by_id(conn, &claim_id)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(claim_id.clone()))?;
+    let repair_job_id = conn
+        .query_row(
+            "SELECT id
+             FROM claim_repair_job
+             WHERE feedback_id = ?1
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1",
+            params![&feedback_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(Some(ClaimFeedbackOutcome {
+        feedback_id,
+        claim_id,
+        action: input.action,
+        new_verification_state: claim.verification_state,
+        applied_at_pending: false,
+        repair_job_id,
+    }))
 }
 
 pub fn targeted_repair_claim_generation_budget(ability_id: &str) -> Option<ClaimGenerationBudget> {
@@ -16683,6 +16889,209 @@ mod tests {
         let (_, _, _, _, _, raw_signal_count) =
             first_invalidation_job(&db, TARGETED_REPAIR_OPERATION);
         assert_eq!(raw_signal_count, 2);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_is_idempotent() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay event")).unwrap());
+        let replay_event_id = "replay-event-idempotent-1";
+
+        let first = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+        let second = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(second.feedback_id, first.feedback_id);
+        assert_eq!(second.claim_id, first.claim_id);
+        assert_eq!(second.action, FeedbackAction::CannotVerify);
+        assert!(first.applied_at_pending);
+        assert!(!second.applied_at_pending);
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(repair_job_count(&db, &claim_id), 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_retarget() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Risk replay first target")).unwrap(),
+        );
+        let mut second_proposal = proposal("Risk replay second target");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id = inserted_claim_id(commit_claim(&ctx, &db, second_proposal).unwrap());
+        let replay_event_id = "replay-event-retarget-1";
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&first_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+
+        let err = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&second_claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .expect_err("replay event must not retarget a different claim");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("already applied to different feedback target"))
+        );
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(repair_job_count(&db, &second_claim_id), 0);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_content_change() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay payload")).unwrap());
+        let replay_event_id = "replay-event-content-1";
+        let mut first = feedback_input(&claim_id, FeedbackAction::NeedsNuance);
+        first.payload_json = Some(
+            serde_json::json!({ "corrected_text": "Risk is limited to the pilot group" })
+                .to_string(),
+        );
+        let mut second = feedback_input(&claim_id, FeedbackAction::NeedsNuance);
+        second.payload_json = Some(
+            serde_json::json!({ "corrected_text": "Risk is limited to the renewal window" })
+                .to_string(),
+        );
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: first,
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .unwrap();
+        let err = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: second,
+                replay_event_id: replay_event_id.to_string(),
+            },
+        )
+        .expect_err("same replay event must not hide changed payload");
+
+        assert!(
+            matches!(err, ClaimError::InvalidFeedback(message) if message.contains("different feedback content"))
+        );
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_race_collision_re_reads_existing_row() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay race")).unwrap());
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER claim_feedback_replay_race
+                 BEFORE INSERT ON claim_feedback
+                 WHEN NEW.replay_event_id = 'replay-event-race-1'
+                   AND NEW.id != 'feedback-race-existing'
+                 BEGIN
+                   INSERT INTO claim_feedback (
+                     id, claim_id, feedback_type, actor, actor_id, payload_json,
+                     submitted_at, applied_at, replay_event_id
+                   ) VALUES (
+                     'feedback-race-existing', NEW.claim_id, NEW.feedback_type,
+                     NEW.actor, NEW.actor_id, NEW.payload_json, NEW.submitted_at,
+                     NULL, NEW.replay_event_id
+                   );
+                 END;",
+            )
+            .unwrap();
+
+        let outcome = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: "replay-event-race-1".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(outcome.feedback_id, "feedback-race-existing");
+        assert!(!outcome.applied_at_pending);
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = 'replay-event-race-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 0);
+        assert_eq!(repair_job_count(&db, &claim_id), 0);
     }
 
     #[test]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -19,7 +19,7 @@ use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, OnceLock};
 
-use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, SecondsFormat, Utc};
 use parking_lot::Mutex;
 use regex::Regex;
 use rusqlite::{params, Connection, OptionalExtension, Params};
@@ -5601,17 +5601,19 @@ pub(crate) fn claim_feedback_replay_content_hash(
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-fn normalize_replay_submitted_at(value: &str) -> Result<String, ClaimError> {
+pub(crate) fn normalize_replay_submitted_at(value: &str) -> Result<String, ClaimError> {
     let submitted_at = value.trim();
     if submitted_at.is_empty() {
         return Err(ClaimError::InvalidFeedback(
             "replay submitted_at is required for correction replay".to_string(),
         ));
     }
-    DateTime::parse_from_rfc3339(submitted_at).map_err(|error| {
+    let parsed = DateTime::parse_from_rfc3339(submitted_at).map_err(|error| {
         ClaimError::InvalidFeedback(format!("replay submitted_at must be RFC3339: {error}"))
     })?;
-    Ok(submitted_at.to_string())
+    Ok(parsed
+        .with_timezone(&Utc)
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true))
 }
 
 fn update_hash_part(hasher: &mut Sha256, value: Option<&str>) {
@@ -6038,6 +6040,7 @@ struct ClaimVersionEventWrite<'a> {
     event_kind: VersionEventKind,
     now: &'a str,
     actor_kind: VersionActorKind,
+    correction_event_log_id: Option<&'a str>,
 }
 
 /// Reason string written into `version_events.reason` for a `claim.write_rejected`
@@ -6136,7 +6139,7 @@ fn finish_claim_version_event_tx(
             current_version: event.current_version,
             reason: None,
             scope_redacted: false,
-            correction_event_log_id: None,
+            correction_event_log_id: event.correction_event_log_id,
             mutation_id: Some(&attempt.mutation_id),
             created_at: event.now,
             actor_kind: event.actor_kind,
@@ -6591,6 +6594,7 @@ where
                     event_kind: VersionEventKind::ClaimSuperseded,
                     now: &now,
                     actor_kind,
+                    correction_event_log_id: None,
                 },
             )?;
             return Ok(CommittedClaim::Inserted { claim });
@@ -6662,6 +6666,7 @@ where
                         event_kind: VersionEventKind::ClaimUpdated,
                         now: &now,
                         actor_kind,
+                        correction_event_log_id: None,
                     },
                 )?;
                 return Ok(CommittedClaim::Reinforced {
@@ -6729,6 +6734,7 @@ where
                                 event_kind: VersionEventKind::ClaimUpdated,
                                 now: &now,
                                 actor_kind,
+                                correction_event_log_id: None,
                             },
                         )?;
                         return Ok(CommittedClaim::Reinforced {
@@ -6860,6 +6866,7 @@ where
                         event_kind: VersionEventKind::ClaimConflictDetected,
                         now: &now,
                         actor_kind,
+                        correction_event_log_id: None,
                     },
                 )?;
 
@@ -6948,6 +6955,7 @@ where
                         event_kind: VersionEventKind::ClaimUpdated,
                         now: &now,
                         actor_kind,
+                        correction_event_log_id: None,
                     },
                 )?;
                 return Ok(CommittedClaim::Inserted { claim });
@@ -7044,6 +7052,7 @@ where
                 event_kind,
                 now: &now,
                 actor_kind,
+                correction_event_log_id: None,
             },
         )?;
 
@@ -7201,6 +7210,7 @@ pub fn withdraw_claim(
                     event_kind: VersionEventKind::ClaimTombstoned,
                     now: &now,
                     actor_kind,
+                    correction_event_log_id: None,
                 },
             )?;
         } else {
@@ -7311,17 +7321,41 @@ pub fn record_claim_feedback_replay(
     db: &ActionDb,
     input: ClaimFeedbackReplayInput,
 ) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    let replay = prepare_claim_feedback_replay(&input)?;
+    record_claim_feedback_inner(ctx, db, input.feedback, None, Some(replay))
+}
+
+pub(crate) fn recorded_claim_feedback_replay_outcome(
+    db: &ActionDb,
+    input: &ClaimFeedbackReplayInput,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    let replay = prepare_claim_feedback_replay(input)?;
+    existing_feedback_replay_outcome(db, &input.feedback, &replay)
+}
+
+fn prepare_claim_feedback_replay(
+    input: &ClaimFeedbackReplayInput,
+) -> Result<ClaimFeedbackReplayWrite, ClaimError> {
+    validate_replay_actor_id(input.feedback.actor_id.as_deref())?;
     let replay_event_id = input.replay_event_id.trim();
     if replay_event_id.is_empty() {
         return Err(ClaimError::InvalidFeedback(
             "replay_event_id is required for correction replay".to_string(),
         ));
     }
-    let replay = ClaimFeedbackReplayWrite {
+    Ok(ClaimFeedbackReplayWrite {
         event_id: replay_event_id.to_string(),
         submitted_at: normalize_replay_submitted_at(&input.submitted_at)?,
-    };
-    record_claim_feedback_inner(ctx, db, input.feedback, None, Some(replay))
+    })
+}
+
+fn validate_replay_actor_id(actor_id: Option<&str>) -> Result<(), ClaimError> {
+    if actor_id.is_some_and(|actor_id| !actor_id.trim().is_empty()) {
+        return Ok(());
+    }
+    Err(ClaimError::InvalidActor(
+        "replay feedback requires stable actor_id".to_string(),
+    ))
 }
 
 fn record_claim_feedback_inner(
@@ -7339,6 +7373,7 @@ fn record_claim_feedback_inner(
 
     if let Some(replay) = replay.as_ref() {
         if let Some(outcome) = existing_feedback_replay_outcome(db, &input, replay)? {
+            repair_claim_feedback_recorded_signal(ctx, db, &outcome.feedback_id)?;
             return Ok(outcome);
         }
     }
@@ -7524,6 +7559,7 @@ fn record_claim_feedback_inner(
                     event_kind,
                     now: &now,
                     actor_kind: version_actor_kind,
+                    correction_event_log_id: replay.as_ref().map(|replay| replay.event_id.as_str()),
                 },
             )?;
         } else {
@@ -7553,29 +7589,33 @@ fn record_claim_feedback_inner(
         }
         let verification_state_after = enum_to_db(&new_verification_state)?;
 
-        Ok(ClaimFeedbackWriteResult::Written(
-            ClaimFeedbackWriteOutcome {
-                outcome: ClaimFeedbackOutcome {
-                    feedback_id,
-                    claim_id: input.claim_id.clone(),
-                    action: input.action,
-                    new_verification_state,
-                    applied_at_pending: true,
-                    repair_job_id,
-                },
-                signal_entity_type,
-                signal_entity_id,
-                verification_state_before,
-                verification_state_after,
+        let write_outcome = ClaimFeedbackWriteOutcome {
+            outcome: ClaimFeedbackOutcome {
+                feedback_id,
+                claim_id: input.claim_id.clone(),
+                action: input.action,
+                new_verification_state,
+                applied_at_pending: true,
+                repair_job_id,
             },
-        ))
+            signal_entity_type,
+            signal_entity_id,
+            verification_state_before,
+            verification_state_after,
+        };
+        persist_claim_feedback_signals(ctx, tx, &write_outcome)?;
+
+        Ok(ClaimFeedbackWriteResult::Written(write_outcome))
     })?;
 
     mutation_guard.mark_completed();
     match write {
-        ClaimFeedbackWriteResult::ExistingReplay(outcome) => Ok(outcome),
+        ClaimFeedbackWriteResult::ExistingReplay(outcome) => {
+            repair_claim_feedback_recorded_signal(ctx, db, &outcome.feedback_id)?;
+            Ok(outcome)
+        }
         ClaimFeedbackWriteResult::Written(write) => {
-            emit_claim_feedback_signals(ctx, db, &write);
+            emit_claim_feedback_event_bridge(&write);
             Ok(write.outcome)
         }
     }
@@ -9466,11 +9506,37 @@ fn signal_target_for_claim(subject: &SubjectRef, claim_id: &str) -> (String, Str
     }
 }
 
-fn emit_claim_feedback_signals(
+fn claim_feedback_recorded_signal_key(feedback_id: &str) -> String {
+    format!("claim-feedback:{feedback_id}:recorded")
+}
+
+fn claim_feedback_recorded_signal_exists(
+    db: &ActionDb,
+    signal_key: &str,
+) -> Result<bool, ClaimError> {
+    let signal_id = crate::signals::bus::signal_id_for_idempotency(
+        crate::signals::bus::SignalIdempotency::Key(signal_key),
+    )?;
+    Ok(db
+        .conn_ref()
+        .query_row(
+            "SELECT 1 FROM signal_events WHERE id = ?1",
+            params![&signal_id],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+fn claim_feedback_verification_signal_key(feedback_id: &str) -> String {
+    format!("claim-feedback:{feedback_id}:verification-state-changed")
+}
+
+fn persist_claim_feedback_signals(
     ctx: &ServiceContext<'_>,
     db: &ActionDb,
     write: &ClaimFeedbackWriteOutcome,
-) {
+) -> Result<(), ClaimError> {
     let payload = serde_json::json!({
         "action": write.outcome.action.as_str(),
         "claim_id": &write.outcome.claim_id,
@@ -9479,24 +9545,18 @@ fn emit_claim_feedback_signals(
     })
     .to_string();
 
-    if let Err(e) = crate::services::signals::emit(
+    crate::services::signals::emit_once_for_key(
         ctx,
         db,
+        &claim_feedback_recorded_signal_key(&write.outcome.feedback_id),
         &write.signal_entity_type,
         &write.signal_entity_id,
         "claim_feedback_recorded",
         "user_feedback",
         Some(&payload),
         0.9,
-    ) {
-        log::warn!(
-            "post-commit signal emission failed; \
-             repair_target=signals_engine \
-             signal_type=claim_feedback_recorded \
-             claim_id={}: {e}",
-            write.outcome.claim_id
-        );
-    }
+    )
+    .map_err(ClaimError::Transaction)?;
 
     if write.verification_state_before != write.verification_state_after {
         let payload = serde_json::json!({
@@ -9504,29 +9564,25 @@ fn emit_claim_feedback_signals(
             "to": &write.verification_state_after,
         })
         .to_string();
-        if let Err(e) = crate::services::signals::emit(
+        crate::services::signals::emit_once_for_key(
             ctx,
             db,
+            &claim_feedback_verification_signal_key(&write.outcome.feedback_id),
             &write.signal_entity_type,
             &write.signal_entity_id,
             "claim_verification_state_changed",
             "user_feedback",
             Some(&payload),
             0.9,
-        ) {
-            log::warn!(
-                "post-commit signal emission failed; \
-                 repair_target=signals_engine \
-                 signal_type=claim_verification_state_changed \
-                 claim_id={}: {e}",
-                write.outcome.claim_id
-            );
-        }
+        )
+        .map_err(ClaimError::Transaction)?;
+    }
 
-        // Bridge the signal to the
-        // `claim_receipt:invalidated` Tauri event so `useClaimReceiptSubscription`
-        // can re-fetch its receipt projection. Best-effort: the bridge is a
-        // no-op in test / headless contexts.
+    Ok(())
+}
+
+fn emit_claim_feedback_event_bridge(write: &ClaimFeedbackWriteOutcome) {
+    if write.verification_state_before != write.verification_state_after {
         crate::services::claim_receipt::event_bridge::emit_claim_receipt_invalidated(
             "claim_verification_state_changed",
             &write.outcome.claim_id,
@@ -9534,6 +9590,63 @@ fn emit_claim_feedback_signals(
             Some(&write.verification_state_after),
         );
     }
+}
+
+pub(crate) fn repair_claim_feedback_recorded_signal(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    feedback_id: &str,
+) -> Result<(), ClaimError> {
+    let signal_key = claim_feedback_recorded_signal_key(feedback_id);
+    if claim_feedback_recorded_signal_exists(db, &signal_key)? {
+        return Ok(());
+    }
+    let Some((claim_id, action, verification_state, subject_ref)) =
+        feedback_signal_repair_row(db, feedback_id)?
+    else {
+        return Ok(());
+    };
+    let subject_value: serde_json::Value = serde_json::from_str(&subject_ref)?;
+    let subject = subject_ref_from_json(&subject_value)?;
+    let (signal_entity_type, signal_entity_id) = signal_target_for_claim(&subject, &claim_id);
+    let payload = serde_json::json!({
+        "action": action,
+        "claim_id": claim_id,
+        "verification_state_before": verification_state,
+        "verification_state_after": verification_state,
+        "recovered": true,
+    })
+    .to_string();
+    crate::services::signals::emit_once_for_key(
+        ctx,
+        db,
+        &signal_key,
+        &signal_entity_type,
+        &signal_entity_id,
+        "claim_feedback_recorded",
+        "user_feedback",
+        Some(&payload),
+        0.9,
+    )
+    .map_err(ClaimError::Transaction)?;
+    Ok(())
+}
+
+fn feedback_signal_repair_row(
+    db: &ActionDb,
+    feedback_id: &str,
+) -> Result<Option<(String, String, String, String)>, ClaimError> {
+    db.conn_ref()
+        .query_row(
+            "SELECT f.claim_id, f.feedback_type, c.verification_state, c.subject_ref
+               FROM claim_feedback f
+               JOIN intelligence_claims c ON c.id = f.claim_id
+              WHERE f.id = ?1",
+            params![feedback_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()
+        .map_err(ClaimError::Rusqlite)
 }
 
 // ---------------------------------------------------------------------------
@@ -10743,6 +10856,7 @@ fn withdraw_claim_ids_for_source_purge_in_tx(
                 event_kind: VersionEventKind::ClaimTombstoned,
                 now: &now,
                 actor_kind,
+                correction_event_log_id: None,
             },
         )?;
         withdrawn += 1;
@@ -11491,6 +11605,7 @@ mod tests {
 
     const TS: &str = "2026-05-02T12:00:00+00:00";
     const REPLAY_TS: &str = "2026-04-01T09:15:00+00:00";
+    const REPLAY_TS_CANONICAL: &str = "2026-04-01T09:15:00Z";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
 
     fn register_canonical_embedding_fixtures() {
@@ -16990,9 +17105,31 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(submitted_at, REPLAY_TS);
+        assert_eq!(submitted_at, REPLAY_TS_CANONICAL);
         assert_eq!(repair_job_count(&db, &claim_id), 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_replay_event_rejects_blank_actor_id() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let ctx = live_ctx(&clock, &rng, &external);
+        let claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, proposal("Risk replay actor")).unwrap());
+        let mut input = replay_input(
+            feedback_input(&claim_id, FeedbackAction::CannotVerify),
+            "replay-event-blank-actor",
+        );
+        input.feedback.actor_id = Some("   ".to_string());
+
+        let err = record_claim_feedback_replay(&ctx, &db, input)
+            .expect_err("blank actor_id must fail replay provenance");
+
+        assert!(
+            matches!(err, ClaimError::InvalidActor(message) if message.contains("stable actor_id"))
+        );
     }
 
     #[test]
@@ -17123,7 +17260,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(submitted_at, REPLAY_TS);
+        assert_eq!(submitted_at, REPLAY_TS_CANONICAL);
     }
 
     #[test]
@@ -17174,7 +17311,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(feedback_count, 1);
-        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 0);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
         assert_eq!(repair_job_count(&db, &claim_id), 0);
     }
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -48,6 +48,7 @@ pub mod mutations;
 pub mod people;
 pub mod projection_signing;
 pub mod projects;
+pub mod rebuild;
 pub mod recommendations;
 pub mod replica_refresh;
 pub mod reports;

--- a/src-tauri/src/services/rebuild.rs
+++ b/src-tauri/src/services/rebuild.rs
@@ -1,0 +1,1687 @@
+//! First-class rebuild helpers for DOS-832.
+//!
+//! This module owns rebuild replay planning and reporting. The L1a slice is
+//! deliberately scoped to current-encrypted/Replica proof: it replays W3 claim
+//! file correction sidecars through the claim service, and it records which
+//! storage/cutover claims remain unproven until DOS-831 lands.
+
+use std::collections::HashSet;
+
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::abilities::feedback::FeedbackAction;
+use crate::db::ActionDb;
+use crate::services::claim_files::{
+    semantic_identity_for_loaded_claim, source_content_hash_for_claim, ClaimFileClaim,
+    ClaimFileFeedbackRow, ClaimFileSidecar, ClaimSemanticIdentityV1,
+    CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+};
+use crate::services::claims::{
+    claim_feedback_replay_content_hash, load_claim_by_id, record_claim_feedback_replay,
+    ClaimFeedbackInput, ClaimFeedbackReplayInput,
+};
+use crate::services::context::ServiceContext;
+
+const LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH: &str = "legacy-v282-unset";
+
+#[derive(Debug, thiserror::Error)]
+pub enum RebuildError {
+    #[error("invalid sidecar: {0}")]
+    InvalidSidecar(String),
+    #[error("claim replay failed: {0}")]
+    ClaimReplay(String),
+    #[error("db: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayEventStatus {
+    Applied,
+    AlreadyApplied,
+    OrphanMissing,
+    OrphanAmbiguous,
+    Failed,
+}
+
+impl ReplayEventStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::AlreadyApplied => "already_applied",
+            Self::OrphanMissing => "orphan_missing",
+            Self::OrphanAmbiguous => "orphan_ambiguous",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayEventOutcome {
+    pub sidecar_event_id: String,
+    pub source_runtime_claim_id: String,
+    pub resolved_claim_id: Option<String>,
+    pub action: String,
+    pub status: ReplayEventStatus,
+    pub reason_code: Option<String>,
+    pub applied_feedback_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectionReplayReport {
+    pub run_id: String,
+    pub sidecar_schema_version: u32,
+    pub applied_count: usize,
+    pub already_applied_count: usize,
+    pub orphaned_count: usize,
+    pub failed_count: usize,
+    pub events: Vec<ReplayEventOutcome>,
+    pub plain_sqlite_recovery_proven: bool,
+    pub live_cutover_proven: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Resolution {
+    Resolved(String),
+    Missing,
+    Ambiguous { candidate_count: usize },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReplayScope<'a> {
+    run_id: &'a str,
+    sidecar_schema_version: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SidecarClaimRef<'a> {
+    runtime_claim_id: &'a str,
+    identity: &'a ClaimSemanticIdentityV1,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SidecarFeedbackRef<'a> {
+    row: &'a ClaimFileFeedbackRow,
+    event_id: &'a str,
+    action: FeedbackAction,
+}
+
+struct ClaimReplayJournalInput<'a> {
+    scope: ReplayScope<'a>,
+    source_claim: SidecarClaimRef<'a>,
+    resolved_claim_id: Option<&'a str>,
+    sidecar_event_id: &'a str,
+    action: &'a str,
+    reason_code: Option<&'a str>,
+    feedback_content_hash: &'a str,
+}
+
+#[derive(Debug, Clone)]
+struct ExistingReplayEvent {
+    sidecar_schema_version: u32,
+    source_runtime_claim_id: String,
+    resolved_claim_id: Option<String>,
+    action: String,
+    status: String,
+    reason_code: Option<String>,
+    semantic_identity_hash: String,
+    feedback_content_hash: String,
+    applied_feedback_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReplayEventClaim {
+    Claimed,
+    ExistingTerminal {
+        status: ReplayEventStatus,
+        reason_code: Option<String>,
+        applied_feedback_id: Option<String>,
+    },
+}
+
+pub fn replay_claim_file_sidecar_corrections(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    run_id: &str,
+    sidecar: &ClaimFileSidecar,
+) -> Result<CorrectionReplayReport, RebuildError> {
+    if run_id.trim().is_empty() {
+        return Err(RebuildError::InvalidSidecar(
+            "run_id is required for rebuild replay".to_string(),
+        ));
+    }
+    validate_replay_sidecar(sidecar)?;
+
+    let scope = ReplayScope {
+        run_id,
+        sidecar_schema_version: sidecar.schema_version,
+    };
+    let mut events = Vec::new();
+    for claim in &sidecar.claims {
+        let resolution = resolve_claim_by_semantic_identity(db, &claim.semantic_identity)?;
+        let source_claim = SidecarClaimRef {
+            runtime_claim_id: &claim.runtime_claim_id,
+            identity: &claim.semantic_identity,
+        };
+        for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            let action = feedback_action_from_slug(&feedback.action)?;
+            let sidecar_event_id =
+                sidecar_feedback_event_id(sidecar, claim, feedback, feedback_index)?;
+            let feedback_ref = SidecarFeedbackRef {
+                row: feedback,
+                event_id: &sidecar_event_id,
+                action,
+            };
+            let event = match &resolution {
+                Resolution::Resolved(claim_id) => {
+                    replay_feedback_event(ctx, db, scope, source_claim, claim_id, feedback_ref)?
+                }
+                Resolution::Missing => record_orphan_replay_event(
+                    db,
+                    scope,
+                    source_claim,
+                    feedback_ref,
+                    ReplayEventStatus::OrphanMissing,
+                    "semantic_identity_missing",
+                )?,
+                Resolution::Ambiguous { candidate_count } => record_orphan_replay_event(
+                    db,
+                    scope,
+                    source_claim,
+                    feedback_ref,
+                    ReplayEventStatus::OrphanAmbiguous,
+                    &format!("semantic_identity_ambiguous_{candidate_count}"),
+                )?,
+            };
+            events.push(event);
+        }
+    }
+
+    let applied_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::Applied)
+        .count();
+    let already_applied_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::AlreadyApplied)
+        .count();
+    let orphaned_count = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.status,
+                ReplayEventStatus::OrphanMissing | ReplayEventStatus::OrphanAmbiguous
+            )
+        })
+        .count();
+    let failed_count = events
+        .iter()
+        .filter(|event| event.status == ReplayEventStatus::Failed)
+        .count();
+
+    Ok(CorrectionReplayReport {
+        run_id: run_id.to_string(),
+        sidecar_schema_version: sidecar.schema_version,
+        applied_count,
+        already_applied_count,
+        orphaned_count,
+        failed_count,
+        events,
+        plain_sqlite_recovery_proven: false,
+        live_cutover_proven: false,
+    })
+}
+
+fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildError> {
+    if !matches!(
+        sidecar.schema_version,
+        CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION | CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+    ) {
+        return Err(RebuildError::InvalidSidecar(
+            "unsupported sidecar schema_version".to_string(),
+        ));
+    }
+    let mut feedback_ids = HashSet::new();
+    for claim in &sidecar.claims {
+        if claim
+            .semantic_identity
+            .source_content_hash
+            .as_deref()
+            .is_none_or(str::is_empty)
+        {
+            return Err(RebuildError::InvalidSidecar(
+                "sidecar semantic identity missing source_content_hash".to_string(),
+            ));
+        }
+        for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            if sidecar.schema_version == CLAIM_FILE_SIDECAR_SCHEMA_VERSION
+                && feedback.feedback_id.trim().is_empty()
+            {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row missing stable feedback_id".to_string(),
+                ));
+            }
+            let event_id = sidecar_feedback_event_id(sidecar, claim, feedback, feedback_index)?;
+            if !feedback_ids.insert(event_id) {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row reused stable feedback_id".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sidecar_feedback_event_id(
+    sidecar: &ClaimFileSidecar,
+    claim: &ClaimFileClaim,
+    feedback: &ClaimFileFeedbackRow,
+    feedback_index: usize,
+) -> Result<String, RebuildError> {
+    let explicit = feedback.feedback_id.trim();
+    if !explicit.is_empty() {
+        return Ok(explicit.to_string());
+    }
+    if sidecar.schema_version != CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar feedback row missing stable feedback_id".to_string(),
+        ));
+    }
+    let action = feedback_action_from_slug(&feedback.action)?;
+    let payload_json = feedback_payload_json(feedback)?;
+    let content_hash = feedback_content_hash(feedback, action, payload_json.as_deref())?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"dailyos-claim-file-feedback-v1");
+    hasher.update([0x1f]);
+    hasher.update(claim.runtime_claim_id.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(claim.runtime_claim_version.to_string().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(claim.semantic_identity.dedup_key_components_hash.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(feedback_index.to_string().as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(feedback.submitted_at.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(content_hash.as_bytes());
+    Ok(format!("legacy-v1:{:x}", hasher.finalize()))
+}
+
+fn feedback_payload_json(feedback: &ClaimFileFeedbackRow) -> Result<Option<String>, RebuildError> {
+    feedback
+        .payload_json
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(RebuildError::Json)
+}
+
+fn feedback_content_hash(
+    feedback: &ClaimFileFeedbackRow,
+    action: FeedbackAction,
+    payload_json: Option<&str>,
+) -> Result<String, RebuildError> {
+    claim_feedback_replay_content_hash(
+        action,
+        &feedback.actor,
+        feedback.actor_id.as_deref(),
+        payload_json,
+    )
+    .map_err(|error| RebuildError::InvalidSidecar(error.to_string()))
+}
+
+fn replay_feedback_event(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    scope: ReplayScope<'_>,
+    source_claim: SidecarClaimRef<'_>,
+    resolved_claim_id: &str,
+    feedback: SidecarFeedbackRef<'_>,
+) -> Result<ReplayEventOutcome, RebuildError> {
+    let payload_json = feedback_payload_json(feedback.row)?;
+    let content_hash =
+        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    if let ReplayEventClaim::ExistingTerminal {
+        status,
+        reason_code,
+        applied_feedback_id,
+    } = claim_replay_event(
+        db,
+        ClaimReplayJournalInput {
+            scope,
+            source_claim,
+            resolved_claim_id: Some(resolved_claim_id),
+            sidecar_event_id: feedback.event_id,
+            action: &feedback.row.action,
+            reason_code: None,
+            feedback_content_hash: &content_hash,
+        },
+    )? {
+        return Ok(ReplayEventOutcome {
+            sidecar_event_id: feedback.event_id.to_string(),
+            source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+            resolved_claim_id: Some(resolved_claim_id.to_string()),
+            action: feedback.row.action.clone(),
+            status,
+            reason_code,
+            applied_feedback_id,
+        });
+    }
+
+    let outcome = match record_claim_feedback_replay(
+        ctx,
+        db,
+        ClaimFeedbackReplayInput {
+            feedback: ClaimFeedbackInput {
+                claim_id: resolved_claim_id.to_string(),
+                action: feedback.action,
+                actor: feedback.row.actor.clone(),
+                actor_id: feedback.row.actor_id.clone(),
+                payload_json,
+            },
+            replay_event_id: feedback.event_id.to_string(),
+        },
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let reason_code = "claim_feedback_replay_failed";
+            let reason_detail_hash = reason_detail_hash(&error.to_string());
+            mark_replay_event_terminal(
+                db,
+                feedback.event_id,
+                ReplayEventStatus::Failed.as_str(),
+                Some(reason_code),
+                Some(&reason_detail_hash),
+                None,
+            )?;
+            return Ok(ReplayEventOutcome {
+                sidecar_event_id: feedback.event_id.to_string(),
+                source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+                resolved_claim_id: Some(resolved_claim_id.to_string()),
+                action: feedback.row.action.clone(),
+                status: ReplayEventStatus::Failed,
+                reason_code: Some(reason_code.to_string()),
+                applied_feedback_id: None,
+            });
+        }
+    };
+
+    let status = if outcome.applied_at_pending {
+        ReplayEventStatus::Applied
+    } else {
+        ReplayEventStatus::AlreadyApplied
+    };
+    mark_replay_event_terminal(
+        db,
+        feedback.event_id,
+        status.as_str(),
+        None,
+        None,
+        Some(&outcome.feedback_id),
+    )?;
+    Ok(ReplayEventOutcome {
+        sidecar_event_id: feedback.event_id.to_string(),
+        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+        resolved_claim_id: Some(resolved_claim_id.to_string()),
+        action: feedback.row.action.clone(),
+        status,
+        reason_code: None,
+        applied_feedback_id: Some(outcome.feedback_id),
+    })
+}
+
+fn record_orphan_replay_event(
+    db: &ActionDb,
+    scope: ReplayScope<'_>,
+    source_claim: SidecarClaimRef<'_>,
+    feedback: SidecarFeedbackRef<'_>,
+    status: ReplayEventStatus,
+    reason_code: &str,
+) -> Result<ReplayEventOutcome, RebuildError> {
+    let payload_json = feedback_payload_json(feedback.row)?;
+    let content_hash =
+        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    if let ReplayEventClaim::ExistingTerminal {
+        status,
+        reason_code,
+        applied_feedback_id,
+    } = claim_replay_event(
+        db,
+        ClaimReplayJournalInput {
+            scope,
+            source_claim,
+            resolved_claim_id: None,
+            sidecar_event_id: feedback.event_id,
+            action: &feedback.row.action,
+            reason_code: Some(reason_code),
+            feedback_content_hash: &content_hash,
+        },
+    )? {
+        return Ok(ReplayEventOutcome {
+            sidecar_event_id: feedback.event_id.to_string(),
+            source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+            resolved_claim_id: None,
+            action: feedback.row.action.clone(),
+            status,
+            reason_code,
+            applied_feedback_id,
+        });
+    }
+    mark_replay_event_terminal(
+        db,
+        feedback.event_id,
+        status.as_str(),
+        Some(reason_code),
+        None,
+        None,
+    )?;
+    Ok(ReplayEventOutcome {
+        sidecar_event_id: feedback.event_id.to_string(),
+        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+        resolved_claim_id: None,
+        action: feedback.row.action.clone(),
+        status,
+        reason_code: Some(reason_code.to_string()),
+        applied_feedback_id: None,
+    })
+}
+
+fn resolve_claim_by_semantic_identity(
+    db: &ActionDb,
+    identity: &ClaimSemanticIdentityV1,
+) -> Result<Resolution, RebuildError> {
+    let subject_kind = identity
+        .subject_ref
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            RebuildError::InvalidSidecar("semantic identity missing subject kind".to_string())
+        })?;
+    let subject_id = identity
+        .subject_ref
+        .get("id")
+        .and_then(serde_json::Value::as_str);
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT id
+         FROM intelligence_claims
+         WHERE claim_type = ?1
+           AND COALESCE(field_path, '') = COALESCE(?2, '')
+           AND json_valid(subject_ref) = 1
+           AND lower(json_extract(subject_ref, '$.kind')) = lower(?3)
+           AND (?4 IS NULL OR json_extract(subject_ref, '$.id') = ?4)
+         ORDER BY created_at ASC, id ASC",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            &identity.claim_type,
+            identity.field_path.as_deref(),
+            subject_kind,
+            subject_id,
+        ],
+        |row| row.get::<_, String>(0),
+    )?;
+    let mut candidates = Vec::new();
+    for row in rows {
+        let claim_id = row?;
+        if let Some(claim) = load_claim_by_id(db.conn_ref(), &claim_id)
+            .map_err(|error| RebuildError::ClaimReplay(error.to_string()))?
+        {
+            let candidate_identity =
+                semantic_identity_for_loaded_claim(&claim).map_err(RebuildError::ClaimReplay)?;
+            if candidate_identity.dedup_key_components_hash == identity.dedup_key_components_hash {
+                candidates.push((claim_id, claim));
+            }
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(Resolution::Missing);
+    }
+    if candidates.len() == 1 {
+        let (claim_id, claim) = candidates.remove(0);
+        return if claim_matches_identity_provenance(&claim, identity) {
+            Ok(Resolution::Resolved(claim_id))
+        } else {
+            Ok(Resolution::Missing)
+        };
+    }
+
+    let narrowed = candidates
+        .iter()
+        .filter(|(_, claim)| claim_matches_identity_provenance(claim, identity))
+        .collect::<Vec<_>>();
+    if narrowed.len() == 1 {
+        return Ok(Resolution::Resolved(narrowed[0].0.clone()));
+    }
+    if narrowed.is_empty() {
+        return Ok(Resolution::Missing);
+    }
+
+    Ok(Resolution::Ambiguous {
+        candidate_count: narrowed.len(),
+    })
+}
+
+fn read_existing_replay_event(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+) -> Result<Option<ExistingReplayEvent>, RebuildError> {
+    db.conn_ref()
+        .query_row(
+            "SELECT sidecar_schema_version, source_runtime_claim_id, resolved_claim_id,
+                    action, status, reason_code, semantic_identity_hash,
+                    feedback_content_hash, applied_feedback_id
+             FROM rebuild_correction_replay_events
+             WHERE sidecar_event_id = ?1",
+            params![sidecar_event_id],
+            |row| {
+                let schema_version = row.get::<_, i64>(0)?;
+                Ok(ExistingReplayEvent {
+                    sidecar_schema_version: schema_version as u32,
+                    source_runtime_claim_id: row.get(1)?,
+                    resolved_claim_id: row.get(2)?,
+                    action: row.get(3)?,
+                    status: row.get(4)?,
+                    reason_code: row.get(5)?,
+                    semantic_identity_hash: row.get(6)?,
+                    feedback_content_hash: row.get(7)?,
+                    applied_feedback_id: row.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(RebuildError::Db)
+}
+
+fn claim_replay_event(
+    db: &ActionDb,
+    input: ClaimReplayJournalInput<'_>,
+) -> Result<ReplayEventClaim, RebuildError> {
+    if let Some(existing) = read_existing_replay_event(db, input.sidecar_event_id)? {
+        validate_existing_replay_event(&existing, &input)?;
+        repair_claimed_legacy_content_hash(db, &existing, &input)?;
+        increment_claimed_attempt_count(db, input.sidecar_event_id)?;
+        return replay_event_claim_from_existing(existing);
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let inserted = db.conn_ref().execute(
+        "INSERT INTO rebuild_correction_replay_events (
+            sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+            resolved_claim_id, action, status, reason_code, semantic_identity_hash,
+            feedback_content_hash, attempt_count, claimed_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', ?7, ?8, ?9, 1, ?10, ?10)
+         ON CONFLICT(sidecar_event_id) DO NOTHING",
+        params![
+            input.sidecar_event_id,
+            input.scope.run_id,
+            input.scope.sidecar_schema_version as i64,
+            input.source_claim.runtime_claim_id,
+            input.resolved_claim_id,
+            input.action,
+            input.reason_code,
+            &input.source_claim.identity.dedup_key_components_hash,
+            input.feedback_content_hash,
+            &now,
+        ],
+    )?;
+    let existing = read_existing_replay_event(db, input.sidecar_event_id)?.ok_or_else(|| {
+        RebuildError::InvalidSidecar("replay event claim was not persisted".to_string())
+    })?;
+    validate_existing_replay_event(&existing, &input)?;
+    repair_claimed_legacy_content_hash(db, &existing, &input)?;
+    if inserted == 0 {
+        increment_claimed_attempt_count(db, input.sidecar_event_id)?;
+    }
+    replay_event_claim_from_existing(existing)
+}
+
+fn increment_claimed_attempt_count(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+) -> Result<(), RebuildError> {
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET attempt_count = attempt_count + 1,
+             updated_at = ?1
+         WHERE sidecar_event_id = ?2
+           AND status = 'claimed'",
+        params![Utc::now().to_rfc3339(), sidecar_event_id],
+    )?;
+    Ok(())
+}
+
+fn validate_existing_replay_event(
+    existing: &ExistingReplayEvent,
+    input: &ClaimReplayJournalInput<'_>,
+) -> Result<(), RebuildError> {
+    if existing.sidecar_schema_version != input.scope.sidecar_schema_version
+        || existing.source_runtime_claim_id != input.source_claim.runtime_claim_id
+        || existing.resolved_claim_id.as_deref() != input.resolved_claim_id
+        || existing.action != input.action
+        || existing.semantic_identity_hash != input.source_claim.identity.dedup_key_components_hash
+    {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different target or feedback content"
+                .to_string(),
+        ));
+    }
+    let content_hash_matches = existing.feedback_content_hash == input.feedback_content_hash
+        || (existing.status == "claimed"
+            && existing.feedback_content_hash == LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+    if !content_hash_matches {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different target or feedback content"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn repair_claimed_legacy_content_hash(
+    db: &ActionDb,
+    existing: &ExistingReplayEvent,
+    input: &ClaimReplayJournalInput<'_>,
+) -> Result<(), RebuildError> {
+    if existing.status != "claimed"
+        || existing.feedback_content_hash != LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH
+    {
+        return Ok(());
+    }
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET feedback_content_hash = ?1,
+             updated_at = ?2
+         WHERE sidecar_event_id = ?3
+           AND status = 'claimed'
+           AND feedback_content_hash = ?4",
+        params![
+            input.feedback_content_hash,
+            Utc::now().to_rfc3339(),
+            input.sidecar_event_id,
+            LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+        ],
+    )?;
+    Ok(())
+}
+
+fn replay_event_claim_from_existing(
+    existing: ExistingReplayEvent,
+) -> Result<ReplayEventClaim, RebuildError> {
+    Ok(match existing.status.as_str() {
+        "claimed" => ReplayEventClaim::Claimed,
+        "applied" | "already_applied" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::AlreadyApplied,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "orphan_missing" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::OrphanMissing,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "orphan_ambiguous" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::OrphanAmbiguous,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        "failed" => ReplayEventClaim::ExistingTerminal {
+            status: ReplayEventStatus::Failed,
+            reason_code: existing.reason_code,
+            applied_feedback_id: existing.applied_feedback_id,
+        },
+        other => {
+            return Err(RebuildError::InvalidSidecar(format!(
+                "unknown replay event status `{other}`"
+            )))
+        }
+    })
+}
+
+fn mark_replay_event_terminal(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+    status: &str,
+    reason_code: Option<&str>,
+    reason_detail_hash: Option<&str>,
+    applied_feedback_id: Option<&str>,
+) -> Result<(), RebuildError> {
+    let now = Utc::now().to_rfc3339();
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET status = ?1,
+             reason_code = COALESCE(?2, reason_code),
+             reason_detail_hash = COALESCE(?3, reason_detail_hash),
+             applied_feedback_id = COALESCE(?4, applied_feedback_id),
+             applied_at = CASE WHEN ?1 IN ('applied', 'already_applied') THEN ?5 ELSE applied_at END,
+             updated_at = ?5
+         WHERE sidecar_event_id = ?6
+           AND NOT (
+             status IN ('applied', 'already_applied')
+             AND ?1 = 'failed'
+           )",
+        params![
+            status,
+            reason_code,
+            reason_detail_hash,
+            applied_feedback_id,
+            &now,
+            sidecar_event_id
+        ],
+    )?;
+    Ok(())
+}
+
+fn claim_matches_identity_provenance(
+    claim: &abilities_runtime::types::IntelligenceClaim,
+    identity: &ClaimSemanticIdentityV1,
+) -> bool {
+    claim.source_ref == identity.source_ref
+        && claim.data_source == identity.data_source
+        && claim.observed_at == identity.observed_at
+        && claim.source_asof == identity.source_asof
+        && identity
+            .source_content_hash
+            .as_deref()
+            .is_some_and(|hash| !hash.is_empty() && source_content_hash_for_claim(claim) == hash)
+}
+
+fn reason_detail_hash(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn feedback_action_from_slug(value: &str) -> Result<FeedbackAction, RebuildError> {
+    match value.trim() {
+        "confirm_current" => Ok(FeedbackAction::ConfirmCurrent),
+        "mark_outdated" => Ok(FeedbackAction::MarkOutdated),
+        "mark_false" => Ok(FeedbackAction::MarkFalse),
+        "wrong_subject" => Ok(FeedbackAction::WrongSubject),
+        "wrong_source" => Ok(FeedbackAction::WrongSource),
+        "cannot_verify" => Ok(FeedbackAction::CannotVerify),
+        "needs_nuance" => Ok(FeedbackAction::NeedsNuance),
+        "surface_inappropriate" => Ok(FeedbackAction::SurfaceInappropriate),
+        "not_relevant_here" => Ok(FeedbackAction::NotRelevantHere),
+        "merge_intent" => Ok(FeedbackAction::MergeIntent),
+        other => Err(RebuildError::InvalidSidecar(format!(
+            "unsupported feedback action `{other}`"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_utils::test_db;
+    use crate::services::claim_files::{
+        ClaimFileClaim, ClaimFileContradictionEdge, ClaimFileLifecycle, ClaimFileProvenanceSummary,
+        ClaimFileReplayStatus, CLAIM_FILE_PROJECTION_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+    };
+    use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim, TombstoneSpec};
+    use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
+    use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
+
+    const TS: &str = "2026-06-05T12:00:00Z";
+    const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
+
+    fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
+        let now = chrono::DateTime::parse_from_rfc3339(TS)
+            .expect("timestamp")
+            .with_timezone(&Utc);
+        (
+            FixedClock::new(now),
+            SeedableRng::new(9),
+            ExternalClients::default(),
+        )
+    }
+
+    fn proposal(text: &str) -> ClaimProposal {
+        ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: SUBJECT.to_string(),
+            claim_type: "risk".to_string(),
+            field_path: Some("health.risk".to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: Some("fixture://source-1".to_string()),
+            source_asof: Some(TS.to_string()),
+            observed_at: TS.to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        }
+    }
+
+    fn inserted_claim_id(outcome: CommittedClaim) -> String {
+        match outcome {
+            CommittedClaim::Inserted { claim }
+            | CommittedClaim::Reinforced { claim, .. }
+            | CommittedClaim::Tombstoned { claim } => claim.id,
+            CommittedClaim::Forked { new_claim_id, .. } => new_claim_id,
+        }
+    }
+
+    fn seed_account(db: &ActionDb) {
+        db.conn_ref()
+            .execute(
+                "INSERT INTO accounts (id, name, updated_at) VALUES (?1, ?2, ?3)",
+                params!["acct-1", "Account 1", TS],
+            )
+            .expect("seed account");
+    }
+
+    fn replay_status() -> ClaimFileReplayStatus {
+        ClaimFileReplayStatus {
+            status: "projected".to_string(),
+            reason: None,
+            last_attempted_at: None,
+        }
+    }
+
+    fn sidecar_for_claim(
+        db: &ActionDb,
+        fresh_claim_id: &str,
+        source_runtime_claim_id: &str,
+        feedback_id: &str,
+    ) -> ClaimFileSidecar {
+        let fresh_claim = load_claim_by_id(db.conn_ref(), fresh_claim_id)
+            .expect("load claim")
+            .expect("claim exists");
+        let mut identity =
+            semantic_identity_for_loaded_claim(&fresh_claim).expect("semantic identity");
+        identity.runtime_claim_id = source_runtime_claim_id.to_string();
+        identity.runtime_claim_version = 4;
+        let subject = serde_json::json!({"kind":"account","id":"acct-1"});
+        ClaimFileSidecar {
+            schema_version: CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+            projection_version: CLAIM_FILE_PROJECTION_VERSION,
+            entity_subject_ref: subject,
+            entity_subject_compact: r#"{"id":"acct-1","kind":"account"}"#.to_string(),
+            markdown_rel_path: "_dailyos_claims/account/acct-1/claims.md".to_string(),
+            sidecar_rel_path: "_dailyos_claims/account/acct-1/claims.corrections.json".to_string(),
+            claims: vec![ClaimFileClaim {
+                semantic_identity: identity,
+                runtime_claim_id: source_runtime_claim_id.to_string(),
+                runtime_claim_version: 4,
+                claim_text: "Renewal risk is elevated".to_string(),
+                trust_band: "likely_current".to_string(),
+                sensitivity: "internal".to_string(),
+                lifecycle: ClaimFileLifecycle {
+                    claim_state: "active".to_string(),
+                    surfacing_state: "active".to_string(),
+                    demotion_reason: None,
+                    retraction_reason: None,
+                    superseded_by: None,
+                    verification_state: "active".to_string(),
+                    verification_reason: None,
+                    needs_user_decision_at: None,
+                },
+                provenance_summary: ClaimFileProvenanceSummary {
+                    data_source: "unit_test".to_string(),
+                    source_ref: Some("fixture://source-1".to_string()),
+                    source_asof: Some(TS.to_string()),
+                    observed_at: TS.to_string(),
+                },
+                feedback_rows: vec![ClaimFileFeedbackRow {
+                    feedback_id: feedback_id.to_string(),
+                    action: "cannot_verify".to_string(),
+                    actor: "user".to_string(),
+                    actor_id: Some("user-fixture".to_string()),
+                    payload_json: None,
+                    submitted_at: TS.to_string(),
+                    applied_at: None,
+                }],
+                contradiction_edges: Vec::<ClaimFileContradictionEdge>::new(),
+                superseded_by_semantic_identity: None,
+                replay_status: replay_status(),
+            }],
+        }
+    }
+
+    fn feedback_count_for_replay(db: &ActionDb, replay_event_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("count replay feedback")
+    }
+
+    fn replay_journal_count(db: &ActionDb) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM rebuild_correction_replay_events",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count replay journal")
+    }
+
+    fn replay_journal_status_and_reason(
+        db: &ActionDb,
+        replay_event_id: &str,
+    ) -> (String, Option<String>, Option<String>) {
+        db.conn_ref()
+            .query_row(
+                "SELECT status, reason_code, reason_detail_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = ?1",
+                params![replay_event_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read replay journal status")
+    }
+
+    fn replay_journal_resolved_claim_id(db: &ActionDb, replay_event_id: &str) -> Option<String> {
+        db.conn_ref()
+            .query_row(
+                "SELECT resolved_claim_id
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("read replay journal target")
+    }
+
+    fn claim_verification_state_and_version(db: &ActionDb, claim_id: &str) -> (String, i64) {
+        db.conn_ref()
+            .query_row(
+                "SELECT verification_state, claim_version
+                 FROM intelligence_claims
+                 WHERE id = ?1",
+                params![claim_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read claim verification state")
+    }
+
+    fn targeted_repair_job_count(db: &ActionDb, claim_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM invalidation_jobs
+                 WHERE job_kind = ?1
+                   AND json_extract(payload_json, '$.claim_id') = ?2",
+                params![crate::db::invalidation_jobs::KIND_TARGETED_REPAIR, claim_id],
+                |row| row.get(0),
+            )
+            .expect("count targeted repair jobs")
+    }
+
+    #[test]
+    fn dos832_replay_sidecar_resolves_fresh_claim_by_semantic_identity_not_runtime_uuid() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-1",
+        );
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 1);
+        assert!(!report.plain_sqlite_recovery_proven);
+        assert!(!report.live_cutover_proven);
+        assert_eq!(
+            report.events[0].source_runtime_claim_id,
+            "old-runtime-claim-id"
+        );
+        assert_eq!(
+            report.events[0].resolved_claim_id.as_deref(),
+            Some(fresh_claim_id.as_str())
+        );
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-1"), 1);
+        let (verification_state, claim_version) =
+            claim_verification_state_and_version(&db, &fresh_claim_id);
+        assert_eq!(verification_state, "contested");
+        assert_eq!(claim_version, 2);
+        assert_eq!(targeted_repair_job_count(&db, &fresh_claim_id), 1);
+    }
+
+    #[test]
+    fn dos832_replay_claims_event_id_before_mutation_and_survives_restart() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-2",
+        );
+
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        let second = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("second replay");
+
+        assert_eq!(second.applied_count, 0);
+        assert_eq!(second.already_applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-2"), 1);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "old-feedback-2");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+    }
+
+    #[test]
+    fn dos832_replay_derives_event_id_for_legacy_v1_sidecar_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
+        sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay legacy sidecar");
+
+        assert_eq!(report.applied_count, 1);
+        assert!(report.events[0].sidecar_event_id.starts_with("legacy-v1:"));
+        assert_eq!(
+            feedback_count_for_replay(&db, &report.events[0].sidecar_event_id),
+            1
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_v2_sidecar_without_source_content_hash() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "missing-source-hash-feedback",
+        );
+        sidecar.claims[0].semantic_identity.source_content_hash = None;
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("v2 sidecar without source hash must reject");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("source_content_hash"))
+        );
+        assert_eq!(
+            feedback_count_for_replay(&db, "missing-source-hash-feedback"),
+            0
+        );
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_same_event_id_with_changed_feedback_content() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut first_sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "payload-event",
+        );
+        first_sidecar.claims[0].feedback_rows[0].action = "needs_nuance".to_string();
+        first_sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "corrected_text": "Risk is limited to the pilot group" }));
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let mut second_sidecar = first_sidecar;
+        second_sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "corrected_text": "Risk is limited to the renewal window" }));
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("same replay id must not hide changed payload");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "payload-event"), 1);
+    }
+
+    #[test]
+    fn dos832_replay_failed_terminal_update_cannot_overwrite_applied() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "applied-event",
+        );
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
+
+        mark_replay_event_terminal(
+            &db,
+            "applied-event",
+            ReplayEventStatus::Failed.as_str(),
+            Some("late_failure"),
+            Some("late-failure-detail"),
+            None,
+        )
+        .expect("late failed mark is ignored");
+
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "applied-event");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+        assert_eq!(detail_hash, None);
+    }
+
+    #[test]
+    fn dos832_replay_repairs_partial_v282_claimed_content_hash_gap() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "partial-v282-event",
+        );
+        let sidecar_claim = &sidecar.claims[0];
+        let feedback = &sidecar_claim.feedback_rows[0];
+        db.conn_ref()
+            .execute(
+                "INSERT INTO rebuild_correction_replay_events (
+                    sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                    resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                    semantic_identity_hash, feedback_content_hash, applied_feedback_id,
+                    attempt_count, claimed_at, applied_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', NULL, NULL, ?7, ?8, NULL, 1, ?9, NULL, ?9)",
+                params![
+                    &feedback.feedback_id,
+                    "run-before-crash",
+                    sidecar.schema_version as i64,
+                    &sidecar_claim.runtime_claim_id,
+                    &fresh_claim_id,
+                    &feedback.action,
+                    &sidecar_claim.semantic_identity.dedup_key_components_hash,
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    TS,
+                ],
+            )
+            .expect("insert partial v282 claimed row");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay repaired claimed row");
+
+        assert_eq!(report.applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "partial-v282-event"), 1);
+        let repaired_hash: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash
+                 FROM rebuild_correction_replay_events
+                 WHERE sidecar_event_id = 'partial-v282-event'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read repaired hash");
+        assert_ne!(repaired_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+        let (status, _, _) = replay_journal_status_and_reason(&db, "partial-v282-event");
+        assert_eq!(status, "applied");
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_claimed_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &first_claim_id,
+            "old-runtime-claim-id",
+            "claimed-event",
+        );
+        let first_claim = &first_sidecar.claims[0];
+        let first_feedback = &first_claim.feedback_rows[0];
+        let action = feedback_action_from_slug(&first_feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(first_feedback).expect("payload json");
+        let content_hash = feedback_content_hash(first_feedback, action, payload_json.as_deref())
+            .expect("content hash");
+        let source_claim = SidecarClaimRef {
+            runtime_claim_id: &first_claim.runtime_claim_id,
+            identity: &first_claim.semantic_identity,
+        };
+        let claim = claim_replay_event(
+            &db,
+            ClaimReplayJournalInput {
+                scope: ReplayScope {
+                    run_id: "run-1",
+                    sidecar_schema_version: first_sidecar.schema_version,
+                },
+                source_claim,
+                resolved_claim_id: Some(first_claim_id.as_str()),
+                sidecar_event_id: "claimed-event",
+                action: &first_feedback.action,
+                reason_code: None,
+                feedback_content_hash: &content_hash,
+            },
+        )
+        .expect("claim replay event");
+        assert_eq!(claim, ReplayEventClaim::Claimed);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar = sidecar_for_claim(
+            &db,
+            &second_claim_id,
+            "other-runtime-claim-id",
+            "claimed-event",
+        );
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("claimed event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "claimed-event"), 0);
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "claimed-event").as_deref(),
+            Some(first_claim_id.as_str())
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_sidecar_feedback_without_stable_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("missing event id must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, ""), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_unsupported_sidecar_schema_before_writes() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "old-feedback-schema",
+        );
+        sidecar.schema_version = CLAIM_FILE_SIDECAR_SCHEMA_VERSION + 1;
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("unsupported sidecar schema must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, "old-feedback-schema"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_duplicate_feedback_ids_before_writes() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "dupe-feedback",
+        );
+        let duplicate_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        sidecar.claims[0].feedback_rows.push(duplicate_feedback);
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect_err("duplicate event id must reject");
+
+        assert!(matches!(err, RebuildError::InvalidSidecar(_)));
+        assert_eq!(feedback_count_for_replay(&db, "dupe-feedback"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_orphans_when_semantic_identity_is_missing() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "missing-feedback",
+        );
+        sidecar.claims[0]
+            .semantic_identity
+            .dedup_key_components_hash = "missing-semantic-identity".to_string();
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanMissing);
+        assert_eq!(
+            report.events[0].reason_code.as_deref(),
+            Some("semantic_identity_missing")
+        );
+        assert_eq!(feedback_count_for_replay(&db, "missing-feedback"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "missing-feedback");
+        assert_eq!(status, "orphan_missing");
+        assert_eq!(reason_code.as_deref(), Some("semantic_identity_missing"));
+    }
+
+    #[test]
+    fn dos832_replay_orphans_single_candidate_when_provenance_mismatches() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "source-mismatch-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        sidecar.claims[0].feedback_rows[0].payload_json =
+            Some(serde_json::json!({ "source_ref": "fixture://source-1" }));
+        sidecar.claims[0].semantic_identity.source_ref = Some("fixture://source-2".to_string());
+        sidecar.claims[0].semantic_identity.source_asof = Some("2026-06-05T13:00:00Z".to_string());
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanMissing);
+        assert_eq!(
+            feedback_count_for_replay(&db, "source-mismatch-feedback"),
+            0
+        );
+    }
+
+    #[test]
+    fn dos832_replay_orphans_ambiguous_semantic_identity_without_mutating_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut tombstone = proposal("Renewal risk is elevated");
+        tombstone.tombstone = Some(TombstoneSpec {
+            retraction_reason: "test tombstone shadow".to_string(),
+            expires_at: None,
+        });
+        let tombstone_id =
+            inserted_claim_id(commit_claim(&ctx, &db, tombstone).expect("commit tombstone claim"));
+        assert_ne!(fresh_claim_id, tombstone_id);
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "ambiguous-feedback",
+        );
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.orphaned_count, 1);
+        assert_eq!(report.events[0].status, ReplayEventStatus::OrphanAmbiguous);
+        assert_eq!(
+            report.events[0].reason_code.as_deref(),
+            Some("semantic_identity_ambiguous_2")
+        );
+        assert_eq!(feedback_count_for_replay(&db, "ambiguous-feedback"), 0);
+    }
+
+    #[test]
+    fn dos832_replay_marks_invalid_feedback_failed_and_continues() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "invalid-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        let mut valid_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        valid_feedback.feedback_id = "valid-feedback-after-failure".to_string();
+        valid_feedback.action = "cannot_verify".to_string();
+        sidecar.claims[0].feedback_rows.push(valid_feedback);
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+            .expect("replay sidecar");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(report.applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "invalid-feedback"), 0);
+        assert_eq!(
+            feedback_count_for_replay(&db, "valid-feedback-after-failure"),
+            1
+        );
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "invalid-feedback");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert!(detail_hash.is_some_and(|hash| hash.len() == 64));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_failed_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut failed_sidecar =
+            sidecar_for_claim(&db, &first_claim_id, "old-runtime-claim-id", "event-1");
+        failed_sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
+        let first_report =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &failed_sidecar)
+                .expect("first replay fails terminally");
+        assert_eq!(first_report.failed_count, 1);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar =
+            sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-1");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("failed event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "event-1"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "event-1");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "event-1").as_deref(),
+            Some(first_claim_id.as_str())
+        );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_retargeting_orphaned_event_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut orphan_sidecar =
+            sidecar_for_claim(&db, &first_claim_id, "old-runtime-claim-id", "event-2");
+        orphan_sidecar.claims[0]
+            .semantic_identity
+            .dedup_key_components_hash = "missing-semantic-identity".to_string();
+        let first_report =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &orphan_sidecar)
+                .expect("first replay orphans");
+        assert_eq!(first_report.orphaned_count, 1);
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let second_sidecar =
+            sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-2");
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("orphaned event id must not retarget");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "event-2"), 0);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "event-2");
+        assert_eq!(status, "orphan_missing");
+        assert_eq!(reason_code.as_deref(), Some("semantic_identity_missing"));
+        assert_eq!(replay_journal_resolved_claim_id(&db, "event-2"), None);
+    }
+
+    #[test]
+    fn dos832_replay_terminal_status_must_match_original_target() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id =
+            inserted_claim_id(commit_claim(&ctx, &db, second_proposal).expect("commit second"));
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &first_claim_id,
+            "old-runtime-claim-id",
+            "reused-feedback",
+        );
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let second_sidecar = sidecar_for_claim(
+            &db,
+            &second_claim_id,
+            "other-runtime-claim-id",
+            "reused-feedback",
+        );
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("reused terminal event id must reject target mismatch");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("different target"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "reused-feedback"), 1);
+    }
+}

--- a/src-tauri/src/services/rebuild.rs
+++ b/src-tauri/src/services/rebuild.rs
@@ -1,13 +1,13 @@
-//! First-class rebuild helpers for DOS-832.
+//! First-class rebuild replay helpers.
 //!
 //! This module owns rebuild replay planning and reporting. The L1a slice is
 //! deliberately scoped to current-encrypted/Replica proof: it replays W3 claim
 //! file correction sidecars through the claim service, and it records which
-//! storage/cutover claims remain unproven until DOS-831 lands.
+//! storage/cutover claims remain outside this proof slice.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use rusqlite::{params, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -16,12 +16,15 @@ use sha2::{Digest, Sha256};
 use crate::abilities::feedback::FeedbackAction;
 use crate::db::ActionDb;
 use crate::services::claim_files::{
-    semantic_identity_for_loaded_claim, source_content_hash_for_claim, ClaimFileClaim,
-    ClaimFileFeedbackRow, ClaimFileSidecar, ClaimSemanticIdentityV1,
-    CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
+    semantic_identity_for_loaded_claim, source_content_hash_for_claim,
+    validate_replay_sidecar_projection_db, ClaimFileClaim, ClaimFileContradictionEdge,
+    ClaimFileFeedbackRow, ClaimFileLifecycle, ClaimFileProvenanceSummary, ClaimFileReplayStatus,
+    ClaimFileSidecar, ClaimSemanticIdentityV1, CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION,
+    CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
 };
 use crate::services::claims::{
     claim_feedback_replay_content_hash, load_claim_by_id, record_claim_feedback_replay,
+    recorded_claim_feedback_replay_outcome, repair_claim_feedback_recorded_signal, ClaimError,
     ClaimFeedbackInput, ClaimFeedbackReplayInput,
 };
 use crate::services::context::ServiceContext;
@@ -98,6 +101,7 @@ enum Resolution {
 #[derive(Debug, Clone, Copy)]
 struct ReplayScope<'a> {
     run_id: &'a str,
+    sidecar_checksum: &'a str,
     sidecar_schema_version: u32,
 }
 
@@ -114,6 +118,12 @@ struct SidecarFeedbackRef<'a> {
     action: FeedbackAction,
 }
 
+#[derive(Debug, Clone)]
+struct SidecarFeedbackReplayIdentity {
+    action: FeedbackAction,
+    content_hash: String,
+}
+
 struct ClaimReplayJournalInput<'a> {
     scope: ReplayScope<'a>,
     source_claim: SidecarClaimRef<'a>,
@@ -127,6 +137,7 @@ struct ClaimReplayJournalInput<'a> {
 #[derive(Debug, Clone)]
 struct ExistingReplayEvent {
     sidecar_schema_version: u32,
+    sidecar_checksum: String,
     source_runtime_claim_id: String,
     resolved_claim_id: Option<String>,
     action: String,
@@ -152,18 +163,30 @@ pub fn replay_claim_file_sidecar_corrections(
     db: &ActionDb,
     run_id: &str,
     sidecar: &ClaimFileSidecar,
+    sidecar_checksum: &str,
 ) -> Result<CorrectionReplayReport, RebuildError> {
     if run_id.trim().is_empty() {
         return Err(RebuildError::InvalidSidecar(
             "run_id is required for rebuild replay".to_string(),
         ));
     }
+    let verified_sidecar_checksum = verified_sidecar_checksum(sidecar, sidecar_checksum)?;
     validate_replay_sidecar(sidecar)?;
+    let committed_projection =
+        validate_replay_sidecar_projection_db(db, sidecar, &verified_sidecar_checksum)
+            .map_err(RebuildError::InvalidSidecar)?;
 
     let scope = ReplayScope {
         run_id,
+        sidecar_checksum: &verified_sidecar_checksum,
         sidecar_schema_version: sidecar.schema_version,
     };
+    log::debug!(
+        "authorized claim-file sidecar replay projection_run_id={} replay_run_id={}",
+        committed_projection.run_id,
+        run_id
+    );
+    let sidecar_feedback_events = sidecar_feedback_events(sidecar)?;
     let mut events = Vec::new();
     for claim in &sidecar.claims {
         let resolution = resolve_claim_by_semantic_identity(db, &claim.semantic_identity)?;
@@ -181,9 +204,15 @@ pub fn replay_claim_file_sidecar_corrections(
                 action,
             };
             let event = match &resolution {
-                Resolution::Resolved(claim_id) => {
-                    replay_feedback_event(ctx, db, scope, source_claim, claim_id, feedback_ref)?
-                }
+                Resolution::Resolved(claim_id) => replay_feedback_event(
+                    ctx,
+                    db,
+                    scope,
+                    source_claim,
+                    claim_id,
+                    feedback_ref,
+                    &sidecar_feedback_events,
+                )?,
                 Resolution::Missing => record_orphan_replay_event(
                     db,
                     scope,
@@ -240,6 +269,190 @@ pub fn replay_claim_file_sidecar_corrections(
     })
 }
 
+fn verified_sidecar_checksum(
+    sidecar: &ClaimFileSidecar,
+    supplied_checksum: &str,
+) -> Result<String, RebuildError> {
+    let supplied_checksum = supplied_checksum.trim();
+    if supplied_checksum.is_empty() {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar checksum does not match supplied sidecar payload".to_string(),
+        ));
+    }
+    for candidate in sidecar_payload_checksum_candidates(sidecar)? {
+        if supplied_checksum == candidate {
+            return Ok(supplied_checksum.to_string());
+        }
+    }
+    Err(RebuildError::InvalidSidecar(
+        "sidecar checksum does not match supplied sidecar payload".to_string(),
+    ))
+}
+
+fn sidecar_payload_checksum_candidates(
+    sidecar: &ClaimFileSidecar,
+) -> Result<Vec<String>, RebuildError> {
+    let mut candidates = vec![sidecar_payload_checksum(sidecar)?];
+    if sidecar.schema_version == CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION {
+        let legacy_checksum = legacy_v1_sidecar_payload_checksum(sidecar)?;
+        if !candidates.contains(&legacy_checksum) {
+            candidates.push(legacy_checksum);
+        }
+    }
+    Ok(candidates)
+}
+
+fn sidecar_payload_checksum(sidecar: &ClaimFileSidecar) -> Result<String, RebuildError> {
+    json_payload_checksum(sidecar)
+}
+
+fn legacy_v1_sidecar_payload_checksum(sidecar: &ClaimFileSidecar) -> Result<String, RebuildError> {
+    json_payload_checksum(&LegacyV1SidecarChecksum::from(sidecar))
+}
+
+fn json_payload_checksum<T: Serialize>(payload: &T) -> Result<String, RebuildError> {
+    let sidecar_json = serde_json::to_string_pretty(payload)?;
+    let mut hasher = Sha256::new();
+    hasher.update(sidecar_json.as_bytes());
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyV1SidecarChecksum<'a> {
+    schema_version: u32,
+    projection_version: u32,
+    entity_subject_ref: &'a serde_json::Value,
+    entity_subject_compact: &'a str,
+    markdown_rel_path: &'a str,
+    sidecar_rel_path: &'a str,
+    claims: Vec<LegacyV1ClaimChecksum<'a>>,
+}
+
+impl<'a> From<&'a ClaimFileSidecar> for LegacyV1SidecarChecksum<'a> {
+    fn from(sidecar: &'a ClaimFileSidecar) -> Self {
+        Self {
+            schema_version: sidecar.schema_version,
+            projection_version: sidecar.projection_version,
+            entity_subject_ref: &sidecar.entity_subject_ref,
+            entity_subject_compact: &sidecar.entity_subject_compact,
+            markdown_rel_path: &sidecar.markdown_rel_path,
+            sidecar_rel_path: &sidecar.sidecar_rel_path,
+            claims: sidecar
+                .claims
+                .iter()
+                .map(LegacyV1ClaimChecksum::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyV1ClaimChecksum<'a> {
+    semantic_identity: &'a ClaimSemanticIdentityV1,
+    runtime_claim_id: &'a str,
+    runtime_claim_version: u64,
+    claim_text: &'a str,
+    trust_band: &'a str,
+    sensitivity: &'a str,
+    lifecycle: &'a ClaimFileLifecycle,
+    provenance_summary: &'a ClaimFileProvenanceSummary,
+    feedback_rows: Vec<LegacyV1FeedbackRowChecksum<'a>>,
+    contradiction_edges: Vec<LegacyV1ContradictionEdgeChecksum<'a>>,
+    replay_status: &'a ClaimFileReplayStatus,
+}
+
+impl<'a> From<&'a ClaimFileClaim> for LegacyV1ClaimChecksum<'a> {
+    fn from(claim: &'a ClaimFileClaim) -> Self {
+        Self {
+            semantic_identity: &claim.semantic_identity,
+            runtime_claim_id: &claim.runtime_claim_id,
+            runtime_claim_version: claim.runtime_claim_version,
+            claim_text: &claim.claim_text,
+            trust_band: &claim.trust_band,
+            sensitivity: &claim.sensitivity,
+            lifecycle: &claim.lifecycle,
+            provenance_summary: &claim.provenance_summary,
+            feedback_rows: claim
+                .feedback_rows
+                .iter()
+                .map(LegacyV1FeedbackRowChecksum::from)
+                .collect(),
+            contradiction_edges: claim
+                .contradiction_edges
+                .iter()
+                .map(LegacyV1ContradictionEdgeChecksum::from)
+                .collect(),
+            replay_status: &claim.replay_status,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyV1FeedbackRowChecksum<'a> {
+    action: &'a str,
+    actor: &'a str,
+    actor_id: &'a Option<String>,
+    payload_json: &'a Option<serde_json::Value>,
+    submitted_at: &'a str,
+    applied_at: &'a Option<String>,
+}
+
+impl<'a> From<&'a ClaimFileFeedbackRow> for LegacyV1FeedbackRowChecksum<'a> {
+    fn from(feedback: &'a ClaimFileFeedbackRow) -> Self {
+        Self {
+            action: &feedback.action,
+            actor: &feedback.actor,
+            actor_id: &feedback.actor_id,
+            payload_json: &feedback.payload_json,
+            submitted_at: &feedback.submitted_at,
+            applied_at: &feedback.applied_at,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LegacyV1ContradictionEdgeChecksum<'a> {
+    edge_id: &'a str,
+    branch_kind: &'a str,
+    role: &'a str,
+    primary_runtime_claim_id: &'a str,
+    contradicting_runtime_claim_id: &'a str,
+    primary_semantic_identity: &'a Option<ClaimSemanticIdentityV1>,
+    contradicting_semantic_identity: &'a Option<ClaimSemanticIdentityV1>,
+    detected_at: &'a str,
+    reconciliation_kind: &'a Option<String>,
+    reconciliation_note: &'a Option<String>,
+    reconciled_at: &'a Option<String>,
+    winner_runtime_claim_id: &'a Option<String>,
+    merged_runtime_claim_id: &'a Option<String>,
+    replay_status: &'a ClaimFileReplayStatus,
+}
+
+impl<'a> From<&'a ClaimFileContradictionEdge> for LegacyV1ContradictionEdgeChecksum<'a> {
+    fn from(edge: &'a ClaimFileContradictionEdge) -> Self {
+        Self {
+            edge_id: &edge.edge_id,
+            branch_kind: &edge.branch_kind,
+            role: &edge.role,
+            primary_runtime_claim_id: &edge.primary_runtime_claim_id,
+            contradicting_runtime_claim_id: &edge.contradicting_runtime_claim_id,
+            primary_semantic_identity: &edge.primary_semantic_identity,
+            contradicting_semantic_identity: &edge.contradicting_semantic_identity,
+            detected_at: &edge.detected_at,
+            reconciliation_kind: &edge.reconciliation_kind,
+            reconciliation_note: &edge.reconciliation_note,
+            reconciled_at: &edge.reconciled_at,
+            winner_runtime_claim_id: &edge.winner_runtime_claim_id,
+            merged_runtime_claim_id: &edge.merged_runtime_claim_id,
+            replay_status: &edge.replay_status,
+        }
+    }
+}
+
 fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildError> {
     if !matches!(
         sidecar.schema_version,
@@ -262,7 +475,24 @@ fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildErro
             ));
         }
         for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
-            validate_feedback_submitted_at(&feedback.submitted_at)?;
+            feedback_action_from_slug(&feedback.action)?;
+            canonical_feedback_submitted_at(&feedback.submitted_at)?;
+            if sidecar.schema_version == CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION
+                && !feedback.feedback_id.trim().is_empty()
+            {
+                return Err(RebuildError::InvalidSidecar(
+                    "legacy v1 sidecar feedback row cannot supply feedback_id".to_string(),
+                ));
+            }
+            if feedback
+                .actor_id
+                .as_deref()
+                .is_none_or(|actor_id| actor_id.trim().is_empty())
+            {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row missing stable actor_id".to_string(),
+                ));
+            }
             if sidecar.schema_version == CLAIM_FILE_SIDECAR_SCHEMA_VERSION
                 && feedback.feedback_id.trim().is_empty()
             {
@@ -281,24 +511,70 @@ fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildErro
     Ok(())
 }
 
+fn sidecar_feedback_events(
+    sidecar: &ClaimFileSidecar,
+) -> Result<HashMap<String, SidecarFeedbackReplayIdentity>, RebuildError> {
+    let mut event_ids = HashMap::new();
+    for claim in &sidecar.claims {
+        for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            let action = feedback_action_from_slug(&feedback.action)?;
+            let payload_json = feedback_payload_json(feedback)?;
+            let submitted_at = canonical_feedback_submitted_at(&feedback.submitted_at)?;
+            let content_hash =
+                feedback_content_hash(feedback, action, payload_json.as_deref(), &submitted_at)?;
+            let event_id = sidecar_feedback_event_id(sidecar, claim, feedback, feedback_index)?;
+            if event_ids
+                .insert(
+                    event_id,
+                    SidecarFeedbackReplayIdentity {
+                        action,
+                        content_hash,
+                    },
+                )
+                .is_some()
+            {
+                return Err(RebuildError::InvalidSidecar(
+                    "sidecar feedback row reused stable feedback_id".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(event_ids)
+}
+
 fn sidecar_feedback_event_id(
     sidecar: &ClaimFileSidecar,
     claim: &ClaimFileClaim,
     feedback: &ClaimFileFeedbackRow,
     feedback_index: usize,
 ) -> Result<String, RebuildError> {
+    if sidecar.schema_version == CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION {
+        if !feedback.feedback_id.trim().is_empty() {
+            return Err(RebuildError::InvalidSidecar(
+                "legacy v1 sidecar feedback row cannot supply feedback_id".to_string(),
+            ));
+        }
+        return legacy_v1_sidecar_feedback_event_id(claim, feedback, feedback_index);
+    }
     let explicit = feedback.feedback_id.trim();
     if !explicit.is_empty() {
         return Ok(explicit.to_string());
     }
-    if sidecar.schema_version != CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION {
-        return Err(RebuildError::InvalidSidecar(
-            "sidecar feedback row missing stable feedback_id".to_string(),
-        ));
-    }
+    Err(RebuildError::InvalidSidecar(
+        "sidecar feedback row missing stable feedback_id".to_string(),
+    ))
+}
+
+fn legacy_v1_sidecar_feedback_event_id(
+    claim: &ClaimFileClaim,
+    feedback: &ClaimFileFeedbackRow,
+    feedback_index: usize,
+) -> Result<String, RebuildError> {
     let action = feedback_action_from_slug(&feedback.action)?;
     let payload_json = feedback_payload_json(feedback)?;
-    let content_hash = feedback_content_hash(feedback, action, payload_json.as_deref())?;
+    let submitted_at = canonical_feedback_submitted_at(&feedback.submitted_at)?;
+    let content_hash =
+        feedback_content_hash(feedback, action, payload_json.as_deref(), &submitted_at)?;
     let mut hasher = Sha256::new();
     hasher.update(b"dailyos-claim-file-feedback-v1");
     hasher.update([0x1f]);
@@ -310,7 +586,7 @@ fn sidecar_feedback_event_id(
     hasher.update([0x1f]);
     hasher.update(feedback_index.to_string().as_bytes());
     hasher.update([0x1f]);
-    hasher.update(feedback.submitted_at.as_bytes());
+    hasher.update(submitted_at.as_bytes());
     hasher.update([0x1f]);
     hasher.update(content_hash.as_bytes());
     Ok(format!("legacy-v1:{:x}", hasher.finalize()))
@@ -329,29 +605,32 @@ fn feedback_content_hash(
     feedback: &ClaimFileFeedbackRow,
     action: FeedbackAction,
     payload_json: Option<&str>,
+    submitted_at: &str,
 ) -> Result<String, RebuildError> {
     claim_feedback_replay_content_hash(
         action,
         &feedback.actor,
         feedback.actor_id.as_deref(),
         payload_json,
-        &feedback.submitted_at,
+        submitted_at,
     )
     .map_err(|error| RebuildError::InvalidSidecar(error.to_string()))
 }
 
-fn validate_feedback_submitted_at(submitted_at: &str) -> Result<(), RebuildError> {
+fn canonical_feedback_submitted_at(submitted_at: &str) -> Result<String, RebuildError> {
     if submitted_at.trim().is_empty() {
         return Err(RebuildError::InvalidSidecar(
             "sidecar feedback row missing submitted_at".to_string(),
         ));
     }
-    DateTime::parse_from_rfc3339(submitted_at.trim()).map_err(|error| {
+    let parsed = DateTime::parse_from_rfc3339(submitted_at.trim()).map_err(|error| {
         RebuildError::InvalidSidecar(format!(
             "sidecar feedback row submitted_at must be RFC3339: {error}"
         ))
     })?;
-    Ok(())
+    Ok(parsed
+        .with_timezone(&Utc)
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true))
 }
 
 fn replay_feedback_event(
@@ -361,10 +640,22 @@ fn replay_feedback_event(
     source_claim: SidecarClaimRef<'_>,
     resolved_claim_id: &str,
     feedback: SidecarFeedbackRef<'_>,
+    sidecar_feedback_events: &HashMap<String, SidecarFeedbackReplayIdentity>,
 ) -> Result<ReplayEventOutcome, RebuildError> {
     let payload_json = feedback_payload_json(feedback.row)?;
-    let content_hash =
-        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    let submitted_at = canonical_feedback_submitted_at(&feedback.row.submitted_at)?;
+    let content_hash = feedback_content_hash(
+        feedback.row,
+        feedback.action,
+        payload_json.as_deref(),
+        &submitted_at,
+    )?;
+    let preserve_legacy_unset_checksum = read_existing_replay_event(db, feedback.event_id)?
+        .as_ref()
+        .is_some_and(|existing| {
+            existing.status == "claimed"
+                && existing.sidecar_checksum == LEGACY_V283_UNSET_SIDECAR_CHECKSUM
+        });
     if let ReplayEventClaim::ExistingTerminal {
         status,
         reason_code,
@@ -392,42 +683,117 @@ fn replay_feedback_event(
         });
     }
 
-    let outcome = match record_claim_feedback_replay(
-        ctx,
-        db,
-        ClaimFeedbackReplayInput {
-            feedback: ClaimFeedbackInput {
-                claim_id: resolved_claim_id.to_string(),
-                action: feedback.action,
-                actor: feedback.row.actor.clone(),
-                actor_id: feedback.row.actor_id.clone(),
-                payload_json,
-            },
-            replay_event_id: feedback.event_id.to_string(),
-            submitted_at: feedback.row.submitted_at.clone(),
+    let replay_input = ClaimFeedbackReplayInput {
+        feedback: ClaimFeedbackInput {
+            claim_id: resolved_claim_id.to_string(),
+            action: feedback.action,
+            actor: feedback.row.actor.clone(),
+            actor_id: feedback.row.actor_id.clone(),
+            payload_json: payload_json.clone(),
         },
-    ) {
+        replay_event_id: feedback.event_id.to_string(),
+        submitted_at: submitted_at.clone(),
+    };
+    let replay_feedback_already_recorded =
+        match recorded_claim_feedback_replay_outcome(db, &replay_input) {
+            Ok(outcome) => outcome.is_some(),
+            Err(error) if claim_replay_error_is_terminal(&error) => {
+                if let Some(existing_feedback) = existing_replay_feedback_for_event(
+                    db,
+                    feedback.event_id,
+                    resolved_claim_id,
+                    feedback.action,
+                    &content_hash,
+                )? {
+                    repair_claim_feedback_recorded_signal(ctx, db, &existing_feedback.feedback_id)
+                        .map_err(|error| RebuildError::ClaimReplay(error.to_string()))?;
+                    let marked = mark_replay_event_already_applied_with_feedback(
+                        db,
+                        feedback.event_id,
+                        &existing_feedback,
+                        preserve_legacy_unset_checksum,
+                    )?;
+                    return replay_event_outcome_from_existing(
+                        feedback.event_id,
+                        source_claim,
+                        Some(resolved_claim_id),
+                        &feedback.row.action,
+                        marked,
+                    );
+                }
+                let reason_code = "claim_feedback_replay_failed";
+                let reason_detail_hash = reason_detail_hash(&error.to_string());
+                let marked = mark_replay_event_terminal(
+                    db,
+                    feedback.event_id,
+                    ReplayEventStatus::Failed.as_str(),
+                    Some(reason_code),
+                    Some(&reason_detail_hash),
+                    None,
+                    Some(&content_hash),
+                )?;
+                return replay_event_outcome_from_existing(
+                    feedback.event_id,
+                    source_claim,
+                    Some(resolved_claim_id),
+                    &feedback.row.action,
+                    marked,
+                );
+            }
+            Err(error) => return Err(RebuildError::ClaimReplay(error.to_string())),
+        };
+
+    if !replay_feedback_already_recorded
+        && replay_feedback_is_stale(
+            db,
+            resolved_claim_id,
+            &submitted_at,
+            sidecar_feedback_events,
+        )?
+    {
+        let reason_code = "stale_replay_watermark";
+        let marked = mark_replay_event_terminal(
+            db,
+            feedback.event_id,
+            ReplayEventStatus::Failed.as_str(),
+            Some(reason_code),
+            None,
+            None,
+            Some(&content_hash),
+        )?;
+        return replay_event_outcome_from_existing(
+            feedback.event_id,
+            source_claim,
+            Some(resolved_claim_id),
+            &feedback.row.action,
+            marked,
+        );
+    }
+
+    let outcome = match record_claim_feedback_replay(ctx, db, replay_input) {
         Ok(outcome) => outcome,
         Err(error) => {
+            if !claim_replay_error_is_terminal(&error) {
+                return Err(RebuildError::ClaimReplay(error.to_string()));
+            }
             let reason_code = "claim_feedback_replay_failed";
             let reason_detail_hash = reason_detail_hash(&error.to_string());
-            mark_replay_event_terminal(
+            let marked = mark_replay_event_terminal(
                 db,
                 feedback.event_id,
                 ReplayEventStatus::Failed.as_str(),
                 Some(reason_code),
                 Some(&reason_detail_hash),
                 None,
+                Some(&content_hash),
             )?;
-            return Ok(ReplayEventOutcome {
-                sidecar_event_id: feedback.event_id.to_string(),
-                source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
-                resolved_claim_id: Some(resolved_claim_id.to_string()),
-                action: feedback.row.action.clone(),
-                status: ReplayEventStatus::Failed,
-                reason_code: Some(reason_code.to_string()),
-                applied_feedback_id: None,
-            });
+            return replay_event_outcome_from_existing(
+                feedback.event_id,
+                source_claim,
+                Some(resolved_claim_id),
+                &feedback.row.action,
+                marked,
+            );
         }
     };
 
@@ -436,23 +802,22 @@ fn replay_feedback_event(
     } else {
         ReplayEventStatus::AlreadyApplied
     };
-    mark_replay_event_terminal(
+    let marked = mark_replay_event_terminal(
         db,
         feedback.event_id,
         status.as_str(),
         None,
         None,
         Some(&outcome.feedback_id),
+        Some(&content_hash),
     )?;
-    Ok(ReplayEventOutcome {
-        sidecar_event_id: feedback.event_id.to_string(),
-        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
-        resolved_claim_id: Some(resolved_claim_id.to_string()),
-        action: feedback.row.action.clone(),
-        status,
-        reason_code: None,
-        applied_feedback_id: Some(outcome.feedback_id),
-    })
+    replay_event_outcome_from_existing(
+        feedback.event_id,
+        source_claim,
+        Some(resolved_claim_id),
+        &feedback.row.action,
+        marked,
+    )
 }
 
 fn record_orphan_replay_event(
@@ -464,8 +829,13 @@ fn record_orphan_replay_event(
     reason_code: &str,
 ) -> Result<ReplayEventOutcome, RebuildError> {
     let payload_json = feedback_payload_json(feedback.row)?;
-    let content_hash =
-        feedback_content_hash(feedback.row, feedback.action, payload_json.as_deref())?;
+    let submitted_at = canonical_feedback_submitted_at(&feedback.row.submitted_at)?;
+    let content_hash = feedback_content_hash(
+        feedback.row,
+        feedback.action,
+        payload_json.as_deref(),
+        &submitted_at,
+    )?;
     if let ReplayEventClaim::ExistingTerminal {
         status,
         reason_code,
@@ -499,6 +869,7 @@ fn record_orphan_replay_event(
         Some(reason_code),
         None,
         None,
+        Some(&content_hash),
     )?;
     Ok(ReplayEventOutcome {
         sidecar_event_id: feedback.event_id.to_string(),
@@ -508,6 +879,180 @@ fn record_orphan_replay_event(
         status,
         reason_code: Some(reason_code.to_string()),
         applied_feedback_id: None,
+    })
+}
+
+fn replay_feedback_is_stale(
+    db: &ActionDb,
+    resolved_claim_id: &str,
+    submitted_at: &str,
+    sidecar_feedback_events: &HashMap<String, SidecarFeedbackReplayIdentity>,
+) -> Result<bool, RebuildError> {
+    let replay_submitted_at = DateTime::parse_from_rfc3339(submitted_at)
+        .map_err(|error| {
+            RebuildError::InvalidSidecar(format!(
+                "sidecar feedback row submitted_at must be RFC3339: {error}"
+            ))
+        })?
+        .with_timezone(&Utc);
+
+    let matching_sidecar_replay_event_ids =
+        matching_sidecar_replay_event_ids(db, resolved_claim_id, sidecar_feedback_events)?;
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT submitted_at, replay_event_id
+           FROM claim_feedback
+          WHERE claim_id = ?1",
+    )?;
+    let feedback_rows = stmt.query_map(params![resolved_claim_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+    })?;
+    for stored in feedback_rows {
+        let (stored, replay_event_id) = stored?;
+        if replay_event_id
+            .as_deref()
+            .is_some_and(|event_id| matching_sidecar_replay_event_ids.contains(event_id))
+        {
+            continue;
+        }
+        if stored_timestamp_after(&stored, replay_submitted_at, "claim_feedback.submitted_at")? {
+            return Ok(true);
+        }
+    }
+
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT created_at, correction_event_log_id
+           FROM version_events
+          WHERE claim_id = ?1
+            AND previous_version IS NOT NULL
+            AND event_kind IN (
+                'claim.updated',
+                'claim.corrected',
+                'claim.superseded',
+                'claim.tombstoned',
+                'claim.conflict_detected'
+            )",
+    )?;
+    let version_rows = stmt.query_map(params![resolved_claim_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+    })?;
+    for stored in version_rows {
+        let (stored, correction_event_log_id) = stored?;
+        if correction_event_log_id
+            .as_deref()
+            .is_some_and(|event_id| matching_sidecar_replay_event_ids.contains(event_id))
+        {
+            continue;
+        }
+        if stored_timestamp_after(&stored, replay_submitted_at, "version_events.created_at")? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn matching_sidecar_replay_event_ids(
+    db: &ActionDb,
+    resolved_claim_id: &str,
+    sidecar_feedback_events: &HashMap<String, SidecarFeedbackReplayIdentity>,
+) -> Result<HashSet<String>, RebuildError> {
+    let mut matching_event_ids = HashSet::new();
+    let mut stmt = db.conn_ref().prepare(
+        "SELECT replay_event_id, feedback_type, actor, actor_id, payload_json, submitted_at
+           FROM claim_feedback
+          WHERE claim_id = ?1
+            AND replay_event_id IS NOT NULL",
+    )?;
+    let rows = stmt.query_map(params![resolved_claim_id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?,
+            row.get::<_, Option<String>>(4)?,
+            row.get::<_, String>(5)?,
+        ))
+    })?;
+    for row in rows {
+        let (event_id, feedback_type, actor, actor_id, payload_json, submitted_at) = row?;
+        let Some(expected) = sidecar_feedback_events.get(&event_id) else {
+            continue;
+        };
+        if feedback_type != expected.action.as_str() {
+            continue;
+        }
+        let content_hash = claim_feedback_replay_content_hash(
+            expected.action,
+            &actor,
+            actor_id.as_deref(),
+            payload_json.as_deref(),
+            &submitted_at,
+        )
+        .map_err(|error| RebuildError::ClaimReplay(error.to_string()))?;
+        if content_hash == expected.content_hash {
+            matching_event_ids.insert(event_id);
+        }
+    }
+    Ok(matching_event_ids)
+}
+
+fn stored_timestamp_after(
+    stored: &str,
+    replay_submitted_at: DateTime<Utc>,
+    field: &str,
+) -> Result<bool, RebuildError> {
+    let stored_at = DateTime::parse_from_rfc3339(stored)
+        .map_err(|error| RebuildError::ClaimReplay(format!("{field} is not RFC3339: {error}")))?
+        .with_timezone(&Utc);
+    Ok(stored_at > replay_submitted_at)
+}
+
+fn claim_replay_error_is_terminal(error: &ClaimError) -> bool {
+    matches!(
+        error,
+        ClaimError::UnknownClaimId(_)
+            | ClaimError::ClaimNotFound(_)
+            | ClaimError::UnsupportedClaimType { .. }
+            | ClaimError::InvalidFeedback(_)
+            | ClaimError::InvalidActor(_)
+            | ClaimError::StaleVersion { .. }
+            | ClaimError::InflatedVersion { .. }
+            | ClaimError::MissingExpectedClaimVersion { .. }
+            | ClaimError::ActorClassNotAllowed { .. }
+            | ClaimError::ActorNotPermittedForClaimType { .. }
+            | ClaimError::TombstonedPreGate
+    )
+}
+
+fn replay_event_outcome_from_existing(
+    sidecar_event_id: &str,
+    source_claim: SidecarClaimRef<'_>,
+    resolved_claim_id: Option<&str>,
+    action: &str,
+    existing: ExistingReplayEvent,
+) -> Result<ReplayEventOutcome, RebuildError> {
+    let status = match existing.status.as_str() {
+        "applied" => ReplayEventStatus::Applied,
+        "already_applied" => ReplayEventStatus::AlreadyApplied,
+        "orphan_missing" => ReplayEventStatus::OrphanMissing,
+        "orphan_ambiguous" => ReplayEventStatus::OrphanAmbiguous,
+        "failed" => ReplayEventStatus::Failed,
+        other => {
+            return Err(RebuildError::InvalidSidecar(format!(
+                "unknown replay event status `{other}`"
+            )))
+        }
+    };
+    Ok(ReplayEventOutcome {
+        sidecar_event_id: sidecar_event_id.to_string(),
+        source_runtime_claim_id: source_claim.runtime_claim_id.to_string(),
+        resolved_claim_id: existing
+            .resolved_claim_id
+            .or_else(|| resolved_claim_id.map(str::to_string)),
+        action: action.to_string(),
+        status,
+        reason_code: existing.reason_code,
+        applied_feedback_id: existing.applied_feedback_id,
     })
 }
 
@@ -593,7 +1138,7 @@ fn read_existing_replay_event(
 ) -> Result<Option<ExistingReplayEvent>, RebuildError> {
     db.conn_ref()
         .query_row(
-            "SELECT sidecar_schema_version, source_runtime_claim_id, resolved_claim_id,
+            "SELECT sidecar_schema_version, sidecar_checksum, source_runtime_claim_id, resolved_claim_id,
                     action, status, reason_code, semantic_identity_hash,
                     feedback_content_hash, applied_feedback_id
              FROM rebuild_correction_replay_events
@@ -603,14 +1148,15 @@ fn read_existing_replay_event(
                 let schema_version = row.get::<_, i64>(0)?;
                 Ok(ExistingReplayEvent {
                     sidecar_schema_version: schema_version as u32,
-                    source_runtime_claim_id: row.get(1)?,
-                    resolved_claim_id: row.get(2)?,
-                    action: row.get(3)?,
-                    status: row.get(4)?,
-                    reason_code: row.get(5)?,
-                    semantic_identity_hash: row.get(6)?,
-                    feedback_content_hash: row.get(7)?,
-                    applied_feedback_id: row.get(8)?,
+                    sidecar_checksum: row.get(1)?,
+                    source_runtime_claim_id: row.get(2)?,
+                    resolved_claim_id: row.get(3)?,
+                    action: row.get(4)?,
+                    status: row.get(5)?,
+                    reason_code: row.get(6)?,
+                    semantic_identity_hash: row.get(7)?,
+                    feedback_content_hash: row.get(8)?,
+                    applied_feedback_id: row.get(9)?,
                 })
             },
         )
@@ -624,7 +1170,10 @@ fn claim_replay_event(
 ) -> Result<ReplayEventClaim, RebuildError> {
     if let Some(existing) = read_existing_replay_event(db, input.sidecar_event_id)? {
         validate_existing_replay_event(&existing, &input)?;
-        repair_claimed_legacy_content_hash(db, &existing, &input)?;
+        if existing_is_recoverable_orphan(&existing) && input.resolved_claim_id.is_some() {
+            reclaim_orphan_replay_event(db, &existing, &input)?;
+            return Ok(ReplayEventClaim::Claimed);
+        }
         increment_claimed_attempt_count(db, input.sidecar_event_id)?;
         return replay_event_claim_from_existing(existing);
     }
@@ -633,15 +1182,16 @@ fn claim_replay_event(
     let inserted = db.conn_ref().execute(
         "INSERT INTO rebuild_correction_replay_events (
             sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
-            resolved_claim_id, action, status, reason_code, semantic_identity_hash,
+            sidecar_checksum, resolved_claim_id, action, status, reason_code, semantic_identity_hash,
             feedback_content_hash, attempt_count, claimed_at, updated_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', ?7, ?8, ?9, 1, ?10, ?10)
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'claimed', ?8, ?9, ?10, 1, ?11, ?11)
          ON CONFLICT(sidecar_event_id) DO NOTHING",
         params![
             input.sidecar_event_id,
             input.scope.run_id,
             input.scope.sidecar_schema_version as i64,
             input.source_claim.runtime_claim_id,
+            input.scope.sidecar_checksum,
             input.resolved_claim_id,
             input.action,
             input.reason_code,
@@ -654,7 +1204,10 @@ fn claim_replay_event(
         RebuildError::InvalidSidecar("replay event claim was not persisted".to_string())
     })?;
     validate_existing_replay_event(&existing, &input)?;
-    repair_claimed_legacy_content_hash(db, &existing, &input)?;
+    if existing_is_recoverable_orphan(&existing) && input.resolved_claim_id.is_some() {
+        reclaim_orphan_replay_event(db, &existing, &input)?;
+        return Ok(ReplayEventClaim::Claimed);
+    }
     if inserted == 0 {
         increment_claimed_attempt_count(db, input.sidecar_event_id)?;
     }
@@ -682,7 +1235,6 @@ fn validate_existing_replay_event(
 ) -> Result<(), RebuildError> {
     if existing.sidecar_schema_version != input.scope.sidecar_schema_version
         || existing.source_runtime_claim_id != input.source_claim.runtime_claim_id
-        || existing.resolved_claim_id.as_deref() != input.resolved_claim_id
         || existing.action != input.action
         || existing.semantic_identity_hash != input.source_claim.identity.dedup_key_components_hash
     {
@@ -691,9 +1243,25 @@ fn validate_existing_replay_event(
                 .to_string(),
         ));
     }
+    if existing.sidecar_checksum != input.scope.sidecar_checksum
+        && existing.sidecar_checksum != LEGACY_V283_UNSET_SIDECAR_CHECKSUM
+    {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different sidecar checksum or feedback content"
+                .to_string(),
+        ));
+    }
+    if existing.resolved_claim_id.as_deref() != input.resolved_claim_id
+        && !(existing_is_recoverable_orphan(existing) && input.resolved_claim_id.is_some())
+    {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar replay event already recorded for a different target or feedback content"
+                .to_string(),
+        ));
+    }
     let content_hash_matches = existing.feedback_content_hash == input.feedback_content_hash
-        || (existing.status == "claimed"
-            && existing.feedback_content_hash == LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+        || (existing.feedback_content_hash == LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH
+            && (existing.status == "claimed" || existing_is_recoverable_orphan(existing)));
     if !content_hash_matches {
         return Err(RebuildError::InvalidSidecar(
             "sidecar replay event already recorded for a different target or feedback content"
@@ -703,30 +1271,43 @@ fn validate_existing_replay_event(
     Ok(())
 }
 
-fn repair_claimed_legacy_content_hash(
+fn existing_is_recoverable_orphan(existing: &ExistingReplayEvent) -> bool {
+    matches!(
+        existing.status.as_str(),
+        "orphan_missing" | "orphan_ambiguous"
+    ) && existing.resolved_claim_id.is_none()
+}
+
+const LEGACY_V283_UNSET_SIDECAR_CHECKSUM: &str = "legacy-v283-unset";
+
+fn reclaim_orphan_replay_event(
     db: &ActionDb,
     existing: &ExistingReplayEvent,
     input: &ClaimReplayJournalInput<'_>,
 ) -> Result<(), RebuildError> {
-    if existing.status != "claimed"
-        || existing.feedback_content_hash != LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH
-    {
-        return Ok(());
-    }
     db.conn_ref().execute(
         "UPDATE rebuild_correction_replay_events
-         SET feedback_content_hash = ?1,
+         SET status = 'claimed',
+             resolved_claim_id = ?1,
+             reason_code = NULL,
+             reason_detail_hash = NULL,
+             applied_feedback_id = NULL,
+             attempt_count = attempt_count + 1,
              updated_at = ?2
          WHERE sidecar_event_id = ?3
-           AND status = 'claimed'
-           AND feedback_content_hash = ?4",
+           AND status IN ('orphan_missing', 'orphan_ambiguous')
+           AND resolved_claim_id IS NULL",
         params![
-            input.feedback_content_hash,
+            input.resolved_claim_id,
             Utc::now().to_rfc3339(),
             input.sidecar_event_id,
-            LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
         ],
     )?;
+    log::debug!(
+        "reclaimed orphaned replay event sidecar_event_id={} prior_status={}",
+        input.sidecar_event_id,
+        existing.status
+    );
     Ok(())
 }
 
@@ -763,6 +1344,107 @@ fn replay_event_claim_from_existing(
     })
 }
 
+struct ExistingReplayFeedback {
+    feedback_id: String,
+    content_hash: String,
+}
+
+fn existing_replay_feedback_for_event(
+    db: &ActionDb,
+    replay_event_id: &str,
+    resolved_claim_id: &str,
+    action: FeedbackAction,
+    expected_content_hash: &str,
+) -> Result<Option<ExistingReplayFeedback>, RebuildError> {
+    let row: Option<(
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        String,
+    )> = db
+        .conn_ref()
+        .query_row(
+            "SELECT id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at
+               FROM claim_feedback
+              WHERE replay_event_id = ?1",
+            params![replay_event_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((feedback_id, claim_id, feedback_type, actor, actor_id, payload_json, submitted_at)) =
+        row
+    else {
+        return Ok(None);
+    };
+    if claim_id != resolved_claim_id || feedback_type != action.as_str() {
+        return Ok(None);
+    }
+    let content_hash = claim_feedback_replay_content_hash(
+        action,
+        &actor,
+        actor_id.as_deref(),
+        payload_json.as_deref(),
+        &submitted_at,
+    )
+    .map_err(|error| RebuildError::ClaimReplay(error.to_string()))?;
+    if content_hash != expected_content_hash {
+        return Ok(None);
+    }
+    Ok(Some(ExistingReplayFeedback {
+        feedback_id,
+        content_hash,
+    }))
+}
+
+fn mark_replay_event_already_applied_with_feedback(
+    db: &ActionDb,
+    sidecar_event_id: &str,
+    feedback: &ExistingReplayFeedback,
+    preserve_legacy_unset_checksum: bool,
+) -> Result<ExistingReplayEvent, RebuildError> {
+    let now = Utc::now().to_rfc3339();
+    let sidecar_checksum =
+        preserve_legacy_unset_checksum.then_some(LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+    db.conn_ref().execute(
+        "UPDATE rebuild_correction_replay_events
+         SET status = 'already_applied',
+             reason_code = NULL,
+             reason_detail_hash = NULL,
+             applied_feedback_id = ?2,
+             feedback_content_hash = ?3,
+             sidecar_checksum = COALESCE(?5, sidecar_checksum),
+             applied_at = ?4,
+             updated_at = ?4
+         WHERE sidecar_event_id = ?1
+           AND status = 'claimed'",
+        params![
+            sidecar_event_id,
+            &feedback.feedback_id,
+            &feedback.content_hash,
+            &now,
+            sidecar_checksum,
+        ],
+    )?;
+    read_existing_replay_event(db, sidecar_event_id)?.ok_or_else(|| {
+        RebuildError::InvalidSidecar(format!(
+            "replay event disappeared before already-applied recovery: {sidecar_event_id}"
+        ))
+    })
+}
+
 fn mark_replay_event_terminal(
     db: &ActionDb,
     sidecar_event_id: &str,
@@ -770,7 +1452,8 @@ fn mark_replay_event_terminal(
     reason_code: Option<&str>,
     reason_detail_hash: Option<&str>,
     applied_feedback_id: Option<&str>,
-) -> Result<(), RebuildError> {
+    feedback_content_hash: Option<&str>,
+) -> Result<ExistingReplayEvent, RebuildError> {
     let now = Utc::now().to_rfc3339();
     db.conn_ref().execute(
         "UPDATE rebuild_correction_replay_events
@@ -778,9 +1461,10 @@ fn mark_replay_event_terminal(
              reason_code = COALESCE(?2, reason_code),
              reason_detail_hash = COALESCE(?3, reason_detail_hash),
              applied_feedback_id = COALESCE(?4, applied_feedback_id),
-             applied_at = CASE WHEN ?1 IN ('applied', 'already_applied') THEN ?5 ELSE applied_at END,
-             updated_at = ?5
-         WHERE sidecar_event_id = ?6
+             feedback_content_hash = COALESCE(?5, feedback_content_hash),
+             applied_at = CASE WHEN ?1 IN ('applied', 'already_applied') THEN ?6 ELSE applied_at END,
+             updated_at = ?6
+         WHERE sidecar_event_id = ?7
            AND NOT (
              status IN ('applied', 'already_applied')
              AND ?1 = 'failed'
@@ -790,11 +1474,16 @@ fn mark_replay_event_terminal(
             reason_code,
             reason_detail_hash,
             applied_feedback_id,
+            feedback_content_hash,
             &now,
             sidecar_event_id
         ],
     )?;
-    Ok(())
+    read_existing_replay_event(db, sidecar_event_id)?.ok_or_else(|| {
+        RebuildError::InvalidSidecar(format!(
+            "replay event disappeared before terminal mark: {sidecar_event_id}"
+        ))
+    })
 }
 
 fn claim_matches_identity_provenance(
@@ -843,7 +1532,10 @@ mod tests {
         ClaimFileClaim, ClaimFileContradictionEdge, ClaimFileLifecycle, ClaimFileProvenanceSummary,
         ClaimFileReplayStatus, CLAIM_FILE_PROJECTION_VERSION, CLAIM_FILE_SIDECAR_SCHEMA_VERSION,
     };
-    use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim, TombstoneSpec};
+    use crate::services::claims::{
+        commit_claim, record_claim_feedback, record_claim_feedback_replay, ClaimFeedbackInput,
+        ClaimFeedbackReplayInput, ClaimProposal, CommittedClaim, TombstoneSpec,
+    };
     use crate::services::context::{ExternalClients, FixedClock, SeedableRng, ServiceContext};
     use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
 
@@ -972,6 +1664,91 @@ mod tests {
         }
     }
 
+    fn sidecar_checksum(sidecar: &ClaimFileSidecar) -> String {
+        let sidecar_json = serde_json::to_string_pretty(sidecar).expect("serialize sidecar");
+        let mut hasher = Sha256::new();
+        hasher.update(sidecar_json.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn authorize_sidecar(db: &ActionDb, sidecar: &ClaimFileSidecar) -> String {
+        let checksum = sidecar_checksum(sidecar);
+        authorize_sidecar_with_checksum(db, sidecar, &checksum);
+        checksum
+    }
+
+    fn authorize_sidecar_with_checksum(db: &ActionDb, sidecar: &ClaimFileSidecar, checksum: &str) {
+        let run_id = format!("projection-run-{}", &checksum[..12]);
+        db.conn_ref()
+            .execute(
+                "INSERT OR IGNORE INTO claim_file_projection_path_bindings (
+                    markdown_rel_path, sidecar_rel_path, entity_subject_compact,
+                    projection_root, created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, '_dailyos_claims', ?4, ?4)",
+                params![
+                    &sidecar.markdown_rel_path,
+                    &sidecar.sidecar_rel_path,
+                    &sidecar.entity_subject_compact,
+                    TS,
+                ],
+            )
+            .expect("insert path binding");
+        db.conn_ref()
+            .execute(
+                "INSERT OR IGNORE INTO claim_file_projection_runs (
+                    id, entity_subject_ref_json, entity_subject_compact, projection_root,
+                    markdown_rel_path, sidecar_rel_path, projection_version,
+                    sidecar_schema_version, entity_claim_invalidation_version, claim_watermark,
+                    markdown_checksum, sidecar_checksum, status, attempted_at, succeeded_at,
+                    created_at, updated_at
+                 ) VALUES (
+                    ?1, ?2, ?3, '_dailyos_claims', ?4, ?5, ?6, ?7, 0, 'watermark',
+                    'markdown-checksum', ?8, 'committed', ?9, ?9, ?9, ?9
+                 )",
+                params![
+                    &run_id,
+                    serde_json::to_string(&sidecar.entity_subject_ref).expect("serialize subject"),
+                    &sidecar.entity_subject_compact,
+                    &sidecar.markdown_rel_path,
+                    &sidecar.sidecar_rel_path,
+                    sidecar.projection_version as i64,
+                    sidecar.schema_version as i64,
+                    &checksum,
+                    TS,
+                ],
+            )
+            .expect("insert projection run");
+        for claim in &sidecar.claims {
+            db.conn_ref()
+                .execute(
+                    "INSERT OR IGNORE INTO claim_file_projection_run_claims (
+                        run_id, claim_id, claim_version, semantic_identity_json,
+                        trust_band, sensitivity
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        &run_id,
+                        &claim.runtime_claim_id,
+                        claim.runtime_claim_version as i64,
+                        serde_json::to_string(&claim.semantic_identity)
+                            .expect("serialize semantic identity"),
+                        &claim.trust_band,
+                        &claim.sensitivity,
+                    ],
+                )
+                .expect("insert projection run claim");
+        }
+    }
+
+    fn replay_authorized(
+        ctx: &ServiceContext<'_>,
+        db: &ActionDb,
+        run_id: &str,
+        sidecar: &ClaimFileSidecar,
+    ) -> Result<CorrectionReplayReport, RebuildError> {
+        let checksum = authorize_sidecar(db, sidecar);
+        replay_claim_file_sidecar_corrections(ctx, db, run_id, sidecar, &checksum)
+    }
+
     fn feedback_count_for_replay(db: &ActionDb, replay_event_id: &str) -> i64 {
         db.conn_ref()
             .query_row(
@@ -980,6 +1757,32 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("count replay feedback")
+    }
+
+    fn feedback_id_for_replay(db: &ActionDb, replay_event_id: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT id FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("read replay feedback id")
+    }
+
+    fn claim_feedback_recorded_signal_id(feedback_id: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(format!("claim-feedback:{feedback_id}:recorded").as_bytes());
+        format!("sig-once-{:x}", hasher.finalize())
+    }
+
+    fn signal_count_for_id(db: &ActionDb, signal_id: &str) -> i64 {
+        db.conn_ref()
+            .query_row(
+                "SELECT count(*) FROM signal_events WHERE id = ?1",
+                params![signal_id],
+                |row| row.get(0),
+            )
+            .expect("count signal by id")
     }
 
     fn replay_journal_count(db: &ActionDb) -> i64 {
@@ -1029,6 +1832,36 @@ mod tests {
             .expect("read replay journal target")
     }
 
+    fn insert_claimed_legacy_replay_journal(
+        db: &ActionDb,
+        sidecar: &ClaimFileSidecar,
+        resolved_claim_id: &str,
+    ) {
+        let sidecar_claim = &sidecar.claims[0];
+        let feedback = &sidecar_claim.feedback_rows[0];
+        db.conn_ref()
+            .execute(
+                "INSERT INTO rebuild_correction_replay_events (
+                    sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                    resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                    semantic_identity_hash, feedback_content_hash, applied_feedback_id,
+                    attempt_count, claimed_at, applied_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', NULL, NULL, ?7, ?8, NULL, 1, ?9, NULL, ?9)",
+                params![
+                    &feedback.feedback_id,
+                    "run-before-crash",
+                    sidecar.schema_version as i64,
+                    &sidecar_claim.runtime_claim_id,
+                    resolved_claim_id,
+                    &feedback.action,
+                    &sidecar_claim.semantic_identity.dedup_key_components_hash,
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    TS,
+                ],
+            )
+            .expect("insert claimed legacy journal row");
+    }
+
     fn claim_verification_state_and_version(db: &ActionDb, claim_id: &str) -> (String, i64) {
         db.conn_ref()
             .query_row(
@@ -1072,8 +1905,7 @@ mod tests {
         );
         sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay sidecar");
+        let report = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay sidecar");
 
         assert_eq!(report.applied_count, 1);
         assert!(!report.plain_sqlite_recovery_proven);
@@ -1099,6 +1931,76 @@ mod tests {
     }
 
     #[test]
+    fn dos832_replay_rejects_uncommitted_sidecar_before_mutation() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "forged-feedback",
+        );
+        let checksum = sidecar_checksum(&sidecar);
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect_err("uncommitted sidecar must not replay");
+
+        assert!(
+            matches!(&err, RebuildError::InvalidSidecar(message) if message.contains("projection path binding missing") || message.contains("committed projection run not found")),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(feedback_count_for_replay(&db, "forged-feedback"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_tampered_sidecar_with_borrowed_committed_checksum() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "committed-feedback",
+        );
+        let committed_checksum = authorize_sidecar(&db, &sidecar);
+
+        let mut tampered = sidecar;
+        tampered.claims[0].feedback_rows[0].feedback_id = "borrowed-checksum-feedback".to_string();
+        tampered.claims[0].feedback_rows[0].action = "mark_false".to_string();
+        tampered.claims[0].feedback_rows[0].submitted_at = "2026-05-02T09:15:00Z".to_string();
+        let err = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-1",
+            &tampered,
+            &committed_checksum,
+        )
+        .expect_err("tampered sidecar must not borrow a committed checksum");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("sidecar checksum"))
+        );
+        assert_eq!(
+            feedback_count_for_replay(&db, "borrowed-checksum-feedback"),
+            0
+        );
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
     fn dos832_replay_claims_event_id_before_mutation_and_survives_restart() {
         let db = test_db();
         let (clock, rng, external) = ctx_parts();
@@ -1115,9 +2017,8 @@ mod tests {
             "old-feedback-2",
         );
 
-        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
-        let second = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("second replay");
+        replay_authorized(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        let second = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("second replay");
 
         assert_eq!(second.applied_count, 0);
         assert_eq!(second.already_applied_count, 1);
@@ -1139,9 +2040,52 @@ mod tests {
         );
         let mut sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
         sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+        sidecar.claims[0]
+            .contradiction_edges
+            .push(ClaimFileContradictionEdge {
+                edge_id: "legacy-edge-1".to_string(),
+                branch_kind: "contradiction".to_string(),
+                role: "primary".to_string(),
+                primary_runtime_claim_id: "old-runtime-claim-id".to_string(),
+                contradicting_runtime_claim_id: "other-runtime-claim-id".to_string(),
+                primary_semantic_identity: None,
+                contradicting_semantic_identity: None,
+                detected_at: TS.to_string(),
+                reconciliation_kind: None,
+                reconciliation_note: None,
+                reconciled_at: None,
+                winner_runtime_claim_id: None,
+                winner_semantic_identity: None,
+                merged_runtime_claim_id: None,
+                merged_semantic_identity: None,
+                replay_status: replay_status(),
+            });
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay legacy sidecar");
+        let legacy_json = serde_json::to_string_pretty(&LegacyV1SidecarChecksum::from(&sidecar))
+            .expect("serialize legacy sidecar");
+        assert!(
+            !legacy_json.contains("\"feedbackId\""),
+            "legacy v1 sidecar checksum must not include defaulted v2 feedbackId"
+        );
+        assert!(
+            !legacy_json.contains("\"supersededBySemanticIdentity\""),
+            "legacy v1 sidecar checksum must not include post-v1 claim fields"
+        );
+        assert!(
+            !legacy_json.contains("\"winnerSemanticIdentity\"")
+                && !legacy_json.contains("\"mergedSemanticIdentity\""),
+            "legacy v1 sidecar checksum must not include post-v1 contradiction fields"
+        );
+        let mut hasher = Sha256::new();
+        hasher.update(legacy_json.as_bytes());
+        let legacy_checksum = format!("{:x}", hasher.finalize());
+        let decoded: ClaimFileSidecar =
+            serde_json::from_str(&legacy_json).expect("decode legacy sidecar");
+        authorize_sidecar_with_checksum(&db, &decoded, &legacy_checksum);
+
+        let report =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &decoded, &legacy_checksum)
+                .expect("replay legacy sidecar");
 
         assert_eq!(report.applied_count, 1);
         assert!(report.events[0].sidecar_event_id.starts_with("legacy-v1:"));
@@ -1149,6 +2093,34 @@ mod tests {
             feedback_count_for_replay(&db, &report.events[0].sidecar_event_id),
             1
         );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_legacy_v1_sidecar_with_injected_feedback_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
+        sidecar.schema_version = CLAIM_FILE_LEGACY_SIDECAR_SCHEMA_VERSION;
+        let legacy_checksum =
+            legacy_v1_sidecar_payload_checksum(&sidecar).expect("legacy checksum");
+        authorize_sidecar_with_checksum(&db, &sidecar, &legacy_checksum);
+        sidecar.claims[0].feedback_rows[0].feedback_id = "chosen-replay-id".to_string();
+
+        let err =
+            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &legacy_checksum)
+                .expect_err("injected v1 feedback_id must reject");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("legacy v1"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "chosen-replay-id"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
     }
 
     #[test]
@@ -1169,7 +2141,7 @@ mod tests {
         );
         sidecar.claims[0].semantic_identity.source_content_hash = None;
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+        let err = replay_authorized(&ctx, &db, "run-1", &sidecar)
             .expect_err("v2 sidecar without source hash must reject");
 
         assert!(
@@ -1201,13 +2173,12 @@ mod tests {
         first_sidecar.claims[0].feedback_rows[0].action = "needs_nuance".to_string();
         first_sidecar.claims[0].feedback_rows[0].payload_json =
             Some(serde_json::json!({ "corrected_text": "Risk is limited to the pilot group" }));
-        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
-            .expect("first replay");
+        replay_authorized(&ctx, &db, "run-1", &first_sidecar).expect("first replay");
 
         let mut second_sidecar = first_sidecar;
         second_sidecar.claims[0].feedback_rows[0].payload_json =
             Some(serde_json::json!({ "corrected_text": "Risk is limited to the renewal window" }));
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("same replay id must not hide changed payload");
 
         assert!(
@@ -1233,12 +2204,11 @@ mod tests {
             "submitted-at-event",
         );
         first_sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
-        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
-            .expect("first replay");
+        replay_authorized(&ctx, &db, "run-1", &first_sidecar).expect("first replay");
 
         let mut second_sidecar = first_sidecar;
         second_sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-02T08:30:00Z".to_string();
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("same replay id must not hide changed submitted_at");
 
         assert!(
@@ -1248,6 +2218,276 @@ mod tests {
             feedback_submitted_at_for_replay(&db, "submitted-at-event"),
             REPLAYED_FEEDBACK_TS
         );
+    }
+
+    #[test]
+    fn dos832_replay_rejects_same_event_id_from_different_sidecar_checksum() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "checksum-event",
+        );
+        replay_authorized(&ctx, &db, "run-1", &first_sidecar).expect("first replay");
+
+        let mut second_sidecar = first_sidecar;
+        second_sidecar.claims[0]
+            .claim_text
+            .push_str(" (projection-only checksum drift)");
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("same replay id must stay bound to original sidecar checksum");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("sidecar checksum"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "checksum-event"), 1);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_sidecar_event_older_than_existing_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "stale-sidecar-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        record_claim_feedback(
+            &ctx,
+            &db,
+            ClaimFeedbackInput {
+                claim_id: fresh_claim_id.clone(),
+                action: FeedbackAction::NeedsNuance,
+                actor: "user".to_string(),
+                actor_id: Some("user-fixture".to_string()),
+                payload_json: Some(
+                    serde_json::json!({ "corrected_text": "newer correction" }).to_string(),
+                ),
+            },
+        )
+        .expect("record newer feedback");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("stale replay is terminalized");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "stale-sidecar-feedback"), 0);
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "stale-sidecar-feedback");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("stale_replay_watermark"));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_offset_sidecar_older_than_existing_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "offset-stale-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-01T09:30:00+02:00".to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: fresh_claim_id.clone(),
+                    action: FeedbackAction::ConfirmCurrent,
+                    actor: "user".to_string(),
+                    actor_id: Some("user-fixture".to_string()),
+                    payload_json: None,
+                },
+                replay_event_id: "existing-newer-feedback".to_string(),
+                submitted_at: "2026-05-01T08:30:00+00:00".to_string(),
+            },
+        )
+        .expect("record newer feedback with offset-compatible timestamp");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("offset stale replay is terminalized");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "offset-stale-feedback"), 0);
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "offset-stale-feedback");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("stale_replay_watermark"));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_fractional_second_newer_feedback_watermark() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "fractional-stale-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-01T08:30:00Z".to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: fresh_claim_id.clone(),
+                    action: FeedbackAction::ConfirmCurrent,
+                    actor: "user".to_string(),
+                    actor_id: Some("user-fixture".to_string()),
+                    payload_json: None,
+                },
+                replay_event_id: "existing-fractional-feedback".to_string(),
+                submitted_at: "2026-05-01T08:30:00.500+00:00".to_string(),
+            },
+        )
+        .expect("record newer fractional feedback");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("fractional stale replay is terminalized");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            feedback_count_for_replay(&db, "fractional-stale-feedback"),
+            0
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "fractional-stale-feedback");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("stale_replay_watermark"));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_fractional_second_newer_version_event_watermark() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "fractional-stale-version-event",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-01T08:30:00Z".to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        db.conn_ref()
+            .execute(
+                "INSERT INTO version_events (
+                    cursor, event_kind, claim_id, previous_version, current_version,
+                    scope_redacted, created_at, actor_kind
+                 ) VALUES (?1, 'claim.corrected', ?2, ?3, ?4, 0, ?5, 'user')",
+                params![
+                    "b821dbf6-9fb9-4235-a45e-0fcf9dc472aa",
+                    fresh_claim_id,
+                    1_i64,
+                    2_i64,
+                    "2026-05-01T08:30:00.500+00:00",
+                ],
+            )
+            .expect("seed newer version event watermark");
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("fractional version-event stale replay is terminalized");
+
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            feedback_count_for_replay(&db, "fractional-stale-version-event"),
+            0
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "fractional-stale-version-event");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("stale_replay_watermark"));
+    }
+
+    #[test]
+    fn dos832_replay_rejects_newer_existing_claim_update_watermark() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "newer-claim-update",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+            .expect("commit newer corroboration");
+        let newer_existing_updates: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM version_events
+                 WHERE claim_id = ?1
+                   AND event_kind = 'claim.updated'
+                   AND previous_version IS NOT NULL
+                   AND created_at > ?2",
+                params![&fresh_claim_id, REPLAYED_FEEDBACK_TS],
+                |row| row.get(0),
+            )
+            .expect("count newer existing-claim updates");
+        assert_eq!(newer_existing_updates, 1);
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("stale replay is terminalized");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            report.events[0].reason_code.as_deref(),
+            Some("stale_replay_watermark")
+        );
+        assert_eq!(feedback_count_for_replay(&db, "newer-claim-update"), 0);
     }
 
     #[test]
@@ -1266,7 +2506,7 @@ mod tests {
             "old-runtime-claim-id",
             "applied-event",
         );
-        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        replay_authorized(&ctx, &db, "run-1", &sidecar).expect("first replay");
 
         mark_replay_event_terminal(
             &db,
@@ -1274,6 +2514,7 @@ mod tests {
             ReplayEventStatus::Failed.as_str(),
             Some("late_failure"),
             Some("late-failure-detail"),
+            None,
             None,
         )
         .expect("late failed mark is ignored");
@@ -1325,8 +2566,8 @@ mod tests {
             )
             .expect("insert partial v282 claimed row");
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay repaired claimed row");
+        let report =
+            replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay repaired claimed row");
 
         assert_eq!(report.applied_count, 1);
         assert_eq!(feedback_count_for_replay(&db, "partial-v282-event"), 1);
@@ -1343,6 +2584,656 @@ mod tests {
         assert_ne!(repaired_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
         let (status, _, _) = replay_journal_status_and_reason(&db, "partial-v282-event");
         assert_eq!(status, "applied");
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_collision_recovers_existing_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "legacy-collision-event",
+        );
+        let sidecar_claim = &sidecar.claims[0];
+        let feedback = &sidecar_claim.feedback_rows[0];
+        let action = feedback_action_from_slug(&feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        let existing_hash = claim_feedback_replay_content_hash(
+            action,
+            &feedback.actor,
+            feedback.actor_id.as_deref(),
+            payload_json.as_deref(),
+            &submitted_at,
+        )
+        .expect("existing content hash");
+        let existing_feedback = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: fresh_claim_id.clone(),
+                    action,
+                    actor: feedback.actor.clone(),
+                    actor_id: feedback.actor_id.clone(),
+                    payload_json: payload_json.clone(),
+                },
+                replay_event_id: feedback.feedback_id.clone(),
+                submitted_at: submitted_at.clone(),
+            },
+        )
+        .expect("record feedback before crash");
+        let recorded_signal_id = claim_feedback_recorded_signal_id(&existing_feedback.feedback_id);
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 1);
+        db.conn_ref()
+            .execute(
+                "DELETE FROM signal_events WHERE id = ?1",
+                params![&recorded_signal_id],
+            )
+            .expect("delete recorded feedback signal");
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 0);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO rebuild_correction_replay_events (
+                    sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                    resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                    semantic_identity_hash, feedback_content_hash, applied_feedback_id,
+                    attempt_count, claimed_at, applied_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', NULL, NULL, ?7, ?8, NULL, 1, ?9, NULL, ?9)",
+                params![
+                    &feedback.feedback_id,
+                    "run-before-crash",
+                    sidecar.schema_version as i64,
+                    &sidecar_claim.runtime_claim_id,
+                    &fresh_claim_id,
+                    &feedback.action,
+                    &sidecar_claim.semantic_identity.dedup_key_components_hash,
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    TS,
+                ],
+            )
+            .expect("insert claimed legacy journal row");
+
+        let mut drifted_sidecar = sidecar.clone();
+        drifted_sidecar.claims[0].claim_text =
+            "Renewal risk is elevated in the sidecar projection".to_string();
+        let drifted_checksum = authorize_sidecar(&db, &drifted_sidecar);
+        assert_ne!(drifted_checksum, sidecar_checksum(&sidecar));
+
+        let drifted_report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-drifted",
+            &drifted_sidecar,
+            &drifted_checksum,
+        )
+        .expect("projection-only drifted retry recovers existing feedback");
+
+        assert_eq!(drifted_report.already_applied_count, 1);
+        assert_eq!(drifted_report.failed_count, 0);
+        assert_eq!(feedback_count_for_replay(&db, "legacy-collision-event"), 1);
+        let (stored_hash, stored_checksum, applied_feedback_id): (String, String, Option<String>) =
+            db.conn_ref()
+                .query_row(
+                    "SELECT feedback_content_hash, sidecar_checksum, applied_feedback_id
+                       FROM rebuild_correction_replay_events
+                      WHERE sidecar_event_id = ?1",
+                    params!["legacy-collision-event"],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .expect("read recovered journal");
+        assert_eq!(stored_hash, existing_hash);
+        assert_eq!(stored_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 1);
+        let repaired_payload: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT value FROM signal_events WHERE id = ?1",
+                params![&recorded_signal_id],
+                |row| row.get(0),
+            )
+            .expect("read repaired signal payload");
+        assert!(
+            repaired_payload.contains("\"recovered\":true"),
+            "claimed collision recovery must repair the deterministic signal"
+        );
+        assert_eq!(
+            applied_feedback_id.as_deref(),
+            Some(existing_feedback.feedback_id.as_str())
+        );
+
+        let drifted_terminal_retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-drifted-terminal",
+            &drifted_sidecar,
+            &drifted_checksum,
+        )
+        .expect("projection-only terminal retry remains checksum-neutral");
+        assert_eq!(drifted_terminal_retry.already_applied_count, 1);
+        let terminal_retry_checksum: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-collision-event"],
+                |row| row.get(0),
+            )
+            .expect("read terminal retry checksum");
+        assert_eq!(
+            terminal_retry_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM,
+            "terminal rows must stay checksum-neutral so retry order cannot lock out the original sidecar"
+        );
+
+        let original_checksum = authorize_sidecar(&db, &sidecar);
+        let original_report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-original",
+            &sidecar,
+            &original_checksum,
+        )
+        .expect("original retry remains recoverable");
+        assert_eq!(original_report.already_applied_count, 1);
+        assert_eq!(original_report.failed_count, 0);
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_signal_repair_failure_remains_retryable() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated")).expect("commit claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &claim_id,
+            "old-runtime-claim-id",
+            "legacy-signal-failure-event",
+        );
+        let feedback = &sidecar.claims[0].feedback_rows[0];
+        let action = feedback_action_from_slug(&feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        let existing_feedback = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: claim_id.clone(),
+                    action,
+                    actor: feedback.actor.clone(),
+                    actor_id: feedback.actor_id.clone(),
+                    payload_json,
+                },
+                replay_event_id: feedback.feedback_id.clone(),
+                submitted_at,
+            },
+        )
+        .expect("record feedback before crash");
+        let recorded_signal_id = claim_feedback_recorded_signal_id(&existing_feedback.feedback_id);
+        db.conn_ref()
+            .execute(
+                "DELETE FROM signal_events WHERE id = ?1",
+                params![&recorded_signal_id],
+            )
+            .expect("delete recorded feedback signal");
+        insert_claimed_legacy_replay_journal(&db, &sidecar, &claim_id);
+
+        let mut drifted_sidecar = sidecar.clone();
+        drifted_sidecar.claims[0].claim_text =
+            "Renewal risk is elevated in the sidecar projection".to_string();
+        let drifted_checksum = authorize_sidecar(&db, &drifted_sidecar);
+        let escaped_signal_id = recorded_signal_id.replace('\'', "''");
+        let fail_signal_trigger = format!(
+            "CREATE TRIGGER fail_claim_feedback_signal_repair
+             BEFORE INSERT ON signal_events
+             WHEN NEW.id = '{escaped_signal_id}'
+             BEGIN
+                SELECT RAISE(FAIL, 'temporary signal repair failure');
+             END;"
+        );
+        db.conn_ref()
+            .execute_batch(&fail_signal_trigger)
+            .expect("install signal repair failure trigger");
+
+        let err = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-drifted-failure",
+            &drifted_sidecar,
+            &drifted_checksum,
+        )
+        .expect_err("signal repair failure remains retryable");
+        assert!(
+            matches!(err, RebuildError::ClaimReplay(message) if message.contains("temporary signal repair failure"))
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "legacy-signal-failure-event");
+        assert_eq!(status, "claimed");
+        assert_eq!(reason_code, None);
+        let stranded_checksum: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-signal-failure-event"],
+                |row| row.get(0),
+            )
+            .expect("read stranded checksum");
+        assert_eq!(stranded_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+
+        db.conn_ref()
+            .execute_batch("DROP TRIGGER fail_claim_feedback_signal_repair;")
+            .expect("remove signal repair failure trigger");
+        let original_checksum = authorize_sidecar(&db, &sidecar);
+        let retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-original-retry",
+            &sidecar,
+            &original_checksum,
+        )
+        .expect("original retry remains recoverable");
+
+        assert_eq!(retry.already_applied_count, 1);
+        assert_eq!(retry.failed_count, 0);
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 1);
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_failed_terminal_update_keeps_content_retryable() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated")).expect("commit claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &claim_id,
+            "old-runtime-claim-id",
+            "legacy-terminal-failure-event",
+        );
+        let feedback = &sidecar.claims[0].feedback_rows[0];
+        let action = feedback_action_from_slug(&feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: claim_id.clone(),
+                    action,
+                    actor: feedback.actor.clone(),
+                    actor_id: feedback.actor_id.clone(),
+                    payload_json,
+                },
+                replay_event_id: feedback.feedback_id.clone(),
+                submitted_at,
+            },
+        )
+        .expect("record feedback before crash");
+        insert_claimed_legacy_replay_journal(&db, &sidecar, &claim_id);
+
+        let mut bad_content_sidecar = sidecar.clone();
+        bad_content_sidecar.claims[0].feedback_rows[0].submitted_at =
+            "2026-05-01T08:30:01Z".to_string();
+        let bad_checksum = authorize_sidecar(&db, &bad_content_sidecar);
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER fail_replay_failed_terminal_update
+                 BEFORE UPDATE ON rebuild_correction_replay_events
+                 WHEN NEW.sidecar_event_id = 'legacy-terminal-failure-event'
+                   AND NEW.status = 'failed'
+                 BEGIN
+                    SELECT RAISE(FAIL, 'temporary terminal update failure');
+                 END;",
+            )
+            .expect("install failed terminal update trigger");
+
+        let err = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-bad-content",
+            &bad_content_sidecar,
+            &bad_checksum,
+        )
+        .expect_err("failed terminal update remains retryable");
+        assert!(
+            format!("{err:?}").contains("temporary terminal update failure"),
+            "unexpected error: {err:?}"
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "legacy-terminal-failure-event");
+        assert_eq!(status, "claimed");
+        assert_eq!(reason_code, None);
+        let (stored_hash, stored_checksum): (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash, sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-terminal-failure-event"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read retryable claimed row");
+        assert_eq!(stored_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+        assert_eq!(stored_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+
+        db.conn_ref()
+            .execute_batch("DROP TRIGGER fail_replay_failed_terminal_update;")
+            .expect("remove failed terminal update trigger");
+        let original_checksum = authorize_sidecar(&db, &sidecar);
+        let retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-original-retry",
+            &sidecar,
+            &original_checksum,
+        )
+        .expect("original retry remains recoverable");
+
+        assert_eq!(retry.already_applied_count, 1);
+        assert_eq!(retry.failed_count, 0);
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_collision_refuses_different_existing_feedback() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let first_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit first claim"),
+        );
+        let first_sidecar = sidecar_for_claim(
+            &db,
+            &first_claim_id,
+            "old-runtime-claim-id",
+            "legacy-mismatch-event",
+        );
+        let first_sidecar_claim = &first_sidecar.claims[0];
+        let first_feedback = &first_sidecar_claim.feedback_rows[0];
+        let action = feedback_action_from_slug(&first_feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(first_feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&first_feedback.submitted_at).expect("submitted at");
+
+        let mut second_proposal = proposal("Renewal risk is elevated for a different field");
+        second_proposal.field_path = Some("health.other_risk".to_string());
+        let second_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, second_proposal).expect("commit second claim"),
+        );
+        let second_feedback = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: second_claim_id.clone(),
+                    action,
+                    actor: first_feedback.actor.clone(),
+                    actor_id: first_feedback.actor_id.clone(),
+                    payload_json: payload_json.clone(),
+                },
+                replay_event_id: first_feedback.feedback_id.clone(),
+                submitted_at: submitted_at.clone(),
+            },
+        )
+        .expect("record mismatched feedback before crash");
+        db.conn_ref()
+            .execute(
+                "INSERT INTO rebuild_correction_replay_events (
+                    sidecar_event_id, run_id, sidecar_schema_version, source_runtime_claim_id,
+                    resolved_claim_id, action, status, reason_code, reason_detail_hash,
+                    semantic_identity_hash, feedback_content_hash, applied_feedback_id,
+                    attempt_count, claimed_at, applied_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'claimed', NULL, NULL, ?7, ?8, NULL, 1, ?9, NULL, ?9)",
+                params![
+                    &first_feedback.feedback_id,
+                    "run-before-crash",
+                    first_sidecar.schema_version as i64,
+                    &first_sidecar_claim.runtime_claim_id,
+                    &first_claim_id,
+                    &first_feedback.action,
+                    &first_sidecar_claim.semantic_identity.dedup_key_components_hash,
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    TS,
+                ],
+            )
+            .expect("insert claimed legacy journal row");
+        let checksum = authorize_sidecar(&db, &first_sidecar);
+
+        let report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-mismatch",
+            &first_sidecar,
+            &checksum,
+        )
+        .expect("mismatched existing feedback is terminalized");
+
+        assert_eq!(report.already_applied_count, 0);
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            feedback_count_for_replay(&db, "legacy-mismatch-event"),
+            1,
+            "the pre-existing mismatched feedback row is left alone"
+        );
+        assert_eq!(
+            feedback_id_for_replay(&db, "legacy-mismatch-event"),
+            second_feedback.feedback_id
+        );
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "legacy-mismatch-event");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert!(detail_hash.is_some());
+        let applied_feedback_id: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT applied_feedback_id
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-mismatch-event"],
+                |row| row.get(0),
+            )
+            .expect("read applied feedback id");
+        assert_eq!(applied_feedback_id, None);
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "legacy-mismatch-event").as_deref(),
+            Some(first_claim_id.as_str())
+        );
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_collision_refuses_same_claim_different_action() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated")).expect("commit claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &claim_id,
+            "old-runtime-claim-id",
+            "legacy-action-mismatch-event",
+        );
+        let feedback = &sidecar.claims[0].feedback_rows[0];
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        let existing_feedback = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: claim_id.clone(),
+                    action: FeedbackAction::ConfirmCurrent,
+                    actor: feedback.actor.clone(),
+                    actor_id: feedback.actor_id.clone(),
+                    payload_json,
+                },
+                replay_event_id: feedback.feedback_id.clone(),
+                submitted_at,
+            },
+        )
+        .expect("record wrong-action feedback before crash");
+        insert_claimed_legacy_replay_journal(&db, &sidecar, &claim_id);
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-action-mismatch",
+            &sidecar,
+            &checksum,
+        )
+        .expect("wrong-action existing feedback is terminalized");
+
+        assert_eq!(report.already_applied_count, 0);
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            feedback_id_for_replay(&db, "legacy-action-mismatch-event"),
+            existing_feedback.feedback_id
+        );
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "legacy-action-mismatch-event");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert!(detail_hash.is_some());
+        let applied_feedback_id: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT applied_feedback_id
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-action-mismatch-event"],
+                |row| row.get(0),
+            )
+            .expect("read applied feedback id");
+        assert_eq!(applied_feedback_id, None);
+    }
+
+    #[test]
+    fn dos832_replay_claimed_legacy_collision_refuses_same_claim_different_content() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated")).expect("commit claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &claim_id,
+            "old-runtime-claim-id",
+            "legacy-content-mismatch-event",
+        );
+        let feedback = &sidecar.claims[0].feedback_rows[0];
+        let action = feedback_action_from_slug(&feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        let expected_content_hash =
+            feedback_content_hash(feedback, action, payload_json.as_deref(), &submitted_at)
+                .expect("expected content hash");
+        let existing_feedback = record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: claim_id.clone(),
+                    action,
+                    actor: feedback.actor.clone(),
+                    actor_id: feedback.actor_id.clone(),
+                    payload_json: payload_json.clone(),
+                },
+                replay_event_id: feedback.feedback_id.clone(),
+                submitted_at: "2026-05-01T08:30:01Z".to_string(),
+            },
+        )
+        .expect("record mismatched-content feedback before crash");
+        insert_claimed_legacy_replay_journal(&db, &sidecar, &claim_id);
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-content-mismatch",
+            &sidecar,
+            &checksum,
+        )
+        .expect("mismatched-content existing feedback is terminalized");
+
+        assert_eq!(report.already_applied_count, 0);
+        assert_eq!(report.failed_count, 1);
+        assert_eq!(
+            feedback_id_for_replay(&db, "legacy-content-mismatch-event"),
+            existing_feedback.feedback_id
+        );
+        let (status, reason_code, detail_hash) =
+            replay_journal_status_and_reason(&db, "legacy-content-mismatch-event");
+        assert_eq!(status, "failed");
+        assert_eq!(reason_code.as_deref(), Some("claim_feedback_replay_failed"));
+        assert!(detail_hash.is_some());
+        let applied_feedback_id: Option<String> = db
+            .conn_ref()
+            .query_row(
+                "SELECT applied_feedback_id
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-content-mismatch-event"],
+                |row| row.get(0),
+            )
+            .expect("read applied feedback id");
+        assert_eq!(applied_feedback_id, None);
+        let stored_hash: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-content-mismatch-event"],
+                |row| row.get(0),
+            )
+            .expect("read terminal content hash");
+        assert_eq!(stored_hash, expected_content_hash);
+        assert_ne!(stored_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+
+        let retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-content-mismatch-retry",
+            &sidecar,
+            &checksum,
+        )
+        .expect("failed terminal retry is idempotent");
+        assert_eq!(retry.failed_count, 1);
+        assert_eq!(
+            retry.events[0].reason_code.as_deref(),
+            Some("claim_feedback_replay_failed")
+        );
     }
 
     #[test]
@@ -1365,8 +3256,15 @@ mod tests {
         let first_feedback = &first_claim.feedback_rows[0];
         let action = feedback_action_from_slug(&first_feedback.action).expect("feedback action");
         let payload_json = feedback_payload_json(first_feedback).expect("payload json");
-        let content_hash = feedback_content_hash(first_feedback, action, payload_json.as_deref())
-            .expect("content hash");
+        let submitted_at =
+            canonical_feedback_submitted_at(&first_feedback.submitted_at).expect("submitted at");
+        let content_hash = feedback_content_hash(
+            first_feedback,
+            action,
+            payload_json.as_deref(),
+            &submitted_at,
+        )
+        .expect("content hash");
         let source_claim = SidecarClaimRef {
             runtime_claim_id: &first_claim.runtime_claim_id,
             identity: &first_claim.semantic_identity,
@@ -1376,6 +3274,7 @@ mod tests {
             ClaimReplayJournalInput {
                 scope: ReplayScope {
                     run_id: "run-1",
+                    sidecar_checksum: &sidecar_checksum(&first_sidecar),
                     sidecar_schema_version: first_sidecar.schema_version,
                 },
                 source_claim,
@@ -1400,7 +3299,7 @@ mod tests {
             "claimed-event",
         );
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("claimed event id must not retarget");
 
         assert!(
@@ -1411,6 +3310,207 @@ mod tests {
             replay_journal_resolved_claim_id(&db, "claimed-event").as_deref(),
             Some(first_claim_id.as_str())
         );
+    }
+
+    #[test]
+    fn dos832_replay_claimed_retry_does_not_self_stale_on_prior_version_event() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "claimed-retry-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let first = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("first replay applies");
+        assert_eq!(first.applied_count, 1);
+        assert_eq!(feedback_count_for_replay(&db, "claimed-retry-feedback"), 1);
+        let feedback_id = feedback_id_for_replay(&db, "claimed-retry-feedback");
+        let recorded_signal_id = claim_feedback_recorded_signal_id(&feedback_id);
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 1);
+        db.conn_ref()
+            .execute(
+                "DELETE FROM signal_events WHERE id = ?1",
+                params![&recorded_signal_id],
+            )
+            .expect("delete recorded feedback signal");
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 0);
+        let newer_replay_version_events: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM version_events
+                 WHERE claim_id = ?1
+                   AND event_kind = 'claim.corrected'
+                   AND created_at > ?2",
+                params![&fresh_claim_id, REPLAYED_FEEDBACK_TS],
+                |row| row.get(0),
+            )
+            .expect("count replay-created version events");
+        assert_eq!(newer_replay_version_events, 1);
+        db.conn_ref()
+            .execute(
+                "UPDATE rebuild_correction_replay_events
+                 SET status = 'claimed',
+                     applied_feedback_id = NULL,
+                     applied_at = NULL,
+                     updated_at = ?2
+                 WHERE sidecar_event_id = ?1",
+                params!["claimed-retry-feedback", TS],
+            )
+            .expect("simulate crash before replay journal terminalization");
+
+        let retry = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &sidecar, &checksum)
+            .expect("retry repairs claimed journal without self-stale");
+
+        assert_eq!(retry.already_applied_count, 1);
+        assert_eq!(retry.failed_count, 0);
+        assert_eq!(feedback_count_for_replay(&db, "claimed-retry-feedback"), 1);
+        assert_eq!(signal_count_for_id(&db, &recorded_signal_id), 1);
+        let repaired_payload: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT value FROM signal_events WHERE id = ?1",
+                params![&recorded_signal_id],
+                |row| row.get(0),
+            )
+            .expect("read repaired signal payload");
+        assert!(
+            repaired_payload.contains("\"recovered\":true"),
+            "retry must reach claim feedback repair path"
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "claimed-retry-feedback");
+        assert_eq!(status, "already_applied");
+        assert_eq!(reason_code, None);
+    }
+
+    #[test]
+    fn dos832_replay_same_sidecar_feedback_rows_do_not_self_stale() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "multi-feedback-1",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        let mut second_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        second_feedback.feedback_id = "multi-feedback-2".to_string();
+        second_feedback.action = "confirm_current".to_string();
+        second_feedback.submitted_at = "2026-05-01T08:31:00Z".to_string();
+        sidecar.claims[0].feedback_rows.push(second_feedback);
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect("same-sidecar feedback rows apply without self-stale");
+
+        assert_eq!(report.applied_count, 2);
+        assert_eq!(report.failed_count, 0);
+        assert_eq!(feedback_count_for_replay(&db, "multi-feedback-1"), 1);
+        assert_eq!(feedback_count_for_replay(&db, "multi-feedback-2"), 1);
+        let (status, reason_code, _) = replay_journal_status_and_reason(&db, "multi-feedback-2");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+        let tagged_replay_version_events: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*)
+                 FROM version_events
+                 WHERE claim_id = ?1
+                   AND correction_event_log_id IN ('multi-feedback-1', 'multi-feedback-2')",
+                params![&fresh_claim_id],
+                |row| row.get(0),
+            )
+            .expect("count tagged replay version events");
+        assert_eq!(tagged_replay_version_events, 2);
+    }
+
+    #[test]
+    fn dos832_replay_mismatched_sidecar_event_does_not_mask_stale_later_row() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "mismatched-stale-1",
+        );
+        sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-01T08:30:00Z".to_string();
+        let mut second_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        second_feedback.feedback_id = "mismatched-stale-2".to_string();
+        second_feedback.action = "confirm_current".to_string();
+        second_feedback.submitted_at = "2026-05-01T08:29:00Z".to_string();
+        sidecar.claims[0].feedback_rows.push(second_feedback);
+
+        let first_feedback = &sidecar.claims[0].feedback_rows[0];
+        let action = feedback_action_from_slug(&first_feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(first_feedback).expect("payload json");
+        record_claim_feedback_replay(
+            &ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: ClaimFeedbackInput {
+                    claim_id: fresh_claim_id.clone(),
+                    action,
+                    actor: first_feedback.actor.clone(),
+                    actor_id: first_feedback.actor_id.clone(),
+                    payload_json,
+                },
+                replay_event_id: first_feedback.feedback_id.clone(),
+                submitted_at: "2026-05-01T08:31:00Z".to_string(),
+            },
+        )
+        .expect("record mismatched newer replay feedback");
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let report = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-mismatched-stale",
+            &sidecar,
+            &checksum,
+        )
+        .expect("mismatched first row does not hide stale watermark");
+
+        assert_eq!(report.applied_count, 0);
+        assert_eq!(report.failed_count, 2);
+        let (first_status, first_reason, _) =
+            replay_journal_status_and_reason(&db, "mismatched-stale-1");
+        assert_eq!(first_status, "failed");
+        assert_eq!(
+            first_reason.as_deref(),
+            Some("claim_feedback_replay_failed")
+        );
+        let (second_status, second_reason, _) =
+            replay_journal_status_and_reason(&db, "mismatched-stale-2");
+        assert_eq!(second_status, "failed");
+        assert_eq!(second_reason.as_deref(), Some("stale_replay_watermark"));
+        assert_eq!(feedback_count_for_replay(&db, "mismatched-stale-1"), 1);
+        assert_eq!(feedback_count_for_replay(&db, "mismatched-stale-2"), 0);
     }
 
     #[test]
@@ -1425,11 +3525,40 @@ mod tests {
         );
         let sidecar = sidecar_for_claim(&db, &fresh_claim_id, "old-runtime-claim-id", "");
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+        let err = replay_authorized(&ctx, &db, "run-1", &sidecar)
             .expect_err("missing event id must reject");
 
         assert!(matches!(err, RebuildError::InvalidSidecar(_)));
         assert_eq!(feedback_count_for_replay(&db, ""), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_sidecar_feedback_without_stable_actor_id() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "blank-actor-feedback",
+        );
+        sidecar.claims[0].feedback_rows[0].actor_id = Some("   ".to_string());
+        let checksum = sidecar_checksum(&sidecar);
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect_err("blank actor_id must reject before replay writes");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("stable actor_id"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "blank-actor-feedback"), 0);
         assert_eq!(replay_journal_count(&db), 0);
     }
 
@@ -1451,7 +3580,7 @@ mod tests {
         );
         sidecar.schema_version = CLAIM_FILE_SIDECAR_SCHEMA_VERSION + 1;
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+        let err = replay_authorized(&ctx, &db, "run-1", &sidecar)
             .expect_err("unsupported sidecar schema must reject");
 
         assert!(matches!(err, RebuildError::InvalidSidecar(_)));
@@ -1478,11 +3607,44 @@ mod tests {
         let duplicate_feedback = sidecar.claims[0].feedback_rows[0].clone();
         sidecar.claims[0].feedback_rows.push(duplicate_feedback);
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
+        let err = replay_authorized(&ctx, &db, "run-1", &sidecar)
             .expect_err("duplicate event id must reject");
 
         assert!(matches!(err, RebuildError::InvalidSidecar(_)));
         assert_eq!(feedback_count_for_replay(&db, "dupe-feedback"), 0);
+        assert_eq!(replay_journal_count(&db), 0);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_unsupported_later_feedback_action_before_writes() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "valid-before-bad-action",
+        );
+        let mut invalid_feedback = sidecar.claims[0].feedback_rows[0].clone();
+        invalid_feedback.feedback_id = "bad-action-after-valid".to_string();
+        invalid_feedback.action = "not_a_real_action".to_string();
+        sidecar.claims[0].feedback_rows.push(invalid_feedback);
+        let checksum = authorize_sidecar(&db, &sidecar);
+
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect_err("unsupported action must reject before any replay writes");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("unsupported feedback action"))
+        );
+        assert_eq!(feedback_count_for_replay(&db, "valid-before-bad-action"), 0);
+        assert_eq!(feedback_count_for_replay(&db, "bad-action-after-valid"), 0);
         assert_eq!(replay_journal_count(&db), 0);
     }
 
@@ -1506,8 +3668,7 @@ mod tests {
             .semantic_identity
             .dedup_key_components_hash = "missing-semantic-identity".to_string();
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay sidecar");
+        let report = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay sidecar");
 
         assert_eq!(report.applied_count, 0);
         assert_eq!(report.orphaned_count, 1);
@@ -1544,8 +3705,7 @@ mod tests {
         sidecar.claims[0].semantic_identity.source_ref = Some("fixture://source-2".to_string());
         sidecar.claims[0].semantic_identity.source_asof = Some("2026-06-05T13:00:00Z".to_string());
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay sidecar");
+        let report = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay sidecar");
 
         assert_eq!(report.applied_count, 0);
         assert_eq!(report.orphaned_count, 1);
@@ -1554,6 +3714,298 @@ mod tests {
             feedback_count_for_replay(&db, "source-mismatch-feedback"),
             0
         );
+    }
+
+    #[test]
+    fn dos832_replay_recovers_orphan_when_same_sidecar_later_resolves() {
+        let db = test_db();
+        let builder_db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        seed_account(&builder_db);
+
+        let mut matching_proposal = proposal("Renewal risk is elevated");
+        matching_proposal.source_ref = Some("fixture://source-2".to_string());
+        matching_proposal.source_asof = Some("2026-06-05T13:00:00Z".to_string());
+        let future_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &builder_db, matching_proposal.clone())
+                .expect("commit future sidecar identity claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &builder_db,
+            &future_claim_id,
+            "old-runtime-claim-id",
+            "recoverable-orphan-feedback",
+        );
+
+        let first = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        assert_eq!(first.orphaned_count, 1);
+        assert_eq!(
+            feedback_count_for_replay(&db, "recoverable-orphan-feedback"),
+            0
+        );
+
+        let resolved_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, matching_proposal).expect("commit matching claim"),
+        );
+        let second = replay_authorized(&ctx, &db, "run-2", &sidecar).expect("retry replay");
+
+        assert_eq!(second.applied_count, 1);
+        assert_eq!(second.orphaned_count, 0);
+        assert_eq!(
+            second.events[0].resolved_claim_id.as_deref(),
+            Some(resolved_claim_id.as_str())
+        );
+        assert_eq!(
+            feedback_count_for_replay(&db, "recoverable-orphan-feedback"),
+            1
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "recoverable-orphan-feedback");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+    }
+
+    #[test]
+    fn dos832_replay_recovers_migrated_orphan_with_legacy_content_placeholder() {
+        let db = test_db();
+        let builder_db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        seed_account(&builder_db);
+
+        let mut matching_proposal = proposal("Renewal risk is elevated");
+        matching_proposal.source_ref = Some("fixture://source-2".to_string());
+        matching_proposal.source_asof = Some("2026-06-05T13:00:00Z".to_string());
+        let future_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &builder_db, matching_proposal.clone())
+                .expect("commit future sidecar identity claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &builder_db,
+            &future_claim_id,
+            "old-runtime-claim-id",
+            "legacy-placeholder-orphan-feedback",
+        );
+
+        let first = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        assert_eq!(first.orphaned_count, 1);
+        db.conn_ref()
+            .execute(
+                "UPDATE rebuild_correction_replay_events
+                    SET feedback_content_hash = ?1,
+                        sidecar_checksum = ?2
+                  WHERE sidecar_event_id = ?3",
+                params![
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    LEGACY_V283_UNSET_SIDECAR_CHECKSUM,
+                    "legacy-placeholder-orphan-feedback",
+                ],
+            )
+            .expect("simulate v283 migrated orphan placeholder");
+
+        let resolved_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, matching_proposal).expect("commit matching claim"),
+        );
+        let mut drifted_sidecar = sidecar.clone();
+        drifted_sidecar.claims[0].claim_text =
+            "Renewal risk is elevated in the sidecar projection".to_string();
+        let drifted_checksum = authorize_sidecar(&db, &drifted_sidecar);
+        let feedback = &sidecar.claims[0].feedback_rows[0];
+        let action = feedback_action_from_slug(&feedback.action).expect("feedback action");
+        let payload_json = feedback_payload_json(feedback).expect("payload json");
+        let submitted_at =
+            canonical_feedback_submitted_at(&feedback.submitted_at).expect("submitted at");
+        let expected_content_hash =
+            feedback_content_hash(feedback, action, payload_json.as_deref(), &submitted_at)
+                .expect("expected content hash");
+
+        let second = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-2",
+            &drifted_sidecar,
+            &drifted_checksum,
+        )
+        .expect("migrated orphan placeholder reclaims");
+
+        assert_eq!(second.applied_count, 1);
+        assert_eq!(second.orphaned_count, 0);
+        assert_eq!(
+            second.events[0].resolved_claim_id.as_deref(),
+            Some(resolved_claim_id.as_str())
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "legacy-placeholder-orphan-feedback");
+        assert_eq!(status, "applied");
+        assert_eq!(reason_code, None);
+        let (stored_hash, stored_checksum): (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash, sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-placeholder-orphan-feedback"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read migrated orphan terminal row");
+        assert_eq!(stored_hash, expected_content_hash);
+        assert_eq!(stored_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+
+        let original_checksum = authorize_sidecar(&db, &sidecar);
+        let original_retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-original",
+            &sidecar,
+            &original_checksum,
+        )
+        .expect("original sidecar remains recoverable");
+        assert_eq!(original_retry.already_applied_count, 1);
+        assert_eq!(original_retry.failed_count, 0);
+
+        let mut changed_content_sidecar = sidecar.clone();
+        changed_content_sidecar.claims[0].feedback_rows[0].submitted_at =
+            "2026-05-01T08:30:01Z".to_string();
+        let changed_content_checksum = authorize_sidecar(&db, &changed_content_sidecar);
+        let err = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-changed-content",
+            &changed_content_sidecar,
+            &changed_content_checksum,
+        )
+        .expect_err("checksum-neutral terminal row still rejects changed content");
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
+        );
+        assert_eq!(
+            feedback_count_for_replay(&db, "legacy-placeholder-orphan-feedback"),
+            1
+        );
+        let (final_status, final_reason, _) =
+            replay_journal_status_and_reason(&db, "legacy-placeholder-orphan-feedback");
+        assert_eq!(final_status, "applied");
+        assert_eq!(final_reason, None);
+        let (final_hash, final_checksum): (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash, sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-placeholder-orphan-feedback"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read unchanged migrated orphan terminal row");
+        assert_eq!(final_hash, stored_hash);
+        assert_eq!(final_checksum, stored_checksum);
+    }
+
+    #[test]
+    fn dos832_replay_migrated_orphan_reclaim_failure_keeps_placeholders_retryable() {
+        let db = test_db();
+        let builder_db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        seed_account(&builder_db);
+
+        let mut matching_proposal = proposal("Renewal risk is elevated");
+        matching_proposal.source_ref = Some("fixture://source-2".to_string());
+        matching_proposal.source_asof = Some("2026-06-05T13:00:00Z".to_string());
+        let future_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &builder_db, matching_proposal.clone())
+                .expect("commit future sidecar identity claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &builder_db,
+            &future_claim_id,
+            "old-runtime-claim-id",
+            "legacy-placeholder-orphan-failure",
+        );
+
+        let first = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("first replay");
+        assert_eq!(first.orphaned_count, 1);
+        db.conn_ref()
+            .execute(
+                "UPDATE rebuild_correction_replay_events
+                    SET feedback_content_hash = ?1,
+                        sidecar_checksum = ?2
+                  WHERE sidecar_event_id = ?3",
+                params![
+                    LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH,
+                    LEGACY_V283_UNSET_SIDECAR_CHECKSUM,
+                    "legacy-placeholder-orphan-failure",
+                ],
+            )
+            .expect("simulate v283 migrated orphan placeholder");
+        let resolved_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, matching_proposal).expect("commit matching claim"),
+        );
+
+        let mut bad_content_sidecar = sidecar.clone();
+        bad_content_sidecar.claims[0].feedback_rows[0].submitted_at =
+            "2026-05-01T08:30:01Z".to_string();
+        let bad_checksum = authorize_sidecar(&db, &bad_content_sidecar);
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER fail_migrated_orphan_replay_insert
+                 BEFORE INSERT ON claim_feedback
+                 WHEN NEW.replay_event_id = 'legacy-placeholder-orphan-failure'
+                 BEGIN
+                    SELECT RAISE(FAIL, 'temporary migrated orphan replay failure');
+                 END;",
+            )
+            .expect("install migrated orphan replay failure trigger");
+
+        let err = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-bad-content",
+            &bad_content_sidecar,
+            &bad_checksum,
+        )
+        .expect_err("transient replay failure remains retryable");
+        assert!(
+            matches!(err, RebuildError::ClaimReplay(message) if message.contains("temporary migrated orphan replay failure"))
+        );
+        assert_eq!(
+            replay_journal_resolved_claim_id(&db, "legacy-placeholder-orphan-failure").as_deref(),
+            Some(resolved_claim_id.as_str())
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "legacy-placeholder-orphan-failure");
+        assert_eq!(status, "claimed");
+        assert_eq!(reason_code, None);
+        let (stored_hash, stored_checksum): (String, String) = db
+            .conn_ref()
+            .query_row(
+                "SELECT feedback_content_hash, sidecar_checksum
+                   FROM rebuild_correction_replay_events
+                  WHERE sidecar_event_id = ?1",
+                params!["legacy-placeholder-orphan-failure"],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read retryable migrated orphan row");
+        assert_eq!(stored_hash, LEGACY_V282_UNSET_FEEDBACK_CONTENT_HASH);
+        assert_eq!(stored_checksum, LEGACY_V283_UNSET_SIDECAR_CHECKSUM);
+
+        db.conn_ref()
+            .execute_batch("DROP TRIGGER fail_migrated_orphan_replay_insert;")
+            .expect("remove migrated orphan replay failure trigger");
+        let original_checksum = authorize_sidecar(&db, &sidecar);
+        let retry = replay_claim_file_sidecar_corrections(
+            &ctx,
+            &db,
+            "run-original",
+            &sidecar,
+            &original_checksum,
+        )
+        .expect("original sidecar remains recoverable");
+        assert_eq!(retry.applied_count, 1);
+        assert_eq!(retry.failed_count, 0);
     }
 
     #[test]
@@ -1581,8 +4033,7 @@ mod tests {
             "ambiguous-feedback",
         );
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay sidecar");
+        let report = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay sidecar");
 
         assert_eq!(report.applied_count, 0);
         assert_eq!(report.orphaned_count, 1);
@@ -1616,8 +4067,7 @@ mod tests {
         valid_feedback.action = "cannot_verify".to_string();
         sidecar.claims[0].feedback_rows.push(valid_feedback);
 
-        let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
-            .expect("replay sidecar");
+        let report = replay_authorized(&ctx, &db, "run-1", &sidecar).expect("replay sidecar");
 
         assert_eq!(report.failed_count, 1);
         assert_eq!(report.applied_count, 1);
@@ -1634,6 +4084,62 @@ mod tests {
     }
 
     #[test]
+    fn dos832_replay_retryable_claim_service_failure_remains_claimed() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "retryable-db-error-feedback",
+        );
+        let checksum = authorize_sidecar(&db, &sidecar);
+        db.conn_ref()
+            .execute_batch(
+                "CREATE TRIGGER fail_retryable_replay_insert
+                 BEFORE INSERT ON claim_feedback
+                 WHEN NEW.replay_event_id = 'retryable-db-error-feedback'
+                 BEGIN
+                    SELECT RAISE(FAIL, 'temporary replay insert failure');
+                 END;",
+            )
+            .expect("install transient failure trigger");
+
+        let first = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar, &checksum)
+            .expect_err("transient db failure should abort replay run");
+        assert!(
+            matches!(&first, RebuildError::ClaimReplay(message) if message.contains("temporary replay insert failure")),
+            "unexpected error: {first:?}"
+        );
+        let (status, reason_code, _) =
+            replay_journal_status_and_reason(&db, "retryable-db-error-feedback");
+        assert_eq!(status, "claimed");
+        assert_eq!(reason_code, None);
+        assert_eq!(
+            feedback_count_for_replay(&db, "retryable-db-error-feedback"),
+            0
+        );
+
+        db.conn_ref()
+            .execute_batch("DROP TRIGGER fail_retryable_replay_insert;")
+            .expect("remove transient failure trigger");
+        let second = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &sidecar, &checksum)
+            .expect("retry succeeds");
+
+        assert_eq!(second.applied_count, 1);
+        assert_eq!(
+            feedback_count_for_replay(&db, "retryable-db-error-feedback"),
+            1
+        );
+    }
+
+    #[test]
     fn dos832_replay_rejects_retargeting_failed_event_id() {
         let db = test_db();
         let (clock, rng, external) = ctx_parts();
@@ -1646,9 +4152,8 @@ mod tests {
         let mut failed_sidecar =
             sidecar_for_claim(&db, &first_claim_id, "old-runtime-claim-id", "event-1");
         failed_sidecar.claims[0].feedback_rows[0].action = "wrong_source".to_string();
-        let first_report =
-            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &failed_sidecar)
-                .expect("first replay fails terminally");
+        let first_report = replay_authorized(&ctx, &db, "run-1", &failed_sidecar)
+            .expect("first replay fails terminally");
         assert_eq!(first_report.failed_count, 1);
 
         let mut second_proposal = proposal("Renewal risk is elevated for a different field");
@@ -1658,7 +4163,7 @@ mod tests {
         let second_sidecar =
             sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-1");
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("failed event id must not retarget");
 
         assert!(
@@ -1690,8 +4195,7 @@ mod tests {
             .semantic_identity
             .dedup_key_components_hash = "missing-semantic-identity".to_string();
         let first_report =
-            replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &orphan_sidecar)
-                .expect("first replay orphans");
+            replay_authorized(&ctx, &db, "run-1", &orphan_sidecar).expect("first replay orphans");
         assert_eq!(first_report.orphaned_count, 1);
 
         let mut second_proposal = proposal("Renewal risk is elevated for a different field");
@@ -1701,7 +4205,7 @@ mod tests {
         let second_sidecar =
             sidecar_for_claim(&db, &second_claim_id, "other-runtime-claim-id", "event-2");
 
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("orphaned event id must not retarget");
 
         assert!(
@@ -1734,8 +4238,7 @@ mod tests {
             "old-runtime-claim-id",
             "reused-feedback",
         );
-        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
-            .expect("first replay");
+        replay_authorized(&ctx, &db, "run-1", &first_sidecar).expect("first replay");
 
         let second_sidecar = sidecar_for_claim(
             &db,
@@ -1743,7 +4246,7 @@ mod tests {
             "other-runtime-claim-id",
             "reused-feedback",
         );
-        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+        let err = replay_authorized(&ctx, &db, "run-2", &second_sidecar)
             .expect_err("reused terminal event id must reject target mismatch");
 
         assert!(

--- a/src-tauri/src/services/rebuild.rs
+++ b/src-tauri/src/services/rebuild.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -262,6 +262,7 @@ fn validate_replay_sidecar(sidecar: &ClaimFileSidecar) -> Result<(), RebuildErro
             ));
         }
         for (feedback_index, feedback) in claim.feedback_rows.iter().enumerate() {
+            validate_feedback_submitted_at(&feedback.submitted_at)?;
             if sidecar.schema_version == CLAIM_FILE_SIDECAR_SCHEMA_VERSION
                 && feedback.feedback_id.trim().is_empty()
             {
@@ -334,8 +335,23 @@ fn feedback_content_hash(
         &feedback.actor,
         feedback.actor_id.as_deref(),
         payload_json,
+        &feedback.submitted_at,
     )
     .map_err(|error| RebuildError::InvalidSidecar(error.to_string()))
+}
+
+fn validate_feedback_submitted_at(submitted_at: &str) -> Result<(), RebuildError> {
+    if submitted_at.trim().is_empty() {
+        return Err(RebuildError::InvalidSidecar(
+            "sidecar feedback row missing submitted_at".to_string(),
+        ));
+    }
+    DateTime::parse_from_rfc3339(submitted_at.trim()).map_err(|error| {
+        RebuildError::InvalidSidecar(format!(
+            "sidecar feedback row submitted_at must be RFC3339: {error}"
+        ))
+    })?;
+    Ok(())
 }
 
 fn replay_feedback_event(
@@ -388,6 +404,7 @@ fn replay_feedback_event(
                 payload_json,
             },
             replay_event_id: feedback.event_id.to_string(),
+            submitted_at: feedback.row.submitted_at.clone(),
         },
     ) {
         Ok(outcome) => outcome,
@@ -831,6 +848,7 @@ mod tests {
     use abilities_runtime::types::{ClaimSensitivity, TemporalScope};
 
     const TS: &str = "2026-06-05T12:00:00Z";
+    const REPLAYED_FEEDBACK_TS: &str = "2026-05-01T08:30:00Z";
     const SUBJECT: &str = r#"{"kind":"account","id":"acct-1"}"#;
 
     fn ctx_parts() -> (FixedClock, SeedableRng, ExternalClients) {
@@ -974,6 +992,16 @@ mod tests {
             .expect("count replay journal")
     }
 
+    fn feedback_submitted_at_for_replay(db: &ActionDb, replay_event_id: &str) -> String {
+        db.conn_ref()
+            .query_row(
+                "SELECT submitted_at FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .expect("read replay feedback submitted_at")
+    }
+
     fn replay_journal_status_and_reason(
         db: &ActionDb,
         replay_event_id: &str,
@@ -1036,12 +1064,13 @@ mod tests {
             commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
                 .expect("commit fresh claim"),
         );
-        let sidecar = sidecar_for_claim(
+        let mut sidecar = sidecar_for_claim(
             &db,
             &fresh_claim_id,
             "old-runtime-claim-id",
             "old-feedback-1",
         );
+        sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
 
         let report = replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &sidecar)
             .expect("replay sidecar");
@@ -1058,6 +1087,10 @@ mod tests {
             Some(fresh_claim_id.as_str())
         );
         assert_eq!(feedback_count_for_replay(&db, "old-feedback-1"), 1);
+        assert_eq!(
+            feedback_submitted_at_for_replay(&db, "old-feedback-1"),
+            REPLAYED_FEEDBACK_TS
+        );
         let (verification_state, claim_version) =
             claim_verification_state_and_version(&db, &fresh_claim_id);
         assert_eq!(verification_state, "contested");
@@ -1181,6 +1214,40 @@ mod tests {
             matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
         );
         assert_eq!(feedback_count_for_replay(&db, "payload-event"), 1);
+    }
+
+    #[test]
+    fn dos832_replay_rejects_same_event_id_with_changed_submitted_at() {
+        let db = test_db();
+        let (clock, rng, external) = ctx_parts();
+        let ctx = ServiceContext::test_live(&clock, &rng, &external);
+        seed_account(&db);
+        let fresh_claim_id = inserted_claim_id(
+            commit_claim(&ctx, &db, proposal("Renewal risk is elevated"))
+                .expect("commit fresh claim"),
+        );
+        let mut first_sidecar = sidecar_for_claim(
+            &db,
+            &fresh_claim_id,
+            "old-runtime-claim-id",
+            "submitted-at-event",
+        );
+        first_sidecar.claims[0].feedback_rows[0].submitted_at = REPLAYED_FEEDBACK_TS.to_string();
+        replay_claim_file_sidecar_corrections(&ctx, &db, "run-1", &first_sidecar)
+            .expect("first replay");
+
+        let mut second_sidecar = first_sidecar;
+        second_sidecar.claims[0].feedback_rows[0].submitted_at = "2026-05-02T08:30:00Z".to_string();
+        let err = replay_claim_file_sidecar_corrections(&ctx, &db, "run-2", &second_sidecar)
+            .expect_err("same replay id must not hide changed submitted_at");
+
+        assert!(
+            matches!(err, RebuildError::InvalidSidecar(message) if message.contains("feedback content"))
+        );
+        assert_eq!(
+            feedback_submitted_at_for_replay(&db, "submitted-at-event"),
+            REPLAYED_FEEDBACK_TS
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linear ticket

DOS-832

## Summary

Adds the DOS-832 L1a correction-replay substrate: claim-file sidecar feedback can replay into regenerated claim IDs through the claim service, with durable replay journals, committed-projection authorization, idempotency, signal repair, stale protection, and legacy-placeholder recovery semantics.

## What changed

- Added replay journal migration/repair coverage for `claim_feedback.replay_event_id`, `rebuild_correction_replay_events`, feedback content hashes, sidecar checksums, and v283 draft-shape repair.
- Added `services::rebuild::replay_claim_file_sidecar_corrections` to authenticate committed sidecars, resolve regenerated claims by semantic identity, claim replay events, replay feedback through `services::claims`, and report applied/orphan/failed outcomes.
- Hardened replay recovery for legacy claimed/orphan placeholders, retryable failures, content/action/claim collisions, signal repair, and content-aware stale-watermark exclusions.
- Extended claim-file sidecars with stable feedback IDs and semantic endpoint identities, while preserving legacy v1 sidecar replay via deterministic derived keys.
- Updated the DOS-832 proof bundle with Cycle 16 all-pass L2 reviewer results.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes
- [x] `pnpm tsc --noEmit` clean
- [ ] `pnpm test` passes (if frontend changes)
- [x] Focused validation:
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib dos832_replay_rejects_unsupported_later_feedback_action_before_writes`
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib dos832_replay_mismatched_sidecar_event_does_not_mask_stale_later_row`
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib migrated_orphan`
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib dos832` (43 passed)
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib apply_claim_file_corrections_repairs_signal_for_already_applied_feedback`
  - `cargo test --manifest-path src-tauri/Cargo.toml --lib record_claim_feedback_replay_event`
  - `cargo test --manifest-path src-tauri/Cargo.toml --test dos7_d4_lint_test`
  - `git diff --check`
- [x] Manual verification: L2 reviewer cycle 16 returned PASS from data migrations, reliability, testing, security, and adversarial subagents.

## Definition of Done

- [x] Acceptance criteria from the Linear ticket are validated with real data (not stubs)
- [x] End-to-end flow works through to rendered surfaces
- [x] No stubs, TODOs, or "Phase 2" deferrals introduced (or each is tracked as its own ticket)
- [x] Tests pass: `cargo clippy -- -D warnings && cargo test && pnpm tsc --noEmit`

## §4 Security

`security_auditor_invoked: true`

**Exemption ID** (when the field above is set false): _none_

**Exemption rationale**: n/a

- [x] Touches `src-tauri/src/services/`, `abilities/`, `bridges/`, `commands/`, or `intelligence/`?
- [x] Modifies `.sql` migrations, `src-tauri/src/migrations.rs`, or `src-tauri/migrations/`?
- [x] Touches a claim-substrate table (`intelligence_claims`, `claim_corroborations`, `claim_contradictions`, `agent_trust_ledger`, `claim_feedback`, `claim_repair_job`, `claim_projection_status`)?
- [ ] Changes a prompt template (`.claude/**/*.md`, `.claude/skills/**`, `.claude/hooks/**`, `.claude/routines/**`, `prompts/**`)?
- [x] Modifies sensitivity, rendering policy, redaction, allowlist, or actor-filter logic?
- [ ] Modifies MCP configs (`.claude/settings*.json`), tool registry, or skill definitions?
- [ ] Adds a new trust boundary (auth, scope, sensitivity tier)?
- [x] Defines a privileged action (push, merge, post, run code, write to claim tables, mutate sensitivity)?
- [ ] Adds or modifies `.github/workflows/*` with network egress, secret access, or merge/publish authority?
- [ ] Adds a new dependency (`Cargo.toml`, `package.json`, lockfiles)?

## Follow-ups

- None in this PR.

## Notes for review

- This is a bounded L1a proof. It does not claim final plain-SQLite rebuild, live cutover, or full DOS-832 release completion; those boundaries are explicit in `.docs/proofs/v1.4.9/dos-832-l1a-correction-replay-proof.md`.
- Migrated `legacy-v283-unset` replay rows intentionally preserve checksum-neutral semantics because the original sidecar checksum was not recorded. Terminal rows still bind canonical feedback content hash.
