### PR TITLE
fix: dedupe sensitivity render policy across crate boundary (DOS-851)

### DIFF
--- a/src-tauri/src/services/claim_receipt/render.rs
+++ b/src-tauri/src/services/claim_receipt/render.rs
@@ -1,7 +1,7 @@
 use abilities_runtime::sensitivity::{
     renderable_claim_text_with_value, RenderActor, RenderSurface,
 };
-use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 
 use crate::db::ActionDb;
 use crate::services::claim_receipt::contracts::*;
@@ -251,20 +251,6 @@ fn render_surface_for(surface: SurfaceContext) -> RenderSurface {
     }
 }
 
-fn freshness_for(source_asof: Option<DateTime<Utc>>, now: DateTime<Utc>) -> Freshness {
-    let Some(source_asof) = source_asof else {
-        return Freshness::Unknown;
-    };
-    let age = now.signed_duration_since(source_asof);
-    if age <= Duration::days(7) {
-        Freshness::Current
-    } else if age <= Duration::days(30) {
-        Freshness::Aging
-    } else {
-        Freshness::Stale
-    }
-}
-
 fn parse_claim_timestamp(value: &str) -> Option<DateTime<Utc>> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -292,8 +278,10 @@ mod tests {
     use abilities_runtime::abilities::trust::types::TrustBand;
     use abilities_runtime::sensitivity::{ClaimVerificationState, RenderPolicyKind};
     use abilities_runtime::types::{ClaimState, SurfacingState};
-    use chrono::TimeZone;
+    use chrono::{Duration, TimeZone};
     use rusqlite::params;
+
+    use crate::services::claim_receipt::render_rules::freshness_for;
 
     async fn test_state() -> (AppState, tempfile::TempDir) {
         let tempdir = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/src/services/meetings.rs
+++ b/src-tauri/src/services/meetings.rs
@@ -5486,8 +5486,8 @@ mod tests {
         db.conn_ref()
             .execute(
                 "INSERT INTO meetings (id, title, meeting_type, start_time, end_time, attendees, created_at)
-                 VALUES (?1, 'Actor Boundary Prep', 'external', '2026-06-10T17:00:00Z',
-                         '2026-06-10T17:30:00Z', '[]', '2026-06-05T09:00:00Z')",
+                 VALUES (?1, 'Actor Boundary Prep', 'external', '2099-06-10T17:00:00Z',
+                         '2099-06-10T17:30:00Z', '[]', '2026-06-05T09:00:00Z')",
                 rusqlite::params![meeting_id],
             )
             .expect("seed future meeting");

--- a/src-tauri/src/services/sensitivity.rs
+++ b/src-tauri/src/services/sensitivity.rs
@@ -13,6 +13,7 @@ use crate::intelligence::{
     ValueItem,
 };
 pub use abilities_runtime::sensitivity::{
+    render_policy_for_surface, renderable_claim_text_with_value, renderable_from_decision,
     ClaimDismissalSurface, RedactionAffordance, RenderActor, RenderDecision, RenderPolicy,
     RenderPolicyKind, RenderSurface, RenderableClaimText,
 };
@@ -101,19 +102,6 @@ pub enum RenderableMcpText {
     Static(RenderableMcpStaticText),
 }
 
-pub fn render_policy_for_surface(
-    claim: &IntelligenceClaim,
-    surface: RenderSurface,
-    actor: &RenderActor,
-) -> RenderDecision {
-    match claim.sensitivity {
-        ClaimSensitivity::Public => public_policy(surface),
-        ClaimSensitivity::Internal => internal_policy(surface),
-        ClaimSensitivity::Confidential => confidential_policy(claim, surface),
-        ClaimSensitivity::UserOnly => user_only_policy(claim, surface, actor),
-    }
-}
-
 pub fn render_policy_for_surface_name(
     claim: &IntelligenceClaim,
     surface: &str,
@@ -152,47 +140,6 @@ pub fn renderable_claim_text(
     actor: &RenderActor,
 ) -> Option<RenderableClaimText> {
     renderable_claim_text_with_value(claim, &claim.text, surface, actor)
-}
-
-pub fn renderable_claim_text_with_value(
-    claim: &IntelligenceClaim,
-    value: &str,
-    surface: RenderSurface,
-    actor: &RenderActor,
-) -> Option<RenderableClaimText> {
-    let decision = render_policy_for_surface(claim, surface, actor);
-    renderable_from_decision(claim, value, surface, decision)
-}
-
-pub fn renderable_from_decision(
-    claim: &IntelligenceClaim,
-    value: &str,
-    surface: RenderSurface,
-    decision: RenderDecision,
-) -> Option<RenderableClaimText> {
-    match decision {
-        RenderDecision::Render => Some(RenderableClaimText {
-            text: value.to_string(),
-            policy: RenderPolicy {
-                kind: RenderPolicyKind::Render,
-                sensitivity: claim.sensitivity.clone(),
-                surface,
-                claim_id: Some(claim.id.clone()),
-                affordance: None,
-            },
-        }),
-        RenderDecision::RenderRedacted { affordance } => Some(RenderableClaimText {
-            text: affordance.label().to_string(),
-            policy: RenderPolicy {
-                kind: RenderPolicyKind::Redacted,
-                sensitivity: claim.sensitivity.clone(),
-                surface,
-                claim_id: Some(claim.id.clone()),
-                affordance: Some(affordance),
-            },
-        }),
-        RenderDecision::Drop => None,
-    }
 }
 
 /// Render a text leaf from a static MCP DTO.
@@ -2132,77 +2079,6 @@ fn claim_type_is_owned_by_active_substrate(claims: &[IntelligenceClaim], claim_t
 
 fn render_surface_dismissal_key(surface: RenderSurface) -> &'static str {
     ClaimDismissalSurface::from(surface).as_str()
-}
-
-fn public_policy(surface: RenderSurface) -> RenderDecision {
-    if matches!(surface, RenderSurface::LogStructured) {
-        RenderDecision::Drop
-    } else {
-        RenderDecision::Render
-    }
-}
-
-fn internal_policy(surface: RenderSurface) -> RenderDecision {
-    if surface.is_first_party_tauri() || surface.is_agent_surface() {
-        RenderDecision::Render
-    } else {
-        RenderDecision::Drop
-    }
-}
-
-fn confidential_policy(claim: &IntelligenceClaim, surface: RenderSurface) -> RenderDecision {
-    if surface.allows_reveal() {
-        RenderDecision::RenderRedacted {
-            affordance: RedactionAffordance::ConfidentialClickToReveal {
-                claim_id: claim.id.clone(),
-                label: "Confidential claim hidden".to_string(),
-                audit_required: true,
-            },
-        }
-    } else if surface.is_first_party_tauri() {
-        RenderDecision::RenderRedacted {
-            affordance: RedactionAffordance::ConfidentialHidden {
-                label: "Confidential claim hidden".to_string(),
-            },
-        }
-    } else {
-        RenderDecision::Drop
-    }
-}
-
-fn user_only_policy(
-    claim: &IntelligenceClaim,
-    surface: RenderSurface,
-    actor: &RenderActor,
-) -> RenderDecision {
-    if surface.is_first_party_tauri() && actor_owns_user_only_claim(claim, actor) {
-        RenderDecision::Render
-    } else if surface.is_first_party_tauri() {
-        RenderDecision::RenderRedacted {
-            affordance: RedactionAffordance::UserOnlyHidden {
-                label: "User-only claim hidden".to_string(),
-            },
-        }
-    } else {
-        RenderDecision::Drop
-    }
-}
-
-fn actor_owns_user_only_claim(claim: &IntelligenceClaim, actor: &RenderActor) -> bool {
-    if !actor.is_user() {
-        return false;
-    }
-    let claim_actor = claim.actor.trim();
-    let actor_label = actor.actor.trim();
-    let Some(user_id) = actor.user_id.as_deref() else {
-        return claim_actor.eq_ignore_ascii_case("user")
-            && actor_label.eq_ignore_ascii_case("user");
-    };
-    claim_actor.eq_ignore_ascii_case(user_id)
-        || claim_actor
-            .strip_prefix("user:")
-            .is_some_and(|suffix| suffix.eq_ignore_ascii_case(user_id))
-        || (claim_actor.eq_ignore_ascii_case("user") && user_id.eq_ignore_ascii_case("user"))
 }
 
 fn rendered_json_values_for_claim_type(


### PR DESCRIPTION
Single fix from the DOS-851 codex worktree, rebased onto dev, full gauntlet green (clippy -D warnings, 3484 tests, tsc). Includes a fixture future-proofing commit (same time-bomb class fixed on the PR #450 branch; reconcile on second merge).

L2: pending — small diff (+5/−141), candidate for a quick bounded pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)