### PR TITLE
feat(mcp): complete public parity runtime

### DIFF
--- a/src-tauri/src/devtools/mod.rs
+++ b/src-tauri/src/devtools/mod.rs
@@ -30,6 +30,9 @@
 //! Composition layout overlays are also not statically seeded: they are local
 //! presentation preferences produced through `services::composition_layout`,
 //! not intelligence substrate or demo content.
+//! MCP target handles follow the same rule: they are conversation-scoped
+//! operational receipts minted by the MCP runtime from already-rendered output,
+//! not stable mock data or a user-facing fixture surface.
 
 use std::path::Path;
 

--- a/src-tauri/src/mcp/main.rs
+++ b/src-tauri/src/mcp/main.rs
@@ -1807,7 +1807,10 @@ fn local_stdio_exposure_for(side: Side, tool_name: &ScopedName) -> McpExposure {
 fn local_stdio_submit_correction_allowed(tool_name: &ScopedName) -> bool {
     matches!(
         tool_name.as_str(),
-        "dailyos.submit.note" | "dailyos.submit.action" | "dailyos.submit.action_status"
+        "dailyos.submit.claim_feedback"
+            | "dailyos.submit.note"
+            | "dailyos.submit.action"
+            | "dailyos.submit.action_status"
     )
 }
 
@@ -2019,6 +2022,13 @@ mod tests {
     fn local_stdio_exposure_keeps_write_handlers_non_invocable() {
         assert!(matches!(
             local_stdio_exposure_for(Side::Read, &ScopedName::new("dailyos.read.account_status")),
+            McpExposure::Invocable
+        ));
+        assert!(matches!(
+            local_stdio_exposure_for(
+                Side::SubmitCorrection,
+                &ScopedName::new("dailyos.submit.claim_feedback")
+            ),
             McpExposure::Invocable
         ));
         assert!(matches!(

--- a/src-tauri/src/migrations.rs
+++ b/src-tauri/src/migrations.rs
@@ -1162,6 +1162,13 @@ const MIGRATIONS: &[Migration] = &[
         version: 287,
         sql: include_str!("migrations/287_correction_stickiness_eval.sql"),
     },
+    // v1.4.9 W5 — registry-backed opaque MCP target handles. The W5 packet
+    // reserved registered schema version 290; current v1.4.9 migrations use
+    // same-number SQL filenames for this range.
+    Migration::Sql {
+        version: 290,
+        sql: include_str!("migrations/290_mcp_target_handles.sql"),
+    },
 ];
 
 const V155_SHADOW_TRUST_VERSION: i64 = 1_401_003;

--- a/src-tauri/src/migrations/290_mcp_target_handles.sql
+++ b/src-tauri/src/migrations/290_mcp_target_handles.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS mcp_target_handles (
+  handle_lookup_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL,
+  conversation_handle_hash TEXT NOT NULL,
+  originating_tool TEXT NOT NULL,
+  result_item_path TEXT NOT NULL,
+  target_kind TEXT NOT NULL CHECK (
+    target_kind IN ('claim', 'action', 'entity', 'source_provenance', 'workspace_source')
+  ),
+  target_ref_ciphertext BLOB NOT NULL,
+  target_ref_key_version INTEGER NOT NULL,
+  render_policy_version TEXT NOT NULL,
+  sensitivity_tier TEXT NOT NULL,
+  provenance_hash TEXT NOT NULL,
+  target_watermark_hash TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  last_used_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  revoked_reason_code TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_target_handles_client_conversation
+  ON mcp_target_handles (client_id, conversation_handle_hash, originating_tool);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_target_handles_expiry
+  ON mcp_target_handles (expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_target_handles_revoked
+  ON mcp_target_handles (revoked_at)
+  WHERE revoked_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mcp_target_handles_target_watermark
+  ON mcp_target_handles (target_kind, target_watermark_hash);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_target_handles_deterministic_target
+  ON mcp_target_handles (
+    client_id,
+    conversation_handle_hash,
+    originating_tool,
+    result_item_path,
+    target_kind,
+    provenance_hash,
+    target_watermark_hash
+  );

--- a/src-tauri/src/services/actions.rs
+++ b/src-tauri/src/services/actions.rs
@@ -8,6 +8,7 @@ use crate::db::ActionDb;
 use crate::services::context::ServiceContext;
 use crate::state::AppState;
 use crate::types::{Action, Priority};
+use rusqlite::params;
 
 /// Emit a propagation signal and warn-log on failure instead of dropping
 /// the Result silently. Action signals feed downstream callouts and
@@ -185,6 +186,97 @@ pub fn complete_action(
     }
 
     Ok(())
+}
+
+/// Complete an action through MCP only when the row is still in an open stored
+/// status at the write boundary.
+pub fn complete_action_for_mcp(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    id: &str,
+) -> Result<Option<String>, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    crate::util::validate_id_slug(id, "id")?;
+    let Some(action) = db.get_action_by_id(id).map_err(|e| e.to_string())? else {
+        return Ok(None);
+    };
+    if action.status == crate::action_status::COMPLETED {
+        return Ok(Some(crate::action_status::COMPLETED.to_string()));
+    }
+    if !matches!(
+        action.status.as_str(),
+        crate::action_status::UNSTARTED | crate::action_status::STARTED
+    ) {
+        return Ok(None);
+    }
+
+    let now = ctx.clock.now().to_rfc3339();
+    let changed = db
+        .conn_ref()
+        .execute(
+            "UPDATE actions
+                SET status = ?1, completed_at = ?2, updated_at = ?2
+              WHERE id = ?3
+                AND status IN (?4, ?5)",
+            params![
+                crate::action_status::COMPLETED,
+                now,
+                id,
+                crate::action_status::UNSTARTED,
+                crate::action_status::STARTED,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    if changed == 0 {
+        return Ok(None);
+    }
+
+    sync_action_claim_after_mutation(ctx, db, id, "complete");
+    emit_action_composition_field_changed_signal(
+        ctx,
+        db,
+        id,
+        "status",
+        serde_json::Value::from(crate::action_status::COMPLETED),
+    );
+
+    let (entity_type, entity_id) = action_entity_info(&action, id);
+    emit_action_signal(
+        ctx,
+        db,
+        engine,
+        entity_type,
+        &entity_id,
+        "action_completed",
+        action.source_type.as_deref().unwrap_or("unknown"),
+        Some(&format!("{{\"action_id\":\"{}\"}}", id)),
+        0.7,
+    );
+
+    if action.action_kind == crate::action_status::KIND_COMMITMENT {
+        emit_action_signal(
+            ctx,
+            db,
+            engine,
+            entity_type,
+            &entity_id,
+            "commitment_delivered",
+            action.source_type.as_deref().unwrap_or("commitment"),
+            Some(&format!(
+                "{{\"action_id\":\"{}\",\"title\":\"{}\"}}",
+                id,
+                action.title.replace('"', "\\\"")
+            )),
+            0.8,
+        );
+        if let Err(e) = crate::services::commitment_bridge::tombstone_commitment_bridge(ctx, db, id)
+        {
+            log::warn!("commitment_bridge tombstone on complete failed (non-fatal): {e}");
+        }
+    }
+
+    Ok(Some(crate::action_status::COMPLETED.to_string()))
 }
 
 /// Reopen a completed action, setting it back to pending.
@@ -497,10 +589,24 @@ pub async fn get_all_actions(state: &AppState) -> ActionsResult {
 }
 
 /// Create a new action with validation and signal emission.
-pub async fn create_action(
+pub fn create_action_with_db(
     ctx: &ServiceContext<'_>,
     request: CreateActionRequest,
-    state: &Arc<AppState>,
+    db: &ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+) -> Result<String, String> {
+    create_action_with_db_with_id(ctx, request, db, engine, None)
+}
+
+/// Create a new action, optionally using a caller-supplied deterministic ID for
+/// server-side MCP replay. When the deterministic row already exists, this
+/// returns it without re-emitting create signals.
+pub fn create_action_with_db_with_id(
+    ctx: &ServiceContext<'_>,
+    request: CreateActionRequest,
+    db: &ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    deterministic_id: Option<&str>,
 ) -> Result<String, String> {
     ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     let CreateActionRequest {
@@ -541,9 +647,21 @@ pub async fn create_action(
     if let Some(ref value) = source_label {
         crate::util::validate_bounded_string(value, "source_label", 1, 200)?;
     }
+    if let Some(id) = deterministic_id {
+        crate::util::validate_id_slug(id, "action_id")?;
+        if db
+            .get_action_by_id(id)
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            return Ok(id.to_string());
+        }
+    }
 
     let now = ctx.clock.now().to_rfc3339();
-    let id = uuid::Uuid::new_v4().to_string();
+    let id = deterministic_id
+        .map(str::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
     let action_kind = action_kind
         .filter(|k| !k.trim().is_empty())
@@ -588,49 +706,58 @@ pub async fn create_action(
         linear_url: None,
     };
 
+    db.upsert_action(&action).map_err(|e| e.to_string())?;
+    sync_action_claim_after_mutation(ctx, db, &action.id, "create");
+
+    // Emit signal for manually created actions.
+    let (entity_type, entity_id) = action_entity_info(&action, &action.id);
+    emit_action_signal(
+        ctx,
+        db,
+        engine,
+        entity_type,
+        &entity_id,
+        "action_created_manually",
+        "user_action",
+        Some(&format!(
+            "{{\"action_id\":\"{}\",\"title\":\"{}\"}}",
+            action.id,
+            action.title.replace('"', "\\\"")
+        )),
+        1.0,
+    );
+
+    // Scan for decision-indicating keywords after creation.
+    #[allow(
+        clippy::let_underscore_must_use,
+        reason = "intentional best-effort discard; preserves existing non-blocking behavior"
+    )]
+    let _ = db.scan_and_flag_decisions();
+
+    // Best-effort auto-link to matching objectives.
+    if let Some(ref acct_id) = action.account_id {
+        if let Err(e) = auto_link_action_to_objectives(ctx, db, &action.id, &action.title, acct_id)
+        {
+            log::warn!("Auto-link action to objectives failed (non-fatal): {}", e);
+        }
+    }
+
+    Ok(id)
+}
+
+/// Create a new action with validation and signal emission.
+pub async fn create_action(
+    ctx: &ServiceContext<'_>,
+    request: CreateActionRequest,
+    state: &Arc<AppState>,
+) -> Result<String, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
     let engine = state.signals.engine.clone();
     let state_for_ctx = state.clone();
     state
         .db_write(move |db| {
             let ctx = state_for_ctx.live_service_context();
-            db.upsert_action(&action).map_err(|e| e.to_string())?;
-            sync_action_claim_after_mutation(&ctx, db, &action.id, "create");
-
-            // Emit signal for manually created actions
-            let (entity_type, entity_id) = action_entity_info(&action, &action.id);
-            emit_action_signal(
-                &ctx,
-                db,
-                &engine,
-                entity_type,
-                &entity_id,
-                "action_created_manually",
-                "user_action",
-                Some(&format!(
-                    "{{\"action_id\":\"{}\",\"title\":\"{}\"}}",
-                    action.id,
-                    action.title.replace('"', "\\\"")
-                )),
-                1.0,
-            );
-
-            // Scan for decision-indicating keywords after creation
-            #[allow(
-                clippy::let_underscore_must_use,
-                reason = "intentional best-effort discard; preserves existing non-blocking behavior"
-            )]
-            let _ = db.scan_and_flag_decisions();
-
-            // Best-effort auto-link to matching objectives
-            if let Some(ref acct_id) = action.account_id {
-                if let Err(e) =
-                    auto_link_action_to_objectives(&ctx, db, &action.id, &action.title, acct_id)
-                {
-                    log::warn!("Auto-link action to objectives failed (non-fatal): {}", e);
-                }
-            }
-
-            Ok(id)
+            create_action_with_db(&ctx, request, db, &engine)
         })
         .await
         .map_err(String::from)
@@ -869,6 +996,207 @@ pub(crate) fn apply_update_action(
         emit_action_composition_field_changed_signal(ctx, db, &action.id, field, value);
     }
     Ok(())
+}
+
+/// Apply MCP's semantic `deferred` status without creating a new stored
+/// status. The action remains in its current open status and only the due date
+/// and optional context are updated through the normal update path.
+pub fn defer_action_for_mcp(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    id: &str,
+    defer_date: &str,
+    reason: Option<&str>,
+) -> Result<Option<String>, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    crate::util::validate_id_slug(id, "id")?;
+    crate::util::validate_yyyy_mm_dd(defer_date, "defer_date")?;
+    if let Some(reason) = reason {
+        crate::util::validate_bounded_string(reason, "reason", 1, 500)?;
+    }
+
+    let action = db
+        .get_action_by_id(id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Action not found: {id}"))?;
+    match action.status.as_str() {
+        crate::action_status::UNSTARTED | crate::action_status::STARTED => {}
+        _ => return Ok(None),
+    }
+
+    let context = reason.map(|reason| {
+        if let Some(existing) = action
+            .context
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            format!("{existing}\n\nDeferred via MCP: {reason}")
+        } else {
+            format!("Deferred via MCP: {reason}")
+        }
+    });
+    let now = ctx.clock.now().to_rfc3339();
+    let changed = db
+        .conn_ref()
+        .execute(
+            "UPDATE actions
+                SET due_date = ?1,
+                    context = COALESCE(?2, context),
+                    updated_at = ?3
+              WHERE id = ?4
+                AND status IN (?5, ?6)",
+            params![
+                defer_date,
+                context.as_deref(),
+                now,
+                id,
+                crate::action_status::UNSTARTED,
+                crate::action_status::STARTED,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+    if changed == 0 {
+        return Ok(None);
+    }
+    sync_action_claim_after_mutation(ctx, db, id, "defer");
+    emit_action_composition_field_changed_signal(
+        ctx,
+        db,
+        id,
+        "due_date",
+        serde_json::Value::from(defer_date),
+    );
+    if let Some(context) = context.as_deref() {
+        emit_action_composition_field_changed_signal(
+            ctx,
+            db,
+            id,
+            "context",
+            serde_json::Value::from(context),
+        );
+    }
+
+    let refreshed = db
+        .get_action_by_id(id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Action not found after defer: {id}"))?;
+    let (entity_type, entity_id) = action_entity_info(&refreshed, id);
+    emit_action_signal(
+        ctx,
+        db,
+        engine,
+        entity_type,
+        &entity_id,
+        "action_deferred",
+        "mcp_action_status",
+        Some(&format!(
+            "{{\"action_id\":\"{}\",\"defer_date\":\"{}\"}}",
+            id, defer_date
+        )),
+        0.7,
+    );
+    Ok(Some(refreshed.status))
+}
+
+/// Apply MCP's semantic `dropped` status through service-owned behavior.
+///
+/// Suggested/backlog rows keep the existing dismissal semantics and archive.
+/// Accepted/open rows become `cancelled` and still sync action claims and emit
+/// propagation signals from the service layer.
+pub fn drop_action_for_mcp(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    id: &str,
+    reason: Option<&str>,
+) -> Result<Option<String>, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+    crate::util::validate_id_slug(id, "id")?;
+    if let Some(reason) = reason {
+        crate::util::validate_bounded_string(reason, "reason", 1, 500)?;
+    }
+
+    let mut action = db
+        .get_action_by_id(id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Action not found: {id}"))?;
+    match action.status.as_str() {
+        crate::action_status::BACKLOG => {
+            match dismiss_suggested_action(ctx, db, engine, id, "mcp_action_status") {
+                Ok(()) => Ok(Some(crate::action_status::ARCHIVED.to_string())),
+                Err(error) if conditional_update_missed(&error) => Ok(None),
+                Err(error) => Err(error),
+            }
+        }
+        crate::action_status::UNSTARTED | crate::action_status::STARTED => {
+            action.status = crate::action_status::CANCELLED.to_string();
+            action.updated_at = ctx.clock.now().to_rfc3339();
+            if let Some(reason) = reason {
+                action.context = Some(
+                    if let Some(existing) = action
+                        .context
+                        .as_deref()
+                        .filter(|value| !value.trim().is_empty())
+                    {
+                        format!("{existing}\n\nDropped via MCP: {reason}")
+                    } else {
+                        format!("Dropped via MCP: {reason}")
+                    },
+                );
+            }
+            let changed = db
+                .conn_ref()
+                .execute(
+                    "UPDATE actions
+                        SET status = ?1,
+                            context = ?2,
+                            updated_at = ?3
+                      WHERE id = ?4
+                        AND status IN (?5, ?6)",
+                    params![
+                        crate::action_status::CANCELLED,
+                        action.context.as_deref(),
+                        action.updated_at.as_str(),
+                        id,
+                        crate::action_status::UNSTARTED,
+                        crate::action_status::STARTED,
+                    ],
+                )
+                .map_err(|e| e.to_string())?;
+            if changed == 0 {
+                return Ok(None);
+            }
+            sync_action_claim_after_mutation(ctx, db, id, "drop");
+            emit_action_composition_field_changed_signal(
+                ctx,
+                db,
+                id,
+                "status",
+                serde_json::Value::from(crate::action_status::CANCELLED),
+            );
+            let (entity_type, entity_id) = action_entity_info(&action, id);
+            emit_action_signal(
+                ctx,
+                db,
+                engine,
+                entity_type,
+                &entity_id,
+                "action_dropped",
+                "mcp_action_status",
+                Some(&format!("{{\"action_id\":\"{}\"}}", id)),
+                0.5,
+            );
+            Ok(Some(crate::action_status::CANCELLED.to_string()))
+        }
+        crate::action_status::CANCELLED => Ok(Some(crate::action_status::CANCELLED.to_string())),
+        crate::action_status::ARCHIVED => Ok(Some(crate::action_status::ARCHIVED.to_string())),
+        _ => Ok(None),
+    }
+}
+
+fn conditional_update_missed(error: &str) -> bool {
+    error.contains("QueryReturnedNoRows") || error.contains("query returned no rows")
 }
 
 /// Get full detail for a single action, with resolved relationships.
@@ -1161,6 +1489,40 @@ mod tests {
                 },
             )
             .unwrap()
+    }
+
+    #[test]
+    fn complete_action_for_mcp_refuses_non_open_status_at_write_boundary() {
+        let db = test_db();
+        make_ctx!(ctx);
+        db.conn_ref()
+            .execute(
+                "INSERT INTO actions
+                 (id, title, priority, status, created_at, updated_at, action_kind)
+                 VALUES ('action-cancelled', 'Cancelled action', 3, 'cancelled',
+                         '2026-01-01', '2026-01-01', 'task')",
+                [],
+            )
+            .unwrap();
+
+        let outcome = complete_action_for_mcp(
+            &ctx,
+            &db,
+            &crate::signals::propagation::PropagationEngine::new(),
+            "action-cancelled",
+        )
+        .unwrap();
+
+        assert_eq!(outcome, None);
+        let status: String = db
+            .conn_ref()
+            .query_row(
+                "SELECT status FROM actions WHERE id = 'action-cancelled'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, crate::action_status::CANCELLED);
     }
 
     #[test]

--- a/src-tauri/src/services/claims.rs
+++ b/src-tauri/src/services/claims.rs
@@ -246,6 +246,13 @@ pub struct VerifiedSurfaceFeedbackDelegation<'a> {
     pub trusted_surface: Option<&'a str>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct McpFeedbackDelegation<'a> {
+    pub client_id_hash: &'a str,
+    pub conversation_handle_hash: &'a str,
+    pub tool_name: &'a str,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClaimFeedbackReplayInput {
     pub feedback: ClaimFeedbackInput,
@@ -273,6 +280,7 @@ pub struct ClaimFileFeedbackApplyInput {
 struct ClaimFeedbackReplayWrite {
     event_id: String,
     submitted_at: String,
+    compare_submitted_at: bool,
 }
 
 /// Claim-generation contract boundary.
@@ -5559,7 +5567,7 @@ fn actor_class_for_actor(actor: &str) -> Option<ClaimActorClass> {
         .next()
         .unwrap_or(normalized.as_str());
     match head {
-        "user" | "human" => Some(ClaimActorClass::User),
+        "user" | "human" | "mcp" | "mcp_client" => Some(ClaimActorClass::User),
         "system" | "system_backfill" | "backfill" | "migration" | "repair" => {
             Some(ClaimActorClass::System)
         }
@@ -5569,6 +5577,14 @@ fn actor_class_for_actor(actor: &str) -> Option<ClaimActorClass> {
 }
 
 fn validate_feedback_actor(actor: &str) -> Result<(), ClaimError> {
+    let normalized = actor.trim().to_ascii_lowercase();
+    let head = normalized
+        .split([':', '/', '@'])
+        .next()
+        .unwrap_or(normalized.as_str());
+    if matches!(head, "user" | "human") {
+        return Ok(());
+    }
     let actor_class = actor_class_for_actor(actor).ok_or_else(|| {
         ClaimError::InvalidFeedback(format!(
             "actor '{}' does not map to a registered actor class",
@@ -5582,6 +5598,22 @@ fn validate_feedback_actor(actor: &str) -> Result<(), ClaimError> {
             "feedback actor '{}' maps to {}, but feedback is only accepted from user actors",
             actor,
             actor_class.as_str()
+        )))
+    }
+}
+
+fn validate_mcp_feedback_actor(actor: &str) -> Result<(), ClaimError> {
+    let normalized = actor.trim().to_ascii_lowercase();
+    let head = normalized
+        .split([':', '/', '@'])
+        .next()
+        .unwrap_or(normalized.as_str());
+    if matches!(head, "mcp" | "mcp_client") {
+        Ok(())
+    } else {
+        Err(ClaimError::InvalidFeedback(format!(
+            "MCP feedback actor must be mcp_client, got '{}'",
+            actor
         )))
     }
 }
@@ -5667,14 +5699,15 @@ fn validate_feedback_invocation(
     input: &ClaimFeedbackInput,
     invocation: FeedbackInvocation<'_>,
 ) -> Result<(), ClaimError> {
-    validate_feedback_actor(&input.actor)?;
     match invocation {
         FeedbackInvocation::Direct => {
+            validate_feedback_actor(&input.actor)?;
             crate::services::correction_artifacts::authorize_lifecycle_actor(service_actor)
                 .map_err(|error| ClaimError::Mode(error.to_string()))?;
             Ok(())
         }
         FeedbackInvocation::VerifiedSurface(delegation) => {
+            validate_feedback_actor(&input.actor)?;
             let normalized = service_actor.trim().to_ascii_lowercase();
             if normalized != "surface_client" {
                 return Err(ClaimError::Mode(format!(
@@ -5691,12 +5724,56 @@ fn validate_feedback_invocation(
             }
             Ok(())
         }
+        FeedbackInvocation::McpClient(delegation) => {
+            validate_mcp_feedback_actor(&input.actor)?;
+            let normalized = service_actor.trim().to_ascii_lowercase();
+            if normalized != "mcp_client" && normalized != "mcp" {
+                return Err(ClaimError::Mode(format!(
+                    "MCP feedback requires mcp_client service actor, got {service_actor}"
+                )));
+            }
+            if delegation.client_id_hash.trim().is_empty()
+                || delegation.conversation_handle_hash.trim().is_empty()
+                || delegation.tool_name.trim().is_empty()
+            {
+                return Err(ClaimError::InvalidFeedback(
+                    "MCP feedback requires client, conversation, and tool attribution hashes"
+                        .to_string(),
+                ));
+            }
+            Ok(())
+        }
         FeedbackInvocation::Replay => {
+            validate_feedback_actor(&input.actor)?;
             crate::services::correction_artifacts::authorize_service_lifecycle_actor(service_actor)
                 .map_err(|error| ClaimError::Mode(error.to_string()))?;
             Ok(())
         }
     }
+}
+
+fn attach_mcp_feedback_delegation_payload(
+    payload_json: Option<String>,
+    delegation: McpFeedbackDelegation<'_>,
+) -> Result<Option<String>, ClaimError> {
+    let mut payload = match payload_json {
+        Some(raw) => serde_json::from_str::<serde_json::Value>(&raw).map_err(|error| {
+            ClaimError::InvalidFeedback(format!("payload_json must be valid JSON: {error}"))
+        })?,
+        None => serde_json::json!({}),
+    };
+    let object = payload.as_object_mut().ok_or_else(|| {
+        ClaimError::InvalidFeedback("payload_json must be a JSON object".to_string())
+    })?;
+    object.insert(
+        "_mcp_delegation".to_string(),
+        serde_json::json!({
+            "client_id_hash": delegation.client_id_hash,
+            "conversation_handle_hash": delegation.conversation_handle_hash,
+            "tool_name": delegation.tool_name,
+        }),
+    );
+    Ok(Some(payload.to_string()))
 }
 
 fn attach_verified_surface_delegation_payload(
@@ -7442,6 +7519,60 @@ pub fn record_claim_feedback_from_verified_surface(
     )
 }
 
+pub fn record_claim_feedback_from_mcp(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    mut input: ClaimFeedbackInput,
+    delegation: McpFeedbackDelegation<'_>,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    load_claim_by_id(db.conn_ref(), &input.claim_id)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(input.claim_id.clone()))?;
+    input.payload_json =
+        attach_mcp_feedback_delegation_payload(input.payload_json.take(), delegation)?;
+    record_claim_feedback_inner(
+        ctx,
+        db,
+        input,
+        None,
+        None,
+        FeedbackInvocation::McpClient(delegation),
+    )
+}
+
+pub fn record_claim_feedback_replay_from_mcp(
+    ctx: &ServiceContext<'_>,
+    db: &ActionDb,
+    mut input: ClaimFeedbackReplayInput,
+    delegation: McpFeedbackDelegation<'_>,
+) -> Result<ClaimFeedbackOutcome, ClaimError> {
+    load_claim_by_id(db.conn_ref(), &input.feedback.claim_id)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(input.feedback.claim_id.clone()))?;
+    input.feedback.payload_json =
+        attach_mcp_feedback_delegation_payload(input.feedback.payload_json.take(), delegation)?;
+    let replay = prepare_mcp_claim_feedback_replay(&input)?;
+    record_claim_feedback_inner(
+        ctx,
+        db,
+        input.feedback,
+        None,
+        Some(replay),
+        FeedbackInvocation::McpClient(delegation),
+    )
+}
+
+pub fn recorded_claim_feedback_replay_outcome_from_mcp(
+    db: &ActionDb,
+    mut input: ClaimFeedbackReplayInput,
+    delegation: McpFeedbackDelegation<'_>,
+) -> Result<Option<ClaimFeedbackOutcome>, ClaimError> {
+    load_claim_by_id(db.conn_ref(), &input.feedback.claim_id)?
+        .ok_or_else(|| ClaimError::UnknownClaimId(input.feedback.claim_id.clone()))?;
+    input.feedback.payload_json =
+        attach_mcp_feedback_delegation_payload(input.feedback.payload_json.take(), delegation)?;
+    let replay = prepare_mcp_claim_feedback_replay(&input)?;
+    existing_feedback_replay_outcome(db, &input.feedback, &replay)
+}
+
 fn validate_verified_surface_payload_for_writer(
     claim: &IntelligenceClaim,
     action: FeedbackAction,
@@ -7555,6 +7686,7 @@ enum FeedbackInvocation<'a> {
     Direct,
     Replay,
     VerifiedSurface(VerifiedSurfaceFeedbackDelegation<'a>),
+    McpClient(McpFeedbackDelegation<'a>),
 }
 
 pub fn record_claim_feedback_replay(
@@ -7594,6 +7726,24 @@ fn prepare_claim_feedback_replay(
     Ok(ClaimFeedbackReplayWrite {
         event_id: replay_event_id.to_string(),
         submitted_at: normalize_replay_submitted_at(&input.submitted_at)?,
+        compare_submitted_at: true,
+    })
+}
+
+fn prepare_mcp_claim_feedback_replay(
+    input: &ClaimFeedbackReplayInput,
+) -> Result<ClaimFeedbackReplayWrite, ClaimError> {
+    validate_mcp_feedback_actor(&input.feedback.actor)?;
+    let replay_event_id = input.replay_event_id.trim();
+    if replay_event_id.is_empty() {
+        return Err(ClaimError::InvalidFeedback(
+            "replay_event_id is required for MCP feedback replay".to_string(),
+        ));
+    }
+    Ok(ClaimFeedbackReplayWrite {
+        event_id: replay_event_id.to_string(),
+        submitted_at: normalize_replay_submitted_at(&input.submitted_at)?,
+        compare_submitted_at: false,
     })
 }
 
@@ -7651,7 +7801,12 @@ fn record_claim_feedback_inner(
             }
         }
         ensure_feedback_target_active(&claim)?;
-        validate_feedback_actor(&input.actor)?;
+        match invocation {
+            FeedbackInvocation::McpClient(_) => validate_mcp_feedback_actor(&input.actor)?,
+            FeedbackInvocation::Direct
+            | FeedbackInvocation::Replay
+            | FeedbackInvocation::VerifiedSurface(_) => validate_feedback_actor(&input.actor)?,
+        }
         let metadata = feedback_metadata_for_claim(&claim, &input, metadata.clone())?;
         let subject_value: serde_json::Value = serde_json::from_str(&claim.subject_ref)?;
         let subject = subject_ref_from_json(&subject_value)?;
@@ -7937,12 +8092,17 @@ fn existing_feedback_replay_outcome_conn(
         payload_json.as_deref(),
         &submitted_at,
     )?;
+    let input_submitted_at = if replay.compare_submitted_at {
+        replay.submitted_at.as_str()
+    } else {
+        submitted_at.as_str()
+    };
     let input_content_hash = claim_feedback_replay_content_hash(
         input.action,
         &input.actor,
         input.actor_id.as_deref(),
         input.payload_json.as_deref(),
-        &replay.submitted_at,
+        input_submitted_at,
     )?;
     if existing_content_hash != input_content_hash {
         return Err(ClaimError::InvalidFeedback(format!(
@@ -14058,6 +14218,24 @@ mod tests {
         }
     }
 
+    fn mcp_feedback_input(claim_id: &str, action: FeedbackAction) -> ClaimFeedbackInput {
+        ClaimFeedbackInput {
+            claim_id: claim_id.to_string(),
+            action,
+            actor: "mcp_client".to_string(),
+            actor_id: Some("mcp-client-hash-fixture".to_string()),
+            payload_json: feedback_payload_for(action),
+        }
+    }
+
+    fn mcp_delegation() -> McpFeedbackDelegation<'static> {
+        McpFeedbackDelegation {
+            client_id_hash: "mcp-client-hash-fixture",
+            conversation_handle_hash: "mcp-conversation-hash-fixture",
+            tool_name: "dailyos.submit.claim_feedback",
+        }
+    }
+
     #[test]
     fn w4_surface_client_feedback_requires_verified_delegation() {
         let db = test_db();
@@ -19074,6 +19252,54 @@ mod tests {
             .unwrap();
         assert_eq!(submitted_at, REPLAY_TS_CANONICAL);
         assert_eq!(repair_job_count(&db, &claim_id), 1);
+        assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
+    }
+
+    #[test]
+    fn record_claim_feedback_mcp_replay_is_idempotent_across_retry_timestamps() {
+        let db = test_db();
+        seed_account(&db);
+        let (clock, rng, external) = ctx_parts();
+        let user_ctx = live_ctx(&clock, &rng, &external);
+        let mcp_ctx = ServiceContext::test_live(&clock, &rng, &external).with_actor("mcp_client");
+        let claim_id = inserted_claim_id(
+            commit_claim(&user_ctx, &db, proposal("Risk replay event from MCP")).unwrap(),
+        );
+        let replay_event_id = "mcp-replay-event-idempotent-1";
+
+        let first = record_claim_feedback_replay_from_mcp(
+            &mcp_ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: mcp_feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+                submitted_at: REPLAY_TS.to_string(),
+            },
+            mcp_delegation(),
+        )
+        .unwrap();
+        let second = record_claim_feedback_replay_from_mcp(
+            &mcp_ctx,
+            &db,
+            ClaimFeedbackReplayInput {
+                feedback: mcp_feedback_input(&claim_id, FeedbackAction::CannotVerify),
+                replay_event_id: replay_event_id.to_string(),
+                submitted_at: "2026-04-01T09:16:00+00:00".to_string(),
+            },
+            mcp_delegation(),
+        )
+        .unwrap();
+
+        assert_eq!(second.feedback_id, first.feedback_id);
+        let feedback_count: i64 = db
+            .conn_ref()
+            .query_row(
+                "SELECT count(*) FROM claim_feedback WHERE replay_event_id = ?1",
+                params![replay_event_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(feedback_count, 1);
         assert_eq!(signal_count(&db, "claim_feedback_recorded"), 1);
     }
 

--- a/src-tauri/src/services/entity_context.rs
+++ b/src-tauri/src/services/entity_context.rs
@@ -89,38 +89,117 @@ pub async fn create_entry(
             let ext = crate::services::context::ExternalClients::default();
             let write_ctx = crate::services::context::ServiceContext::new_live(&clock, &rng, &ext)
                 .with_actor("user");
-            let proposal = user_note_claim_proposal(UserNoteProposal {
-                id: None,
-                supersedes: None,
-                entity_type: &entity_type,
-                entity_id: &entity_id,
-                title: &title,
-                content: &content,
-                actor: "user",
-                observed_at: &observed_at,
-                source_ref: None,
-                provenance_json: user_note_provenance_json(None),
-            })?;
-            let committed = commit_claim(&write_ctx, db, proposal)
-                .map_err(|error| format!("Failed to create entity context note claim: {error}"))?;
-            let claim = inserted_claim(committed)?;
-
-            crate::services::signals::emit_and_propagate_or_log(
+            create_entry_with_db(
                 &write_ctx,
                 db,
                 &engine,
                 &entity_type,
                 &entity_id,
-                "user_note_added",
-                "user_note",
-                Some(&title),
-                0.85,
-            );
-
-            entity_context_entry_for_claim(claim)
+                &title,
+                &content,
+                "user",
+                &observed_at,
+                None,
+            )
         })
         .await
         .map_err(String::from)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_entry_with_db(
+    ctx: &crate::services::context::ServiceContext<'_>,
+    db: &crate::db::ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    entity_type: &str,
+    entity_id: &str,
+    title: &str,
+    content: &str,
+    actor: &str,
+    observed_at: &str,
+    source_ref: Option<&str>,
+) -> Result<EntityContextEntry, String> {
+    create_entry_with_db_with_claim_id(
+        ctx,
+        db,
+        engine,
+        entity_type,
+        entity_id,
+        title,
+        content,
+        actor,
+        observed_at,
+        source_ref,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_entry_with_db_with_claim_id(
+    ctx: &crate::services::context::ServiceContext<'_>,
+    db: &crate::db::ActionDb,
+    engine: &crate::signals::propagation::PropagationEngine,
+    entity_type: &str,
+    entity_id: &str,
+    title: &str,
+    content: &str,
+    actor: &str,
+    observed_at: &str,
+    source_ref: Option<&str>,
+    deterministic_claim_id: Option<&str>,
+) -> Result<EntityContextEntry, String> {
+    ctx.check_mutation_allowed().map_err(|e| e.to_string())?;
+
+    let entity_type = normalize_entity_type(entity_type)?;
+    crate::util::validate_id_slug(entity_id, "entity_id")?;
+    crate::util::validate_bounded_string(title, "title", 1, 200)?;
+    crate::util::validate_bounded_string(content, "content", 1, 2000)?;
+    crate::util::validate_bounded_string(actor, "actor", 1, 120)?;
+    if let Some(claim_id) = deterministic_claim_id {
+        crate::util::validate_id_slug(claim_id, "claim_id")?;
+        if let Some(existing) = load_claim_by_id(db.conn_ref(), claim_id).map_err(|error| {
+            format!("Failed to load deterministic entity context claim: {error}")
+        })? {
+            ensure_user_note_claim(&existing)?;
+            return entity_context_entry_for_claim(existing);
+        }
+    }
+
+    let proposal = user_note_claim_proposal(UserNoteProposal {
+        id: None,
+        supersedes: None,
+        entity_type,
+        entity_id,
+        title,
+        content,
+        actor,
+        observed_at,
+        source_ref,
+        provenance_json: user_note_provenance_json(None),
+    })?;
+    let committed = match deterministic_claim_id {
+        Some(claim_id) => {
+            let wrapped = DeterministicInsertProposal::new(claim_id.to_string(), proposal);
+            commit_claim(ctx, db, wrapped)
+        }
+        None => commit_claim(ctx, db, proposal),
+    }
+    .map_err(|error| format!("Failed to create entity context note claim: {error}"))?;
+    let claim = inserted_claim(committed)?;
+
+    crate::services::signals::emit_and_propagate_or_log(
+        ctx,
+        db,
+        engine,
+        entity_type,
+        entity_id,
+        "user_note_added",
+        "user_note",
+        Some(title),
+        0.85,
+    );
+
+    entity_context_entry_for_claim(claim)
 }
 
 /// Update an existing user note by superseding the old immutable claim.

--- a/src-tauri/src/services/mcp_v2/audit.rs
+++ b/src-tauri/src/services/mcp_v2/audit.rs
@@ -21,6 +21,8 @@ use super::local_runtime;
 
 pub const PARAM_PAYLOAD_KEYS: &[&str] = &["params", "parameters"];
 pub const RESPONSE_PAYLOAD_KEYS: &[&str] = &["response", "response_or_error", "result"];
+const EXTRA_SENSITIVE_DETAIL_KEYS: &[&str] =
+    &["client_id", "conversation_handle", "mutation_cursor"];
 
 /// MCP-specific audit write failures.
 #[derive(Debug, thiserror::Error)]
@@ -97,10 +99,8 @@ pub fn write_with_conn(
 }
 
 fn detail_with_attribution(actor: &Actor, detail: Value, side: Side) -> Result<Value, AuditError> {
-    let mut detail = match side {
-        Side::Read => digest_payload_detail(detail)?,
-        Side::Write | Side::SubmitCorrection => sanitize_detail(detail),
-    };
+    let _side = side;
+    let mut detail = digest_payload_detail(detail)?;
     add_actor_attribution(actor, &mut detail);
     Ok(Value::Object(detail))
 }
@@ -112,28 +112,16 @@ fn object_detail(detail: Value) -> Map<String, Value> {
     }
 }
 
-fn sanitize_detail(detail: Value) -> Map<String, Value> {
-    let mut map = object_detail(detail);
-    for key in PARAM_PAYLOAD_KEYS
-        .iter()
-        .chain(RESPONSE_PAYLOAD_KEYS.iter())
-        .copied()
-    {
-        map.remove(key);
-    }
-    map
-}
-
 fn digest_payload_detail(detail: Value) -> Result<Map<String, Value>, AuditError> {
     let mut map = object_detail(detail);
     for key in PARAM_PAYLOAD_KEYS
         .iter()
         .chain(RESPONSE_PAYLOAD_KEYS.iter())
+        .chain(EXTRA_SENSITIVE_DETAIL_KEYS.iter())
         .copied()
     {
         if let Some(payload) = map.remove(key) {
-            let digest = local_runtime::digest_json_value_hex(&payload)
-                .map_err(|error| AuditError::Digest(error.to_string()))?;
+            let digest = digest_value(&payload)?;
             map.insert(format!("{key}_digest"), Value::String(digest));
             map.insert(
                 format!("{key}_digest_algorithm"),
@@ -144,6 +132,11 @@ fn digest_payload_detail(detail: Value) -> Result<Map<String, Value>, AuditError
     Ok(map)
 }
 
+fn digest_value(value: &Value) -> Result<String, AuditError> {
+    local_runtime::digest_json_value_hex(value)
+        .map_err(|error| AuditError::Digest(error.to_string()))
+}
+
 fn add_actor_attribution(actor: &Actor, detail: &mut Map<String, Value>) {
     if let Actor::McpClient {
         client_id,
@@ -151,16 +144,29 @@ fn add_actor_attribution(actor: &Actor, detail: &mut Map<String, Value>) {
     } = actor
     {
         detail
-            .entry("client_id".to_string())
-            .or_insert_with(|| Value::String(client_id.as_str().to_string()));
-        detail
-            .entry("conversation_handle".to_string())
+            .entry("actor_client_id_digest".to_string())
             .or_insert_with(|| {
-                conversation_handle
+                digest_value(&Value::String(client_id.as_str().to_string()))
+                    .map(Value::String)
+                    .unwrap_or_else(|_| Value::String("digest_error".to_string()))
+            });
+        detail
+            .entry("actor_client_id_digest_algorithm".to_string())
+            .or_insert_with(|| Value::String(local_runtime::AUDIT_DIGEST_ALGORITHM.to_string()));
+        detail
+            .entry("actor_conversation_handle_digest".to_string())
+            .or_insert_with(|| {
+                let value = conversation_handle
                     .as_ref()
                     .map(|handle| Value::String(handle.as_str().to_string()))
-                    .unwrap_or(Value::Null)
+                    .unwrap_or(Value::Null);
+                digest_value(&value)
+                    .map(Value::String)
+                    .unwrap_or_else(|_| Value::String("digest_error".to_string()))
             });
+        detail
+            .entry("actor_conversation_handle_digest_algorithm".to_string())
+            .or_insert_with(|| Value::String(local_runtime::AUDIT_DIGEST_ALGORITHM.to_string()));
     }
 }
 
@@ -287,23 +293,55 @@ mod tests {
                 out["params_digest_algorithm"],
                 local_runtime::AUDIT_DIGEST_ALGORITHM
             );
-            assert_eq!(out["client_id"], "client-a");
+            assert!(out.get("client_id").is_none());
+            assert!(out.get("conversation_handle").is_none());
+            assert_eq!(out["actor_client_id_digest"].as_str().unwrap().len(), 64);
+            assert_eq!(
+                out["actor_client_id_digest_algorithm"],
+                local_runtime::AUDIT_DIGEST_ALGORITHM
+            );
         });
     }
 
     #[test]
-    fn write_detail_masks_payload_keys() {
-        let detail = json!({
-            "tool_name": "dailyos.submit.note",
-            "params": { "text": "sensitive note" },
-            "response": { "note_id": "note-1" },
-            "mutation_cursor": { "note_id": "note-1" }
+    fn write_detail_persists_hashes_not_raw_payload_or_handles() {
+        local_runtime::with_audit_digest_key_for_tests([9_u8; 32], || {
+            let detail = json!({
+                "tool_name": "dailyos.submit.note",
+                "client_id": "client-a",
+                "conversation_handle": "conv-a",
+                "params": { "text": "sensitive note", "entity_handle": "mth_public" },
+                "response": { "note_id": "note-1", "status": "ok" },
+                "result_status": "ok",
+                "mutation_cursor": { "note_id": "note-1" }
+            });
+            let out = detail_with_attribution(&actor(), detail, Side::SubmitCorrection).unwrap();
+            let serialized = serde_json::to_string(&out).expect("serialize audit detail");
+
+            for raw in [
+                "sensitive note",
+                "note-1",
+                "mth_public",
+                "conv-a",
+                "client-a",
+            ] {
+                assert!(
+                    !serialized.contains(raw),
+                    "audit detail must not contain raw {raw}"
+                );
+            }
+            assert_eq!(out["result_status"], "ok");
+            assert_eq!(out["params_digest"].as_str().unwrap().len(), 64);
+            assert_eq!(out["response_digest"].as_str().unwrap().len(), 64);
+            assert_eq!(out["mutation_cursor_digest"].as_str().unwrap().len(), 64);
+            assert_eq!(
+                out["actor_conversation_handle_digest"]
+                    .as_str()
+                    .unwrap()
+                    .len(),
+                64
+            );
         });
-        let out = detail_with_attribution(&actor(), detail, Side::SubmitCorrection).unwrap();
-        assert!(out.get("params").is_none());
-        assert!(out.get("response").is_none());
-        assert_eq!(out["mutation_cursor"]["note_id"], "note-1");
-        assert_eq!(out["conversation_handle"], "conv-a");
     }
 
     #[test]

--- a/src-tauri/src/services/mcp_v2/gateway.rs
+++ b/src-tauri/src/services/mcp_v2/gateway.rs
@@ -630,6 +630,15 @@ impl Gateway {
                     }
                     eprintln!("mcp_v2 audit single-failure: {err}");
                 }
+                if let Some(owned) = self.connection.as_ref() {
+                    let connection = owned.connection();
+                    let guard = connection
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if let Err(error) = super::target_handles::cleanup_target_handles(&guard) {
+                        eprintln!("mcp_v2 target handle cleanup failed: {error}");
+                    }
+                }
 
                 self.emitter.emit_invoked(
                     asserted_client_id,
@@ -831,6 +840,10 @@ fn build_audit_detail(
         "conversation_handle": conversation_handle.as_str(),
         "tool_name": tool_name.as_str(),
         "params": params,
+        "result_status": response
+            .and_then(|value| value.get("status"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("ok"),
     });
     if let Some(value) = response {
         detail["response"] = value.clone();

--- a/src-tauri/src/services/mcp_v2/handlers/mod.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/mod.rs
@@ -4,6 +4,7 @@
 pub mod registration;
 pub mod tool_account_status;
 pub mod tool_briefing;
+pub mod tool_claim_feedback;
 pub mod tool_create_action;
 pub mod tool_note;
 pub mod tool_pagination;
@@ -11,5 +12,6 @@ pub mod tool_placement;
 pub mod tool_portfolio;
 pub mod tool_resources;
 pub mod tool_update_action_status;
+pub mod tool_utils;
 pub mod tool_workspace_search;
 pub mod tool_workspace_source_provenance;

--- a/src-tauri/src/services/mcp_v2/handlers/registration.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/registration.rs
@@ -11,7 +11,11 @@ use crate::services::mcp_v2::taxonomy::TaxonomyCatalog;
 use crate::signals::propagation::PropagationEngine;
 
 use super::tool_account_status::AccountStatusHandler;
-use super::tool_placement::PlacementHandler;
+use super::tool_claim_feedback::ClaimFeedbackHandler;
+use super::tool_create_action::CreateActionHandler;
+use super::tool_note::NoteHandler;
+use super::tool_update_action_status::UpdateActionStatusHandler;
+use super::tool_workspace_source_provenance::WorkspaceSourceProvenanceHandler;
 
 /// Errors registering wave-scoped handlers at boot.
 #[derive(Debug)]
@@ -38,12 +42,11 @@ impl std::fmt::Display for RegistrationError {
 
 impl std::error::Error for RegistrationError {}
 
-/// Register all v1.4.7 W2-A Phase-A handlers on the gateway.
+/// Register the W5 MCP parity handler set on the gateway.
 ///
-/// Current registered scope includes the account status read tool plus the
-/// v1.4.5 workspace placement write tool once its placement substrate is
-/// present on the rebased base. Phase-B (daily_briefing) adds its handler via
-/// this same helper once its sub-ticket lands.
+/// Hidden W5 tools stay absent from this registry. In particular,
+/// `dailyos.write.place_document` remains implemented elsewhere but is not
+/// advertised or invocable through the W5 MCP parity surface.
 pub fn register_v147_handlers(
     gateway: &mut Gateway,
     catalog: &Arc<dyn TaxonomyCatalog>,
@@ -60,15 +63,46 @@ pub fn register_v147_handlers(
         .map_err(RegistrationError::AbilityRegistry)?;
     gateway.register(Arc::new(handler));
 
-    let placement_name = ScopedName::new("dailyos.write.place_document");
-    let description = catalog
-        .description_for(&placement_name)
-        .ok_or_else(|| RegistrationError::CatalogEntryMissing(placement_name.clone()))?
-        .clone();
-
-    let handler = PlacementHandler::from_runtime(description, runtime, Arc::clone(&signal_engine))
-        .map_err(RegistrationError::AbilityRegistry)?;
-    gateway.register(Arc::new(handler));
+    for name in [
+        "dailyos.read.workspace_source_provenance",
+        "dailyos.submit.claim_feedback",
+        "dailyos.submit.note",
+        "dailyos.submit.action",
+        "dailyos.submit.action_status",
+    ] {
+        let scoped = ScopedName::new(name);
+        let description = catalog
+            .description_for(&scoped)
+            .ok_or_else(|| RegistrationError::CatalogEntryMissing(scoped.clone()))?
+            .clone();
+        match name {
+            "dailyos.read.workspace_source_provenance" => {
+                gateway.register(Arc::new(WorkspaceSourceProvenanceHandler::new(description)));
+            }
+            "dailyos.submit.claim_feedback" => {
+                gateway.register(Arc::new(ClaimFeedbackHandler::new(description)));
+            }
+            "dailyos.submit.note" => {
+                gateway.register(Arc::new(NoteHandler::new(
+                    description,
+                    Arc::clone(&signal_engine),
+                )));
+            }
+            "dailyos.submit.action" => {
+                gateway.register(Arc::new(CreateActionHandler::new(
+                    description,
+                    Arc::clone(&signal_engine),
+                )));
+            }
+            "dailyos.submit.action_status" => {
+                gateway.register(Arc::new(UpdateActionStatusHandler::new(
+                    description,
+                    Arc::clone(&signal_engine),
+                )));
+            }
+            _ => unreachable!("registered W5 tool name is exhaustive"),
+        }
+    }
 
     Ok(())
 }
@@ -85,7 +119,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registers_workspace_placement_handler_from_catalog() {
+    fn registers_w5_handlers_from_catalog() {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         let catalog: Arc<dyn TaxonomyCatalog> =
             Arc::new(YamlTaxonomyCatalog::load_embedded().expect("catalog"));
@@ -101,12 +135,24 @@ mod tests {
         .expect("register handlers");
 
         let registered = gateway.registered_tools().cloned().collect::<Vec<_>>();
-        assert!(registered.contains(&ScopedName::new("dailyos.read.account_status")));
-        assert!(registered.contains(&ScopedName::new("dailyos.write.place_document")));
+        for name in [
+            "dailyos.read.account_status",
+            "dailyos.read.workspace_source_provenance",
+            "dailyos.submit.claim_feedback",
+            "dailyos.submit.note",
+            "dailyos.submit.action",
+            "dailyos.submit.action_status",
+        ] {
+            assert!(
+                registered.contains(&ScopedName::new(name)),
+                "missing registered W5 tool: {name}"
+            );
+        }
+        assert!(!registered.contains(&ScopedName::new("dailyos.write.place_document")));
         let pending = gateway.seal().expect("registered handlers match catalog");
         assert!(
-            !pending.contains(&ScopedName::new("dailyos.write.place_document")),
-            "placement handler should no longer be a catalog-only placeholder"
+            pending.is_empty(),
+            "W5 catalog entries should all have registered handlers: {pending:?}"
         );
     }
 }

--- a/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_account_status.rs
@@ -10,7 +10,7 @@
 //! See `.docs/plans/v1.4.7-w1-foundation/dos-175-l0-plan.md` for the L0
 //! contract.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use abilities_runtime::abilities::registry::{AbilityRegistry, McpExposure};
@@ -22,6 +22,7 @@ use crate::bridges::types::{
     BRIDGE_NOOP_INTELLIGENCE_PROVIDER,
 };
 use crate::bridges::{BridgeActor, BridgeSurface};
+use crate::db::claims::{ClaimState, IntelligenceClaim, SurfacingState};
 use crate::db::{ActionDb, DbAccount, DbError, LocalKeychain};
 use crate::helpers::normalize_key;
 use crate::services::context::{
@@ -35,6 +36,10 @@ use crate::services::mcp_v2::runtime_projection::{
     compact_text, evidence_suffix, humanize_token, open_loop_suffix, project_runtime_evidence,
     string_at, RuntimeEvidenceProjection,
 };
+use crate::services::mcp_v2::target_handles::{mint_target_handle, MintTargetHandle, TargetKind};
+use crate::services::sensitivity::{renderable_claim_text, RenderActor, RenderSurface};
+
+use super::tool_utils::{current_entity_watermark, source_provenance_watermark};
 
 const ACTOR_LABEL: &str = concat!("agent:dailyos-mcp-v2:", env!("CARGO_PKG_VERSION"));
 
@@ -169,6 +174,7 @@ impl McpToolHandler for AccountStatusHandler {
             .await
             .map_err(map_invoke_error)?;
             let invocation_id = response.invocation_id.0.to_string();
+            let raw_envelope = response.data.clone();
             let mut payload = present_account_status_response_with_context(
                 &resolved_subject.entity_id,
                 response.data,
@@ -177,6 +183,13 @@ impl McpToolHandler for AccountStatusHandler {
                 None,
             );
             attach_account_subject_resolution(&mut payload, &resolved_subject);
+            handleize_account_status_payload(
+                ctx,
+                actor,
+                &mut payload,
+                &resolved_subject,
+                &raw_envelope,
+            )?;
             Ok(payload)
         })
     }
@@ -264,31 +277,19 @@ fn resolve_account_subject_with_db(
     subject: &str,
 ) -> Result<AccountSubjectResolution, ToolError> {
     if let Some(account) = db
-        .get_account(subject)
-        .map_err(map_subject_resolution_db_error)?
-    {
-        return Ok(resolved_account_subject(
-            subject,
-            AccountSubjectCandidate::from(account),
-            "account_id",
-            "id",
-            "exact",
-            1.0,
-        ));
-    }
-
-    if let Some(account) = db
         .get_account_by_name(subject)
         .map_err(map_subject_resolution_db_error)?
     {
-        return Ok(resolved_account_subject(
-            subject,
-            AccountSubjectCandidate::from(account),
-            "account_name",
-            "name",
-            "exact",
-            1.0,
-        ));
+        if !account.archived {
+            return Ok(resolved_account_subject(
+                subject,
+                AccountSubjectCandidate::from(account),
+                "account_name",
+                "name",
+                "exact",
+                1.0,
+            ));
+        }
     }
 
     let accounts = db
@@ -305,10 +306,6 @@ fn resolve_account_subject_from_accounts(
     accounts: &[AccountSubjectCandidate],
 ) -> AccountSubjectResolution {
     let input = subject.trim().to_string();
-
-    if let Some(account) = accounts.iter().find(|account| account.id == input) {
-        return resolved_account_subject(&input, account.clone(), "account_id", "id", "exact", 1.0);
-    }
 
     if let Some(account) = accounts
         .iter()
@@ -331,9 +328,8 @@ fn resolve_account_subject_from_accounts(
 
     let mut matches = BTreeMap::new();
     for account in accounts.iter().cloned() {
-        let id_matches = normalize_key(&account.id) == normalized_input;
         let name_matches = normalize_key(&account.name) == normalized_input;
-        if id_matches || name_matches {
+        if name_matches {
             matches.entry(account.id.clone()).or_insert(account);
         }
     }
@@ -345,7 +341,7 @@ fn resolve_account_subject_from_accounts(
             &input,
             account.clone(),
             "normalized_slug",
-            "normalized_id_or_name",
+            "normalized_name",
             "high",
             0.95,
         ),
@@ -379,7 +375,6 @@ fn attach_account_subject_resolution(payload: &mut Value, subject: &ResolvedAcco
     }
     if let Some(subject_object) = payload.get_mut("subject").and_then(Value::as_object_mut) {
         subject_object.insert("input".to_string(), Value::String(subject.input.clone()));
-        subject_object.insert("id".to_string(), Value::String(subject.entity_id.clone()));
         subject_object.insert(
             "displayLabel".to_string(),
             Value::String(subject.display_label.clone()),
@@ -396,6 +391,7 @@ fn attach_account_subject_resolution(payload: &mut Value, subject: &ResolvedAcco
             "matchConfidenceScore".to_string(),
             json!(subject.match_confidence_score),
         );
+        strip_public_entity_identifier_keys(subject_object);
     }
 }
 
@@ -403,7 +399,6 @@ fn account_subject_resolution_json(subject: &ResolvedAccountSubject) -> Value {
     json!({
         "input": subject.input,
         "entityType": "account",
-        "resolvedEntityId": subject.entity_id,
         "displayLabel": subject.display_label,
         "resolutionKind": subject.resolution_kind,
         "matchBasis": subject.match_basis,
@@ -417,16 +412,15 @@ fn account_subject_not_found_response(input: &str) -> Value {
     account_subject_resolution_response(
         "not_found",
         input,
-        "DailyOS could not resolve the requested subject to an account in the local workspace. Try an exact account name or account id.",
+        "DailyOS could not resolve the requested subject to an account in the local workspace. Try an exact account name or normalized account slug.",
         json!({
             "input": input,
             "entityType": "account",
-            "resolvedEntityId": Value::Null,
             "resolutionKind": "not_found",
             "matchConfidence": "none",
             "matchConfidenceScore": 0.0,
             "candidates": [],
-            "caveats": ["No matching account id, exact account name, or normalized account slug was found."],
+            "caveats": ["No matching exact account name or normalized account slug was found."],
         }),
     )
 }
@@ -440,7 +434,6 @@ fn account_subject_ambiguous_response(
         .take(5)
         .map(|candidate| {
             json!({
-                "entityId": candidate.id,
                 "displayLabel": candidate.name,
             })
         })
@@ -448,11 +441,10 @@ fn account_subject_ambiguous_response(
     account_subject_resolution_response(
         "clarification_required",
         input,
-        "DailyOS found multiple local accounts matching the requested subject. Retry with an exact account id.",
+        "DailyOS found multiple local accounts matching the requested subject. Retry with an exact account name.",
         json!({
             "input": input,
             "entityType": "account",
-            "resolvedEntityId": Value::Null,
             "resolutionKind": "ambiguous",
             "matchConfidence": "none",
             "matchConfidenceScore": 0.0,
@@ -480,6 +472,7 @@ fn account_subject_resolution_response(
         .unwrap_or("Subject resolution did not produce a single local account.");
     json!({
         "schemaVersion": ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION,
+        "schema_version": "mcp.account_status.v2",
         "toolName": TOOL_NAME,
         "surface": TOOL_NAME,
         "producer": ABILITY_NAME,
@@ -490,6 +483,7 @@ fn account_subject_resolution_response(
             "kind": "account",
             "input": input,
             "displayLabel": input,
+            "rawEntityIdsIncluded": false,
         },
         "resolution": resolution,
         "answer": answer,
@@ -513,6 +507,8 @@ fn account_subject_resolution_response(
             "sources": [],
             "redactionApplied": false,
             "rawClaimIdsIncluded": false,
+            "rawEntityIdsIncluded": false,
+            "rawSourceIdsIncluded": false,
         },
         "sectionStates": {
             "facts": section_state,
@@ -572,17 +568,10 @@ pub fn present_account_status_response_with_context(
             subject_value
                 .get("displayLabel")
                 .and_then(Value::as_str)
-                .map(compact_text)
-                .filter(|value| !value.is_empty())
+                .and_then(public_display_label_candidate)
         })
         .unwrap_or_else(|| subject.to_string());
-    let subject_value = if display_label_override.is_some() {
-        let mut subject_map = subject_value.as_object().cloned().unwrap_or_default();
-        subject_map.insert("displayLabel".to_string(), Value::String(label.clone()));
-        Value::Object(subject_map)
-    } else {
-        subject_value
-    };
+    let subject_value = public_subject_value(subject, subject_value, Some(label.as_str()));
 
     let projection = project_runtime_evidence(&envelope);
     let answer = build_account_status_answer(&label, &projection, &envelope);
@@ -600,6 +589,7 @@ pub fn present_account_status_response_with_context(
 
     json!({
         "schemaVersion": ACCOUNT_STATUS_RESPONSE_SCHEMA_VERSION,
+        "schema_version": "mcp.account_status.v2",
         "toolName": TOOL_NAME,
         "surface": TOOL_NAME,
         "producer": ABILITY_NAME,
@@ -633,9 +623,444 @@ pub fn present_account_status_response_with_context(
 fn fallback_subject(subject: &str) -> Value {
     json!({
         "kind": "account",
-        "id": subject,
         "displayLabel": subject,
+        "rawEntityIdsIncluded": false,
     })
+}
+
+fn public_subject_value(
+    subject: &str,
+    subject_value: Value,
+    display_label_override: Option<&str>,
+) -> Value {
+    let mut subject_map = subject_value.as_object().cloned().unwrap_or_default();
+    subject_map
+        .entry("kind".to_string())
+        .or_insert_with(|| Value::String("account".to_string()));
+    subject_map
+        .entry("displayLabel".to_string())
+        .or_insert_with(|| Value::String(subject.to_string()));
+    if let Some(label) = display_label_override {
+        subject_map.insert("displayLabel".to_string(), Value::String(label.to_string()));
+    }
+    strip_public_entity_identifier_keys(&mut subject_map);
+    Value::Object(subject_map)
+}
+
+fn public_display_label_candidate(value: &str) -> Option<String> {
+    let value = compact_text(value);
+    if value.is_empty() || looks_like_internal_entity_label(&value) {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn looks_like_internal_entity_label(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    ["account:", "project:", "person:", "meeting:"]
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+fn strip_public_entity_identifier_keys(subject_object: &mut serde_json::Map<String, Value>) {
+    for key in [
+        "id",
+        "subjectRef",
+        "subject_ref",
+        "entityId",
+        "entity_id",
+        "resolvedEntityId",
+        "resolved_entity_id",
+        "accountId",
+        "account_id",
+    ] {
+        subject_object.remove(key);
+    }
+    subject_object.insert("rawEntityIdsIncluded".to_string(), Value::Bool(false));
+}
+
+fn handleize_account_status_payload(
+    ctx: &McpHandlerContext,
+    actor: &McpActor,
+    payload: &mut Value,
+    subject: &ResolvedAccountSubject,
+    raw_envelope: &Value,
+) -> Result<(), ToolError> {
+    if let Some(object) = payload.as_object_mut() {
+        object.insert(
+            "schema_version".to_string(),
+            Value::String("mcp.account_status.v2".to_string()),
+        );
+        object.insert("invocationId".to_string(), Value::Null);
+        object.insert("provenanceHandle".to_string(), Value::Null);
+    }
+    if let Some(provenance) = payload.get_mut("provenance").and_then(Value::as_object_mut) {
+        provenance.insert("rawClaimIdsIncluded".to_string(), Value::Bool(false));
+        provenance.insert("rawEntityIdsIncluded".to_string(), Value::Bool(false));
+        provenance.insert("rawActionIdsIncluded".to_string(), Value::Bool(false));
+        provenance.insert("rawSourceIdsIncluded".to_string(), Value::Bool(false));
+    }
+
+    let Some(result) = ctx.with_conn(|db| {
+        let entity_target_ref = json!({
+            "entity_type": "account",
+            "entity_id": subject.entity_id,
+        });
+        let Some(entity_watermark) = current_entity_watermark(db, &entity_target_ref)? else {
+            attach_source_handles(db, actor, payload, raw_envelope)?;
+            attach_feedback_handles(db, actor, payload, raw_envelope)?;
+            return Ok(());
+        };
+        let entity_handle = mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &crate::services::mcp_v2::contracts::ScopedName::new(TOOL_NAME),
+                result_item_path: "/subject",
+                target_kind: TargetKind::Entity,
+                target_ref: entity_target_ref,
+                sensitivity_tier: "internal",
+                provenance_material: &format!("account:{}", subject.entity_id),
+                watermark_material: &entity_watermark,
+            },
+        )
+        .map_err(|error| ToolError::Internal {
+            trace_id: format!("mcp_account_entity_handle_mint:{error}"),
+        })?;
+        attach_entity_handle(payload, &entity_handle);
+        attach_source_handles(db, actor, payload, raw_envelope)?;
+        attach_feedback_handles(db, actor, payload, raw_envelope)?;
+        Ok(())
+    }) else {
+        return Ok(());
+    };
+    result
+}
+
+fn attach_entity_handle(payload: &mut Value, entity_handle: &str) {
+    if let Some(subject_object) = payload.get_mut("subject").and_then(Value::as_object_mut) {
+        strip_public_entity_identifier_keys(subject_object);
+        subject_object.insert(
+            "entity_handle".to_string(),
+            Value::String(entity_handle.to_string()),
+        );
+        subject_object.insert(
+            "entityHandle".to_string(),
+            Value::String(entity_handle.to_string()),
+        );
+        subject_object.insert(
+            "entityType".to_string(),
+            Value::String("account".to_string()),
+        );
+    }
+    if let Some(resolution_object) = payload.get_mut("resolution").and_then(Value::as_object_mut) {
+        strip_public_entity_identifier_keys(resolution_object);
+        resolution_object.insert(
+            "entity_handle".to_string(),
+            Value::String(entity_handle.to_string()),
+        );
+        resolution_object.insert(
+            "entityHandle".to_string(),
+            Value::String(entity_handle.to_string()),
+        );
+    }
+}
+
+fn attach_source_handles(
+    db: &ActionDb,
+    actor: &McpActor,
+    payload: &mut Value,
+    raw_envelope: &Value,
+) -> Result<(), ToolError> {
+    let raw_sources = raw_envelope
+        .pointer("/provenance/sources")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let Some(projected_sources) = payload
+        .pointer_mut("/provenance/sources")
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(());
+    };
+
+    for (index, source) in projected_sources.iter_mut().enumerate() {
+        let Some(source_object) = source.as_object_mut() else {
+            continue;
+        };
+        let raw_source = raw_sources.get(index).cloned().unwrap_or_else(|| json!({}));
+        let label = source_object
+            .get("label")
+            .and_then(Value::as_str)
+            .unwrap_or("DailyOS source")
+            .to_string();
+        let source_type = source_object
+            .get("sourceType")
+            .or_else(|| source_object.get("source_type"))
+            .and_then(Value::as_str)
+            .unwrap_or("source")
+            .to_string();
+        let as_of = source_object
+            .get("asOf")
+            .or_else(|| source_object.get("as_of"))
+            .cloned()
+            .unwrap_or(Value::Null);
+        let redaction_applied = source_object
+            .get("redacted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let source_target_ref = json!({
+            "label": label,
+            "source_type": source_type,
+            "source_asof": as_of,
+            "trust_band": raw_source.get("trustBand").or_else(|| raw_source.get("trust_band")).cloned().unwrap_or(Value::Null),
+            "redaction_applied": redaction_applied,
+        });
+        let source_watermark = source_provenance_watermark(&source_target_ref);
+        let handle = mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &crate::services::mcp_v2::contracts::ScopedName::new(TOOL_NAME),
+                result_item_path: &format!("/provenance/sources/{index}"),
+                target_kind: TargetKind::SourceProvenance,
+                target_ref: source_target_ref,
+                sensitivity_tier: "internal",
+                provenance_material: &source_watermark,
+                watermark_material: &source_watermark,
+            },
+        )
+        .map_err(|error| ToolError::Internal {
+            trace_id: format!("mcp_account_source_handle_mint:{error}"),
+        })?;
+        source_object.insert(
+            "source_provenance_handle".to_string(),
+            Value::String(handle.clone()),
+        );
+        source_object.insert("sourceProvenanceHandle".to_string(), Value::String(handle));
+    }
+    Ok(())
+}
+
+fn attach_feedback_handles(
+    db: &ActionDb,
+    actor: &McpActor,
+    payload: &mut Value,
+    raw_envelope: &Value,
+) -> Result<(), ToolError> {
+    attach_feedback_handles_for_section(
+        db,
+        actor,
+        payload,
+        "/assessment/facts",
+        raw_envelope
+            .pointer("/facts/items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        feedback_candidate_from_fact,
+        projected_fact_text,
+    )?;
+    attach_feedback_handles_for_section(
+        db,
+        actor,
+        payload,
+        "/assessment/openLoops",
+        raw_envelope
+            .pointer("/openLoops/items")
+            .or_else(|| raw_envelope.pointer("/open_loops/items"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        feedback_candidate_from_open_loop,
+        projected_open_loop_text,
+    )?;
+    attach_feedback_handles_for_section(
+        db,
+        actor,
+        payload,
+        "/assessment/recordEntries",
+        raw_envelope
+            .pointer("/recordEntries/items")
+            .or_else(|| raw_envelope.pointer("/record_entries/items"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        feedback_candidate_from_record_entry,
+        projected_fact_text,
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FeedbackTargetCandidate {
+    claim_id: String,
+    match_text: String,
+}
+
+fn attach_feedback_handles_for_section(
+    db: &ActionDb,
+    actor: &McpActor,
+    payload: &mut Value,
+    projected_pointer: &str,
+    raw_items: Vec<Value>,
+    candidate_for: fn(&Value) -> Option<FeedbackTargetCandidate>,
+    projected_text_for: fn(&Value) -> Option<String>,
+) -> Result<(), ToolError> {
+    let Some(projected_items) = payload
+        .pointer_mut(projected_pointer)
+        .and_then(Value::as_array_mut)
+    else {
+        return Ok(());
+    };
+    let candidates = raw_items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| candidate_for(item).map(|candidate| (index, candidate)))
+        .collect::<Vec<_>>();
+    let mut used_raw_indexes = BTreeSet::new();
+    for (index, projected) in projected_items.iter_mut().enumerate() {
+        let Some(projected_text) = projected_text_for(projected) else {
+            continue;
+        };
+        let Some((raw_index, candidate)) = candidates.iter().find(|(raw_index, candidate)| {
+            !used_raw_indexes.contains(raw_index) && candidate.match_text == projected_text
+        }) else {
+            continue;
+        };
+        used_raw_indexes.insert(*raw_index);
+        let claim_id = candidate.claim_id.clone();
+        let Some(watermark) = claim_watermark(db, &claim_id)? else {
+            continue;
+        };
+        let handle = mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &crate::services::mcp_v2::contracts::ScopedName::new(TOOL_NAME),
+                result_item_path: &format!("{projected_pointer}/{index}"),
+                target_kind: TargetKind::Claim,
+                target_ref: json!({ "claim_id": claim_id }),
+                sensitivity_tier: "internal",
+                provenance_material: &format!("{projected_pointer}:{index}"),
+                watermark_material: &watermark,
+            },
+        )
+        .map_err(|error| ToolError::Internal {
+            trace_id: format!("mcp_account_feedback_handle_mint:{error}"),
+        })?;
+        if let Some(object) = projected.as_object_mut() {
+            object.insert(
+                "feedback_target_handle".to_string(),
+                Value::String(handle.clone()),
+            );
+            object.insert("feedbackTargetHandle".to_string(), Value::String(handle));
+        }
+    }
+    Ok(())
+}
+
+fn feedback_candidate_from_fact(item: &Value) -> Option<FeedbackTargetCandidate> {
+    Some(FeedbackTargetCandidate {
+        claim_id: claim_id_from_fact(item)?,
+        match_text: rendered_fact_text(item)?,
+    })
+}
+
+fn feedback_candidate_from_record_entry(item: &Value) -> Option<FeedbackTargetCandidate> {
+    Some(FeedbackTargetCandidate {
+        claim_id: claim_id_from_fact(item)?,
+        match_text: rendered_record_entry_text(item)?,
+    })
+}
+
+fn feedback_candidate_from_open_loop(item: &Value) -> Option<FeedbackTargetCandidate> {
+    let open_loop = item
+        .get("openLoop")
+        .or_else(|| item.get("open_loop"))
+        .unwrap_or(item);
+    Some(FeedbackTargetCandidate {
+        claim_id: claim_id_from_open_loop(item)?,
+        match_text: string_at(open_loop, "/description")
+            .map(compact_text)
+            .filter(|value| !value.is_empty())?,
+    })
+}
+
+fn rendered_fact_text(item: &Value) -> Option<String> {
+    string_at(item, "/renderedText/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+}
+
+fn rendered_record_entry_text(item: &Value) -> Option<String> {
+    string_at(item, "/renderedText/text")
+        .or_else(|| string_at(item, "/rendered_text/text"))
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+}
+
+fn projected_fact_text(item: &Value) -> Option<String> {
+    string_at(item, "/text")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+}
+
+fn projected_open_loop_text(item: &Value) -> Option<String> {
+    string_at(item, "/description")
+        .map(compact_text)
+        .filter(|value| !value.is_empty())
+}
+
+fn claim_id_from_fact(item: &Value) -> Option<String> {
+    item.get("claimId")
+        .or_else(|| item.get("claim_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn claim_id_from_open_loop(item: &Value) -> Option<String> {
+    item.get("openLoop")
+        .or_else(|| item.get("open_loop"))
+        .unwrap_or(item)
+        .get("id")
+        .or_else(|| item.get("claimId"))
+        .or_else(|| item.get("claim_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn claim_watermark(db: &ActionDb, claim_id: &str) -> Result<Option<String>, ToolError> {
+    match crate::services::claims::load_claim_by_id(db.conn_ref(), claim_id) {
+        Ok(Some(claim)) if claim_is_public_mcp_feedback_target(&claim) => {
+            Ok(Some(claim_watermark_for_handle(&claim)))
+        }
+        Ok(Some(_)) | Ok(None) => Ok(None),
+        Err(error) => {
+            eprintln!("mcp_v2 dailyos.read.account_status feedback target load failed: {error:?}");
+            Err(ToolError::Internal {
+                trace_id: "mcp_account_feedback_claim_load".to_string(),
+            })
+        }
+    }
+}
+
+fn claim_is_public_mcp_feedback_target(claim: &IntelligenceClaim) -> bool {
+    claim.claim_state == ClaimState::Active
+        && claim.surfacing_state == SurfacingState::Active
+        && renderable_claim_text(
+            claim,
+            RenderSurface::McpTool,
+            &RenderActor::agent("agent:mcp"),
+        )
+        .is_some()
+}
+
+fn claim_watermark_for_handle(claim: &IntelligenceClaim) -> String {
+    format!(
+        "claim:{}:{}:{:?}:{:?}",
+        claim.id, claim.claim_version, claim.claim_state, claim.verification_state
+    )
 }
 
 fn build_account_status_answer(
@@ -833,9 +1258,13 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
+    use crate::db::claims::{ClaimSensitivity, TemporalScope};
+    use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim};
     use crate::services::mcp_v2::contracts::{
         McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
     };
+    use crate::services::mcp_v2::local_runtime;
+    use crate::services::mcp_v2::target_handles::{resolve_target_handle, ResolveTargetHandle};
 
     fn stub_actor() -> McpActor {
         McpActor::Client {
@@ -893,6 +1322,41 @@ mod tests {
             ..Default::default()
         })
         .expect("seed account");
+    }
+
+    fn seed_renderable_claim(db: &ActionDb, claim_type: &str, text: &str) -> IntelligenceClaim {
+        seed_account(db, "acct-feedback-route", "Feedback Route Account");
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let ctx = ServiceContext::new_live(&clock, &rng, &external).with_actor("user:test");
+        let proposal = ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: r#"{"kind":"account","id":"acct-feedback-route"}"#.to_string(),
+            claim_type: claim_type.to_string(),
+            field_path: Some("health.summary".to_string()),
+            topic_key: None,
+            text: text.to_string(),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: None,
+            source_asof: Some("2026-06-01T12:00:00Z".to_string()),
+            observed_at: "2026-06-01T12:00:00Z".to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        };
+        match commit_claim(&ctx, db, proposal).expect("commit renderable claim") {
+            CommittedClaim::Inserted { claim }
+            | CommittedClaim::Reinforced { claim, .. }
+            | CommittedClaim::Tombstoned { claim } => claim,
+            CommittedClaim::Forked { primary_claim, .. } => primary_claim,
+        }
     }
 
     fn test_description() -> ToolDescription {
@@ -997,23 +1461,18 @@ mod tests {
     }
 
     #[test]
-    fn account_subject_resolver_prefers_exact_id() {
+    fn account_subject_resolver_rejects_raw_account_id_subjects() {
         let accounts = vec![
             account_candidate("example-account", "Different Name"),
-            account_candidate("other-account", "Example Account"),
+            account_candidate("other-account", "Other Account"),
         ];
 
         let resolved = resolve_account_subject_from_accounts("example-account", &accounts);
 
-        match resolved {
-            AccountSubjectResolution::Resolved(subject) => {
-                assert_eq!(subject.entity_id, "example-account");
-                assert_eq!(subject.display_label, "Different Name");
-                assert_eq!(subject.resolution_kind, "account_id");
-                assert_eq!(subject.match_confidence, "exact");
-            }
-            other => panic!("expected resolved subject, got {other:?}"),
-        }
+        assert!(
+            matches!(resolved, AccountSubjectResolution::NotFound { .. }),
+            "raw account ids must not resolve through MCP subject lookup: {resolved:?}"
+        );
     }
 
     #[test]
@@ -1082,15 +1541,13 @@ mod tests {
             account_candidate("example-account", "Example Account"),
             account_candidate("exampleaccount", "ExampleAccount"),
             account_candidate("another-account", "Another Account"),
+            account_candidate("raw-id-only", "Unrelated Label"),
         ];
 
-        let exact_id = resolve_account_subject_from_accounts("another-account", &accounts);
+        let exact_id = resolve_account_subject_from_accounts("raw-id-only", &accounts);
         assert!(matches!(
             exact_id,
-            AccountSubjectResolution::Resolved(ResolvedAccountSubject {
-                resolution_kind: "account_id",
-                ..
-            })
+            AccountSubjectResolution::NotFound { .. }
         ));
 
         let exact_name = resolve_account_subject_from_accounts("example account", &accounts);
@@ -1144,8 +1601,11 @@ mod tests {
                 "schemaVersion": 2,
                 "subject": {
                     "kind": "account",
-                    "id": "example-account",
-                    "displayLabel": "account:example-account"
+                    "id": "acct-raw-123",
+                    "entityId": "acct-raw-456",
+                    "subjectRef": { "account": "acct-raw-789" },
+                    "subject_ref": { "account": "acct-raw-snake" },
+                    "displayLabel": "account:acct-raw-123"
                 },
                 "facts": { "items": [] },
                 "openLoops": { "items": [] },
@@ -1169,17 +1629,139 @@ mod tests {
             entity_id: "example-account".to_string(),
             display_label: "Example Account".to_string(),
             resolution_kind: "normalized_slug",
-            match_basis: "normalized_id_or_name",
+            match_basis: "normalized_name",
             match_confidence: "high",
             match_confidence_score: 0.95,
         };
 
         attach_account_subject_resolution(&mut payload, &subject);
 
-        assert_eq!(payload["resolution"]["resolvedEntityId"], "example-account");
+        assert!(payload["resolution"].get("resolvedEntityId").is_none());
+        assert!(payload["subject"].get("id").is_none());
+        assert!(payload["subject"].get("entityId").is_none());
+        assert!(payload["subject"].get("subjectRef").is_none());
+        assert!(payload["subject"].get("subject_ref").is_none());
         assert_eq!(payload["subject"]["input"], "Example Account");
         assert_eq!(payload["subject"]["displayLabel"], "Example Account");
         assert_eq!(payload["subject"]["resolutionKind"], "normalized_slug");
+        let serialized = serde_json::to_string(&payload).expect("payload serializes");
+        assert!(!serialized.contains("acct-raw-123"));
+        assert!(!serialized.contains("acct-raw-456"));
+        assert!(!serialized.contains("acct-raw-789"));
+        assert!(!serialized.contains("acct-raw-snake"));
+    }
+
+    #[test]
+    fn feedback_handle_minting_skips_missing_claim_targets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = ActionDb::open_at_unencrypted(dir.path().join("missing-feedback-claim.db"))
+            .expect("open db");
+        let actor = stub_actor();
+        let mut payload = json!({
+            "assessment": {
+                "facts": [{
+                    "text": "Visible fact from runtime projection"
+                }]
+            }
+        });
+
+        attach_feedback_handles_for_section(
+            &db,
+            &actor,
+            &mut payload,
+            "/assessment/facts",
+            vec![json!({ "claimId": "missing-claim-id" })],
+            feedback_candidate_from_fact,
+            projected_fact_text,
+        )
+        .expect("missing claim should not be an internal mint error");
+
+        assert!(
+            payload["assessment"]["facts"][0]
+                .get("feedback_target_handle")
+                .is_none(),
+            "MCP must not mint live-looking feedback handles for missing claim rows"
+        );
+        assert!(
+            payload["assessment"]["facts"][0]
+                .get("feedbackTargetHandle")
+                .is_none(),
+            "camel-case feedback handle must also stay absent"
+        );
+    }
+
+    #[test]
+    fn feedback_handle_minting_targets_visible_filtered_claim_not_raw_index() {
+        local_runtime::with_target_handle_key_for_tests([41_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("feedback-route.db"))
+                .expect("open db");
+            let hidden_claim = seed_renderable_claim(
+                &db,
+                "risk",
+                "Hidden filtered fact should not receive visible feedback.",
+            );
+            let visible_claim = seed_renderable_claim(
+                &db,
+                "risk",
+                "Visible fact should receive the feedback handle.",
+            );
+            let actor = stub_actor();
+            let mut payload = json!({
+                "assessment": {
+                    "facts": [{
+                        "text": "Visible fact should receive the feedback handle."
+                    }]
+                }
+            });
+
+            attach_feedback_handles_for_section(
+                &db,
+                &actor,
+                &mut payload,
+                "/assessment/facts",
+                vec![
+                    json!({
+                        "claimId": hidden_claim.id,
+                        "claimType": "risk"
+                    }),
+                    json!({
+                        "claimId": visible_claim.id,
+                        "claimType": "risk",
+                        "renderedText": {
+                            "text": "Visible fact should receive the feedback handle.",
+                            "policy": {}
+                        }
+                    }),
+                ],
+                feedback_candidate_from_fact,
+                projected_fact_text,
+            )
+            .expect("feedback handle mint");
+
+            let handle = payload["assessment"]["facts"][0]["feedback_target_handle"]
+                .as_str()
+                .expect("feedback handle");
+            let resolved = resolve_target_handle(
+                &db,
+                ResolveTargetHandle {
+                    actor: &actor,
+                    handle,
+                    expected_kind: TargetKind::Claim,
+                    current_watermark_material: Some(&claim_watermark_for_handle(&visible_claim)),
+                },
+            )
+            .expect("visible claim handle resolves");
+
+            let resolved_claim_id = resolved.target_ref["claim_id"]
+                .as_str()
+                .expect("resolved claim id");
+            assert_eq!(resolved_claim_id, visible_claim.id);
+            assert_ne!(
+                resolved_claim_id, hidden_claim.id,
+                "filtered raw rows must not receive handles by projected index"
+            );
+        });
     }
 
     #[test]

--- a/src-tauri/src/services/mcp_v2/handlers/tool_claim_feedback.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_claim_feedback.rs
@@ -1,0 +1,940 @@
+//! `dailyos.submit.claim_feedback` MCP handler.
+
+use abilities_runtime::abilities::feedback::FeedbackAction;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::services::claims::{
+    ClaimFeedbackInput, ClaimFeedbackReplayInput, McpFeedbackDelegation,
+};
+use crate::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::handler_context::McpHandlerContext;
+use crate::services::mcp_v2::target_handles::{
+    mint_target_handle, public_handle_hash, resolve_target_handle,
+    resolved_target_watermark_matches, MintTargetHandle, ResolveTargetHandle,
+    TargetHandleResolutionError, TargetKind,
+};
+use crate::services::sensitivity::{renderable_claim_text, RenderActor, RenderSurface};
+
+use super::tool_utils::{
+    actor_origin_hashes, bad_params, mutation_cursor_for_target, reject_raw_id_params,
+    required_str, source_provenance_watermark, unavailable_payload, validate_bounded_string,
+};
+
+const SCHEMA_VERSION: &str = "mcp.claim_feedback.v1";
+
+pub struct ClaimFeedbackHandler {
+    description: ToolDescription,
+}
+
+impl ClaimFeedbackHandler {
+    pub fn new(description: ToolDescription) -> Self {
+        Self { description }
+    }
+}
+
+impl McpToolHandler for ClaimFeedbackHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext,
+        actor: &McpActor,
+        params: Value,
+    ) -> Result<Value, ToolError> {
+        reject_raw_id_params(&params)?;
+        let feedback_target_handle = required_str(&params, "feedback_target_handle")?;
+        let action = parse_feedback_action(&required_str(&params, "action")?)?;
+        let metadata = sanitize_mcp_feedback_metadata(action, params.get("metadata"))?;
+        let (client_id_hash, conversation_handle_hash, tool_name) = actor_origin_hashes(actor)?;
+
+        let result = ctx.with_conn(|db| {
+            let resolved = match resolve_target_handle(
+                db,
+                ResolveTargetHandle {
+                    actor,
+                    handle: &feedback_target_handle,
+                    expected_kind: TargetKind::Claim,
+                    current_watermark_material: None,
+                },
+            ) {
+                Ok(resolved) => resolved,
+                Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        refresh_required,
+                        Some(&feedback_target_handle),
+                    ));
+                }
+                Err(TargetHandleResolutionError::Internal(detail)) => {
+                    return Err(ToolError::Internal {
+                        trace_id: format!("mcp_feedback_handle_resolve:{detail}"),
+                    });
+                }
+            };
+            let claim_id = resolved
+                .target_ref
+                .get("claim_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| bad_params("feedback target handle is unavailable"))?
+                .to_string();
+            let claim = match crate::services::claims::load_claim_by_id(db.conn_ref(), &claim_id)
+                .map_err(|error| ToolError::Internal {
+                    trace_id: format!("mcp_feedback_claim_load:{error}"),
+                })? {
+                Some(claim) => claim,
+                None => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        true,
+                        Some(&feedback_target_handle),
+                    ));
+                }
+            };
+            let current_watermark = claim_watermark_for_handle(&claim);
+            if !resolved_target_watermark_matches(&resolved, &current_watermark).map_err(
+                |error| ToolError::Internal {
+                    trace_id: format!("mcp_feedback_handle_watermark:{error}"),
+                },
+            )? {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    Some(&feedback_target_handle),
+                ));
+            }
+            if claim.claim_state != crate::db::claims::ClaimState::Active
+                || claim.surfacing_state != crate::db::claims::SurfacingState::Active
+                || renderable_claim_text(
+                    &claim,
+                    RenderSurface::McpTool,
+                    &RenderActor::agent("agent:mcp"),
+                )
+                .is_none()
+            {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    Some(&feedback_target_handle),
+                ));
+            }
+            let service_metadata =
+                match materialize_mcp_feedback_metadata(db, actor, action, &metadata)? {
+                    MetadataMaterialization::Available(metadata) => metadata,
+                    MetadataMaterialization::Unavailable { refresh_required } => {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            refresh_required,
+                            Some(&feedback_target_handle),
+                        ));
+                    }
+                };
+            let clock = SystemClock;
+            let rng = SystemRng;
+            let external = ExternalClients::default();
+            let service_ctx =
+                ServiceContext::new_live(&clock, &rng, &external).with_actor("mcp_client");
+            let delegation = McpFeedbackDelegation {
+                client_id_hash: &client_id_hash,
+                conversation_handle_hash: &conversation_handle_hash,
+                tool_name: &tool_name,
+            };
+            let feedback_input = ClaimFeedbackInput {
+                claim_id: claim_id.clone(),
+                action,
+                actor: "mcp_client".to_string(),
+                actor_id: Some(client_id_hash.clone()),
+                payload_json: service_metadata.clone().map(|value| value.to_string()),
+            };
+            let replay_input = ClaimFeedbackReplayInput {
+                feedback: feedback_input,
+                replay_event_id: mcp_feedback_replay_event_id(
+                    &feedback_target_handle,
+                    action,
+                    service_metadata.as_ref(),
+                    &client_id_hash,
+                    &conversation_handle_hash,
+                    &tool_name,
+                )?,
+                submitted_at: service_ctx.clock.now().to_rfc3339(),
+            };
+            if let Some(outcome) =
+                match crate::services::claims::recorded_claim_feedback_replay_outcome_from_mcp(
+                    db,
+                    replay_input.clone(),
+                    delegation,
+                ) {
+                    Ok(outcome) => outcome,
+                    Err(
+                        crate::services::claims::ClaimError::UnknownClaimId(_)
+                        | crate::services::claims::ClaimError::ClaimNotFound(_),
+                    ) => {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            true,
+                            Some(&feedback_target_handle),
+                        ));
+                    }
+                    Err(error) => {
+                        return Err(ToolError::UpstreamFailure {
+                            detail: error.to_string(),
+                        });
+                    }
+                }
+            {
+                return Ok(json!({
+                    "schema_version": SCHEMA_VERSION,
+                    "tool_name": self.description.name.as_str(),
+                    "status": "already_recorded",
+                    "action": outcome.action.as_str(),
+                    "verification_state": serde_json::to_value(outcome.new_verification_state)
+                        .unwrap_or(Value::String("unknown".to_string())),
+                    "applied_at_pending": outcome.applied_at_pending,
+                    "repair_queued": outcome.repair_job_id.is_some(),
+                    "mutation_cursor": mutation_cursor_for_target(
+                        &self.description.name,
+                        "already_recorded",
+                        "claim",
+                        &feedback_target_handle,
+                    ),
+                }));
+            }
+            let outcome = match crate::services::claims::record_claim_feedback_replay_from_mcp(
+                &service_ctx,
+                db,
+                replay_input,
+                delegation,
+            ) {
+                Ok(outcome) => outcome,
+                Err(
+                    crate::services::claims::ClaimError::UnknownClaimId(_)
+                    | crate::services::claims::ClaimError::ClaimNotFound(_),
+                ) => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        true,
+                        Some(&feedback_target_handle),
+                    ));
+                }
+                Err(error) => {
+                    return Err(ToolError::UpstreamFailure {
+                        detail: error.to_string(),
+                    });
+                }
+            };
+
+            let claim = crate::services::claims::load_claim_by_id(db.conn_ref(), &claim_id)
+                .map_err(|error| ToolError::UpstreamFailure {
+                    detail: error.to_string(),
+                })?
+                .ok_or_else(|| ToolError::UpstreamFailure {
+                    detail: "feedback target claim could not be reloaded".to_string(),
+                })?;
+            let watermark = claim_watermark_for_handle(&claim);
+            let next_handle = mint_target_handle(
+                db,
+                MintTargetHandle {
+                    actor,
+                    originating_tool: &self.description.name,
+                    result_item_path: "/feedback_target",
+                    target_kind: TargetKind::Claim,
+                    target_ref: json!({
+                        "claim_id": claim.id,
+                        "claim_version": claim.claim_version,
+                    }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "mcp_claim_feedback",
+                    watermark_material: &watermark,
+                },
+            )
+            .map_err(|error| ToolError::Internal {
+                trace_id: format!("mcp_feedback_handle_mint:{error}"),
+            })?;
+
+            Ok(json!({
+                "schema_version": SCHEMA_VERSION,
+                "tool_name": self.description.name.as_str(),
+                "status": "ok",
+                "action": outcome.action.as_str(),
+                "verification_state": serde_json::to_value(outcome.new_verification_state)
+                    .unwrap_or(Value::String("unknown".to_string())),
+                "applied_at_pending": outcome.applied_at_pending,
+                "repair_queued": outcome.repair_job_id.is_some(),
+                "feedback_target_handle": next_handle,
+                "mutation_cursor": mutation_cursor_for_target(
+                    &self.description.name,
+                    "ok",
+                    "claim",
+                    &next_handle,
+                ),
+            }))
+        });
+        result.unwrap_or_else(|| {
+            Err(ToolError::Internal {
+                trace_id: "mcp_claim_feedback_missing_owned_connection".to_string(),
+            })
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SanitizedMcpFeedbackMetadata {
+    payload_json: Option<Value>,
+    source_provenance_handle: Option<String>,
+}
+
+enum MetadataMaterialization {
+    Available(Option<Value>),
+    Unavailable { refresh_required: bool },
+}
+
+fn sanitize_mcp_feedback_metadata(
+    action: FeedbackAction,
+    metadata: Option<&Value>,
+) -> Result<SanitizedMcpFeedbackMetadata, ToolError> {
+    let Some(metadata) = metadata else {
+        return match action {
+            FeedbackAction::WrongSource
+            | FeedbackAction::NeedsNuance
+            | FeedbackAction::SurfaceInappropriate
+            | FeedbackAction::NotRelevantHere => Err(bad_params(format!(
+                "`metadata` is required for `{}` feedback",
+                action.as_str()
+            ))),
+            _ => Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: None,
+                source_provenance_handle: None,
+            }),
+        };
+    };
+    let object = metadata
+        .as_object()
+        .ok_or_else(|| bad_params("`metadata` must be a JSON object when present"))?;
+    reject_disallowed_metadata_keys_recursive(metadata)?;
+
+    let allowed_keys = allowed_metadata_keys(action);
+    for key in object.keys() {
+        if !allowed_keys.contains(&key.as_str()) {
+            return Err(bad_params(format!(
+                "`metadata.{key}` is not accepted for `{}` feedback",
+                action.as_str()
+            )));
+        }
+        if disallowed_metadata_key(key) {
+            return Err(bad_params(format!(
+                "`metadata.{key}` cannot contain caller-supplied identifiers"
+            )));
+        }
+    }
+
+    match action {
+        FeedbackAction::WrongSource => {
+            let handle = required_metadata_string(
+                object,
+                "source_provenance_handle",
+                action,
+                1,
+                256,
+                StringPolicy::AllowPublicHandle,
+            )?;
+            if !handle.starts_with("mth_") {
+                return Err(bad_params(
+                    "`metadata.source_provenance_handle` must be a server-issued MCP handle",
+                ));
+            }
+            Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: None,
+                source_provenance_handle: Some(handle),
+            })
+        }
+        FeedbackAction::NeedsNuance => {
+            let corrected_text = required_metadata_string(
+                object,
+                "corrected_text",
+                action,
+                1,
+                2_000,
+                StringPolicy::RejectPublicHandle,
+            )?;
+            Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: Some(json!({ "corrected_text": corrected_text })),
+                source_provenance_handle: None,
+            })
+        }
+        FeedbackAction::SurfaceInappropriate => {
+            let surface = required_metadata_string(
+                object,
+                "surface",
+                action,
+                1,
+                120,
+                StringPolicy::RejectPublicHandle,
+            )?;
+            Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: Some(json!({ "surface": surface })),
+                source_provenance_handle: None,
+            })
+        }
+        FeedbackAction::NotRelevantHere => {
+            let invocation_id = required_metadata_string(
+                object,
+                "invocation_id",
+                action,
+                1,
+                160,
+                StringPolicy::RejectPublicHandle,
+            )?;
+            let note =
+                optional_metadata_string(object, "note", 1, 200, StringPolicy::RejectPublicHandle)?;
+            let mut payload = serde_json::Map::new();
+            payload.insert("invocation_id".to_string(), Value::String(invocation_id));
+            if let Some(note) = note {
+                payload.insert("note".to_string(), Value::String(note));
+            }
+            Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: Some(Value::Object(payload)),
+                source_provenance_handle: None,
+            })
+        }
+        _ => {
+            if !object.is_empty() {
+                return Err(bad_params(format!(
+                    "`metadata` is not accepted for `{}` feedback",
+                    action.as_str()
+                )));
+            }
+            Ok(SanitizedMcpFeedbackMetadata {
+                payload_json: None,
+                source_provenance_handle: None,
+            })
+        }
+    }
+}
+
+fn materialize_mcp_feedback_metadata(
+    db: &crate::db::ActionDb,
+    actor: &McpActor,
+    action: FeedbackAction,
+    metadata: &SanitizedMcpFeedbackMetadata,
+) -> Result<MetadataMaterialization, ToolError> {
+    if !matches!(action, FeedbackAction::WrongSource) {
+        return Ok(MetadataMaterialization::Available(
+            metadata.payload_json.clone(),
+        ));
+    }
+    let Some(source_handle) = metadata.source_provenance_handle.as_deref() else {
+        return Err(bad_params(
+            "`metadata.source_provenance_handle` is required for `wrong_source` feedback",
+        ));
+    };
+    let resolved = match resolve_target_handle(
+        db,
+        ResolveTargetHandle {
+            actor,
+            handle: source_handle,
+            expected_kind: TargetKind::SourceProvenance,
+            current_watermark_material: None,
+        },
+    ) {
+        Ok(resolved) => resolved,
+        Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+            return Ok(MetadataMaterialization::Unavailable { refresh_required });
+        }
+        Err(TargetHandleResolutionError::Internal(detail)) => {
+            return Err(ToolError::Internal {
+                trace_id: format!("mcp_feedback_source_handle_resolve:{detail}"),
+            });
+        }
+    };
+    let current_watermark = source_provenance_watermark(&resolved.target_ref);
+    if !resolved_target_watermark_matches(&resolved, &current_watermark).map_err(|error| {
+        ToolError::Internal {
+            trace_id: format!("mcp_feedback_source_watermark:{error}"),
+        }
+    })? {
+        return Ok(MetadataMaterialization::Unavailable {
+            refresh_required: true,
+        });
+    }
+    let handle_hash = public_handle_hash(source_handle).map_err(|error| ToolError::Internal {
+        trace_id: format!("mcp_feedback_source_handle_hash:{error}"),
+    })?;
+    Ok(MetadataMaterialization::Available(Some(json!({
+        "source_ref": json!({
+            "kind": "mcp_source_provenance_handle",
+            "handle_hash": handle_hash,
+        })
+        .to_string(),
+    }))))
+}
+
+fn allowed_metadata_keys(action: FeedbackAction) -> &'static [&'static str] {
+    match action {
+        FeedbackAction::WrongSource => &["source_provenance_handle"],
+        FeedbackAction::NeedsNuance => &["corrected_text"],
+        FeedbackAction::SurfaceInappropriate => &["surface"],
+        FeedbackAction::NotRelevantHere => &["invocation_id", "note"],
+        _ => &[],
+    }
+}
+
+fn disallowed_metadata_key(key: &str) -> bool {
+    matches!(
+        key,
+        "claim_id"
+            | "claimId"
+            | "action_id"
+            | "actionId"
+            | "entity_id"
+            | "entityId"
+            | "account_id"
+            | "accountId"
+            | "project_id"
+            | "projectId"
+            | "person_id"
+            | "personId"
+            | "meeting_id"
+            | "meetingId"
+            | "source_id"
+            | "sourceId"
+            | "source_ref"
+            | "sourceRef"
+            | "workspace_id"
+            | "workspaceId"
+            | "file_path"
+            | "filePath"
+            | "path"
+            | "idempotency_key"
+            | "idempotencyKey"
+            | "feedback_target_handle"
+            | "feedbackTargetHandle"
+            | "entity_handle"
+            | "entityHandle"
+    )
+}
+
+fn reject_disallowed_metadata_keys_recursive(value: &Value) -> Result<(), ToolError> {
+    match value {
+        Value::Object(object) => {
+            for (key, nested) in object {
+                if key != "source_provenance_handle" && disallowed_metadata_key(key) {
+                    return Err(bad_params(format!(
+                        "`metadata.{key}` cannot contain caller-supplied identifiers"
+                    )));
+                }
+                reject_disallowed_metadata_keys_recursive(nested)?;
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                reject_disallowed_metadata_keys_recursive(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StringPolicy {
+    AllowPublicHandle,
+    RejectPublicHandle,
+}
+
+fn required_metadata_string(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+    action: FeedbackAction,
+    min_chars: usize,
+    max_chars: usize,
+    policy: StringPolicy,
+) -> Result<String, ToolError> {
+    let value = object.get(key).ok_or_else(|| {
+        bad_params(format!(
+            "`metadata.{key}` is required for `{}` feedback",
+            action.as_str()
+        ))
+    })?;
+    metadata_string_value(value, key, min_chars, max_chars, policy)
+}
+
+fn optional_metadata_string(
+    object: &serde_json::Map<String, Value>,
+    key: &str,
+    min_chars: usize,
+    max_chars: usize,
+    policy: StringPolicy,
+) -> Result<Option<String>, ToolError> {
+    object
+        .get(key)
+        .map(|value| metadata_string_value(value, key, min_chars, max_chars, policy))
+        .transpose()
+}
+
+fn metadata_string_value(
+    value: &Value,
+    key: &str,
+    min_chars: usize,
+    max_chars: usize,
+    policy: StringPolicy,
+) -> Result<String, ToolError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| bad_params(format!("`metadata.{key}` must be a string")))?;
+    let value = validate_bounded_string(value, &format!("metadata.{key}"), min_chars, max_chars)?;
+    if policy == StringPolicy::RejectPublicHandle && value.contains("mth_") {
+        return Err(bad_params(format!(
+            "`metadata.{key}` cannot contain MCP target handles"
+        )));
+    }
+    Ok(value)
+}
+
+fn claim_watermark_for_handle(claim: &crate::db::claims::IntelligenceClaim) -> String {
+    format!(
+        "claim:{}:{}:{:?}:{:?}",
+        claim.id, claim.claim_version, claim.claim_state, claim.verification_state
+    )
+}
+
+fn mcp_feedback_replay_event_id(
+    handle: &str,
+    action: FeedbackAction,
+    metadata: Option<&Value>,
+    client_id_hash: &str,
+    conversation_handle_hash: &str,
+    tool_name: &str,
+) -> Result<String, ToolError> {
+    let handle_hash = public_handle_hash(handle).map_err(|error| ToolError::Internal {
+        trace_id: format!("mcp_feedback_replay_handle_hash:{error}"),
+    })?;
+    let mut hasher = Sha256::new();
+    update_replay_hash_part(&mut hasher, &handle_hash);
+    update_replay_hash_part(&mut hasher, action.as_str());
+    update_replay_hash_part(&mut hasher, client_id_hash);
+    update_replay_hash_part(&mut hasher, conversation_handle_hash);
+    update_replay_hash_part(&mut hasher, tool_name);
+    if let Some(metadata) = metadata {
+        update_replay_hash_part(&mut hasher, &canonical_json_string(metadata));
+    }
+    Ok(format!("mcp:{:x}", hasher.finalize()))
+}
+
+fn update_replay_hash_part(hasher: &mut Sha256, value: &str) {
+    hasher.update(value.len().to_string().as_bytes());
+    hasher.update(b":");
+    hasher.update(value.as_bytes());
+    hasher.update(b"|");
+}
+
+fn canonical_json_string(value: &Value) -> String {
+    canonical_json_value(value).to_string()
+}
+
+fn canonical_json_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(canonical_json_value).collect()),
+        Value::Object(map) => {
+            let mut keys = map.keys().collect::<Vec<_>>();
+            keys.sort();
+            let mut out = serde_json::Map::new();
+            for key in keys {
+                if let Some(value) = map.get(key) {
+                    out.insert(key.clone(), canonical_json_value(value));
+                }
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+fn parse_feedback_action(value: &str) -> Result<FeedbackAction, ToolError> {
+    match value {
+        "confirm_current" => Ok(FeedbackAction::ConfirmCurrent),
+        "mark_false" => Ok(FeedbackAction::MarkFalse),
+        "needs_nuance" => Ok(FeedbackAction::NeedsNuance),
+        "wrong_source" => Ok(FeedbackAction::WrongSource),
+        "not_relevant_here" => Ok(FeedbackAction::NotRelevantHere),
+        "surface_inappropriate" => Ok(FeedbackAction::SurfaceInappropriate),
+        "cannot_verify" => Ok(FeedbackAction::CannotVerify),
+        other => Err(bad_params(format!("unsupported feedback action `{other}`"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::db::claims::{ClaimSensitivity, IntelligenceClaim, TemporalScope};
+    use crate::db::{ActionDb, DbAccount};
+    use crate::services::claims::{commit_claim, ClaimProposal, CommittedClaim};
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
+    };
+    use crate::services::mcp_v2::handler_context::McpHandlerContext;
+    use crate::services::mcp_v2::local_runtime;
+
+    const TOOL_NAME: &str = "dailyos.submit.claim_feedback";
+    const TS: &str = "2026-06-01T12:00:00Z";
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new(TOOL_NAME),
+            summary: String::new(),
+            when_to_call: String::new(),
+            when_not_to_call: String::new(),
+            side: Side::SubmitCorrection,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: String::new(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new(TOOL_NAME)],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-claim-feedback-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new(
+                "conversation-claim-feedback-test",
+            )),
+            tool_name: ScopedName::new(TOOL_NAME),
+            granted_scopes: vec![Scope::new(TOOL_NAME)],
+        }
+    }
+
+    fn handler() -> ClaimFeedbackHandler {
+        ClaimFeedbackHandler::new(description())
+    }
+
+    fn seed_claim(db: &ActionDb) -> IntelligenceClaim {
+        db.upsert_account(&DbAccount {
+            id: "acct-feedback-test".to_string(),
+            name: "Feedback Test Account".to_string(),
+            updated_at: TS.to_string(),
+            ..Default::default()
+        })
+        .expect("seed account");
+        let clock = SystemClock;
+        let rng = SystemRng;
+        let external = ExternalClients::default();
+        let ctx = ServiceContext::new_live(&clock, &rng, &external).with_actor("user:test");
+        let proposal = ClaimProposal {
+            id: None,
+            expected_claim_version: None,
+            subject_ref: r#"{"kind":"account","id":"acct-feedback-test"}"#.to_string(),
+            claim_type: "risk".to_string(),
+            field_path: Some("health.risk".to_string()),
+            topic_key: None,
+            text: "Procurement risk is elevated.".to_string(),
+            actor: "agent:test".to_string(),
+            data_source: "unit_test".to_string(),
+            source_ref: None,
+            source_asof: Some(TS.to_string()),
+            observed_at: TS.to_string(),
+            provenance_json: "{}".to_string(),
+            metadata_json: None,
+            thread_id: None,
+            temporal_scope: Some(TemporalScope::State),
+            sensitivity: Some(ClaimSensitivity::Internal),
+            supersedes: None,
+            tombstone: None,
+        };
+        match commit_claim(&ctx, db, proposal).expect("commit claim") {
+            CommittedClaim::Inserted { claim }
+            | CommittedClaim::Reinforced { claim, .. }
+            | CommittedClaim::Tombstoned { claim } => claim,
+            CommittedClaim::Forked { primary_claim, .. } => primary_claim,
+        }
+    }
+
+    fn mint_feedback_handle(db: &ActionDb, actor: &McpActor, claim: &IntelligenceClaim) -> String {
+        let watermark = claim_watermark_for_handle(claim);
+        mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                result_item_path: "/assessment/facts/0",
+                target_kind: TargetKind::Claim,
+                target_ref: json!({
+                    "claim_id": claim.id,
+                    "claim_version": claim.claim_version,
+                }),
+                sensitivity_tier: "internal",
+                provenance_material: "test-claim-feedback-target",
+                watermark_material: &watermark,
+            },
+        )
+        .expect("mint feedback handle")
+    }
+
+    fn mint_missing_feedback_handle(db: &ActionDb, actor: &McpActor) -> String {
+        mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                result_item_path: "/assessment/facts/0",
+                target_kind: TargetKind::Claim,
+                target_ref: json!({ "claim_id": "missing-claim" }),
+                sensitivity_tier: "internal",
+                provenance_material: "test-missing-claim-feedback-target",
+                watermark_material: "claim:missing-claim:unknown",
+            },
+        )
+        .expect("mint missing claim handle")
+    }
+
+    fn mint_source_handle(db: &ActionDb, actor: &McpActor) -> String {
+        let target_ref = json!({
+            "label": "DailyOS source",
+            "source_type": "meeting",
+            "source_asof": TS,
+            "trust_band": "likely_current",
+            "redaction_applied": false,
+        });
+        let watermark = source_provenance_watermark(&target_ref);
+        mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                result_item_path: "/provenance/sources/0",
+                target_kind: TargetKind::SourceProvenance,
+                target_ref,
+                sensitivity_tier: "internal",
+                provenance_material: &watermark,
+                watermark_material: &watermark,
+            },
+        )
+        .expect("mint source handle")
+    }
+
+    #[test]
+    fn claim_feedback_rejects_raw_metadata_keys_recursively() {
+        let err = handler()
+            .invoke(
+                &McpHandlerContext::without_connection(),
+                &actor(),
+                json!({
+                    "feedback_target_handle": "mth_placeholder",
+                    "action": "needs_nuance",
+                    "metadata": {
+                        "corrected_text": "The risk needs more context.",
+                        "nested": { "source_id": "raw-source-id" }
+                    }
+                }),
+            )
+            .expect_err("raw metadata keys must be rejected before DB access");
+        assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[test]
+    fn claim_feedback_rejects_wrong_source_raw_source_ref_metadata() {
+        let err = handler()
+            .invoke(
+                &McpHandlerContext::without_connection(),
+                &actor(),
+                json!({
+                    "feedback_target_handle": "mth_placeholder",
+                    "action": "wrong_source",
+                    "metadata": {
+                        "source_ref": "fixture://raw-source"
+                    }
+                }),
+            )
+            .expect_err("caller-supplied source_ref must be rejected");
+        assert!(matches!(err, ToolError::BadParams { .. }));
+    }
+
+    #[test]
+    fn claim_feedback_missing_claim_handle_returns_unavailable() {
+        local_runtime::with_target_handle_key_for_tests([41_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("missing-claim-feedback.db"))
+                .expect("open db");
+            let actor = actor();
+            let handle = mint_missing_feedback_handle(&db, &actor);
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+
+            let payload = handler()
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "feedback_target_handle": handle,
+                        "action": "confirm_current"
+                    }),
+                )
+                .expect("missing claim handle returns a no-op payload");
+
+            assert_eq!(payload["status"], "unavailable");
+            assert_eq!(payload["refresh_required"], true);
+        });
+    }
+
+    #[test]
+    fn wrong_source_feedback_persists_source_handle_hash_not_public_handle() {
+        local_runtime::with_target_handle_key_for_tests([42_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("wrong-source-feedback.db"))
+                .expect("open db");
+            let actor = actor();
+            let claim = seed_claim(&db);
+            let feedback_handle = mint_feedback_handle(&db, &actor, &claim);
+            let source_handle = mint_source_handle(&db, &actor);
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+
+            let payload = handler()
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "feedback_target_handle": feedback_handle,
+                        "action": "wrong_source",
+                        "metadata": {
+                            "source_provenance_handle": source_handle
+                        }
+                    }),
+                )
+                .expect("wrong_source feedback response");
+            assert_eq!(payload["status"], "ok");
+
+            let persisted_payload: String = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT payload_json FROM claim_feedback WHERE claim_id = ?1",
+                    [&claim.id],
+                    |row| row.get(0),
+                )
+                .expect("feedback payload");
+            assert!(
+                !persisted_payload.contains("mth_"),
+                "public MCP handles must not be persisted in feedback payloads: {persisted_payload}"
+            );
+            assert!(
+                persisted_payload.contains("mcp_source_provenance_handle"),
+                "wrong_source stores a service-derived source handle hash"
+            );
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_create_action.rs
@@ -1,1 +1,419 @@
-//! Placeholder. Handler implementation pending.
+//! `dailyos.submit.action` MCP handler.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use crate::commands::CreateActionRequest;
+use crate::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::handler_context::McpHandlerContext;
+use crate::services::mcp_v2::target_handles::{
+    mint_replacing_target_handle, resolve_target_handle, resolved_target_watermark_matches,
+    MintTargetHandle, ResolveTargetHandle, TargetHandleResolutionError, TargetKind,
+};
+use crate::signals::propagation::PropagationEngine;
+
+use super::tool_utils::{
+    bad_params, current_entity_watermark, deterministic_uuid_from_replay_key,
+    mcp_submit_replay_key, mutation_cursor_for_target, reject_raw_id_params, required_str,
+    unavailable_payload, validate_bounded_string, validate_yyyy_mm_dd,
+};
+
+const SCHEMA_VERSION: &str = "mcp.action_submit.v1";
+
+pub struct CreateActionHandler {
+    description: ToolDescription,
+    signal_engine: Arc<PropagationEngine>,
+}
+
+impl CreateActionHandler {
+    pub fn new(description: ToolDescription, signal_engine: Arc<PropagationEngine>) -> Self {
+        Self {
+            description,
+            signal_engine,
+        }
+    }
+}
+
+impl McpToolHandler for CreateActionHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext,
+        actor: &McpActor,
+        params: Value,
+    ) -> Result<Value, ToolError> {
+        reject_raw_id_params(&params)?;
+        let description = validate_bounded_string(
+            &required_str(&params, "description")?,
+            "description",
+            1,
+            280,
+        )?;
+        let due_date = super::tool_utils::optional_str(&params, "due_date")?;
+        if let Some(date) = due_date.as_deref() {
+            validate_yyyy_mm_dd(date, "due_date")?;
+        }
+        let priority = super::tool_utils::optional_str(&params, "priority")?
+            .map(|value| priority_to_service_value(&value))
+            .transpose()?;
+        let entity_handle = super::tool_utils::optional_str(&params, "entity_handle")?;
+
+        let result = ctx.with_conn(|db| {
+            let (account_id, project_id, person_id) = if let Some(handle) = entity_handle.as_deref()
+            {
+                match resolve_target_handle(
+                    db,
+                    ResolveTargetHandle {
+                        actor,
+                        handle,
+                        expected_kind: TargetKind::Entity,
+                        current_watermark_material: None,
+                    },
+                ) {
+                    Ok(resolved) => {
+                        let Some(current_watermark) =
+                            current_entity_watermark(db, &resolved.target_ref)?
+                        else {
+                            return Ok(unavailable_payload(
+                                SCHEMA_VERSION,
+                                &self.description.name,
+                                true,
+                                Some(handle),
+                            ));
+                        };
+                        if !resolved_target_watermark_matches(&resolved, &current_watermark)
+                            .map_err(|error| ToolError::Internal {
+                                trace_id: format!("mcp_action_entity_handle_watermark:{error}"),
+                            })?
+                        {
+                            return Ok(unavailable_payload(
+                                SCHEMA_VERSION,
+                                &self.description.name,
+                                true,
+                                Some(handle),
+                            ));
+                        }
+                        entity_target_for_action(&resolved.target_ref)?
+                    }
+                    Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            refresh_required,
+                            Some(handle),
+                        ));
+                    }
+                    Err(TargetHandleResolutionError::Internal(detail)) => {
+                        return Err(ToolError::Internal {
+                            trace_id: format!("mcp_action_entity_handle_resolve:{detail}"),
+                        });
+                    }
+                }
+            } else {
+                (None, None, None)
+            };
+
+            let clock = SystemClock;
+            let rng = SystemRng;
+            let external = ExternalClients::default();
+            let service_ctx =
+                ServiceContext::new_live(&clock, &rng, &external).with_actor("mcp_client");
+            let replay_key = mcp_submit_replay_key(
+                actor,
+                &self.description.name,
+                "submit.action",
+                &json!({
+                    "description": description.clone(),
+                    "priority": priority.clone(),
+                    "due_date": due_date.clone(),
+                    "account_id": account_id.clone(),
+                    "project_id": project_id.clone(),
+                    "person_id": person_id.clone(),
+                }),
+            )?;
+            let deterministic_action_id =
+                deterministic_uuid_from_replay_key("action", &replay_key)?;
+            let action_id = crate::services::actions::create_action_with_db_with_id(
+                &service_ctx,
+                CreateActionRequest {
+                    title: description.clone(),
+                    priority,
+                    due_date,
+                    account_id,
+                    project_id,
+                    person_id,
+                    context: None,
+                    source_label: Some("MCP".to_string()),
+                    action_kind: Some(crate::action_status::KIND_TASK.to_string()),
+                },
+                db,
+                &self.signal_engine,
+                Some(&deterministic_action_id),
+            )
+            .map_err(|error| ToolError::UpstreamFailure { detail: error })?;
+            let action = db
+                .get_action_by_id(&action_id)
+                .map_err(|error| ToolError::UpstreamFailure {
+                    detail: error.to_string(),
+                })?
+                .ok_or_else(|| ToolError::UpstreamFailure {
+                    detail: "created action could not be reloaded".to_string(),
+                })?;
+            let watermark = action_watermark(&action);
+            let action_handle = mint_replacing_target_handle(
+                db,
+                MintTargetHandle {
+                    actor,
+                    originating_tool: &self.description.name,
+                    result_item_path: "/action",
+                    target_kind: TargetKind::Action,
+                    target_ref: json!({ "action_id": action.id }),
+                    sensitivity_tier: "internal",
+                    provenance_material: &format!("mcp_submit_action:{}", action.id),
+                    watermark_material: &watermark,
+                },
+            )
+            .map_err(|error| ToolError::Internal {
+                trace_id: format!("mcp_action_handle_mint:{}", error),
+            })?;
+
+            Ok(json!({
+                "schema_version": SCHEMA_VERSION,
+                "tool_name": self.description.name.as_str(),
+                "status": "ok",
+                "action_handle": action_handle,
+                "semantic_status": "created",
+                "stored_status": action.status,
+                "mutation_cursor": mutation_cursor_for_target(
+                    &self.description.name,
+                    "ok",
+                    "action",
+                    &action_handle,
+                ),
+            }))
+        });
+        result.unwrap_or_else(|| {
+            Err(ToolError::Internal {
+                trace_id: "mcp_submit_action_missing_owned_connection".to_string(),
+            })
+        })
+    }
+}
+
+fn priority_to_service_value(value: &str) -> Result<String, ToolError> {
+    match value {
+        "none" => Ok(crate::action_status::PRIORITY_NONE.to_string()),
+        "urgent" => Ok(crate::action_status::PRIORITY_URGENT.to_string()),
+        "high" => Ok(crate::action_status::PRIORITY_HIGH.to_string()),
+        "medium" => Ok(crate::action_status::PRIORITY_MEDIUM.to_string()),
+        "low" => Ok(crate::action_status::PRIORITY_LOW.to_string()),
+        other => Err(bad_params(format!("unsupported priority `{other}`"))),
+    }
+}
+
+type EntityActionTarget = (Option<String>, Option<String>, Option<String>);
+
+fn entity_target_for_action(target_ref: &Value) -> Result<EntityActionTarget, ToolError> {
+    let entity_type = target_ref
+        .get("entity_type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| bad_params("entity handle is unavailable"))?;
+    let entity_id = target_ref
+        .get("entity_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| bad_params("entity handle is unavailable"))?
+        .to_string();
+    Ok(match entity_type {
+        "account" => (Some(entity_id), None, None),
+        "project" => (None, Some(entity_id), None),
+        "person" => (None, None, Some(entity_id)),
+        _ => return Err(bad_params("entity handle cannot target an action")),
+    })
+}
+
+fn action_watermark(action: &crate::db::DbAction) -> String {
+    format!(
+        "action:{}:{}:{}",
+        action.id, action.updated_at, action.status
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use super::*;
+    use crate::db::{ActionDb, DbAccount};
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
+    };
+    use crate::services::mcp_v2::handlers::tool_utils::entity_watermark_from_parts;
+    use crate::services::mcp_v2::local_runtime;
+    use crate::services::mcp_v2::target_handles::mint_target_handle;
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new("dailyos.submit.action"),
+            summary: String::new(),
+            when_to_call: String::new(),
+            when_not_to_call: String::new(),
+            side: Side::SubmitCorrection,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: String::new(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("dailyos.submit.action")],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-action-submit-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new(
+                "conversation-action-submit-test",
+            )),
+            tool_name: ScopedName::new("dailyos.submit.action"),
+            granted_scopes: vec![Scope::new("dailyos.submit.action")],
+        }
+    }
+
+    fn account(id: &str, name: &str, updated_at: &str, archived: bool) -> DbAccount {
+        DbAccount {
+            id: id.to_string(),
+            name: name.to_string(),
+            updated_at: updated_at.to_string(),
+            archived,
+            ..Default::default()
+        }
+    }
+
+    fn handler() -> CreateActionHandler {
+        CreateActionHandler::new(description(), Arc::new(PropagationEngine::new()))
+    }
+
+    #[test]
+    fn submit_action_replay_reuses_durable_action_row() {
+        local_runtime::with_target_handle_key_for_tests([21_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db =
+                ActionDb::open_at_unencrypted(dir.path().join("submit-action-replay.db")).unwrap();
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+            let actor = actor();
+            let handler = handler();
+            let params = json!({ "description": "Follow up on contract review" });
+
+            let first = handler
+                .invoke(&ctx, &actor, params.clone())
+                .expect("first action response");
+            let second = handler
+                .invoke(&ctx, &actor, params)
+                .expect("second action response");
+
+            assert_eq!(first["status"], "ok");
+            assert_eq!(second["status"], "ok");
+            let count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM actions WHERE title = ?1",
+                    ["Follow up on contract review"],
+                    |row| row.get(0),
+                )
+                .expect("action count");
+            assert_eq!(count, 1, "MCP retry must not duplicate durable actions");
+            let handle_count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM mcp_target_handles WHERE originating_tool = ?1",
+                    ["dailyos.submit.action"],
+                    |row| row.get(0),
+                )
+                .expect("target handle count");
+            assert_eq!(
+                handle_count, 1,
+                "MCP retry must not duplicate durable action handle rows"
+            );
+        });
+    }
+
+    #[test]
+    fn submit_action_rejects_archived_entity_handle() {
+        local_runtime::with_target_handle_key_for_tests([22_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db =
+                ActionDb::open_at_unencrypted(dir.path().join("submit-action-stale.db")).unwrap();
+            let actor = actor();
+            let active_updated_at = "2026-06-01T00:00:00Z";
+            let active = account("acct-stale", "Stale Account", active_updated_at, false);
+            db.upsert_account(&active).expect("seed account");
+            let watermark = entity_watermark_from_parts(
+                "account",
+                &active.id,
+                &active.updated_at,
+                active.archived,
+            );
+            let entity_handle = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/subject",
+                    target_kind: TargetKind::Entity,
+                    target_ref: json!({
+                        "entity_type": "account",
+                        "entity_id": active.id,
+                    }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "test-account",
+                    watermark_material: &watermark,
+                },
+            )
+            .expect("mint entity handle");
+            let mut archived = active;
+            archived.archived = true;
+            archived.updated_at = Utc::now().to_rfc3339();
+            db.upsert_account(&archived).expect("archive account");
+
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+            let payload = handler()
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "description": "Follow up with archived account",
+                        "entity_handle": entity_handle,
+                    }),
+                )
+                .expect("handler response");
+
+            assert_eq!(payload["status"], "unavailable");
+            assert_eq!(payload["refresh_required"], true);
+            let count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM actions WHERE title = ?1",
+                    ["Follow up with archived account"],
+                    |row| row.get(0),
+                )
+                .expect("action count");
+            assert_eq!(count, 0, "stale entity handles must not create actions");
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_note.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_note.rs
@@ -1,1 +1,533 @@
-//! Placeholder. Handler implementation pending.
+//! `dailyos.submit.note` MCP handler.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use crate::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::handler_context::McpHandlerContext;
+use crate::services::mcp_v2::target_handles::{
+    mint_replacing_target_handle, public_handle_hash, resolve_target_handle,
+    resolved_target_watermark_matches, MintTargetHandle, ResolveTargetHandle,
+    TargetHandleResolutionError, TargetKind,
+};
+use crate::signals::propagation::PropagationEngine;
+
+use super::tool_utils::{
+    bad_params, current_entity_watermark, deterministic_uuid_from_replay_key,
+    mcp_submit_replay_key, mutation_cursor_for_target, reject_raw_id_params, required_str,
+    source_provenance_watermark, unavailable_payload, validate_bounded_string,
+};
+
+const SCHEMA_VERSION: &str = "mcp.note_submit.v1";
+
+pub struct NoteHandler {
+    description: ToolDescription,
+    signal_engine: Arc<PropagationEngine>,
+}
+
+impl NoteHandler {
+    pub fn new(description: ToolDescription, signal_engine: Arc<PropagationEngine>) -> Self {
+        Self {
+            description,
+            signal_engine,
+        }
+    }
+}
+
+impl McpToolHandler for NoteHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext,
+        actor: &McpActor,
+        params: Value,
+    ) -> Result<Value, ToolError> {
+        reject_raw_id_params(&params)?;
+        let text = validate_bounded_string(&required_str(&params, "text")?, "text", 1, 2000)?;
+        let entity_handle = required_str(&params, "entity_handle")?;
+        let subject_text = super::tool_utils::optional_str(&params, "subject_text")?
+            .unwrap_or_else(|| "MCP note".to_string());
+        let title = validate_bounded_string(&subject_text, "subject_text", 1, 200)?;
+        let source_handle = super::tool_utils::optional_str(&params, "source_provenance_handle")?;
+
+        let result = ctx.with_conn(|db| {
+            let resolved_entity = match resolve_target_handle(
+                db,
+                ResolveTargetHandle {
+                    actor,
+                    handle: &entity_handle,
+                    expected_kind: TargetKind::Entity,
+                    current_watermark_material: None,
+                },
+            ) {
+                Ok(resolved) => resolved,
+                Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        refresh_required,
+                        Some(&entity_handle),
+                    ));
+                }
+                Err(TargetHandleResolutionError::Internal(detail)) => {
+                    return Err(ToolError::Internal {
+                        trace_id: format!("mcp_note_entity_handle_resolve:{detail}"),
+                    });
+                }
+            };
+            let Some(current_entity_watermark) =
+                current_entity_watermark(db, &resolved_entity.target_ref)?
+            else {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    Some(&entity_handle),
+                ));
+            };
+            if !resolved_target_watermark_matches(&resolved_entity, &current_entity_watermark)
+                .map_err(|error| ToolError::Internal {
+                    trace_id: format!("mcp_note_entity_handle_watermark:{error}"),
+                })?
+            {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    Some(&entity_handle),
+                ));
+            }
+            let entity_type = resolved_entity
+                .target_ref
+                .get("entity_type")
+                .and_then(Value::as_str)
+                .ok_or_else(|| bad_params("entity handle is unavailable"))?
+                .to_string();
+            let entity_id = resolved_entity
+                .target_ref
+                .get("entity_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| bad_params("entity handle is unavailable"))?
+                .to_string();
+            let source_ref = if let Some(handle) = source_handle.as_deref() {
+                match resolve_target_handle(
+                    db,
+                    ResolveTargetHandle {
+                        actor,
+                        handle,
+                        expected_kind: TargetKind::SourceProvenance,
+                        current_watermark_material: None,
+                    },
+                ) {
+                    Ok(resolved_source) => {
+                        let current_source_watermark =
+                            source_provenance_watermark(&resolved_source.target_ref);
+                        if !resolved_target_watermark_matches(
+                            &resolved_source,
+                            &current_source_watermark,
+                        )
+                        .map_err(|error| ToolError::Internal {
+                            trace_id: format!("mcp_note_source_handle_watermark:{error}"),
+                        })? {
+                            return Ok(unavailable_payload(
+                                SCHEMA_VERSION,
+                                &self.description.name,
+                                true,
+                                Some(handle),
+                            ));
+                        }
+                        let handle_hash =
+                            public_handle_hash(handle).map_err(|error| ToolError::Internal {
+                                trace_id: format!("mcp_note_source_handle_hash:{error}"),
+                            })?;
+                        Some(
+                            json!({
+                                "kind": "mcp_source_provenance_handle",
+                                "handle_hash": handle_hash,
+                            })
+                            .to_string(),
+                        )
+                    }
+                    Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            refresh_required,
+                            Some(handle),
+                        ));
+                    }
+                    Err(TargetHandleResolutionError::Internal(detail)) => {
+                        return Err(ToolError::Internal {
+                            trace_id: format!("mcp_note_source_handle_resolve:{detail}"),
+                        });
+                    }
+                }
+            } else {
+                None
+            };
+
+            let clock = SystemClock;
+            let rng = SystemRng;
+            let external = ExternalClients::default();
+            let service_ctx =
+                ServiceContext::new_live(&clock, &rng, &external).with_actor("mcp_client");
+            let observed_at = service_ctx.clock.now().to_rfc3339();
+            let replay_key = mcp_submit_replay_key(
+                actor,
+                &self.description.name,
+                "submit.note",
+                &json!({
+                    "entity_type": entity_type.clone(),
+                    "entity_id": entity_id.clone(),
+                    "title": title.clone(),
+                    "text": text.clone(),
+                    "source_ref": source_ref.clone(),
+                }),
+            )?;
+            let deterministic_claim_id =
+                deterministic_uuid_from_replay_key("note_claim", &replay_key)?;
+            let entry = crate::services::entity_context::create_entry_with_db_with_claim_id(
+                &service_ctx,
+                db,
+                &self.signal_engine,
+                &entity_type,
+                &entity_id,
+                &title,
+                &text,
+                "mcp_client",
+                &observed_at,
+                source_ref.as_deref(),
+                Some(&deterministic_claim_id),
+            )
+            .map_err(|error| ToolError::UpstreamFailure { detail: error })?;
+            let claim = crate::services::claims::load_claim_by_id(db.conn_ref(), &entry.id)
+                .map_err(|error| ToolError::UpstreamFailure {
+                    detail: error.to_string(),
+                })?
+                .ok_or_else(|| ToolError::UpstreamFailure {
+                    detail: "created note claim could not be reloaded".to_string(),
+                })?;
+            let watermark = claim_watermark_for_handle(&claim);
+            let note_handle = mint_replacing_target_handle(
+                db,
+                MintTargetHandle {
+                    actor,
+                    originating_tool: &self.description.name,
+                    result_item_path: "/note",
+                    target_kind: TargetKind::Claim,
+                    target_ref: json!({ "claim_id": entry.id.clone() }),
+                    sensitivity_tier: "internal",
+                    provenance_material: &format!("mcp_submit_note:{}:note", entry.id),
+                    watermark_material: &watermark,
+                },
+            )
+            .map_err(|error| ToolError::Internal {
+                trace_id: format!("mcp_note_handle_mint:{error}"),
+            })?;
+            let feedback_target_handle = mint_replacing_target_handle(
+                db,
+                MintTargetHandle {
+                    actor,
+                    originating_tool: &self.description.name,
+                    result_item_path: "/feedback_target",
+                    target_kind: TargetKind::Claim,
+                    target_ref: json!({ "claim_id": entry.id.clone() }),
+                    sensitivity_tier: "internal",
+                    provenance_material: &format!("mcp_submit_note:{}:feedback", entry.id),
+                    watermark_material: &watermark,
+                },
+            )
+            .map_err(|error| ToolError::Internal {
+                trace_id: format!("mcp_note_feedback_handle_mint:{error}"),
+            })?;
+            Ok(json!({
+                "schema_version": SCHEMA_VERSION,
+                "tool_name": self.description.name.as_str(),
+                "status": "ok",
+                "note_handle": note_handle,
+                "feedback_target_handle": feedback_target_handle,
+                "mutation_cursor": mutation_cursor_for_target(
+                    &self.description.name,
+                    "ok",
+                    "claim",
+                    &note_handle,
+                ),
+            }))
+        });
+        result.unwrap_or_else(|| {
+            Err(ToolError::Internal {
+                trace_id: "mcp_submit_note_missing_owned_connection".to_string(),
+            })
+        })
+    }
+}
+
+fn claim_watermark_for_handle(claim: &crate::db::claims::IntelligenceClaim) -> String {
+    format!(
+        "claim:{}:{}:{:?}:{:?}",
+        claim.id, claim.claim_version, claim.claim_state, claim.verification_state
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use super::*;
+    use crate::db::{ActionDb, DbAccount};
+    use crate::services::entity_context::USER_NOTE_CLAIM_TYPE;
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
+    };
+    use crate::services::mcp_v2::handlers::tool_utils::entity_watermark_from_parts;
+    use crate::services::mcp_v2::local_runtime;
+    use crate::services::mcp_v2::target_handles::mint_target_handle;
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new("dailyos.submit.note"),
+            summary: String::new(),
+            when_to_call: String::new(),
+            when_not_to_call: String::new(),
+            side: Side::SubmitCorrection,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: String::new(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("dailyos.submit.note")],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-note-submit-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new(
+                "conversation-note-submit-test",
+            )),
+            tool_name: ScopedName::new("dailyos.submit.note"),
+            granted_scopes: vec![Scope::new("dailyos.submit.note")],
+        }
+    }
+
+    fn account(id: &str, name: &str, updated_at: &str, archived: bool) -> DbAccount {
+        DbAccount {
+            id: id.to_string(),
+            name: name.to_string(),
+            updated_at: updated_at.to_string(),
+            archived,
+            ..Default::default()
+        }
+    }
+
+    fn seed_entity_handle(db: &ActionDb, actor: &McpActor, account: &DbAccount) -> String {
+        let watermark = entity_watermark_from_parts(
+            "account",
+            &account.id,
+            &account.updated_at,
+            account.archived,
+        );
+        mint_target_handle(
+            db,
+            MintTargetHandle {
+                actor,
+                originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                result_item_path: "/subject",
+                target_kind: TargetKind::Entity,
+                target_ref: json!({
+                    "entity_type": "account",
+                    "entity_id": account.id,
+                }),
+                sensitivity_tier: "internal",
+                provenance_material: "test-account",
+                watermark_material: &watermark,
+            },
+        )
+        .expect("mint entity handle")
+    }
+
+    fn handler() -> NoteHandler {
+        NoteHandler::new(description(), Arc::new(PropagationEngine::new()))
+    }
+
+    #[test]
+    fn submit_note_replay_reuses_durable_claim_row() {
+        local_runtime::with_target_handle_key_for_tests([31_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("submit-note-replay.db"))
+                .expect("open db");
+            let actor = actor();
+            let account = account(
+                "acct-note-replay",
+                "Replay Account",
+                "2026-06-01T00:00:00Z",
+                false,
+            );
+            db.upsert_account(&account).expect("seed account");
+            let entity_handle = seed_entity_handle(&db, &actor, &account);
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+            let handler = handler();
+            let params = json!({
+                "entity_handle": entity_handle,
+                "subject_text": "Renewal note",
+                "text": "The renewal owner asked for an updated rollout plan.",
+            });
+
+            let first = handler
+                .invoke(&ctx, &actor, params.clone())
+                .expect("first note response");
+            let second = handler
+                .invoke(&ctx, &actor, params)
+                .expect("second note response");
+
+            assert_eq!(first["status"], "ok");
+            assert_eq!(second["status"], "ok");
+            let count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM intelligence_claims WHERE claim_type = ?1 AND text = ?2",
+                    [
+                        USER_NOTE_CLAIM_TYPE,
+                        "The renewal owner asked for an updated rollout plan.",
+                    ],
+                    |row| row.get(0),
+                )
+                .expect("claim count");
+            assert_eq!(count, 1, "MCP retry must not duplicate note claims");
+            let handle_count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM mcp_target_handles WHERE originating_tool = ?1",
+                    ["dailyos.submit.note"],
+                    |row| row.get(0),
+                )
+                .expect("target handle count");
+            assert_eq!(
+                handle_count, 2,
+                "MCP retry must replace, not duplicate, note and feedback handles"
+            );
+        });
+    }
+
+    #[test]
+    fn submit_note_feedback_handle_matches_live_claim_watermark() {
+        local_runtime::with_target_handle_key_for_tests([33_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("submit-note-feedback.db"))
+                .expect("open db");
+            let actor = actor();
+            let account = account(
+                "acct-note-feedback",
+                "Feedback Account",
+                "2026-06-01T00:00:00Z",
+                false,
+            );
+            db.upsert_account(&account).expect("seed account");
+            let entity_handle = seed_entity_handle(&db, &actor, &account);
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+
+            let payload = handler()
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "entity_handle": entity_handle,
+                        "subject_text": "Feedback-ready note",
+                        "text": "The implementation owner asked to confirm the launch checklist.",
+                    }),
+                )
+                .expect("note response");
+
+            let feedback_handle = payload["feedback_target_handle"]
+                .as_str()
+                .expect("feedback handle");
+            let guard = db.lock().unwrap();
+            let resolved = resolve_target_handle(
+                &guard,
+                ResolveTargetHandle {
+                    actor: &actor,
+                    handle: feedback_handle,
+                    expected_kind: TargetKind::Claim,
+                    current_watermark_material: None,
+                },
+            )
+            .expect("feedback handle resolves");
+            let claim_id = resolved.target_ref["claim_id"]
+                .as_str()
+                .expect("claim id from sealed target ref");
+            let claim = crate::services::claims::load_claim_by_id(guard.conn_ref(), claim_id)
+                .expect("load note claim")
+                .expect("note claim exists");
+            assert!(
+                resolved_target_watermark_matches(&resolved, &claim_watermark_for_handle(&claim))
+                    .expect("watermark hash"),
+                "returned feedback handle must be immediately valid for claim_feedback"
+            );
+        });
+    }
+
+    #[test]
+    fn submit_note_rejects_archived_entity_handle() {
+        local_runtime::with_target_handle_key_for_tests([32_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("submit-note-stale.db"))
+                .expect("open db");
+            let actor = actor();
+            let active = account(
+                "acct-note-stale",
+                "Stale Note Account",
+                "2026-06-01T00:00:00Z",
+                false,
+            );
+            db.upsert_account(&active).expect("seed account");
+            let entity_handle = seed_entity_handle(&db, &actor, &active);
+            let mut archived = active;
+            archived.archived = true;
+            archived.updated_at = Utc::now().to_rfc3339();
+            db.upsert_account(&archived).expect("archive account");
+
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::clone(&db));
+            let payload = handler()
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "entity_handle": entity_handle,
+                        "subject_text": "Archived note",
+                        "text": "This note should not be committed.",
+                    }),
+                )
+                .expect("handler response");
+
+            assert_eq!(payload["status"], "unavailable");
+            assert_eq!(payload["refresh_required"], true);
+            let count: i64 = db
+                .lock()
+                .unwrap()
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM intelligence_claims WHERE claim_type = ?1 AND text = ?2",
+                    [USER_NOTE_CLAIM_TYPE, "This note should not be committed."],
+                    |row| row.get(0),
+                )
+                .expect("claim count");
+            assert_eq!(count, 0, "stale entity handles must not create notes");
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_update_action_status.rs
@@ -1,1 +1,412 @@
-//! Placeholder. Handler implementation pending.
+//! `dailyos.submit.action_status` MCP handler.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use crate::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::handler_context::McpHandlerContext;
+use crate::services::mcp_v2::target_handles::{
+    resolve_target_handle, resolved_target_watermark_matches, ResolveTargetHandle,
+    TargetHandleResolutionError, TargetKind,
+};
+use crate::signals::propagation::PropagationEngine;
+
+use super::tool_utils::{
+    bad_params, mutation_cursor_for_target, reject_raw_id_params, required_str,
+    unavailable_payload, validate_bounded_string, validate_yyyy_mm_dd,
+};
+
+const SCHEMA_VERSION: &str = "mcp.action_status.v1";
+
+pub struct UpdateActionStatusHandler {
+    description: ToolDescription,
+    signal_engine: Arc<PropagationEngine>,
+}
+
+impl UpdateActionStatusHandler {
+    pub fn new(description: ToolDescription, signal_engine: Arc<PropagationEngine>) -> Self {
+        Self {
+            description,
+            signal_engine,
+        }
+    }
+}
+
+impl McpToolHandler for UpdateActionStatusHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext,
+        actor: &McpActor,
+        params: Value,
+    ) -> Result<Value, ToolError> {
+        reject_raw_id_params(&params)?;
+        let action_handle = required_str(&params, "action_handle")?;
+        let semantic_status = required_str(&params, "status")?;
+        let reason = super::tool_utils::optional_str(&params, "reason")?;
+        if let Some(reason) = reason.as_deref() {
+            validate_bounded_string(reason, "reason", 1, 500)?;
+        }
+        let defer_date = super::tool_utils::optional_str(&params, "defer_date")?;
+        match semantic_status.as_str() {
+            "deferred" => {
+                let Some(date) = defer_date.as_deref() else {
+                    return Err(bad_params("`defer_date` is required for deferred"));
+                };
+                validate_yyyy_mm_dd(date, "defer_date")?;
+            }
+            "done" | "dropped" => {
+                if defer_date.is_some() {
+                    return Err(bad_params("`defer_date` is only valid for deferred"));
+                }
+            }
+            other => return Err(bad_params(format!("unsupported status `{other}`"))),
+        }
+
+        let result = ctx.with_conn(|db| {
+            let resolved = match resolve_target_handle(
+                db,
+                ResolveTargetHandle {
+                    actor,
+                    handle: &action_handle,
+                    expected_kind: TargetKind::Action,
+                    current_watermark_material: None,
+                },
+            ) {
+                Ok(resolved) => resolved,
+                Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        refresh_required,
+                        Some(&action_handle),
+                    ));
+                }
+                Err(TargetHandleResolutionError::Internal(detail)) => {
+                    return Err(ToolError::Internal {
+                        trace_id: format!("mcp_action_handle_resolve:{detail}"),
+                    });
+                }
+            };
+            let action_id = resolved
+                .target_ref
+                .get("action_id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| bad_params("action handle is unavailable"))?
+                .to_string();
+            let Some(action) =
+                db.get_action_by_id(&action_id)
+                    .map_err(|error| ToolError::UpstreamFailure {
+                        detail: error.to_string(),
+                    })?
+            else {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    false,
+                    Some(&action_handle),
+                ));
+            };
+            let current_watermark = action_watermark_for_handle(&action);
+            if !resolved_target_watermark_matches(&resolved, &current_watermark).map_err(
+                |error| ToolError::Internal {
+                    trace_id: format!("mcp_action_handle_watermark:{error}"),
+                },
+            )? {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    Some(&action_handle),
+                ));
+            }
+
+            let clock = SystemClock;
+            let rng = SystemRng;
+            let external = ExternalClients::default();
+            let service_ctx =
+                ServiceContext::new_live(&clock, &rng, &external).with_actor("mcp_client");
+            let (status, stored_status) = match semantic_status.as_str() {
+                "done" if action.status == crate::action_status::COMPLETED => {
+                    ("already_current", action.status)
+                }
+                "done"
+                    if matches!(
+                        action.status.as_str(),
+                        crate::action_status::UNSTARTED | crate::action_status::STARTED
+                    ) =>
+                {
+                    let Some(stored) = crate::services::actions::complete_action_for_mcp(
+                        &service_ctx,
+                        db,
+                        &self.signal_engine,
+                        &action_id,
+                    )
+                    .map_err(|error| ToolError::UpstreamFailure { detail: error })?
+                    else {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            false,
+                            Some(&action_handle),
+                        ));
+                    };
+                    ("ok", stored)
+                }
+                "done" => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        false,
+                        Some(&action_handle),
+                    ));
+                }
+                "deferred"
+                    if !matches!(
+                        action.status.as_str(),
+                        crate::action_status::UNSTARTED | crate::action_status::STARTED
+                    ) =>
+                {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        false,
+                        Some(&action_handle),
+                    ));
+                }
+                "deferred" => {
+                    let Some(stored) = crate::services::actions::defer_action_for_mcp(
+                        &service_ctx,
+                        db,
+                        &self.signal_engine,
+                        &action_id,
+                        defer_date.as_deref().expect("validated"),
+                        reason.as_deref(),
+                    )
+                    .map_err(|error| ToolError::UpstreamFailure { detail: error })?
+                    else {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            false,
+                            Some(&action_handle),
+                        ));
+                    };
+                    ("ok", stored)
+                }
+                "dropped"
+                    if matches!(
+                        action.status.as_str(),
+                        crate::action_status::CANCELLED | crate::action_status::ARCHIVED
+                    ) =>
+                {
+                    ("already_current", action.status)
+                }
+                "dropped"
+                    if !matches!(
+                        action.status.as_str(),
+                        crate::action_status::BACKLOG
+                            | crate::action_status::UNSTARTED
+                            | crate::action_status::STARTED
+                    ) =>
+                {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        false,
+                        Some(&action_handle),
+                    ));
+                }
+                "dropped" => {
+                    let Some(stored) = crate::services::actions::drop_action_for_mcp(
+                        &service_ctx,
+                        db,
+                        &self.signal_engine,
+                        &action_id,
+                        reason.as_deref(),
+                    )
+                    .map_err(|error| ToolError::UpstreamFailure { detail: error })?
+                    else {
+                        return Ok(unavailable_payload(
+                            SCHEMA_VERSION,
+                            &self.description.name,
+                            false,
+                            Some(&action_handle),
+                        ));
+                    };
+                    ("ok", stored)
+                }
+                _ => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        false,
+                        Some(&action_handle),
+                    ));
+                }
+            };
+
+            Ok(json!({
+                "schema_version": SCHEMA_VERSION,
+                "tool_name": self.description.name.as_str(),
+                "status": status,
+                "semantic_status": semantic_status,
+                "stored_status": stored_status,
+                "mutation_cursor": mutation_cursor_for_target(
+                    &self.description.name,
+                    status,
+                    "action",
+                    &action_handle,
+                ),
+            }))
+        });
+        result.unwrap_or_else(|| {
+            Err(ToolError::Internal {
+                trace_id: "mcp_action_status_missing_owned_connection".to_string(),
+            })
+        })
+    }
+}
+
+fn action_watermark_for_handle(action: &crate::db::DbAction) -> String {
+    format!(
+        "action:{}:{}:{}",
+        action.id, action.updated_at, action.status
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use super::*;
+    use crate::db::{ActionDb, DbAction};
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
+    };
+    use crate::services::mcp_v2::local_runtime;
+    use crate::services::mcp_v2::target_handles::{mint_target_handle, MintTargetHandle};
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new("dailyos.submit.action_status"),
+            summary: String::new(),
+            when_to_call: String::new(),
+            when_not_to_call: String::new(),
+            side: Side::SubmitCorrection,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: String::new(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("dailyos.submit.action_status")],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-action-status-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new(
+                "conversation-action-status-test",
+            )),
+            tool_name: ScopedName::new("dailyos.submit.action_status"),
+            granted_scopes: vec![Scope::new("dailyos.submit.action_status")],
+        }
+    }
+
+    fn action(id: &str, status: &str) -> DbAction {
+        let now = Utc::now().to_rfc3339();
+        DbAction {
+            id: id.to_string(),
+            title: "Follow up".to_string(),
+            priority: crate::action_status::PRIORITY_MEDIUM,
+            status: status.to_string(),
+            created_at: now.clone(),
+            due_date: None,
+            completed_at: (status == crate::action_status::COMPLETED).then(|| now.clone()),
+            account_id: None,
+            project_id: None,
+            source_type: None,
+            source_id: None,
+            source_label: None,
+            action_kind: crate::action_status::KIND_TASK.to_string(),
+            commitment_id: None,
+            owner_raw: None,
+            owner_entity_id: None,
+            owner_confidence: None,
+            owner_source: None,
+            trust_score: None,
+            trust_band: None,
+            commitment_source_count: None,
+            context: None,
+            waiting_on: None,
+            updated_at: now,
+            person_id: None,
+            account_name: None,
+            next_meeting_title: None,
+            next_meeting_start: None,
+            needs_decision: false,
+            decision_owner: None,
+            decision_stakes: None,
+            linear_identifier: None,
+            linear_url: None,
+        }
+    }
+
+    #[test]
+    fn completed_action_defer_returns_unavailable_payload_with_cursor() {
+        local_runtime::with_target_handle_key_for_tests([11_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("action-status-unavailable.db");
+            let db = ActionDb::open_at_unencrypted(path).expect("open db");
+            let actor = actor();
+            let description = description();
+            let action = action("action-completed", crate::action_status::COMPLETED);
+            db.upsert_action(&action).expect("seed action");
+            let watermark = action_watermark_for_handle(&action);
+            let handle = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &actor,
+                    originating_tool: &description.name,
+                    result_item_path: "/action",
+                    target_kind: TargetKind::Action,
+                    target_ref: json!({ "action_id": action.id }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "test-action",
+                    watermark_material: &watermark,
+                },
+            )
+            .expect("mint action handle");
+            let handler =
+                UpdateActionStatusHandler::new(description, Arc::new(PropagationEngine::new()));
+            let ctx = McpHandlerContext::with_owned_connection(Arc::new(Mutex::new(db)));
+
+            let payload = handler
+                .invoke(
+                    &ctx,
+                    &actor,
+                    json!({
+                        "action_handle": handle,
+                        "status": "deferred",
+                        "defer_date": "2026-06-08"
+                    }),
+                )
+                .expect("handler response");
+
+            assert_eq!(payload["status"], "unavailable");
+            assert_eq!(payload["reason"], "target_unavailable");
+            assert_eq!(payload["refresh_required"], false);
+            assert!(payload["mutation_cursor"].is_object());
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_utils.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_utils.rs
@@ -1,0 +1,353 @@
+//! Shared helpers for W5 MCP tool handlers.
+
+use serde_json::{json, Value};
+
+use crate::db::ActionDb;
+use crate::services::mcp_v2::contracts::{
+    McpActor, McpClientId, OpaqueConversationHandle, ScopedName, ToolError,
+};
+use crate::services::mcp_v2::local_runtime;
+use crate::services::mcp_v2::target_handles;
+
+const MCP_SUBMIT_REPLAY_NAMESPACE: &str = "7f8a3cf2-0c26-5879-9c04-1e1f7d43cfaa";
+
+const RAW_ID_PARAM_KEYS: &[&str] = &[
+    "claim_id",
+    "claimId",
+    "action_id",
+    "actionId",
+    "entity_id",
+    "entityId",
+    "account_id",
+    "accountId",
+    "project_id",
+    "projectId",
+    "person_id",
+    "personId",
+    "meeting_id",
+    "meetingId",
+    "source_id",
+    "sourceId",
+    "source_ref",
+    "sourceRef",
+    "workspace_id",
+    "workspaceId",
+    "file_path",
+    "filePath",
+    "path",
+    "actor",
+    "actor_id",
+    "actorId",
+    "surface",
+    "sensitivity",
+    "idempotency_key",
+    "idempotencyKey",
+    "granted_scopes",
+    "grantedScopes",
+    "conversation_handle",
+    "conversationHandle",
+    "tool_side",
+    "toolSide",
+];
+
+pub fn required_str(params: &Value, key: &str) -> Result<String, ToolError> {
+    let value = params
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ToolError::BadParams {
+            detail: format!("missing `{key}` parameter"),
+        })?;
+    Ok(value.to_string())
+}
+
+pub fn optional_str(params: &Value, key: &str) -> Result<Option<String>, ToolError> {
+    let Some(value) = params.get(key) else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_str() else {
+        return Err(ToolError::BadParams {
+            detail: format!("`{key}` must be a string"),
+        });
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+pub fn reject_raw_id_params(params: &Value) -> Result<(), ToolError> {
+    let Some(object) = params.as_object() else {
+        return Err(ToolError::BadParams {
+            detail: "tool parameters must be an object".to_string(),
+        });
+    };
+    for key in RAW_ID_PARAM_KEYS {
+        if object.contains_key(*key) {
+            return Err(ToolError::BadParams {
+                detail: format!(
+                    "`{key}` is not accepted by this MCP tool; use server-issued handles"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_yyyy_mm_dd(value: &str, key: &str) -> Result<(), ToolError> {
+    crate::util::validate_yyyy_mm_dd(value, key)
+        .map(|_| ())
+        .map_err(|detail| ToolError::BadParams { detail })
+}
+
+pub fn validate_bounded_string(
+    value: &str,
+    key: &str,
+    min_chars: usize,
+    max_chars: usize,
+) -> Result<String, ToolError> {
+    crate::util::validate_bounded_string(value, key, min_chars, max_chars)
+        .map_err(|detail| ToolError::BadParams { detail })
+}
+
+pub fn bad_params(detail: impl Into<String>) -> ToolError {
+    ToolError::BadParams {
+        detail: detail.into(),
+    }
+}
+
+pub fn actor_origin(
+    actor: &McpActor,
+) -> Result<(&McpClientId, &OpaqueConversationHandle, &ScopedName), ToolError> {
+    let McpActor::Client {
+        client_id,
+        conversation_handle,
+        tool_name,
+        ..
+    } = actor;
+    let conversation_handle = conversation_handle
+        .as_ref()
+        .ok_or_else(|| bad_params("MCP target handles require a conversation handle"))?;
+    Ok((client_id, conversation_handle, tool_name))
+}
+
+pub fn actor_origin_hashes(actor: &McpActor) -> Result<(String, String, String), ToolError> {
+    let (client_id, conversation_handle, tool_name) = actor_origin(actor)?;
+    let client_id_hash = local_runtime::target_handle_hmac_hex(client_id.as_str())
+        .map_err(|error| internal_trace("mcp_client_hash", error))?;
+    let conversation_handle_hash =
+        local_runtime::target_handle_hmac_hex(conversation_handle.as_str())
+            .map_err(|error| internal_trace("mcp_conversation_hash", error))?;
+    Ok((
+        client_id_hash,
+        conversation_handle_hash,
+        tool_name.as_str().to_string(),
+    ))
+}
+
+pub fn internal_trace(prefix: &str, detail: impl std::fmt::Display) -> ToolError {
+    let digest = sha256_hex(&detail.to_string());
+    ToolError::Internal {
+        trace_id: format!("{prefix}:{digest}"),
+    }
+}
+
+pub fn no_op_mutation_cursor(tool_name: &ScopedName, status: &str, handle: Option<&str>) -> Value {
+    let handle_hash = handle
+        .and_then(|handle| target_handles::public_handle_hash(handle).ok())
+        .unwrap_or_else(|| "none".to_string());
+    json!({
+        "schema_version": "mcp.mutation_cursor.v1",
+        "tool_name": tool_name.as_str(),
+        "status": status,
+        "target_handle_hash": handle_hash,
+    })
+}
+
+pub fn mutation_cursor_for_target(
+    tool_name: &ScopedName,
+    status: &str,
+    target_kind: &str,
+    target_handle: &str,
+) -> Value {
+    let target_handle_hash = target_handles::public_handle_hash(target_handle)
+        .unwrap_or_else(|_| sha256_hex(target_handle));
+    json!({
+        "schema_version": "mcp.mutation_cursor.v1",
+        "tool_name": tool_name.as_str(),
+        "status": status,
+        "target_kind": target_kind,
+        "target_handle_hash": target_handle_hash,
+    })
+}
+
+pub fn unavailable_payload(
+    schema_version: &str,
+    tool_name: &ScopedName,
+    refresh_required: bool,
+    include_cursor_for_handle: Option<&str>,
+) -> Value {
+    let mut payload = json!({
+        "schema_version": schema_version,
+        "tool_name": tool_name.as_str(),
+        "status": "unavailable",
+        "reason": "target_unavailable",
+        "refresh_required": refresh_required,
+    });
+    if let Some(handle) = include_cursor_for_handle {
+        payload["mutation_cursor"] = no_op_mutation_cursor(tool_name, "unavailable", Some(handle));
+    }
+    payload
+}
+
+pub fn canonical_json_string(value: &Value) -> String {
+    serde_json::to_string(&canonical_json_value(value)).unwrap_or_else(|_| "null".to_string())
+}
+
+pub fn source_provenance_watermark(target_ref: &Value) -> String {
+    format!("source_provenance:{}", canonical_json_string(target_ref))
+}
+
+pub fn entity_watermark_from_parts(
+    entity_type: &str,
+    entity_id: &str,
+    updated_at: &str,
+    archived: bool,
+) -> String {
+    format!("entity:{entity_type}:{entity_id}:{updated_at}:archived={archived}")
+}
+
+pub fn current_entity_watermark(
+    db: &ActionDb,
+    target_ref: &Value,
+) -> Result<Option<String>, ToolError> {
+    let entity_type = target_ref
+        .get("entity_type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| bad_params("entity handle is unavailable"))?;
+    let entity_id = target_ref
+        .get("entity_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| bad_params("entity handle is unavailable"))?;
+    match entity_type {
+        "account" => db
+            .get_account(entity_id)
+            .map_err(|error| ToolError::UpstreamFailure {
+                detail: error.to_string(),
+            })
+            .map(|account| {
+                account.and_then(|account| {
+                    (!account.archived).then(|| {
+                        entity_watermark_from_parts(
+                            "account",
+                            &account.id,
+                            &account.updated_at,
+                            account.archived,
+                        )
+                    })
+                })
+            }),
+        "project" => db
+            .get_project(entity_id)
+            .map_err(|error| ToolError::UpstreamFailure {
+                detail: error.to_string(),
+            })
+            .map(|project| {
+                project.and_then(|project| {
+                    (!project.archived).then(|| {
+                        entity_watermark_from_parts(
+                            "project",
+                            &project.id,
+                            &project.updated_at,
+                            project.archived,
+                        )
+                    })
+                })
+            }),
+        "person" => db
+            .get_person(entity_id)
+            .map_err(|error| ToolError::UpstreamFailure {
+                detail: error.to_string(),
+            })
+            .map(|person| {
+                person.and_then(|person| {
+                    (!person.archived).then(|| {
+                        entity_watermark_from_parts(
+                            "person",
+                            &person.id,
+                            &person.updated_at,
+                            person.archived,
+                        )
+                    })
+                })
+            }),
+        _ => Err(bad_params("entity handle cannot target this MCP tool")),
+    }
+}
+
+pub fn mcp_submit_replay_key(
+    actor: &McpActor,
+    tool_name: &ScopedName,
+    purpose: &str,
+    material: &Value,
+) -> Result<String, ToolError> {
+    use sha2::{Digest, Sha256};
+
+    let (client_id_hash, conversation_handle_hash, actor_tool_name) = actor_origin_hashes(actor)?;
+    let canonical_material = canonical_json_string(material);
+    let mut hasher = Sha256::new();
+    for part in [
+        "dailyos.mcp.submit.replay.v1",
+        purpose,
+        tool_name.as_str(),
+        &actor_tool_name,
+        &client_id_hash,
+        &conversation_handle_hash,
+        &canonical_material,
+    ] {
+        hasher.update(part.len().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(part.as_bytes());
+        hasher.update(b"\0");
+    }
+    Ok(format!("mcp_submit_{:x}", hasher.finalize()))
+}
+
+pub fn deterministic_uuid_from_replay_key(
+    kind: &str,
+    replay_key: &str,
+) -> Result<String, ToolError> {
+    let namespace = uuid::Uuid::parse_str(MCP_SUBMIT_REPLAY_NAMESPACE).map_err(|error| {
+        ToolError::Internal {
+            trace_id: format!("mcp_submit_replay_namespace:{error}"),
+        }
+    })?;
+    Ok(uuid::Uuid::new_v5(&namespace, format!("{kind}:{replay_key}").as_bytes()).to_string())
+}
+
+fn canonical_json_value(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(canonical_json_value).collect()),
+        Value::Object(object) => {
+            let mut entries = object.iter().collect::<Vec<_>>();
+            entries.sort_by_key(|(key, _)| *key);
+            let mut sorted = serde_json::Map::new();
+            for (key, value) in entries {
+                sorted.insert(key.clone(), canonical_json_value(value));
+            }
+            Value::Object(sorted)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn sha256_hex(value: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}

--- a/src-tauri/src/services/mcp_v2/handlers/tool_workspace_source_provenance.rs
+++ b/src-tauri/src/services/mcp_v2/handlers/tool_workspace_source_provenance.rs
@@ -1,1 +1,196 @@
-//! Placeholder. Handler implementation pending.
+//! `dailyos.read.workspace_source_provenance` MCP handler.
+
+use serde_json::{json, Value};
+
+use crate::services::mcp_v2::contracts::{McpActor, McpToolHandler, ToolDescription, ToolError};
+use crate::services::mcp_v2::handler_context::McpHandlerContext;
+use crate::services::mcp_v2::target_handles::{
+    resolve_target_handle, resolved_target_watermark_matches, ResolveTargetHandle,
+    TargetHandleResolutionError, TargetKind,
+};
+
+use super::tool_utils::{
+    reject_raw_id_params, required_str, source_provenance_watermark, unavailable_payload,
+};
+
+const SCHEMA_VERSION: &str = "mcp.workspace_source_provenance.v1";
+
+pub struct WorkspaceSourceProvenanceHandler {
+    description: ToolDescription,
+}
+
+impl WorkspaceSourceProvenanceHandler {
+    pub fn new(description: ToolDescription) -> Self {
+        Self { description }
+    }
+}
+
+impl McpToolHandler for WorkspaceSourceProvenanceHandler {
+    fn description(&self) -> &ToolDescription {
+        &self.description
+    }
+
+    fn invoke(
+        &self,
+        ctx: &McpHandlerContext,
+        actor: &McpActor,
+        params: Value,
+    ) -> Result<Value, ToolError> {
+        reject_raw_id_params(&params)?;
+        let handle = required_str(&params, "source_provenance_handle")?;
+        let result = ctx.with_conn(|db| {
+            let resolved = match resolve_target_handle(
+                db,
+                ResolveTargetHandle {
+                    actor,
+                    handle: &handle,
+                    expected_kind: TargetKind::SourceProvenance,
+                    current_watermark_material: None,
+                },
+            ) {
+                Ok(resolved) => resolved,
+                Err(TargetHandleResolutionError::Unavailable { refresh_required }) => {
+                    return Ok(unavailable_payload(
+                        SCHEMA_VERSION,
+                        &self.description.name,
+                        refresh_required,
+                        None,
+                    ));
+                }
+                Err(TargetHandleResolutionError::Internal(detail)) => {
+                    return Err(ToolError::Internal {
+                        trace_id: format!("mcp_source_handle_resolve:{detail}"),
+                    });
+                }
+            };
+            let current_source_watermark = source_provenance_watermark(&resolved.target_ref);
+            if !resolved_target_watermark_matches(&resolved, &current_source_watermark).map_err(
+                |error| ToolError::Internal {
+                    trace_id: format!("mcp_source_handle_watermark:{error}"),
+                },
+            )? {
+                return Ok(unavailable_payload(
+                    SCHEMA_VERSION,
+                    &self.description.name,
+                    true,
+                    None,
+                ));
+            }
+            let mut source = json!({
+                "label": resolved.target_ref.get("label").and_then(Value::as_str).unwrap_or("DailyOS source"),
+                "source_type": resolved.target_ref.get("source_type").and_then(Value::as_str).unwrap_or("source"),
+                "sourceType": resolved.target_ref.get("source_type").and_then(Value::as_str).unwrap_or("source"),
+                "source_asof": resolved.target_ref.get("source_asof").cloned().unwrap_or(Value::Null),
+                "sourceAsof": resolved.target_ref.get("source_asof").cloned().unwrap_or(Value::Null),
+                "trust_band": resolved.target_ref.get("trust_band").cloned().unwrap_or(Value::Null),
+                "trustBand": resolved.target_ref.get("trust_band").cloned().unwrap_or(Value::Null),
+                "redaction_applied": resolved.target_ref.get("redaction_applied").and_then(Value::as_bool).unwrap_or(true),
+                "redactionApplied": resolved.target_ref.get("redaction_applied").and_then(Value::as_bool).unwrap_or(true),
+            });
+            if let Some(object) = source.as_object_mut() {
+                object.remove("source_id");
+                object.remove("path");
+                object.remove("file_path");
+            }
+            Ok(json!({
+                "schema_version": SCHEMA_VERSION,
+                "tool_name": self.description.name.as_str(),
+                "status": "ok",
+                "source": source,
+                "provenance": {
+                    "render_policy_version": resolved.render_policy_version,
+                    "sensitivity_tier": resolved.sensitivity_tier,
+                    "raw_source_ids_included": false,
+                    "raw_paths_included": false,
+                },
+            }))
+        });
+        result.unwrap_or_else(|| {
+            Err(ToolError::Internal {
+                trace_id: "mcp_source_provenance_missing_owned_connection".to_string(),
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::db::ActionDb;
+    use crate::services::mcp_v2::contracts::{
+        McpClientId, OpaqueConversationHandle, ParamSchema, ReturnSpec, Scope, ScopedName, Side,
+    };
+    use crate::services::mcp_v2::local_runtime;
+    use crate::services::mcp_v2::target_handles::{mint_target_handle, MintTargetHandle};
+
+    fn description() -> ToolDescription {
+        ToolDescription {
+            name: ScopedName::new("dailyos.read.workspace_source_provenance"),
+            summary: String::new(),
+            when_to_call: String::new(),
+            when_not_to_call: String::new(),
+            side: Side::Read,
+            parameters: vec![],
+            returns: ReturnSpec {
+                schema: ParamSchema(json!({})),
+                description: String::new(),
+            },
+            examples: vec![],
+            scopes_required: vec![Scope::new("dailyos.read.workspace_source_provenance")],
+        }
+    }
+
+    fn actor() -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new("client-source-provenance-test"),
+            conversation_handle: Some(OpaqueConversationHandle::new(
+                "conversation-source-provenance-test",
+            )),
+            tool_name: ScopedName::new("dailyos.read.workspace_source_provenance"),
+            granted_scopes: vec![Scope::new("dailyos.read.workspace_source_provenance")],
+        }
+    }
+
+    #[test]
+    fn source_provenance_rejects_stale_watermark_before_display() {
+        local_runtime::with_target_handle_key_for_tests([41_u8; 32], || {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let db = ActionDb::open_at_unencrypted(dir.path().join("source-provenance-stale.db"))
+                .expect("open db");
+            let actor = actor();
+            let target_ref = json!({
+                "label": "DailyOS source",
+                "source_type": "claim",
+                "source_asof": "2026-06-01T00:00:00Z",
+                "trust_band": "likely_current",
+                "redaction_applied": true,
+            });
+            let handle = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/provenance/sources/0",
+                    target_kind: TargetKind::SourceProvenance,
+                    target_ref,
+                    sensitivity_tier: "internal",
+                    provenance_material: "legacy-source-material",
+                    watermark_material: "legacy-source-material",
+                },
+            )
+            .expect("mint source handle");
+            let db = Arc::new(Mutex::new(db));
+            let ctx = McpHandlerContext::with_owned_connection(db);
+            let payload = WorkspaceSourceProvenanceHandler::new(description())
+                .invoke(&ctx, &actor, json!({ "source_provenance_handle": handle }))
+                .expect("handler response");
+
+            assert_eq!(payload["status"], "unavailable");
+            assert_eq!(payload["refresh_required"], true);
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/local_runtime.rs
+++ b/src-tauri/src/services/mcp_v2/local_runtime.rs
@@ -24,6 +24,7 @@ use super::contracts::{McpClientId, OpaqueConversationHandle};
 const KEYCHAIN_SERVICE: &str = "com.dailyos.desktop.mcp-local";
 const CLIENT_ID_ACCOUNT: &str = "local-stdio-client-id-v1";
 const AUDIT_DIGEST_KEY_ACCOUNT: &str = "read-audit-digest-key-v1";
+const TARGET_HANDLE_KEY_ACCOUNT: &str = "target-handle-aead-key-v1";
 const DIGEST_KEY_BYTES: usize = 32;
 const CONVERSATION_STORE_RELATIVE_PATH: &str = "mcp/conversation-handles.json";
 const DEFAULT_CONVERSATION_TTL: Duration = Duration::from_secs(60 * 60 * 24);
@@ -306,6 +307,37 @@ pub fn digest_json_value_hex(value: &serde_json::Value) -> Result<String, LocalR
     let encoded = load_or_seed_keychain_string(AUDIT_DIGEST_KEY_ACCOUNT, generate_digest_key)?;
     let key = decode_digest_key(&encoded)?;
     hmac_sha256_json_hex_for_key(&key, value).map_err(LocalRuntimeError::Serialization)
+}
+
+/// HMAC-SHA256 over a server-local target-handle value. Target handle lookup,
+/// audit correlation, and watermark checks use this instead of storing public
+/// handles or internal ids in plaintext.
+pub(crate) fn target_handle_hmac_hex(value: &str) -> Result<String, LocalRuntimeError> {
+    let key = target_handle_key_v1()?;
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).expect("HMAC accepts 32-byte keys");
+    mac.update(value.as_bytes());
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+pub(crate) fn target_handle_key_v1() -> Result<[u8; DIGEST_KEY_BYTES], LocalRuntimeError> {
+    let encoded = load_or_seed_keychain_string(TARGET_HANDLE_KEY_ACCOUNT, generate_digest_key)?;
+    decode_digest_key(&encoded)
+}
+
+#[cfg(test)]
+pub(crate) fn with_target_handle_key_for_tests<R>(
+    key: [u8; DIGEST_KEY_BYTES],
+    f: impl FnOnce() -> R,
+) -> R {
+    let keychain = Arc::new(TestKeychain::default());
+    keychain
+        .upsert(
+            KEYCHAIN_SERVICE,
+            TARGET_HANDLE_KEY_ACCOUNT,
+            &base64::engine::general_purpose::STANDARD.encode(key),
+        )
+        .expect("seed target handle key");
+    with_test_keychain(keychain, f)
 }
 
 pub fn hmac_sha256_json_hex_for_key(

--- a/src-tauri/src/services/mcp_v2/mod.rs
+++ b/src-tauri/src/services/mcp_v2/mod.rs
@@ -19,5 +19,6 @@ pub mod handler_context;
 pub mod handlers;
 pub mod local_runtime;
 pub mod runtime_projection;
+pub mod target_handles;
 pub mod taxonomy;
 pub mod transport;

--- a/src-tauri/src/services/mcp_v2/resources/tool_descriptions.yaml
+++ b/src-tauri/src/services/mcp_v2/resources/tool_descriptions.yaml
@@ -2,914 +2,337 @@
   {
     "name": "dailyos.read.account_status",
     "side": "Read",
-    "summary": "Returns DailyOS-assessed account intelligence from the local abilities runtime: facts, open loops, relationships, recent and upcoming touchpoints, priorities, caveats, trust state, freshness, and redacted provenance refs.",
-    "when_to_call": "When the user asks for a briefing, status, risks, wins, stakeholders, priorities, current state, or relationship context for a specific account they work with. Prefer this over raw file or broad-corpus search because this payload is claim-backed and already policy-filtered for the MCP surface.",
-    "when_NOT_to_call": "Do NOT call for broad enterprise/web corpus search, generic company research, workspace note lookup, or verbatim source passages. If this tool returns no renderable evidence, say DailyOS has no claim-backed account intelligence instead of falling back to generated JSON or legacy static rows.",
-    "scopesRequired": [
-      "dailyos.read.account_status"
-    ],
+    "summary": "Returns MCP-safe account intelligence from DailyOS: rendered facts, open loops, relationships, touchpoints, priorities, caveats, trust state, and opaque follow-up handles.",
+    "when_to_call": "When the user asks for status, risks, wins, stakeholders, priorities, current state, or relationship context for a specific account they work with. Prefer this for a named account because this payload is claim-backed and policy-filtered for the MCP surface.",
+    "when_NOT_to_call": "Do NOT call for broad web research, generic workspace note lookup, unrelated scheduling questions, team-prep requests, cross-account triage, or verbatim source passages. If this tool returns no renderable evidence, say DailyOS has no claim-backed account intelligence for that subject.",
+    "scopesRequired": ["dailyos.read.account_status"],
     "parameters": [
       {
         "name": "subject",
-        "schema": {
-          "type": "string"
-        },
+        "schema": { "type": "string", "minLength": 1 },
         "required": true,
-        "description": "Account id, exact account name, or normalized account slug"
+        "description": "Account name or normalized account slug. Raw internal ids are rejected and are never returned."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Claim-backed account status payload with answer prose, assessment arrays, section states, truncation metadata, trust/sensitivity, and redacted source refs. Raw claim ids and source ids are not included."
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "MCP account status v2 payload with opaque entity, feedback-target, and source-provenance handles. Raw claim, source, entity, action, meeting, or workspace ids are not included."
     },
     "examples": [
       {
-        "prompt": "What's going on with Acme?",
+        "prompt": "What's going on with Example Account?",
         "invocation": {
           "name": "dailyos.read.account_status",
-          "arguments": {
-            "subject": "acme"
-          }
+          "arguments": { "subject": "example account" }
         },
         "expectedResponseShape": {
-          "account_id": "opaque",
-          "status": "enum",
-          "answer": "string",
-          "assessment": {
-            "facts": [],
-            "openLoops": [],
-            "relationships": [],
-            "touchpoints": [],
-            "recordEntries": [],
-            "priorities": [],
-            "caveats": []
-          },
-          "provenance": {
-            "sources": [],
-            "rawClaimIdsIncluded": false
-          }
+          "schemaVersion": 2,
+          "schema_version": "mcp.account_status.v2",
+          "status": "ok",
+          "subject": { "entityHandle": "opaque" },
+          "assessment": { "facts": [], "openLoops": [] },
+          "provenance": { "sources": [], "rawClaimIdsIncluded": false }
         }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "What's going on with Acme?",
-          "expectedTool": "dailyos.read.account_status"
-        },
-        {
-          "prompt": "How are things looking with the Hooli deal?",
-          "expectedTool": "dailyos.read.account_status"
-        }
+        { "prompt": "What's going on with Example Account?", "expectedTool": "dailyos.read.account_status" },
+        { "prompt": "How are things looking with the Example renewal?", "expectedTool": "dailyos.read.account_status" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Search the web for SaaS pricing benchmarks",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "What's the company's vacation policy?",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Search the web for SaaS pricing benchmarks", "expectedToolClass": "external" },
+        { "prompt": "What's the company's vacation policy?", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "What did I write about the Q1 readout?",
-          "expectedTool": "dailyos.search.workspace_memory"
-        }
-      ]
-    }
-  },
-  {
-    "name": "dailyos.read.daily_briefing",
-    "side": "Read",
-    "summary": "Returns the user's current-day briefing.",
-    "when_to_call": "When the user asks about today's priorities.",
-    "when_NOT_to_call": "Do NOT call for general news or weather.",
-    "scopesRequired": [
-      "dailyos.read.daily_briefing"
-    ],
-    "parameters": [],
-    "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Daily briefing payload"
-    },
-    "examples": [
-      {
-        "prompt": "What's on my plate today?",
-        "invocation": {
-          "name": "dailyos.read.daily_briefing",
-          "arguments": {}
-        },
-        "expectedResponseShape": {
-          "date": "iso8601",
-          "priorities": []
-        }
-      }
-    ],
-    "selectionFixtures": {
-      "positive": [
-        {
-          "prompt": "What's on my plate today?",
-          "expectedTool": "dailyos.read.daily_briefing"
-        },
-        {
-          "prompt": "Give me my morning rundown",
-          "expectedTool": "dailyos.read.daily_briefing"
-        }
-      ],
-      "negativeBroadCorpus": [
-        {
-          "prompt": "What's the weather today?",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Show me today's news headlines",
-          "expectedToolClass": "external"
-        }
-      ],
-      "negativeAdjacentTool": [
-        {
-          "prompt": "What should I prep for my 2pm with Acme?",
-          "expectedTool": "dailyos.read.meeting_briefing"
-        }
-      ]
-    }
-  },
-  {
-    "name": "dailyos.read.meeting_briefing",
-    "side": "Read",
-    "summary": "Returns the prep briefing for a specific meeting.",
-    "when_to_call": "When the user asks for prep notes on a specific meeting.",
-    "when_NOT_to_call": "Do NOT call for the user's overall day rundown.",
-    "scopesRequired": [
-      "dailyos.read.meeting_briefing"
-    ],
-    "parameters": [
-      {
-        "name": "meeting_id",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "description": "Opaque meeting identifier"
-      }
-    ],
-    "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Meeting briefing payload"
-    },
-    "examples": [
-      {
-        "prompt": "What should I prep for my 2pm?",
-        "invocation": {
-          "name": "dailyos.read.meeting_briefing",
-          "arguments": {
-            "meeting_id": "opaque"
-          }
-        },
-        "expectedResponseShape": {
-          "meeting_id": "opaque",
-          "attendees": []
-        }
-      }
-    ],
-    "selectionFixtures": {
-      "positive": [
-        {
-          "prompt": "What should I prep for my 2pm with Acme?",
-          "expectedTool": "dailyos.read.meeting_briefing"
-        },
-        {
-          "prompt": "Brief me on my next call with Hooli",
-          "expectedTool": "dailyos.read.meeting_briefing"
-        }
-      ],
-      "negativeBroadCorpus": [
-        {
-          "prompt": "Show me the company holiday calendar",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Search the web for meeting facilitation techniques",
-          "expectedToolClass": "external"
-        }
-      ],
-      "negativeAdjacentTool": [
-        {
-          "prompt": "What's on my plate today overall?",
-          "expectedTool": "dailyos.read.daily_briefing"
-        }
-      ]
-    }
-  },
-  {
-    "name": "dailyos.read.portfolio_attention",
-    "side": "Read",
-    "summary": "Returns accounts that currently need attention.",
-    "when_to_call": "When the user asks which accounts are at risk or need follow-up.",
-    "when_NOT_to_call": "Do NOT call for general account state of a specific named account.",
-    "scopesRequired": [
-      "dailyos.read.portfolio_attention"
-    ],
-    "parameters": [],
-    "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Ranked account attention list"
-    },
-    "examples": [
-      {
-        "prompt": "What accounts need my attention?",
-        "invocation": {
-          "name": "dailyos.read.portfolio_attention",
-          "arguments": {}
-        },
-        "expectedResponseShape": {
-          "accounts": []
-        }
-      }
-    ],
-    "selectionFixtures": {
-      "positive": [
-        {
-          "prompt": "What accounts need my attention?",
-          "expectedTool": "dailyos.read.portfolio_attention"
-        },
-        {
-          "prompt": "Where should I focus this week?",
-          "expectedTool": "dailyos.read.portfolio_attention"
-        }
-      ],
-      "negativeBroadCorpus": [
-        {
-          "prompt": "Show me the Q3 sales report",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Search the web for customer churn benchmarks",
-          "expectedToolClass": "external"
-        }
-      ],
-      "negativeAdjacentTool": [
-        {
-          "prompt": "What's going on with Acme specifically?",
-          "expectedTool": "dailyos.read.account_status"
-        }
-      ]
-    }
-  },
-  {
-    "name": "dailyos.search.workspace_memory",
-    "side": "Read",
-    "summary": "Searches the user's working memory.",
-    "when_to_call": "When the user asks what they wrote, said, or noted about a topic.",
-    "when_NOT_to_call": "Do NOT call for general web search.",
-    "scopesRequired": [
-      "read.workspace_graph"
-    ],
-    "parameters": [
-      {
-        "name": "query",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "description": "Natural-language search query"
-      }
-    ],
-    "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Workspace memory matches"
-    },
-    "examples": [
-      {
-        "prompt": "What did I write about the Q1 readout?",
-        "invocation": {
-          "name": "dailyos.search.workspace_memory",
-          "arguments": {
-            "query": "Q1 readout"
-          }
-        },
-        "expectedResponseShape": {
-          "matches": []
-        }
-      }
-    ],
-    "selectionFixtures": {
-      "positive": [
-        {
-          "prompt": "What did I write about the Q1 readout?",
-          "expectedTool": "dailyos.search.workspace_memory"
-        },
-        {
-          "prompt": "Find my notes on the Acme renewal",
-          "expectedTool": "dailyos.search.workspace_memory"
-        }
-      ],
-      "negativeBroadCorpus": [
-        {
-          "prompt": "Search the web for Q1 readout templates",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Find company-wide Q1 reports in Glean",
-          "expectedToolClass": "external"
-        }
-      ],
-      "negativeAdjacentTool": [
-        {
-          "prompt": "What's the current state of the Acme account?",
-          "expectedTool": "dailyos.read.account_status"
-        }
+        { "prompt": "Where did that source handle come from?", "expectedTool": "dailyos.read.workspace_source_provenance" }
       ]
     }
   },
   {
     "name": "dailyos.read.workspace_source_provenance",
     "side": "Read",
-    "summary": "Returns provenance metadata for a workspace memory entry.",
-    "when_to_call": "When the user asks where a specific memory entry came from.",
-    "when_NOT_to_call": "Do NOT call without a prior memory entry reference.",
-    "scopesRequired": [
-      "dailyos.read.workspace_source_provenance"
-    ],
+    "summary": "Returns display-safe provenance detail for a server-issued source provenance handle from a prior DailyOS MCP response.",
+    "when_to_call": "When the user asks where a specific DailyOS MCP fact, open loop, note, or source reference came from and you already have a source_provenance_handle from a prior DailyOS response.",
+    "when_NOT_to_call": "Do NOT call with raw file paths, source ids, claim ids, workspace ids, or guesses. Do not use it for broad unscoped lookup.",
+    "scopesRequired": ["dailyos.read.workspace_source_provenance"],
     "parameters": [
       {
-        "name": "entry_id",
-        "schema": {
-          "type": "string"
-        },
+        "name": "source_provenance_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
         "required": true,
-        "description": "Opaque memory entry identifier"
+        "description": "Server-issued opaque source provenance handle from a prior DailyOS MCP response."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false
-      },
-      "description": "Source attribution metadata"
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "Source-as-of, trust, lifecycle, redaction, and display-safe provenance metadata. Raw paths and source ids are not returned."
     },
     "examples": [
       {
-        "prompt": "Where did that note about Acme come from?",
+        "prompt": "Where did that DailyOS source come from?",
         "invocation": {
           "name": "dailyos.read.workspace_source_provenance",
-          "arguments": {
-            "entry_id": "opaque"
-          }
+          "arguments": { "source_provenance_handle": "mth_opaque" }
         },
         "expectedResponseShape": {
-          "source": "string"
+          "status": "ok",
+          "source": { "label": "string", "sourceType": "string", "source_type": "string" }
         }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "Where did that note about Acme come from?",
-          "expectedTool": "dailyos.read.workspace_source_provenance"
-        },
-        {
-          "prompt": "What's the source of this memory entry?",
-          "expectedTool": "dailyos.read.workspace_source_provenance"
-        }
+        { "prompt": "Where did that DailyOS source handle come from?", "expectedTool": "dailyos.read.workspace_source_provenance" },
+        { "prompt": "Show the provenance for this source_provenance_handle", "expectedTool": "dailyos.read.workspace_source_provenance" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Search the web for source attribution best practices",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Show me the org-wide data provenance policy",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Search the web for source attribution best practices", "expectedToolClass": "external" },
+        { "prompt": "Show me the org-wide data provenance policy", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "Find the actual note about Acme",
-          "expectedTool": "dailyos.search.workspace_memory"
-        }
+        { "prompt": "What's the current state of Example Account?", "expectedTool": "dailyos.read.account_status" }
       ]
     }
   },
   {
-    "name": "dailyos.write.place_document",
-    "side": "Write",
-    "summary": "Places a text document into local workspace memory for a specific entity.",
-    "when_to_call": "When the user wants to save or file a text document for a known account, person, or project in DailyOS workspace memory.",
-    "when_NOT_to_call": "Do NOT call for general file upload to shared drives.",
-    "scopesRequired": [
-      "write.workspace_place_document"
-    ],
+    "name": "dailyos.submit.claim_feedback",
+    "side": "SubmitCorrection",
+    "summary": "Submits typed feedback on a claim-backed DailyOS MCP item using a server-issued feedback target handle.",
+    "when_to_call": "When the user corrects, confirms, disputes, marks irrelevant, or requests nuance for a specific DailyOS MCP fact/open loop that includes a feedback_target_handle.",
+    "when_NOT_to_call": "Do NOT call for generic notes, new action creation, raw claim ids, source ids, or guessed targets. Do not infer feedback from unrelated prose.",
+    "scopesRequired": ["dailyos.submit.claim_feedback"],
     "parameters": [
       {
-        "name": "schema_version",
-        "schema": {
-          "type": "integer",
-          "const": 1
-        },
+        "name": "feedback_target_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
         "required": true,
-        "description": "Workspace placement schema version. Must be 1."
+        "description": "Server-issued opaque feedback target handle from a prior DailyOS MCP read."
       },
       {
-        "name": "entity",
-        "schema": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "entity_type",
-            "entity_id"
-          ],
-          "properties": {
-            "entity_type": {
-              "type": "string",
-              "enum": [
-                "account",
-                "person",
-                "project"
-              ]
-            },
-            "entity_id": {
-              "type": "string"
-            }
-          }
-        },
-        "required": true,
-        "description": "Target DailyOS entity."
-      },
-      {
-        "name": "content_b64",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "description": "RFC 4648 standard base64 text bytes with required padding."
-      },
-      {
-        "name": "content_type",
+        "name": "action",
         "schema": {
           "type": "string",
-          "enum": [
-            "text/markdown",
-            "text/plain",
-            "application/json"
-          ]
+          "enum": ["confirm_current", "mark_false", "needs_nuance", "wrong_source", "not_relevant_here", "surface_inappropriate", "cannot_verify"]
         },
         "required": true,
-        "description": "Textual document content type."
+        "description": "Typed ADR-0123 feedback action."
       },
       {
-        "name": "filename_hint",
-        "schema": {
-          "type": "string"
-        },
+        "name": "metadata",
+        "schema": { "type": "object" },
         "required": false,
-        "description": "Optional safe filename hint."
-      },
-      {
-        "name": "category",
-        "schema": {
-          "type": "string"
-        },
-        "required": true,
-        "description": "Required workspace category slug allowed for the target entity type."
-      },
-      {
-        "name": "client_dedup_key",
-        "schema": {
-          "type": "string"
-        },
-        "required": false,
-        "description": "Optional caller idempotency key."
-      },
-      {
-        "name": "dry_run",
-        "schema": {
-          "type": "boolean"
-        },
-        "required": false,
-        "description": "Preview placement without writing a document."
+        "description": "Action-specific bounded metadata. For wrong_source, pass source_provenance_handle from a prior DailyOS MCP response; raw ids and caller-supplied source references are rejected."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "schema_version": {
-            "type": "integer"
-          },
-          "document_handle": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "source_handle": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "entity_type": {
-            "type": "string"
-          },
-          "entity_id": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "workspace_file_kind": {
-            "type": "string"
-          },
-          "source_asof": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "lifecycle_state": {
-            "type": "string"
-          },
-          "claim_count_produced": {
-            "type": "integer"
-          },
-          "idempotent_replay": {
-            "type": "boolean"
-          },
-          "dry_run": {
-            "type": "boolean"
-          },
-          "resolved_path": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "mutation_cursor": {
-            "type": "object"
-          }
-        }
-      },
-      "description": "Opaque placement receipt"
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "Feedback status with mandatory mutation_cursor, lifecycle/repair flags, sanitized warnings, and no raw claim ids."
     },
     "examples": [
       {
-        "prompt": "Save this renewal context for the selected account",
+        "prompt": "That DailyOS fact is wrong",
         "invocation": {
-          "name": "dailyos.write.place_document",
-          "arguments": {
-            "schema_version": 1,
-            "entity": {
-              "entity_type": "account",
-              "entity_id": "acct_123"
-            },
-            "content_b64": "b3BhcXVl",
-            "content_type": "text/markdown",
-            "filename_hint": "renewal-notes.md",
-            "category": "notes",
-            "dry_run": false
-          }
+          "name": "dailyos.submit.claim_feedback",
+          "arguments": { "feedback_target_handle": "mth_opaque", "action": "mark_false" }
         },
-        "expectedResponseShape": {
-          "schema_version": 1,
-          "document_handle": "opaque",
-          "source_handle": "opaque",
-          "lifecycle_state": "ingested",
-          "mutation_cursor": {
-            "kind": "workspace_placement",
-            "document_handle": "opaque",
-            "source_handle": "opaque",
-            "idempotency_id": "opaque"
-          }
-        }
+        "expectedResponseShape": { "status": "ok", "mutation_cursor": {} }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "Save this renewal context for the selected account",
-          "expectedTool": "dailyos.write.place_document"
-        },
-        {
-          "prompt": "File this note for the selected project",
-          "expectedTool": "dailyos.write.place_document"
-        }
+        { "prompt": "Mark that DailyOS fact false using its feedback handle", "expectedTool": "dailyos.submit.claim_feedback" },
+        { "prompt": "Confirm the claim from the account status result is current", "expectedTool": "dailyos.submit.claim_feedback" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Upload this file to Drive",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Save this to the company wiki",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Search the web for claim correction workflows", "expectedToolClass": "external" },
+        { "prompt": "Open the CRM correction queue", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "Add a quick note about Acme",
-          "expectedTool": "dailyos.submit.note"
-        }
+        { "prompt": "Save this as a note", "expectedTool": "dailyos.submit.note" }
       ]
     }
   },
   {
     "name": "dailyos.submit.note",
     "side": "SubmitCorrection",
-    "summary": "Submits a free-form note.",
-    "when_to_call": "When the user wants to capture a quick thought or observation.",
-    "when_NOT_to_call": "Do NOT call for structured action items.",
-    "scopesRequired": [
-      "dailyos.submit.note"
-    ],
+    "summary": "Submits a bounded entity-scoped observation note through DailyOS claim/source services using a server-issued entity handle.",
+    "when_to_call": "When the user wants to add a note or observation to a specific DailyOS entity and you have an entity_handle from a prior DailyOS MCP response.",
+    "when_NOT_to_call": "Do NOT call without an entity_handle, for raw entity ids, for feedback on an existing claim, or to create an action/reminder.",
+    "scopesRequired": ["dailyos.submit.note"],
     "parameters": [
       {
         "name": "text",
-        "schema": {
-          "type": "string"
-        },
+        "schema": { "type": "string", "minLength": 1, "maxLength": 2000 },
         "required": true,
-        "description": "Note text"
+        "description": "Bounded note text. Treated as hostile input and rendered through claim sensitivity policy."
       },
       {
-        "name": "subject",
-        "schema": {
-          "type": "string"
-        },
+        "name": "entity_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
+        "required": true,
+        "description": "Server-issued opaque entity handle from a prior DailyOS MCP read."
+      },
+      {
+        "name": "subject_text",
+        "schema": { "type": "string", "maxLength": 200 },
         "required": false,
-        "description": "Optional subject"
+        "description": "Optional display hint. It never selects the entity by itself."
+      },
+      {
+        "name": "source_provenance_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
+        "required": false,
+        "description": "Optional server-issued source provenance handle."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "note_id": {
-            "type": "string"
-          },
-          "mutation_cursor": {
-            "type": "object"
-          }
-        }
-      },
-      "description": "New note identifier"
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "Submit status with mandatory mutation_cursor and opaque note/feedback handles when available."
     },
     "examples": [
       {
-        "prompt": "Note that Acme is concerned about pricing",
+        "prompt": "Add a note to Example Account that onboarding risk is rising",
         "invocation": {
           "name": "dailyos.submit.note",
-          "arguments": {
-            "text": "Acme concerned about pricing",
-            "subject": "Acme"
-          }
+          "arguments": { "entity_handle": "mth_opaque", "text": "Onboarding risk is rising." }
         },
-        "expectedResponseShape": {
-          "note_id": "opaque",
-          "mutation_cursor": {
-            "note_id": "opaque"
-          }
-        }
+        "expectedResponseShape": { "status": "ok", "note_handle": "opaque", "mutation_cursor": {} }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "Note that Acme is concerned about pricing",
-          "expectedTool": "dailyos.submit.note"
-        },
-        {
-          "prompt": "Quick observation that Hooli champion is moving teams",
-          "expectedTool": "dailyos.submit.note"
-        }
+        { "prompt": "Add this observation to the account", "expectedTool": "dailyos.submit.note" },
+        { "prompt": "Save this note against the DailyOS entity handle", "expectedTool": "dailyos.submit.note" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Post this announcement to the company channel",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Send this note to the team via email",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Write this note into Google Docs", "expectedToolClass": "external" },
+        { "prompt": "Upload this note to shared drive", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "Save this full document for the selected account",
-          "expectedTool": "dailyos.write.place_document"
-        }
+        { "prompt": "Mark that existing fact wrong", "expectedTool": "dailyos.submit.claim_feedback" }
       ]
     }
   },
   {
     "name": "dailyos.submit.action",
     "side": "SubmitCorrection",
-    "summary": "Submits a structured action item.",
-    "when_to_call": "When the user wants to capture a task or follow-up.",
-    "when_NOT_to_call": "Do NOT call for free-form notes.",
-    "scopesRequired": [
-      "dailyos.submit.action"
-    ],
+    "summary": "Creates a bounded DailyOS action through the action service and returns an opaque action handle for follow-up status changes.",
+    "when_to_call": "When the user asks to create a task, follow-up, reminder-like work item, or action in DailyOS. Use an entity_handle when the action belongs to an account, person, or project.",
+    "when_NOT_to_call": "Do NOT call for claim feedback, generic notes, raw action ids, raw entity ids, content publishing, or external task systems.",
+    "scopesRequired": ["dailyos.submit.action"],
     "parameters": [
       {
         "name": "description",
-        "schema": {
-          "type": "string"
-        },
+        "schema": { "type": "string", "minLength": 1, "maxLength": 280 },
         "required": true,
-        "description": "Action description"
+        "description": "Action title/description."
       },
       {
-        "name": "due_at",
-        "schema": {
-          "type": "string",
-          "format": "date-time"
-        },
+        "name": "due_date",
+        "schema": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
         "required": false,
-        "description": "Optional due time"
+        "description": "Optional due date as YYYY-MM-DD. Timestamps are rejected."
       },
       {
-        "name": "subject",
-        "schema": {
-          "type": "string"
-        },
+        "name": "priority",
+        "schema": { "type": "string", "enum": ["none", "urgent", "high", "medium", "low"] },
         "required": false,
-        "description": "Optional subject"
+        "description": "Optional DailyOS priority."
+      },
+      {
+        "name": "entity_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
+        "required": false,
+        "description": "Optional server-issued entity handle."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "action_id": {
-            "type": "string"
-          },
-          "mutation_cursor": {
-            "type": "object"
-          }
-        }
-      },
-      "description": "New action identifier"
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "Action creation status with mandatory mutation_cursor, action_handle, semantic_status, and stored_status. Raw action ids are not returned."
     },
     "examples": [
       {
-        "prompt": "Remind me to follow up with Acme next Tuesday",
+        "prompt": "Create an action to follow up next Friday",
         "invocation": {
           "name": "dailyos.submit.action",
-          "arguments": {
-            "description": "Follow up with Acme",
-            "due_at": "iso8601",
-            "subject": "Acme"
-          }
+          "arguments": { "description": "Follow up on renewal plan", "due_date": "2026-06-12" }
         },
-        "expectedResponseShape": {
-          "action_id": "opaque",
-          "mutation_cursor": {
-            "action_id": "opaque"
-          }
-        }
+        "expectedResponseShape": { "status": "ok", "action_handle": "opaque", "mutation_cursor": {} }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "Remind me to follow up with Acme next Tuesday",
-          "expectedTool": "dailyos.submit.action"
-        },
-        {
-          "prompt": "Add a task to send the Hooli proposal by Friday",
-          "expectedTool": "dailyos.submit.action"
-        }
+        { "prompt": "Create a DailyOS action to follow up Friday", "expectedTool": "dailyos.submit.action" },
+        { "prompt": "Add a task for the account owner", "expectedTool": "dailyos.submit.action" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Add this to the team's Jira backlog",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Create a calendar invite for the meeting",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Create a Jira ticket", "expectedToolClass": "external" },
+        { "prompt": "Send an email reminder", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "Note that Acme is concerned about pricing",
-          "expectedTool": "dailyos.submit.note"
-        }
+        { "prompt": "Mark this action done", "expectedTool": "dailyos.submit.action_status" }
       ]
     }
   },
   {
     "name": "dailyos.submit.action_status",
     "side": "SubmitCorrection",
-    "summary": "Updates the status of an existing action.",
-    "when_to_call": "When the user reports an action as done, deferred, or dropped.",
-    "when_NOT_to_call": "Do NOT call to create a new action.",
-    "scopesRequired": [
-      "dailyos.submit.action_status"
-    ],
+    "summary": "Updates a DailyOS action through service-backed semantic status values using a server-issued action handle.",
+    "when_to_call": "When the user asks to mark a DailyOS action done, defer it to a new due date, or drop it and you have an action_handle from a prior DailyOS MCP response.",
+    "when_NOT_to_call": "Do NOT call with raw action ids, without an action_handle, for creating new actions, or for claim feedback.",
+    "scopesRequired": ["dailyos.submit.action_status"],
     "parameters": [
       {
-        "name": "action_id",
-        "schema": {
-          "type": "string"
-        },
+        "name": "action_handle",
+        "schema": { "type": "string", "pattern": "^mth_[A-Za-z0-9_-]+$" },
         "required": true,
-        "description": "Opaque action identifier"
+        "description": "Server-issued opaque action handle."
       },
       {
         "name": "status",
-        "schema": {
-          "type": "string",
-          "enum": [
-            "done",
-            "deferred",
-            "dropped"
-          ]
-        },
+        "schema": { "type": "string", "enum": ["done", "deferred", "dropped"] },
         "required": true,
-        "description": "New status"
+        "description": "Semantic status to apply."
+      },
+      {
+        "name": "defer_date",
+        "schema": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+        "required": false,
+        "description": "Required for deferred; forbidden for done and dropped."
+      },
+      {
+        "name": "reason",
+        "schema": { "type": "string", "maxLength": 500 },
+        "required": false,
+        "description": "Optional bounded reason stored only through service metadata."
       }
     ],
     "returns": {
-      "schema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "action_id": {
-            "type": "string"
-          },
-          "mutation_cursor": {
-            "type": "object"
-          }
-        }
-      },
-      "description": "Updated action identifier"
+      "schema": { "type": "object", "additionalProperties": false },
+      "description": "Semantic action-status result with mandatory mutation_cursor, semantic_status, and stored_status. Raw action ids are not returned."
     },
     "examples": [
       {
-        "prompt": "I finished the Acme follow-up",
+        "prompt": "Mark that DailyOS action done",
         "invocation": {
           "name": "dailyos.submit.action_status",
-          "arguments": {
-            "action_id": "opaque",
-            "status": "done"
-          }
+          "arguments": { "action_handle": "mth_opaque", "status": "done" }
         },
-        "expectedResponseShape": {
-          "action_id": "opaque",
-          "mutation_cursor": {
-            "action_id": "opaque"
-          }
-        }
+        "expectedResponseShape": { "status": "ok", "semantic_status": "done", "stored_status": "completed", "mutation_cursor": {} }
       }
     ],
     "selectionFixtures": {
       "positive": [
-        {
-          "prompt": "I finished the Acme follow-up",
-          "expectedTool": "dailyos.submit.action_status"
-        },
-        {
-          "prompt": "Mark the Hooli proposal task as dropped",
-          "expectedTool": "dailyos.submit.action_status"
-        }
+        { "prompt": "Mark that DailyOS action done", "expectedTool": "dailyos.submit.action_status" },
+        { "prompt": "Defer this action to next Friday", "expectedTool": "dailyos.submit.action_status" }
       ],
       "negativeBroadCorpus": [
-        {
-          "prompt": "Mark this Jira ticket as done",
-          "expectedToolClass": "external"
-        },
-        {
-          "prompt": "Update the project status in the company wiki",
-          "expectedToolClass": "external"
-        }
+        { "prompt": "Close the Jira ticket", "expectedToolClass": "external" },
+        { "prompt": "Update the CRM task", "expectedToolClass": "external" }
       ],
       "negativeAdjacentTool": [
-        {
-          "prompt": "Add a new task to call Hooli tomorrow",
-          "expectedTool": "dailyos.submit.action"
-        }
+        { "prompt": "Create a new follow-up action", "expectedTool": "dailyos.submit.action" }
       ]
     }
   }

--- a/src-tauri/src/services/mcp_v2/target_handles.rs
+++ b/src-tauri/src/services/mcp_v2/target_handles.rs
@@ -1,0 +1,704 @@
+//! Registry-backed opaque target handles for MCP v2.
+//!
+//! Public MCP payloads carry `mth_...` handles. The database stores only a
+//! keyed lookup hash plus AEAD-sealed target refs, so raw claim/action/entity
+//! ids never appear in public responses, audit detail, or plaintext indexes.
+
+use base64::Engine as _;
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use rand::Rng;
+use ring::aead;
+use rusqlite::{params, OptionalExtension};
+use serde_json::Value;
+
+use crate::db::ActionDb;
+
+use super::contracts::{McpActor, McpClientId, OpaqueConversationHandle, ScopedName};
+use super::local_runtime::{self, LocalRuntimeError};
+
+const HANDLE_PREFIX: &str = "mth_";
+const HANDLE_RANDOM_BYTES: usize = 24;
+const TARGET_REF_KEY_VERSION: i64 = 1;
+const TARGET_REF_MAGIC: &[u8] = b"DOSMTH1";
+const NONCE_BYTES: usize = 12;
+const DEFAULT_RENDER_POLICY_VERSION: &str = "mcp_target_handle_v1";
+const HANDLE_TTL: Duration = Duration::hours(24);
+const CLEANUP_RETENTION: Duration = Duration::days(7);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetKind {
+    Claim,
+    Action,
+    Entity,
+    SourceProvenance,
+    WorkspaceSource,
+}
+
+impl TargetKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claim => "claim",
+            Self::Action => "action",
+            Self::Entity => "entity",
+            Self::SourceProvenance => "source_provenance",
+            Self::WorkspaceSource => "workspace_source",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "claim" => Self::Claim,
+            "action" => Self::Action,
+            "entity" => Self::Entity,
+            "source_provenance" => Self::SourceProvenance,
+            "workspace_source" => Self::WorkspaceSource,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct MintTargetHandle<'a> {
+    pub actor: &'a McpActor,
+    pub originating_tool: &'a ScopedName,
+    pub result_item_path: &'a str,
+    pub target_kind: TargetKind,
+    pub target_ref: Value,
+    pub sensitivity_tier: &'a str,
+    pub provenance_material: &'a str,
+    pub watermark_material: &'a str,
+}
+
+#[derive(Debug)]
+pub struct ResolveTargetHandle<'a> {
+    pub actor: &'a McpActor,
+    pub handle: &'a str,
+    pub expected_kind: TargetKind,
+    pub current_watermark_material: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedTargetHandle {
+    pub target_ref: Value,
+    pub result_item_path: String,
+    pub originating_tool: String,
+    pub render_policy_version: String,
+    pub sensitivity_tier: String,
+    target_watermark_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetHandleResolutionError {
+    Unavailable { refresh_required: bool },
+    Internal(String),
+}
+
+impl TargetHandleResolutionError {
+    pub fn unavailable() -> Self {
+        Self::Unavailable {
+            refresh_required: false,
+        }
+    }
+
+    pub fn refresh_required() -> Self {
+        Self::Unavailable {
+            refresh_required: true,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TargetHandleError {
+    #[error("target handle actor is not an MCP client")]
+    Actor,
+    #[error("target handle requires an MCP conversation handle")]
+    MissingConversation,
+    #[error("target handle key unavailable: {0}")]
+    LocalRuntime(#[from] LocalRuntimeError),
+    #[error("target handle serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("target handle encryption failed")]
+    Crypto,
+    #[error("target handle database write failed: {0}")]
+    Db(#[from] rusqlite::Error),
+}
+
+pub fn public_handle_hash(handle: &str) -> Result<String, LocalRuntimeError> {
+    local_runtime::target_handle_hmac_hex(handle)
+}
+
+pub fn mint_target_handle(
+    db: &ActionDb,
+    input: MintTargetHandle<'_>,
+) -> Result<String, TargetHandleError> {
+    mint_target_handle_with_mode(db, input, false)
+}
+
+pub fn mint_replacing_target_handle(
+    db: &ActionDb,
+    input: MintTargetHandle<'_>,
+) -> Result<String, TargetHandleError> {
+    mint_target_handle_with_mode(db, input, true)
+}
+
+fn mint_target_handle_with_mode(
+    db: &ActionDb,
+    input: MintTargetHandle<'_>,
+    replace_existing: bool,
+) -> Result<String, TargetHandleError> {
+    let (client_id, conversation_handle) = actor_parts(input.actor)?;
+    let handle = mint_public_handle();
+    let handle_lookup_hash = local_runtime::target_handle_hmac_hex(&handle)?;
+    let conversation_handle_hash =
+        local_runtime::target_handle_hmac_hex(conversation_handle.as_str())?;
+    let provenance_hash = local_runtime::target_handle_hmac_hex(input.provenance_material)?;
+    let target_watermark_hash = local_runtime::target_handle_hmac_hex(input.watermark_material)?;
+    let render_policy_version = DEFAULT_RENDER_POLICY_VERSION;
+    let ciphertext = seal_target_ref(
+        &input.target_ref,
+        &target_ref_aad(
+            client_id,
+            &conversation_handle_hash,
+            input.originating_tool,
+            input.target_kind,
+            render_policy_version,
+        ),
+    )?;
+    let now = Utc::now();
+    let created_at = rfc3339(now);
+    let expires_at = rfc3339(now + HANDLE_TTL);
+
+    if replace_existing {
+        db.conn_ref().execute(
+            "DELETE FROM mcp_target_handles
+              WHERE client_id = ?1
+                AND conversation_handle_hash = ?2
+                AND originating_tool = ?3
+                AND result_item_path = ?4
+                AND target_kind = ?5
+                AND provenance_hash = ?6
+                AND target_watermark_hash = ?7",
+            params![
+                client_id.as_str(),
+                conversation_handle_hash,
+                input.originating_tool.as_str(),
+                input.result_item_path,
+                input.target_kind.as_str(),
+                provenance_hash,
+                target_watermark_hash,
+            ],
+        )?;
+    }
+
+    db.conn_ref().execute(
+        "INSERT INTO mcp_target_handles (
+            handle_lookup_hash, client_id, conversation_handle_hash, originating_tool,
+            result_item_path, target_kind, target_ref_ciphertext, target_ref_key_version,
+            render_policy_version, sensitivity_tier, provenance_hash, target_watermark_hash,
+            created_at, last_used_at, expires_at, revoked_at, revoked_reason_code
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13, ?14, NULL, NULL)",
+        params![
+            handle_lookup_hash,
+            client_id.as_str(),
+            conversation_handle_hash,
+            input.originating_tool.as_str(),
+            input.result_item_path,
+            input.target_kind.as_str(),
+            ciphertext,
+            TARGET_REF_KEY_VERSION,
+            render_policy_version,
+            input.sensitivity_tier,
+            provenance_hash,
+            target_watermark_hash,
+            created_at,
+            expires_at,
+        ],
+    )?;
+
+    Ok(handle)
+}
+
+pub fn resolve_target_handle(
+    db: &ActionDb,
+    input: ResolveTargetHandle<'_>,
+) -> Result<ResolvedTargetHandle, TargetHandleResolutionError> {
+    if !input.handle.starts_with(HANDLE_PREFIX) {
+        return Err(TargetHandleResolutionError::unavailable());
+    }
+
+    let (client_id, conversation_handle) = actor_parts(input.actor)
+        .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+    let handle_lookup_hash = public_handle_hash(input.handle)
+        .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+    let expected_conversation_hash =
+        local_runtime::target_handle_hmac_hex(conversation_handle.as_str())
+            .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+    let row = load_row(db, &handle_lookup_hash)
+        .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?
+        .ok_or_else(TargetHandleResolutionError::unavailable)?;
+
+    if row.client_id != client_id.as_str()
+        || row.conversation_handle_hash != expected_conversation_hash
+        || row.revoked_at.is_some()
+    {
+        return Err(TargetHandleResolutionError::unavailable());
+    }
+    if row.target_kind != input.expected_kind {
+        return Err(TargetHandleResolutionError::unavailable());
+    }
+    if parse_rfc3339(&row.expires_at)
+        .map(|expires_at| expires_at < Utc::now())
+        .unwrap_or(true)
+    {
+        return Err(TargetHandleResolutionError::unavailable());
+    }
+    if let Some(material) = input.current_watermark_material {
+        let current = local_runtime::target_handle_hmac_hex(material)
+            .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+        if current != row.target_watermark_hash {
+            return Err(TargetHandleResolutionError::refresh_required());
+        }
+    }
+
+    let target_ref = open_target_ref(
+        &row.target_ref_ciphertext,
+        &target_ref_aad(
+            client_id,
+            &row.conversation_handle_hash,
+            &ScopedName::new(row.originating_tool.clone()),
+            row.target_kind,
+            &row.render_policy_version,
+        ),
+    )
+    .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+
+    let now = Utc::now();
+    let new_expires_at = rfc3339(now + HANDLE_TTL);
+    db.conn_ref()
+        .execute(
+            "UPDATE mcp_target_handles
+                SET last_used_at = ?2, expires_at = ?3
+              WHERE handle_lookup_hash = ?1",
+            params![handle_lookup_hash, rfc3339(now), new_expires_at],
+        )
+        .map_err(|error| TargetHandleResolutionError::Internal(error.to_string()))?;
+
+    Ok(ResolvedTargetHandle {
+        target_ref,
+        result_item_path: row.result_item_path,
+        originating_tool: row.originating_tool,
+        render_policy_version: row.render_policy_version,
+        sensitivity_tier: row.sensitivity_tier,
+        target_watermark_hash: row.target_watermark_hash,
+    })
+}
+
+pub fn resolved_target_watermark_matches(
+    resolved: &ResolvedTargetHandle,
+    current_watermark_material: &str,
+) -> Result<bool, LocalRuntimeError> {
+    let current = local_runtime::target_handle_hmac_hex(current_watermark_material)?;
+    Ok(current == resolved.target_watermark_hash)
+}
+
+pub fn cleanup_target_handles(db: &ActionDb) -> Result<usize, rusqlite::Error> {
+    let cutoff = rfc3339(Utc::now() - CLEANUP_RETENTION);
+    db.conn_ref().execute(
+        "DELETE FROM mcp_target_handles
+          WHERE expires_at < ?1
+             OR (revoked_at IS NOT NULL AND revoked_at < ?1)",
+        params![cutoff],
+    )
+}
+
+fn actor_parts(
+    actor: &McpActor,
+) -> Result<(&McpClientId, &OpaqueConversationHandle), TargetHandleError> {
+    let McpActor::Client {
+        client_id,
+        conversation_handle,
+        ..
+    } = actor;
+    let conversation_handle = conversation_handle
+        .as_ref()
+        .ok_or(TargetHandleError::MissingConversation)?;
+    Ok((client_id, conversation_handle))
+}
+
+#[derive(Debug)]
+struct TargetHandleRow {
+    client_id: String,
+    conversation_handle_hash: String,
+    originating_tool: String,
+    result_item_path: String,
+    target_kind: TargetKind,
+    target_ref_ciphertext: Vec<u8>,
+    render_policy_version: String,
+    sensitivity_tier: String,
+    target_watermark_hash: String,
+    expires_at: String,
+    revoked_at: Option<String>,
+}
+
+fn load_row(
+    db: &ActionDb,
+    handle_lookup_hash: &str,
+) -> Result<Option<TargetHandleRow>, rusqlite::Error> {
+    db.conn_ref()
+        .query_row(
+            "SELECT client_id, conversation_handle_hash, originating_tool,
+                    result_item_path, target_kind, target_ref_ciphertext,
+                    render_policy_version, sensitivity_tier, target_watermark_hash,
+                    expires_at, revoked_at
+               FROM mcp_target_handles
+              WHERE handle_lookup_hash = ?1",
+            params![handle_lookup_hash],
+            |row| {
+                let kind_raw: String = row.get(4)?;
+                let target_kind = TargetKind::parse(&kind_raw).ok_or_else(|| {
+                    rusqlite::Error::InvalidColumnType(
+                        4,
+                        "target_kind".to_string(),
+                        rusqlite::types::Type::Text,
+                    )
+                })?;
+                Ok(TargetHandleRow {
+                    client_id: row.get(0)?,
+                    conversation_handle_hash: row.get(1)?,
+                    originating_tool: row.get(2)?,
+                    result_item_path: row.get(3)?,
+                    target_kind,
+                    target_ref_ciphertext: row.get(5)?,
+                    render_policy_version: row.get(6)?,
+                    sensitivity_tier: row.get(7)?,
+                    target_watermark_hash: row.get(8)?,
+                    expires_at: row.get(9)?,
+                    revoked_at: row.get(10)?,
+                })
+            },
+        )
+        .optional()
+}
+
+fn mint_public_handle() -> String {
+    let mut bytes = [0_u8; HANDLE_RANDOM_BYTES];
+    rand::rng().fill_bytes(&mut bytes);
+    format!(
+        "{HANDLE_PREFIX}{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    )
+}
+
+fn seal_target_ref(target_ref: &Value, aad: &str) -> Result<Vec<u8>, TargetHandleError> {
+    let key_bytes = local_runtime::target_handle_key_v1()?;
+    let unbound = aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes)
+        .map_err(|_| TargetHandleError::Crypto)?;
+    let key = aead::LessSafeKey::new(unbound);
+    let mut nonce_bytes = [0_u8; NONCE_BYTES];
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+    let mut in_out = serde_json::to_vec(target_ref)?;
+    key.seal_in_place_append_tag(nonce, aead::Aad::from(aad.as_bytes()), &mut in_out)
+        .map_err(|_| TargetHandleError::Crypto)?;
+
+    let mut blob = Vec::with_capacity(TARGET_REF_MAGIC.len() + NONCE_BYTES + in_out.len());
+    blob.extend_from_slice(TARGET_REF_MAGIC);
+    blob.extend_from_slice(&nonce_bytes);
+    blob.extend_from_slice(&in_out);
+    Ok(blob)
+}
+
+fn open_target_ref(ciphertext: &[u8], aad: &str) -> Result<Value, TargetHandleError> {
+    if ciphertext.len() <= TARGET_REF_MAGIC.len() + NONCE_BYTES
+        || !ciphertext.starts_with(TARGET_REF_MAGIC)
+    {
+        return Err(TargetHandleError::Crypto);
+    }
+    let mut nonce_bytes = [0_u8; NONCE_BYTES];
+    nonce_bytes
+        .copy_from_slice(&ciphertext[TARGET_REF_MAGIC.len()..TARGET_REF_MAGIC.len() + NONCE_BYTES]);
+    let mut in_out = ciphertext[TARGET_REF_MAGIC.len() + NONCE_BYTES..].to_vec();
+    let key_bytes = local_runtime::target_handle_key_v1()?;
+    let unbound = aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes)
+        .map_err(|_| TargetHandleError::Crypto)?;
+    let key = aead::LessSafeKey::new(unbound);
+    let plaintext = key
+        .open_in_place(
+            aead::Nonce::assume_unique_for_key(nonce_bytes),
+            aead::Aad::from(aad.as_bytes()),
+            &mut in_out,
+        )
+        .map_err(|_| TargetHandleError::Crypto)?;
+    serde_json::from_slice(plaintext).map_err(TargetHandleError::from)
+}
+
+fn target_ref_aad(
+    client_id: &McpClientId,
+    conversation_handle_hash: &str,
+    originating_tool: &ScopedName,
+    target_kind: TargetKind,
+    render_policy_version: &str,
+) -> String {
+    format!(
+        "dailyos.mcp.target-ref.v1\0{}\0{}\0{}\0{}\0{}",
+        client_id.as_str(),
+        conversation_handle_hash,
+        originating_tool.as_str(),
+        target_kind.as_str(),
+        render_policy_version
+    )
+}
+
+fn parse_rfc3339(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+}
+
+fn rfc3339(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::mcp_v2::contracts::Scope;
+
+    fn actor(client: &str, conversation: &str) -> McpActor {
+        McpActor::Client {
+            client_id: McpClientId::new(client),
+            conversation_handle: Some(OpaqueConversationHandle::new(conversation)),
+            tool_name: ScopedName::new("dailyos.read.account_status"),
+            granted_scopes: vec![Scope::new("dailyos.read.account_status")],
+        }
+    }
+
+    fn db() -> ActionDb {
+        let dir = tempfile::tempdir().expect("tempdir");
+        ActionDb::open_at_unencrypted(dir.path().join("target-handles.db")).expect("open db")
+    }
+
+    fn with_key<R>(f: impl FnOnce() -> R) -> R {
+        local_runtime::with_target_handle_key_for_tests([7_u8; 32], f)
+    }
+
+    #[test]
+    fn mint_stores_only_hash_and_ciphertext_then_resolves_for_same_actor() {
+        with_key(|| {
+            let db = db();
+            let primary_actor = actor("client-a", "conversation-a");
+            let handle = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &primary_actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/assessment/facts/0",
+                    target_kind: TargetKind::Claim,
+                    target_ref: serde_json::json!({ "claim_id": "claim-secret-1" }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "source-a",
+                    watermark_material: "claim-secret-1:v1:active",
+                },
+            )
+            .expect("mint handle");
+            assert!(handle.starts_with(HANDLE_PREFIX));
+
+            let plaintext_columns: String = db
+                .conn_ref()
+                .query_row(
+                    "SELECT handle_lookup_hash || ' ' || client_id || ' ' ||
+                            conversation_handle_hash || ' ' || originating_tool || ' ' ||
+                            result_item_path || ' ' || target_kind || ' ' ||
+                            render_policy_version || ' ' || sensitivity_tier || ' ' ||
+                            provenance_hash || ' ' || target_watermark_hash
+                       FROM mcp_target_handles",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("row");
+            assert!(!plaintext_columns.contains(&handle));
+            assert!(!plaintext_columns.contains("claim-secret-1"));
+            assert!(!plaintext_columns.contains("conversation-a"));
+
+            let resolved = resolve_target_handle(
+                &db,
+                ResolveTargetHandle {
+                    actor: &primary_actor,
+                    handle: &handle,
+                    expected_kind: TargetKind::Claim,
+                    current_watermark_material: Some("claim-secret-1:v1:active"),
+                },
+            )
+            .expect("resolve handle");
+            assert_eq!(resolved.target_ref["claim_id"], "claim-secret-1");
+        });
+    }
+
+    #[test]
+    fn replacing_mint_keeps_one_deterministic_row_and_revokes_old_public_handle() {
+        with_key(|| {
+            let db = db();
+            let actor = actor("client-a", "conversation-a");
+            let tool = ScopedName::new("dailyos.submit.action");
+            let input = |path: &'static str| MintTargetHandle {
+                actor: &actor,
+                originating_tool: &tool,
+                result_item_path: path,
+                target_kind: TargetKind::Action,
+                target_ref: serde_json::json!({ "action_id": "action-1" }),
+                sensitivity_tier: "internal",
+                provenance_material: "mcp_submit_action:action-1",
+                watermark_material: "action:action-1:updated:pending",
+            };
+
+            let first = mint_replacing_target_handle(&db, input("/action")).expect("first handle");
+            let second =
+                mint_replacing_target_handle(&db, input("/action")).expect("second handle");
+            assert_ne!(
+                first, second,
+                "replacement still returns a fresh public handle"
+            );
+
+            let row_count: i64 = db
+                .conn_ref()
+                .query_row("SELECT COUNT(*) FROM mcp_target_handles", [], |row| {
+                    row.get(0)
+                })
+                .expect("row count");
+            assert_eq!(
+                row_count, 1,
+                "deterministic replay must not accumulate handle rows"
+            );
+
+            assert_eq!(
+                resolve_target_handle(
+                    &db,
+                    ResolveTargetHandle {
+                        actor: &actor,
+                        handle: &first,
+                        expected_kind: TargetKind::Action,
+                        current_watermark_material: Some("action:action-1:updated:pending"),
+                    },
+                ),
+                Err(TargetHandleResolutionError::unavailable()),
+                "the old public handle must not remain live after replacement"
+            );
+            let resolved = resolve_target_handle(
+                &db,
+                ResolveTargetHandle {
+                    actor: &actor,
+                    handle: &second,
+                    expected_kind: TargetKind::Action,
+                    current_watermark_material: Some("action:action-1:updated:pending"),
+                },
+            )
+            .expect("replacement handle resolves");
+            assert_eq!(resolved.target_ref["action_id"], "action-1");
+        });
+    }
+
+    #[test]
+    fn resolve_rejects_cross_client_and_stale_watermark_without_existence_hint() {
+        with_key(|| {
+            let db = db();
+            let primary_actor = actor("client-a", "conversation-a");
+            let handle = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &primary_actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/subject",
+                    target_kind: TargetKind::Entity,
+                    target_ref: serde_json::json!({ "entity_type": "account", "entity_id": "acct-1" }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "entity:acct-1",
+                    watermark_material: "account:acct-1:v1",
+                },
+            )
+            .expect("mint handle");
+
+            let wrong_actor = actor("client-b", "conversation-a");
+            assert_eq!(
+                resolve_target_handle(
+                    &db,
+                    ResolveTargetHandle {
+                        actor: &wrong_actor,
+                        handle: &handle,
+                        expected_kind: TargetKind::Entity,
+                        current_watermark_material: Some("account:acct-1:v1"),
+                    },
+                ),
+                Err(TargetHandleResolutionError::unavailable())
+            );
+
+            assert_eq!(
+                resolve_target_handle(
+                    &db,
+                    ResolveTargetHandle {
+                        actor: &primary_actor,
+                        handle: &handle,
+                        expected_kind: TargetKind::Entity,
+                        current_watermark_material: Some("account:acct-1:v2"),
+                    },
+                ),
+                Err(TargetHandleResolutionError::refresh_required())
+            );
+        });
+    }
+
+    #[test]
+    fn cleanup_keeps_fresh_expired_rows_and_drops_old_rows() {
+        with_key(|| {
+            let db = db();
+            let actor = actor("client-a", "conversation-a");
+            let fresh = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/fresh",
+                    target_kind: TargetKind::Entity,
+                    target_ref: serde_json::json!({ "entity_id": "fresh" }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "fresh",
+                    watermark_material: "fresh",
+                },
+            )
+            .expect("fresh handle");
+            let old = mint_target_handle(
+                &db,
+                MintTargetHandle {
+                    actor: &actor,
+                    originating_tool: &ScopedName::new("dailyos.read.account_status"),
+                    result_item_path: "/old",
+                    target_kind: TargetKind::Entity,
+                    target_ref: serde_json::json!({ "entity_id": "old" }),
+                    sensitivity_tier: "internal",
+                    provenance_material: "old",
+                    watermark_material: "old",
+                },
+            )
+            .expect("old handle");
+            let fresh_hash = public_handle_hash(&fresh).expect("fresh hash");
+            let old_hash = public_handle_hash(&old).expect("old hash");
+            let old_expiry = rfc3339(Utc::now() - Duration::days(8));
+            db.conn_ref()
+                .execute(
+                    "UPDATE mcp_target_handles SET expires_at = ?1 WHERE handle_lookup_hash = ?2",
+                    params![old_expiry, old_hash],
+                )
+                .expect("age old row");
+
+            assert_eq!(cleanup_target_handles(&db).expect("cleanup"), 1);
+            let count: i64 = db
+                .conn_ref()
+                .query_row(
+                    "SELECT COUNT(*) FROM mcp_target_handles WHERE handle_lookup_hash = ?1",
+                    params![fresh_hash],
+                    |row| row.get(0),
+                )
+                .expect("count");
+            assert_eq!(count, 1);
+        });
+    }
+}

--- a/src-tauri/src/services/mcp_v2/taxonomy.rs
+++ b/src-tauri/src/services/mcp_v2/taxonomy.rs
@@ -566,22 +566,22 @@ mod tests {
     }
 
     #[test]
-    fn embedded_catalog_loads_clean_with_ten_entries() {
+    fn embedded_catalog_loads_clean_with_w5_entries() {
         let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
-        assert_eq!(catalog.len(), 10, "expected 10 tool entries per DOS-478 §5");
+        assert_eq!(
+            catalog.len(),
+            6,
+            "W5 advertises only the approved MCP parity tools"
+        );
     }
 
     #[test]
-    fn embedded_catalog_contains_required_inventory() {
+    fn embedded_catalog_contains_w5_inventory() {
         let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
         for name in [
             "dailyos.read.account_status",
-            "dailyos.read.daily_briefing",
-            "dailyos.read.meeting_briefing",
-            "dailyos.read.portfolio_attention",
-            "dailyos.search.workspace_memory",
             "dailyos.read.workspace_source_provenance",
-            "dailyos.write.place_document",
+            "dailyos.submit.claim_feedback",
             "dailyos.submit.note",
             "dailyos.submit.action",
             "dailyos.submit.action_status",
@@ -590,6 +590,49 @@ mod tests {
                 catalog.description_for(&ScopedName::new(name)).is_some(),
                 "missing required tool: {name}",
             );
+        }
+        for hidden in [
+            "dailyos.read.daily_briefing",
+            "dailyos.read.meeting_briefing",
+            "dailyos.read.portfolio_attention",
+            "dailyos.search.workspace_memory",
+            "dailyos.write.place_document",
+        ] {
+            assert!(
+                catalog.description_for(&ScopedName::new(hidden)).is_none(),
+                "W5 hidden tool leaked into catalog: {hidden}",
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_catalog_visible_descriptions_do_not_name_hidden_categories() {
+        let catalog = YamlTaxonomyCatalog::load_embedded().expect("embedded catalog loads");
+        let forbidden = [
+            "daily schedule",
+            "briefing",
+            "meeting prep",
+            "portfolio",
+            "memory search",
+            "document lookup",
+            "file search",
+            "place document",
+            "file placement",
+            "resources",
+        ];
+        for (_name, description, _) in catalog.entries_with_fixtures() {
+            let published_description = format!(
+                "{}\n{}\n{}",
+                description.summary, description.when_to_call, description.when_not_to_call
+            )
+            .to_lowercase();
+            for term in forbidden {
+                assert!(
+                    !published_description.contains(term),
+                    "visible MCP description for `{}` leaks hidden category `{term}`",
+                    description.name,
+                );
+            }
         }
     }
 
@@ -678,7 +721,7 @@ mod tests {
                 && fixture.expected_tool_class.as_deref() == Some("external")
         }));
         assert!(fixtures.negative_adjacent_tool.iter().any(|fixture| {
-            fixture.expected_tool == ScopedName::new("dailyos.search.workspace_memory")
+            fixture.expected_tool == ScopedName::new("dailyos.read.workspace_source_provenance")
         }));
     }
 

--- a/src-tauri/src/services/mcp_v2/transport.rs
+++ b/src-tauri/src/services/mcp_v2/transport.rs
@@ -175,7 +175,7 @@ impl ServerHandler for V2ServerHandler {
             },
             instructions: Some(
                 "DailyOS MCP v2. Personal working intelligence for the paired user — \
-                 accounts, briefings, attention, working memory, notes, actions. \
+                 account status, source provenance, claim feedback, notes, and actions. \
                  Not for broad enterprise or web corpus search."
                     .to_string(),
             ),
@@ -390,12 +390,11 @@ fn tool_error_to_mcp_error(err: ToolError) -> ErrorData {
                 "retry_after_seconds": retry_after_seconds,
             })),
         ),
-        ToolError::ExposureForbidden { tool_name } => ErrorData::new(
+        ToolError::ExposureForbidden { tool_name: _ } => ErrorData::new(
             ErrorCode::METHOD_NOT_FOUND,
             "tool is not exposed to your pairing".to_string(),
             Some(json!({
                 "kind": "exposure_forbidden",
-                "tool_name": tool_name.as_str(),
             })),
         ),
         ToolError::PairingRevoked => ErrorData::invalid_request(
@@ -771,6 +770,47 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn call_tool_exposure_error_does_not_echo_hidden_requested_name() {
+        let visible_tool_name = "dailyos.read.account_status";
+        let hidden_tool_name = "dailyos.read.daily_briefing";
+        let description = fake_desc(visible_tool_name);
+        let invocations = Arc::new(Mutex::new(Vec::new()));
+        let conversation_dir = tempfile::tempdir().expect("conversation tempdir");
+        let mut gateway = Gateway::new().with_local_conversation_store_for_tests(
+            LocalConversationStore::new(conversation_dir.path().join("handles.json")),
+        );
+        gateway.register(Arc::new(RecordingHandler {
+            description: description.clone(),
+            invocations,
+        }));
+        let handler = V2ServerHandler::from_local_stdio(
+            Arc::new(gateway),
+            Arc::new(SingleToolCatalog {
+                description: description.clone(),
+            }),
+            vec![local_stdio_grant(&description.name)],
+            McpClientId::new("local-client-a"),
+        );
+
+        let err = handler
+            .call_tool(
+                CallToolRequestParam {
+                    name: Cow::Borrowed(hidden_tool_name),
+                    arguments: Some(JsonObject::new()),
+                },
+                request_context(),
+            )
+            .await
+            .expect_err("hidden tool call must be rejected");
+        assert_eq!(err.code, ErrorCode::METHOD_NOT_FOUND);
+        let wire = serde_json::to_string(&err.data).unwrap_or_default();
+        assert!(
+            !wire.contains(hidden_tool_name) && !err.message.contains(hidden_tool_name),
+            "hidden tool name must not be echoed on the public wire error: data={wire}"
+        );
+    }
+
     #[test]
     fn tool_description_composes_summary_when_to_call_when_not() {
         let desc = fake_desc("dailyos.read.account_status");
@@ -831,6 +871,10 @@ mod tests {
         assert_eq!(err.code, ErrorCode::METHOD_NOT_FOUND);
         let data = err.data.as_ref().expect("data present");
         assert_eq!(data["kind"], "exposure_forbidden");
+        assert!(
+            data.get("tool_name").is_none(),
+            "exposure errors must not echo probed tool names"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/v146_validation.rs
+++ b/src-tauri/tests/v146_validation.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use chrono::{DateTime, Duration, Utc};
 use dailyos_lib::abilities::provenance::source::EntityId;
 use dailyos_lib::abilities::provenance::trust::claim_trust_band_from_score;
-use dailyos_lib::abilities::registry::McpExposure;
 use dailyos_lib::abilities::source_management_ledger::contracts::{
     SourceManagementActionInput, SourceManagementActionKind, SourceManagementActionRequest,
     SourceManagementLedgerInput, SourceManagementLedgerPrivacyProfile,
@@ -35,10 +34,7 @@ use dailyos_lib::services::context::{ClaimDismissalSurface, FixedClock, Seedable
 #[cfg(feature = "test-harness")]
 use dailyos_lib::services::context::{EntityContextClaimReadFuture, EntityContextClaimReadHandle};
 use dailyos_lib::services::context::{ExternalClients, ServiceContext, SystemClock, SystemRng};
-use dailyos_lib::services::mcp_v2::actor_policy::{ToolGrant, ToolRateLimit};
-use dailyos_lib::services::mcp_v2::contracts::{
-    McpClientId, McpToolRequestEnvelope, McpToolResult, ScopedName, ToolError,
-};
+use dailyos_lib::services::mcp_v2::contracts::ScopedName;
 use dailyos_lib::services::mcp_v2::gateway::Gateway;
 use dailyos_lib::services::mcp_v2::handlers::registration::register_v147_handlers;
 use dailyos_lib::services::mcp_v2::taxonomy::{TaxonomyCatalog, YamlTaxonomyCatalog};
@@ -66,7 +62,7 @@ use rusqlite::{params, Connection};
 use serde_json::json;
 
 #[test]
-fn mcp_placement_handler_registered_but_not_local_stdio_invocable() {
+fn mcp_w5_registers_only_public_six_tools_and_hides_placement() {
     let runtime = tokio::runtime::Runtime::new().expect("runtime");
     let catalog: Arc<dyn TaxonomyCatalog> =
         Arc::new(YamlTaxonomyCatalog::load_embedded().expect("catalog"));
@@ -81,35 +77,25 @@ fn mcp_placement_handler_registered_but_not_local_stdio_invocable() {
     .expect("register v2 handlers");
     gateway.seal().expect("registered handlers validate");
 
-    let tool_name = ScopedName::new("dailyos.write.place_document");
-    assert!(gateway.registered_tools().any(|name| name == &tool_name));
+    let registered: std::collections::BTreeSet<_> = gateway
+        .registered_tools()
+        .map(|name| name.as_str().to_string())
+        .collect();
+    let expected = std::collections::BTreeSet::from([
+        "dailyos.read.account_status".to_string(),
+        "dailyos.read.workspace_source_provenance".to_string(),
+        "dailyos.submit.claim_feedback".to_string(),
+        "dailyos.submit.note".to_string(),
+        "dailyos.submit.action".to_string(),
+        "dailyos.submit.action_status".to_string(),
+    ]);
 
-    let response = gateway.handle_local_stdio_tool_call(
-        &McpClientId::new("validation-client"),
-        McpToolRequestEnvelope {
-            conversation_handle: None,
-            tool_name: tool_name.clone(),
-            params: serde_json::json!({}),
-        },
-        &[ToolGrant {
-            tool_name: tool_name.clone(),
-            scopes_granted: vec![],
-            exposure: McpExposure::None,
-            rate_limit: ToolRateLimit {
-                max_calls: 0,
-                window_seconds: 0,
-            },
-        }],
-    );
-
-    assert_eq!(
-        response.result,
-        McpToolResult::Error {
-            error: ToolError::ExposureForbidden {
-                tool_name: tool_name.clone()
-            }
-        },
-        "registered placement handler should stay unavailable to local stdio until ADR-0128 expands write exposure"
+    assert_eq!(registered, expected);
+    assert!(
+        catalog
+            .description_for(&ScopedName::new("dailyos.write.place_document"))
+            .is_none(),
+        "W5 hides placement entirely until it is re-authorized by a later packet"
     );
 }
 


### PR DESCRIPTION
## Summary

W5 public MCP tools now operate on opaque, conversation-scoped target handles instead of exposing internal identifiers or source details to clients. The runtime can create and update actions, submit notes, route feedback, report account status, and expose source provenance through public descriptors while failing closed when a target is stale, hidden, or unavailable.

## Design Decisions

| Area | Decision |
| --- | --- |
| Durable handles | Add a service-owned `mcp_target_handles` table so rendered MCP results can carry revocable public handles backed by hashed target material. |
| Replay behavior | Deterministic mutation replays replace prior response handles for the same target instead of minting duplicate durable rows. |
| Feedback routing | Claim feedback sanitizes metadata, resolves source provenance through safe handles, and validates target availability before replay or write paths run. |
| Public parity | Action, note, status, account status, claim feedback, and source provenance handlers are registered through the local runtime with parity descriptors. |
| Trust boundary | Tool descriptions, taxonomy checks, and exposure errors avoid leaking hidden tool categories or hidden requested tool names. |

## Review Notes

L2 reran after blocker patches and all reviewers passed: adversarial, API contract, data migrations, reliability, and security.

Remaining notes are advisory rather than W5 blockers: deterministic handle uniqueness is enforced in service flow rather than by a unique database constraint, stale handle resolution can extend TTL before caller-level validation rejects the target, and duplicate visible account-status text can still make target routing ambiguous.

## §4 Security

`security_auditor_invoked: true`

Security review ran because this PR touches MCP trust-boundary paths, service write paths, migrations, target-handle persistence, and sensitivity/actor-filter logic.

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml mcp_v2 --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm tsc --noEmit`
- `git diff --check public/dev`
- Hidden MCP description scan for forbidden categories

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
